### PR TITLE
Fix :order-by not working in queries

### DIFF
--- a/datalog/compare.go
+++ b/datalog/compare.go
@@ -75,6 +75,8 @@ func CompareValues(left, right interface{}) int {
 		return compareNumeric(int64(l), right)
 	case int64:
 		return compareNumeric(l, right)
+	case uint64:
+		return compareUint64(l, right)
 	case float64:
 		return compareFloat(l, right)
 	case string:
@@ -187,6 +189,38 @@ func compareInt64s(a, b int64) int {
 
 // compareFloats compares two float64 values
 func compareFloats(a, b float64) int {
+	if a < b {
+		return -1
+	} else if a > b {
+		return 1
+	}
+	return 0
+}
+
+// compareUint64 compares a uint64 with another numeric value
+func compareUint64(left uint64, right interface{}) int {
+	switch r := right.(type) {
+	case uint64:
+		return compareUint64s(left, r)
+	case int:
+		if r < 0 {
+			return 1 // unsigned is always >= 0
+		}
+		return compareUint64s(left, uint64(r))
+	case int64:
+		if r < 0 {
+			return 1 // unsigned is always >= 0
+		}
+		return compareUint64s(left, uint64(r))
+	case float64:
+		return compareFloats(float64(left), r)
+	}
+	// Non-numeric: type mismatch
+	return -1
+}
+
+// compareUint64s compares two uint64 values
+func compareUint64s(a, b uint64) int {
 	if a < b {
 		return -1
 	} else if a > b {

--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -324,7 +324,14 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 		return nil, nil
 	}
 
-	return currentGroups[0], nil
+	finalResult := currentGroups[0]
+
+	// Apply ordering if specified
+	if len(plan.Query.OrderBy) > 0 {
+		finalResult = finalResult.Sort(plan.Query.OrderBy)
+	}
+
+	return finalResult, nil
 }
 
 // executePhasesWithInputs executes a query plan with input relations


### PR DESCRIPTION
Two bugs fixed:

1. CompareValues didn't handle uint64 type

   Transaction IDs (?tx in queries) are uint64, but CompareValues only handled int, int64, and float64 in its switch statement. uint64 values fell through to string comparison, causing incorrect sort order.

   Added compareUint64() and compareUint64s() functions to properly handle uint64 comparison with other numeric types.

2. ExecuteRealized missing :order-by handling

   The new QueryExecutor path (UseQueryExecutor=true, the default since October 2025) was missing the :order-by application that existed in the legacy executePhasesWithInputs path.

   Added Sort() call before returning from ExecuteRealized when plan.Query.OrderBy is specified.

Symptom: [:find ?e ?tx :where [...] :order-by [[?tx :asc]]] returned results sorted by entity ID instead of transaction time.