### PR TITLE
Fix table formatter to dereference *uint64/*int64 pointers

### DIFF
--- a/datalog/executor/table_formatter.go
+++ b/datalog/executor/table_formatter.go
@@ -120,6 +120,10 @@ func (tf *TableFormatter) formatValue(val interface{}) string {
 			s = v.String()
 		case datalog.Keyword:
 			s = v.String()
+		case *uint64:
+			s = fmt.Sprintf("%d", *v)
+		case *int64:
+			s = fmt.Sprintf("%d", *v)
 		default:
 			s = fmt.Sprintf("%v", v)
 		}


### PR DESCRIPTION
The interned tuple builder stores tx values as *uint64 pointers for performance. The table formatter was displaying these as memory addresses (0x14000...) instead of the actual values.

Added cases to dereference pointer types when formatting for display.