### PR TITLE
Implement Datomic-style database functions: get-else, missing?, get-some

### DIFF
--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -7,6 +7,7 @@ This guide is for developers familiar with Datomic who want to understand what j
 Janus-datalog implements a pragmatic subset of Datomic's Datalog query language with:
 - ✅ Core query patterns, expressions, aggregations, and subqueries
 - ✅ Time-based queries using transaction IDs
+- ✅ Database functions: `get-else`, `missing?`, `get-some`
 - ✅ BadgerDB persistent storage with EAVT model
 - ❌ No Pull API, rules, schema, or transaction functions
 - ❌ No NOT/OR clauses or entity API
@@ -143,7 +144,41 @@ Standard Datomic input patterns:
 - `[[?x ?y]]` - tuple
 - `[[?x ?y] ...]` - relation
 
-### 7. Time-Based Queries
+### 7. Database Functions
+
+Functions that access the database for attribute lookups:
+
+**get-else - default values for missing attributes:**
+```clojure
+[:find ?name ?nickname
+ :where [?e :person/name ?name]
+        [(get-else $ ?e :person/nickname "No Nickname") ?nickname]]
+```
+
+**missing? - test if attribute is absent (as predicate filter):**
+```clojure
+[:find ?name
+ :where [?e :user/name ?name]
+        [(missing? $ ?e :user/email)]]  ; Only users without email
+```
+
+**missing? - as expression (returns boolean):**
+```clojure
+[:find ?name ?needs_verification
+ :where [?e :user/name ?name]
+        [(missing? $ ?e :user/verified) ?needs_verification]]
+```
+
+**get-some - first available attribute from fallback list:**
+```clojure
+[:find ?id ?display-name
+ :where [?e :user/id ?id]
+        [(get-some $ ?e :user/nickname :user/fullname :user/email) ?display-name]]
+```
+
+These functions require the `$` database reference as their first argument.
+
+### 8. Time-Based Queries
 
 Query database as of specific times:
 
@@ -242,11 +277,14 @@ No entity navigation:
 (touch entity)
 ```
 
-### 7. Advanced Query Features ❌
+### 7. Advanced Query Features (Partial) ⚠️
 
-Missing query conveniences:
-- `get-else` - no default values
-- `missing?` - cannot test attribute absence
+**Implemented:**
+- `get-else` - default values for missing attributes ✅
+- `missing?` - test attribute absence ✅
+- `get-some` - first available attribute from fallback list ✅
+
+**Not implemented:**
 - `tuple` - no tuple destructuring in find
 - `keys` - no map results
 - `with` - no duplicate control

--- a/README.md
+++ b/README.md
@@ -154,6 +154,32 @@ Predicates apply as soon as their variables are available. You can also chain co
 
 Expression clauses compute new values. The result gets bound to the variable on the right.
 
+### Database Functions
+
+Handle missing attributes gracefully with database functions:
+
+```go
+; Return nickname if exists, otherwise "Anonymous"
+[:find ?name ?display
+ :where [?user :user/name ?name]
+        [(get-else $ ?user :user/nickname "Anonymous") ?display]]
+
+; Filter to users without email addresses
+[:find ?name
+ :where [?user :user/name ?name]
+        [(missing? $ ?user :user/email)]]
+
+; Use first available: nickname → fullname → email
+[:find ?id ?display
+ :where [?user :user/id ?id]
+        [(get-some $ ?user :user/nickname :user/fullname :user/email) ?display]]
+```
+
+The `$` is the database reference. These functions look up attributes at query time:
+- `get-else` – returns attribute value or default
+- `missing?` – filters to entities lacking an attribute (or binds boolean)
+- `get-some` – returns first existing attribute from a list
+
 ### Aggregations
 
 ```go

--- a/datalog/executor/expressions_and_predicates.go
+++ b/datalog/executor/expressions_and_predicates.go
@@ -20,6 +20,12 @@ func (e *Executor) applyExpressionsAndPredicates(ctx Context, phase *planner.Pha
 		return NewMaterializedRelationWithOptions(phase.Provides, []Tuple{}, e.options), nil
 	}
 
+	// Get entity lookup if matcher supports it (for database functions)
+	var lookup query.EntityLookup
+	if lookupMatcher, ok := e.matcher.(EntityLookupMatcher); ok {
+		lookup = entityLookupAdapter{lookupMatcher}
+	}
+
 	// Keep track of relation groups - they might join after expressions add symbols
 	groups := relations
 
@@ -90,12 +96,12 @@ func (e *Executor) applyExpressionsAndPredicates(ctx Context, phase *planner.Pha
 			if exprPlan.IsEquality {
 				// This is an equality expression - apply as a filter using Eval
 				result = ctx.FilterRelation(group, exprPlan.Expression.String(), func() Relation {
-					return filterWithExpression(group, exprPlan.Expression)
+					return filterWithExpressionAndLookup(group, exprPlan.Expression, lookup)
 				})
 			} else {
 				// This is a binding expression - evaluate and add column
 				result = ctx.EvaluateExpressionRelation(group, exprPlan.Expression.String(), func() Relation {
-					return evaluateExpressionNew(group, exprPlan.Expression)
+					return evaluateExpressionWithLookup(group, exprPlan.Expression, lookup)
 				})
 			}
 
@@ -162,7 +168,7 @@ func (e *Executor) applyExpressionsAndPredicates(ctx Context, phase *planner.Pha
 			}
 
 			result := ctx.FilterRelation(group, predPlan.Predicate.String(), func() Relation {
-				return filterWithPredicate(group, predPlan.Predicate)
+				return filterWithPredicateAndLookup(group, predPlan.Predicate, lookup)
 			})
 
 			// CRITICAL: Don't call IsEmpty() - it consumes streaming iterators!
@@ -316,6 +322,12 @@ func (e *Executor) applyExpressionsAndPredicates(ctx Context, phase *planner.Pha
 
 // filterWithPredicate filters a relation using a Predicate's Eval method
 func filterWithPredicate(rel Relation, pred query.Predicate) Relation {
+	return filterWithPredicateAndLookup(rel, pred, nil)
+}
+
+// filterWithPredicateAndLookup filters a relation using a Predicate's Eval method
+// with optional database lookup support for DatabaseFunctionPredicates.
+func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup query.EntityLookup) Relation {
 	columns := rel.Columns()
 
 	// Pre-allocate filtered only for materialized relations to avoid forcing materialization
@@ -328,6 +340,9 @@ func filterWithPredicate(rel Relation, pred query.Predicate) Relation {
 
 	// Reuse single bindings map to avoid repeated allocations
 	bindings := make(map[query.Symbol]interface{}, len(columns))
+
+	// Check if this is a DatabaseFunctionPredicate that needs lookup
+	dbFuncPred, isDbFuncPred := pred.(*query.DatabaseFunctionPredicate)
 
 	iter := rel.Iterator()
 	for iter.Next() {
@@ -342,7 +357,13 @@ func filterWithPredicate(rel Relation, pred query.Predicate) Relation {
 		}
 
 		// Evaluate the predicate
-		passes, err := pred.Eval(bindings)
+		var passes bool
+		var err error
+		if isDbFuncPred && lookup != nil {
+			passes, err = dbFuncPred.EvalWithLookup(bindings, lookup)
+		} else {
+			passes, err = pred.Eval(bindings)
+		}
 		if err != nil {
 			// Log error but continue processing
 			// TODO: Consider better error handling strategy
@@ -361,6 +382,11 @@ func filterWithPredicate(rel Relation, pred query.Predicate) Relation {
 
 // filterWithExpression filters a relation using an Expression that acts as a predicate (IsEquality = true)
 func filterWithExpression(rel Relation, expr *query.Expression) Relation {
+	return filterWithExpressionAndLookup(rel, expr, nil)
+}
+
+// filterWithExpressionAndLookup filters a relation using an Expression with optional database lookup
+func filterWithExpressionAndLookup(rel Relation, expr *query.Expression, lookup query.EntityLookup) Relation {
 	columns := rel.Columns()
 
 	// Pre-allocate filtered only for materialized relations to avoid forcing materialization
@@ -387,7 +413,13 @@ func filterWithExpression(rel Relation, expr *query.Expression) Relation {
 		}
 
 		// Evaluate the expression (should return a boolean)
-		result, err := expr.Function.Eval(bindings)
+		var result interface{}
+		var err error
+		if dbFunc, ok := expr.Function.(query.DatabaseFunction); ok && lookup != nil {
+			result, err = dbFunc.EvalWithLookup(bindings, lookup)
+		} else {
+			result, err = expr.Function.Eval(bindings)
+		}
 		if err != nil {
 			continue
 		}
@@ -404,7 +436,16 @@ func filterWithExpression(rel Relation, expr *query.Expression) Relation {
 }
 
 // evaluateExpressionNew evaluates an expression and adds the result as a new column
+// This version does not support database functions (get-else, missing?, get-some).
+// Use evaluateExpressionWithLookup for queries that may contain database functions.
 func evaluateExpressionNew(rel Relation, expr *query.Expression) Relation {
+	return evaluateExpressionWithLookup(rel, expr, nil)
+}
+
+// evaluateExpressionWithLookup evaluates an expression with optional database lookup support.
+// If lookup is non-nil and the expression is a DatabaseFunction, it uses EvalWithLookup.
+// Otherwise, it falls back to the standard Eval method.
+func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup query.EntityLookup) Relation {
 	columns := rel.Columns()
 
 	// Add the binding column if it doesn't exist
@@ -446,10 +487,23 @@ func evaluateExpressionNew(rel Relation, expr *query.Expression) Relation {
 		}
 
 		// Evaluate the expression
-		result, err := expr.Function.Eval(bindings)
+		// Check if this is a database function that needs lookup access
+		var result interface{}
+		var err error
+		if dbFunc, ok := expr.Function.(query.DatabaseFunction); ok && lookup != nil {
+			result, err = dbFunc.EvalWithLookup(bindings, lookup)
+		} else {
+			result, err = expr.Function.Eval(bindings)
+		}
 		if err != nil {
 			// Skip tuples where expression fails
 			continue
+		}
+
+		// Extract value from GetSomeResult if needed
+		// get-some returns a struct with Attr and Value; we just want the Value for binding
+		if gsr, ok := result.(*query.GetSomeResult); ok {
+			result = gsr.Value
 		}
 
 		// Create new tuple with result

--- a/datalog/executor/interfaces.go
+++ b/datalog/executor/interfaces.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/constraints"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
@@ -22,4 +23,14 @@ type PredicateAwareMatcher interface {
 		bindings Relations,
 		constraints []StorageConstraint,
 	) (Relation, error)
+}
+
+// EntityLookupMatcher extends PatternMatcher with entity attribute lookup capability.
+// This is used by database functions (get-else, missing?, get-some) that need
+// to lookup specific entity attributes during expression evaluation.
+type EntityLookupMatcher interface {
+	PatternMatcher
+	// LookupAttribute retrieves the value of an attribute for an entity.
+	// Returns (value, true) if the attribute exists, (nil, false) otherwise.
+	LookupAttribute(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool)
 }

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"fmt"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
@@ -296,11 +297,27 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 	// Product() handles single relation passthrough
 	joined := Relations(relevantRels).Product()
 
-	// Evaluate expression
-	result := evaluateExpressionNew(joined, expr)
+	// Check if this expression might need database access (database functions)
+	// If the matcher supports EntityLookup, pass it to the expression evaluator
+	var lookup query.EntityLookup
+	if lookupMatcher, ok := e.matcher.(EntityLookupMatcher); ok {
+		lookup = entityLookupAdapter{lookupMatcher}
+	}
+
+	// Evaluate expression with optional lookup support
+	result := evaluateExpressionWithLookup(joined, expr, lookup)
 
 	// Return result + unchanged relations
 	return append([]Relation{result}, otherRels...), nil
+}
+
+// entityLookupAdapter adapts EntityLookupMatcher to query.EntityLookup
+type entityLookupAdapter struct {
+	matcher EntityLookupMatcher
+}
+
+func (a entityLookupAdapter) LookupAttribute(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool) {
+	return a.matcher.LookupAttribute(entity, attr)
 }
 
 // executePredicate filters relations using a predicate
@@ -341,8 +358,15 @@ func (e *DefaultQueryExecutor) executePredicate(ctx Context, pred query.Predicat
 	// Product() handles single relation passthrough
 	joined := Relations(relevantRels).Product()
 
-	// Filter using predicate
-	result := filterWithPredicate(joined, pred)
+	// Check if this predicate might need database access (DatabaseFunctionPredicate)
+	// If the matcher supports EntityLookup, pass it to the predicate evaluator
+	var lookup query.EntityLookup
+	if lookupMatcher, ok := e.matcher.(EntityLookupMatcher); ok {
+		lookup = entityLookupAdapter{lookupMatcher}
+	}
+
+	// Filter using predicate with optional lookup support
+	result := filterWithPredicateAndLookup(joined, pred, lookup)
 
 	// Return result + unchanged relations
 	return append([]Relation{result}, otherRels...), nil

--- a/datalog/parser/database_function_test.go
+++ b/datalog/parser/database_function_test.go
@@ -1,0 +1,369 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+func TestParseGetElse(t *testing.T) {
+	tests := []struct {
+		name        string
+		queryStr    string
+		wantErr     bool
+		errContains string
+		validate    func(t *testing.T, q *query.Query)
+	}{
+		{
+			name:     "basic get-else with string default",
+			queryStr: `[:find ?e ?name :where [?e :entity/id _] [(get-else $ ?e :entity/name "Unknown") ?name]]`,
+			wantErr:  false,
+			validate: func(t *testing.T, q *query.Query) {
+				if len(q.Where) != 2 {
+					t.Fatalf("expected 2 where clauses, got %d", len(q.Where))
+				}
+				expr, ok := q.Where[1].(*query.Expression)
+				if !ok {
+					t.Fatalf("expected Expression, got %T", q.Where[1])
+				}
+				getElse, ok := expr.Function.(*query.GetElseFunction)
+				if !ok {
+					t.Fatalf("expected GetElseFunction, got %T", expr.Function)
+				}
+				if getElse.Attr.String() != ":entity/name" {
+					t.Errorf("expected attr :entity/name, got %s", getElse.Attr.String())
+				}
+				if getElse.Default != "Unknown" {
+					t.Errorf("expected default 'Unknown', got %v", getElse.Default)
+				}
+				if expr.Binding != "?name" {
+					t.Errorf("expected binding ?name, got %s", expr.Binding)
+				}
+			},
+		},
+		{
+			name:     "get-else with integer default",
+			queryStr: `[:find ?e ?count :where [?e :entity/id _] [(get-else $ ?e :entity/count 0) ?count]]`,
+			wantErr:  false,
+			validate: func(t *testing.T, q *query.Query) {
+				expr := q.Where[1].(*query.Expression)
+				getElse := expr.Function.(*query.GetElseFunction)
+				// Note: EDN parser may return int64 for integers
+				switch v := getElse.Default.(type) {
+				case int64:
+					if v != 0 {
+						t.Errorf("expected default 0, got %v", v)
+					}
+				case int:
+					if v != 0 {
+						t.Errorf("expected default 0, got %v", v)
+					}
+				default:
+					t.Errorf("expected numeric default, got %T", getElse.Default)
+				}
+			},
+		},
+		{
+			name:     "get-else with empty string default",
+			queryStr: `[:find ?e ?desc :where [?e :entity/id _] [(get-else $ ?e :entity/description "") ?desc]]`,
+			wantErr:  false,
+			validate: func(t *testing.T, q *query.Query) {
+				expr := q.Where[1].(*query.Expression)
+				getElse := expr.Function.(*query.GetElseFunction)
+				if getElse.Default != "" {
+					t.Errorf("expected empty string default, got %v", getElse.Default)
+				}
+			},
+		},
+		{
+			name:        "get-else missing database ref",
+			queryStr:    `[:find ?e ?name :where [?e :entity/id _] [(get-else ?e :entity/name "Unknown") ?name]]`,
+			wantErr:     true,
+			errContains: "get-else requires exactly 4 arguments",
+		},
+		{
+			name:        "get-else wrong number of args",
+			queryStr:    `[:find ?e ?name :where [?e :entity/id _] [(get-else $ ?e :entity/name) ?name]]`,
+			wantErr:     true,
+			errContains: "get-else requires exactly 4 arguments",
+		},
+		{
+			name:        "get-else with variable as attribute (invalid)",
+			queryStr:    `[:find ?e ?name :where [?e :entity/id _] [(get-else $ ?e ?attr "Unknown") ?name]]`,
+			wantErr:     true,
+			errContains: "attribute must be a keyword",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, err := ParseQuery(tt.queryStr)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.validate != nil {
+				tt.validate(t, q)
+			}
+		})
+	}
+}
+
+func TestParseMissingAttr(t *testing.T) {
+	tests := []struct {
+		name        string
+		queryStr    string
+		wantErr     bool
+		errContains string
+		validate    func(t *testing.T, q *query.Query)
+	}{
+		{
+			name:     "missing? as predicate filter (no binding)",
+			queryStr: `[:find ?e :where [?e :entity/id _] [(missing? $ ?e :entity/name)]]`,
+			wantErr:  false,
+			validate: func(t *testing.T, q *query.Query) {
+				if len(q.Where) != 2 {
+					t.Fatalf("expected 2 where clauses, got %d", len(q.Where))
+				}
+				// missing? without binding is parsed as DatabaseFunctionPredicate
+				pred, ok := q.Where[1].(*query.DatabaseFunctionPredicate)
+				if !ok {
+					t.Fatalf("expected DatabaseFunctionPredicate, got %T", q.Where[1])
+				}
+				missing, ok := pred.Function.(*query.MissingFunction)
+				if !ok {
+					t.Fatalf("expected MissingFunction, got %T", pred.Function)
+				}
+				if missing.Attr.String() != ":entity/name" {
+					t.Errorf("expected attr :entity/name, got %s", missing.Attr.String())
+				}
+			},
+		},
+		{
+			name:     "missing? as expression (with binding)",
+			queryStr: `[:find ?e ?is_missing :where [?e :entity/id _] [(missing? $ ?e :entity/name) ?is_missing]]`,
+			wantErr:  false,
+			validate: func(t *testing.T, q *query.Query) {
+				if len(q.Where) != 2 {
+					t.Fatalf("expected 2 where clauses, got %d", len(q.Where))
+				}
+				// missing? with binding is parsed as Expression
+				expr, ok := q.Where[1].(*query.Expression)
+				if !ok {
+					t.Fatalf("expected Expression, got %T", q.Where[1])
+				}
+				missing, ok := expr.Function.(*query.MissingFunction)
+				if !ok {
+					t.Fatalf("expected MissingFunction, got %T", expr.Function)
+				}
+				if missing.Attr.String() != ":entity/name" {
+					t.Errorf("expected attr :entity/name, got %s", missing.Attr.String())
+				}
+				if expr.Binding != "?is_missing" {
+					t.Errorf("expected binding ?is_missing, got %s", expr.Binding)
+				}
+			},
+		},
+		{
+			name:        "missing? with wrong arg count",
+			queryStr:    `[:find ?e :where [?e :entity/id _] [(missing? $ ?e)]]`,
+			wantErr:     true,
+			errContains: "missing? requires exactly 3 arguments",
+		},
+		{
+			name:        "missing? without database ref",
+			queryStr:    `[:find ?e :where [?e :entity/id _] [(missing? ?e :entity/name)]]`,
+			wantErr:     true,
+			errContains: "missing? requires exactly 3 arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, err := ParseQuery(tt.queryStr)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.validate != nil {
+				tt.validate(t, q)
+			}
+		})
+	}
+}
+
+func TestParseGetSome(t *testing.T) {
+	tests := []struct {
+		name        string
+		queryStr    string
+		wantErr     bool
+		errContains string
+		validate    func(t *testing.T, q *query.Query)
+	}{
+		{
+			name:     "get-some with two attributes",
+			queryStr: `[:find ?e ?val :where [?e :entity/id _] [(get-some $ ?e :user/nickname :user/name) ?val]]`,
+			wantErr:  false,
+			validate: func(t *testing.T, q *query.Query) {
+				if len(q.Where) != 2 {
+					t.Fatalf("expected 2 where clauses, got %d", len(q.Where))
+				}
+				expr := q.Where[1].(*query.Expression)
+				getSome, ok := expr.Function.(*query.GetSomeFunction)
+				if !ok {
+					t.Fatalf("expected GetSomeFunction, got %T", expr.Function)
+				}
+				if len(getSome.Attrs) != 2 {
+					t.Errorf("expected 2 attrs, got %d", len(getSome.Attrs))
+				}
+				if getSome.Attrs[0].String() != ":user/nickname" {
+					t.Errorf("expected first attr :user/nickname, got %s", getSome.Attrs[0].String())
+				}
+				if getSome.Attrs[1].String() != ":user/name" {
+					t.Errorf("expected second attr :user/name, got %s", getSome.Attrs[1].String())
+				}
+			},
+		},
+		{
+			name:     "get-some with three attributes",
+			queryStr: `[:find ?e ?val :where [?e :entity/id _] [(get-some $ ?e :user/nickname :user/name :user/email) ?val]]`,
+			wantErr:  false,
+			validate: func(t *testing.T, q *query.Query) {
+				expr := q.Where[1].(*query.Expression)
+				getSome := expr.Function.(*query.GetSomeFunction)
+				if len(getSome.Attrs) != 3 {
+					t.Errorf("expected 3 attrs, got %d", len(getSome.Attrs))
+				}
+			},
+		},
+		{
+			name:        "get-some with only one attribute (invalid - need at least 2 for fallback)",
+			queryStr:    `[:find ?e ?val :where [?e :entity/id _] [(get-some $ ?e :user/name) ?val]]`,
+			wantErr:     false, // Actually valid - at least 1 attr is fine
+			validate: func(t *testing.T, q *query.Query) {
+				expr := q.Where[1].(*query.Expression)
+				getSome := expr.Function.(*query.GetSomeFunction)
+				if len(getSome.Attrs) != 1 {
+					t.Errorf("expected 1 attr, got %d", len(getSome.Attrs))
+				}
+			},
+		},
+		{
+			name:        "get-some without attributes",
+			queryStr:    `[:find ?e ?val :where [?e :entity/id _] [(get-some $ ?e) ?val]]`,
+			wantErr:     true,
+			errContains: "get-some requires at least 3 arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, err := ParseQuery(tt.queryStr)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.validate != nil {
+				tt.validate(t, q)
+			}
+		})
+	}
+}
+
+func TestDatabaseFunctionRequiredSymbols(t *testing.T) {
+	// Test that RequiredSymbols correctly identifies the entity variable
+	getElse := &query.GetElseFunction{
+		Entity:  query.VariableTerm{Symbol: "?e"},
+		Attr:    datalog.NewKeyword(":entity/name"),
+		Default: "",
+	}
+	syms := getElse.RequiredSymbols()
+	if len(syms) != 1 || syms[0] != "?e" {
+		t.Errorf("expected [?e], got %v", syms)
+	}
+
+	missing := &query.MissingFunction{
+		Entity: query.VariableTerm{Symbol: "?person"},
+		Attr:   datalog.NewKeyword(":person/email"),
+	}
+	syms = missing.RequiredSymbols()
+	if len(syms) != 1 || syms[0] != "?person" {
+		t.Errorf("expected [?person], got %v", syms)
+	}
+
+	getSome := &query.GetSomeFunction{
+		Entity: query.VariableTerm{Symbol: "?user"},
+		Attrs: []datalog.Keyword{
+			datalog.NewKeyword(":user/nickname"),
+			datalog.NewKeyword(":user/name"),
+		},
+	}
+	syms = getSome.RequiredSymbols()
+	if len(syms) != 1 || syms[0] != "?user" {
+		t.Errorf("expected [?user], got %v", syms)
+	}
+}
+
+func TestDatabaseFunctionString(t *testing.T) {
+	// Test String() methods for debugging output
+	getElse := &query.GetElseFunction{
+		Entity:  query.VariableTerm{Symbol: "?e"},
+		Attr:    datalog.NewKeyword(":entity/name"),
+		Default: "Unknown",
+	}
+	str := getElse.String()
+	if !strings.Contains(str, "get-else") || !strings.Contains(str, ":entity/name") {
+		t.Errorf("unexpected String() output: %s", str)
+	}
+
+	missing := &query.MissingFunction{
+		Entity: query.VariableTerm{Symbol: "?e"},
+		Attr:   datalog.NewKeyword(":entity/email"),
+	}
+	str = missing.String()
+	if !strings.Contains(str, "missing?") || !strings.Contains(str, ":entity/email") {
+		t.Errorf("unexpected String() output: %s", str)
+	}
+
+	getSome := &query.GetSomeFunction{
+		Entity: query.VariableTerm{Symbol: "?e"},
+		Attrs: []datalog.Keyword{
+			datalog.NewKeyword(":a"),
+			datalog.NewKeyword(":b"),
+		},
+	}
+	str = getSome.String()
+	if !strings.Contains(str, "get-some") || !strings.Contains(str, ":a") || !strings.Contains(str, ":b") {
+		t.Errorf("unexpected String() output: %s", str)
+	}
+}
+

--- a/datalog/parser/function_parser.go
+++ b/datalog/parser/function_parser.go
@@ -2,10 +2,14 @@ package parser
 
 import (
 	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
 // parseFunction creates a concrete Function from expression pattern arguments
+// Note: Database functions (get-else, missing?, get-some) return query.DatabaseFunction
+// which also satisfies query.Function through embedding.
 func parseFunction(fn string, args []query.PatternElement) (query.Function, error) {
 	switch fn {
 	case "+", "-", "*", "/":
@@ -18,6 +22,13 @@ func parseFunction(fn string, args []query.PatternElement) (query.Function, erro
 		return parseGroundFunction(args)
 	case "identity":
 		return parseIdentity(args)
+	// Database functions - require $ and database access
+	case "get-else":
+		return parseGetElse(args)
+	case "missing?":
+		return parseMissingAttr(args)
+	case "get-some":
+		return parseGetSome(args)
 	default:
 		return nil, fmt.Errorf("unsupported function: %s", fn)
 	}
@@ -118,5 +129,173 @@ func parseAggregate(fn string, varName query.Symbol) (query.AggregateFunction, e
 		return &query.MaxAggregate{Var: varName}, nil
 	default:
 		return nil, fmt.Errorf("unsupported aggregate function: %s", fn)
+	}
+}
+
+// =============================================================================
+// Database Function Parsers
+// =============================================================================
+
+// parseGetElse parses (get-else $ ?entity :attribute default-value)
+// Returns the attribute value if it exists, or the default if missing.
+func parseGetElse(args []query.PatternElement) (query.Function, error) {
+	// Syntax: (get-else $ ?e :attr default)
+	// args[0] = $ (database reference)
+	// args[1] = ?e (entity variable or constant)
+	// args[2] = :attr (attribute keyword)
+	// args[3] = default (any value)
+	if len(args) != 4 {
+		return nil, fmt.Errorf("get-else requires exactly 4 arguments ($ entity attr default), got %d", len(args))
+	}
+
+	// Validate database reference ($)
+	if err := validateDatabaseRef(args[0]); err != nil {
+		return nil, fmt.Errorf("get-else: %w", err)
+	}
+
+	// Parse entity (can be variable or constant)
+	entity := elementToTerm(args[1])
+
+	// Parse attribute (must be a keyword)
+	attr, err := extractKeyword(args[2])
+	if err != nil {
+		return nil, fmt.Errorf("get-else: attribute must be a keyword: %w", err)
+	}
+
+	// Parse default value
+	defaultVal, err := extractConstantValue(args[3])
+	if err != nil {
+		return nil, fmt.Errorf("get-else: default must be a constant value: %w", err)
+	}
+
+	return &query.GetElseFunction{
+		Entity:  entity,
+		Attr:    attr,
+		Default: defaultVal,
+	}, nil
+}
+
+// parseMissingAttr parses (missing? $ ?entity :attribute)
+// Returns true if the entity does NOT have the specified attribute.
+// Note: Named parseMissingAttr to avoid conflict with parseMissing in predicate_parser.go
+func parseMissingAttr(args []query.PatternElement) (query.Function, error) {
+	// Syntax: (missing? $ ?e :attr)
+	// args[0] = $ (database reference)
+	// args[1] = ?e (entity variable or constant)
+	// args[2] = :attr (attribute keyword)
+	if len(args) != 3 {
+		return nil, fmt.Errorf("missing? requires exactly 3 arguments ($ entity attr), got %d", len(args))
+	}
+
+	// Validate database reference ($)
+	if err := validateDatabaseRef(args[0]); err != nil {
+		return nil, fmt.Errorf("missing?: %w", err)
+	}
+
+	// Parse entity (can be variable or constant)
+	entity := elementToTerm(args[1])
+
+	// Parse attribute (must be a keyword)
+	attr, err := extractKeyword(args[2])
+	if err != nil {
+		return nil, fmt.Errorf("missing?: attribute must be a keyword: %w", err)
+	}
+
+	return &query.MissingFunction{
+		Entity: entity,
+		Attr:   attr,
+	}, nil
+}
+
+// parseGetSome parses (get-some $ ?entity :attr1 :attr2 ...)
+// Returns the first attribute that exists along with its value.
+func parseGetSome(args []query.PatternElement) (query.Function, error) {
+	// Syntax: (get-some $ ?e :attr1 :attr2 :attr3 ...)
+	// args[0] = $ (database reference)
+	// args[1] = ?e (entity variable or constant)
+	// args[2..] = :attr1, :attr2, ... (attribute keywords)
+	if len(args) < 3 {
+		return nil, fmt.Errorf("get-some requires at least 3 arguments ($ entity attr...), got %d", len(args))
+	}
+
+	// Validate database reference ($)
+	if err := validateDatabaseRef(args[0]); err != nil {
+		return nil, fmt.Errorf("get-some: %w", err)
+	}
+
+	// Parse entity (can be variable or constant)
+	entity := elementToTerm(args[1])
+
+	// Parse attributes (must all be keywords)
+	attrs := make([]datalog.Keyword, 0, len(args)-2)
+	for i := 2; i < len(args); i++ {
+		attr, err := extractKeyword(args[i])
+		if err != nil {
+			return nil, fmt.Errorf("get-some: argument %d must be a keyword: %w", i, err)
+		}
+		attrs = append(attrs, attr)
+	}
+
+	return &query.GetSomeFunction{
+		Entity: entity,
+		Attrs:  attrs,
+	}, nil
+}
+
+// validateDatabaseRef validates that an argument is the database reference ($)
+func validateDatabaseRef(arg query.PatternElement) error {
+	switch a := arg.(type) {
+	case query.Variable:
+		if a.Name == "$" {
+			return nil
+		}
+		return fmt.Errorf("expected database reference ($), got variable %s", a.Name)
+	case query.Constant:
+		// $ is parsed as Constant{Value: Symbol("$")}
+		if sym, ok := a.Value.(query.Symbol); ok && sym == "$" {
+			return nil
+		}
+		if str, ok := a.Value.(string); ok && str == "$" {
+			return nil
+		}
+		return fmt.Errorf("expected database reference ($), got %v", a.Value)
+	default:
+		return fmt.Errorf("expected database reference ($), got %T", arg)
+	}
+}
+
+// extractKeyword extracts a Keyword from a pattern element
+func extractKeyword(arg query.PatternElement) (datalog.Keyword, error) {
+	switch a := arg.(type) {
+	case query.Constant:
+		switch v := a.Value.(type) {
+		case datalog.Keyword:
+			return v, nil
+		case *datalog.Keyword:
+			return *v, nil
+		case string:
+			// Allow string that looks like a keyword
+			if len(v) > 0 && v[0] == ':' {
+				return datalog.NewKeyword(v), nil
+			}
+			return datalog.Keyword{}, fmt.Errorf("string %q is not a keyword (must start with :)", v)
+		default:
+			return datalog.Keyword{}, fmt.Errorf("expected keyword, got %T", v)
+		}
+	default:
+		return datalog.Keyword{}, fmt.Errorf("expected keyword constant, got %T", arg)
+	}
+}
+
+// extractConstantValue extracts the value from a constant pattern element
+func extractConstantValue(arg query.PatternElement) (interface{}, error) {
+	switch a := arg.(type) {
+	case query.Constant:
+		return a.Value, nil
+	case query.Variable:
+		// Variables are not allowed as default values
+		return nil, fmt.Errorf("expected constant, got variable %s", a.Name)
+	default:
+		return nil, fmt.Errorf("expected constant, got %T", arg)
 	}
 }

--- a/datalog/parser/predicate_parser.go
+++ b/datalog/parser/predicate_parser.go
@@ -2,6 +2,8 @@ package parser
 
 import (
 	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -18,6 +20,9 @@ func parsePredicate(fn string, args []query.PatternElement) (query.Predicate, er
 		return parseGround(args)
 	case "missing":
 		return parseMissing(args)
+	case "missing?":
+		// Database function used as predicate filter: [(missing? $ ?e :attr)]
+		return parseMissingAttrPredicate(args)
 	case "day", "month", "year", "hour", "minute", "second":
 		// Time extraction predicates - these are FunctionPredicates
 		return &query.FunctionPredicate{
@@ -175,5 +180,83 @@ func elementToTerm(elem query.PatternElement) query.Term {
 		// For other types, treat as constant
 		// This handles literals that might not be wrapped in Constant
 		return query.ConstantTerm{Value: elem}
+	}
+}
+
+// parseMissingAttrPredicate parses (missing? $ ?entity :attribute) as a predicate
+// This is used when missing? is used as a filter without a binding
+func parseMissingAttrPredicate(args []query.PatternElement) (query.Predicate, error) {
+	// Syntax: (missing? $ ?e :attr)
+	if len(args) != 3 {
+		return nil, fmt.Errorf("missing? requires exactly 3 arguments ($ entity attr), got %d", len(args))
+	}
+
+	// Validate database reference ($)
+	if err := validateDatabaseRefPredicate(args[0]); err != nil {
+		return nil, fmt.Errorf("missing?: %w", err)
+	}
+
+	// Parse entity (can be variable or constant)
+	entity := elementToTerm(args[1])
+
+	// Parse attribute (must be a keyword)
+	attr, err := extractKeywordPredicate(args[2])
+	if err != nil {
+		return nil, fmt.Errorf("missing?: attribute must be a keyword: %w", err)
+	}
+
+	// Create a MissingFunction and wrap it in a DatabaseFunctionPredicate
+	missingFn := &query.MissingFunction{
+		Entity: entity,
+		Attr:   attr,
+	}
+
+	return &query.DatabaseFunctionPredicate{
+		Function: missingFn,
+	}, nil
+}
+
+// validateDatabaseRefPredicate validates that an argument is the database reference ($)
+// This is a copy for the predicate parser to avoid circular imports
+func validateDatabaseRefPredicate(arg query.PatternElement) error {
+	switch a := arg.(type) {
+	case query.Variable:
+		if a.Name == "$" {
+			return nil
+		}
+		return fmt.Errorf("expected database reference ($), got variable %s", a.Name)
+	case query.Constant:
+		if sym, ok := a.Value.(query.Symbol); ok && sym == "$" {
+			return nil
+		}
+		if str, ok := a.Value.(string); ok && str == "$" {
+			return nil
+		}
+		return fmt.Errorf("expected database reference ($), got %v", a.Value)
+	default:
+		return fmt.Errorf("expected database reference ($), got %T", arg)
+	}
+}
+
+// extractKeywordPredicate extracts a Keyword from a pattern element
+// This is a copy for the predicate parser to avoid circular imports
+func extractKeywordPredicate(arg query.PatternElement) (datalog.Keyword, error) {
+	switch a := arg.(type) {
+	case query.Constant:
+		switch v := a.Value.(type) {
+		case datalog.Keyword:
+			return v, nil
+		case *datalog.Keyword:
+			return *v, nil
+		case string:
+			if len(v) > 0 && v[0] == ':' {
+				return datalog.NewKeyword(v), nil
+			}
+			return datalog.Keyword{}, fmt.Errorf("string %q is not a keyword", v)
+		default:
+			return datalog.Keyword{}, fmt.Errorf("expected keyword, got %T", v)
+		}
+	default:
+		return datalog.Keyword{}, fmt.Errorf("expected keyword constant, got %T", arg)
 	}
 }

--- a/datalog/query/database_function.go
+++ b/datalog/query/database_function.go
@@ -1,0 +1,269 @@
+package query
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// EntityLookup is the interface for looking up entity attributes in the database.
+// This is a focused interface for database functions, avoiding circular dependencies
+// with the full PatternMatcher interface.
+type EntityLookup interface {
+	// LookupAttribute retrieves the value of an attribute for an entity.
+	// Returns (value, true) if the attribute exists, (nil, false) otherwise.
+	LookupAttribute(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool)
+}
+
+// DatabaseFunction is a function that requires database access to evaluate.
+// Unlike pure Functions, these need read-only access to the database snapshot.
+// The database is passed explicitly via the `$` parameter in the syntax.
+//
+// DatabaseFunctions are still semantically pure - given the same database snapshot,
+// entity, and attributes, they always return the same result.
+type DatabaseFunction interface {
+	Pattern
+
+	// RequiredSymbols returns all symbols needed to evaluate this function
+	RequiredSymbols() []Symbol
+
+	// EvalWithLookup evaluates the function with bindings and database access
+	EvalWithLookup(bindings map[Symbol]interface{}, lookup EntityLookup) (interface{}, error)
+
+	// ReturnType hints at what type this function returns
+	ReturnType() string
+}
+
+// GetElseFunction implements the Datomic get-else function.
+// Syntax: [(get-else $ ?entity :attribute default-value) ?result]
+// Returns the attribute value if it exists, or the default value if missing.
+type GetElseFunction struct {
+	Entity  Term            // The entity to look up (usually a variable like ?e)
+	Attr    datalog.Keyword // The attribute to retrieve
+	Default interface{}     // Default value if attribute is missing
+}
+
+func (g *GetElseFunction) RequiredSymbols() []Symbol {
+	return g.Entity.RequiredSymbols()
+}
+
+// Eval is required by the Function interface but should not be called directly.
+// Use EvalWithLookup instead, which is called by the executor when it detects
+// a DatabaseFunction.
+func (g *GetElseFunction) Eval(bindings map[Symbol]interface{}) (interface{}, error) {
+	return nil, fmt.Errorf("get-else requires database access; use EvalWithLookup instead")
+}
+
+func (g *GetElseFunction) EvalWithLookup(bindings map[Symbol]interface{}, lookup EntityLookup) (interface{}, error) {
+	// Resolve entity
+	entityVal, ok := g.Entity.Resolve(bindings)
+	if !ok {
+		return nil, fmt.Errorf("get-else: cannot resolve entity %s", g.Entity)
+	}
+
+	// Convert to Identity
+	entity, err := toIdentity(entityVal)
+	if err != nil {
+		return nil, fmt.Errorf("get-else: %w", err)
+	}
+
+	// Look up the attribute
+	if value, found := lookup.LookupAttribute(entity, g.Attr); found {
+		return value, nil
+	}
+
+	// Return default value
+	return g.Default, nil
+}
+
+func (g *GetElseFunction) ReturnType() string {
+	return "any"
+}
+
+func (g *GetElseFunction) String() string {
+	return fmt.Sprintf("(get-else $ %s %s %v)", g.Entity, g.Attr, g.Default)
+}
+
+// MissingFunction implements the Datomic missing? function.
+// Syntax: [(missing? $ ?entity :attribute)]
+// Returns true if the entity does NOT have the specified attribute.
+// This is a predicate (filter), not a binding expression.
+type MissingFunction struct {
+	Entity Term            // The entity to check
+	Attr   datalog.Keyword // The attribute to check for
+}
+
+func (m *MissingFunction) RequiredSymbols() []Symbol {
+	return m.Entity.RequiredSymbols()
+}
+
+// Eval is required by the Function interface but should not be called directly.
+// Use EvalWithLookup instead, which is called by the executor when it detects
+// a DatabaseFunction.
+func (m *MissingFunction) Eval(bindings map[Symbol]interface{}) (interface{}, error) {
+	return nil, fmt.Errorf("missing? requires database access; use EvalWithLookup instead")
+}
+
+func (m *MissingFunction) EvalWithLookup(bindings map[Symbol]interface{}, lookup EntityLookup) (interface{}, error) {
+	// Resolve entity
+	entityVal, ok := m.Entity.Resolve(bindings)
+	if !ok {
+		return nil, fmt.Errorf("missing?: cannot resolve entity %s", m.Entity)
+	}
+
+	// Convert to Identity
+	entity, err := toIdentity(entityVal)
+	if err != nil {
+		return nil, fmt.Errorf("missing?: %w", err)
+	}
+
+	// Check if attribute is missing
+	_, found := lookup.LookupAttribute(entity, m.Attr)
+	return !found, nil
+}
+
+func (m *MissingFunction) ReturnType() string {
+	return "boolean"
+}
+
+func (m *MissingFunction) String() string {
+	return fmt.Sprintf("(missing? $ %s %s)", m.Entity, m.Attr)
+}
+
+// GetSomeFunction implements the Datomic get-some function.
+// Syntax: [(get-some $ ?entity :attr1 :attr2 :attr3) [?found-attr ?value]]
+// Returns the first attribute that exists along with its value.
+// Useful for fallback chains like "use nickname, else name, else email".
+type GetSomeFunction struct {
+	Entity Term              // The entity to look up
+	Attrs  []datalog.Keyword // Attributes to try, in order
+}
+
+// GetSomeResult holds the result of a get-some evaluation
+type GetSomeResult struct {
+	Attr  datalog.Keyword
+	Value interface{}
+}
+
+func (gs *GetSomeFunction) RequiredSymbols() []Symbol {
+	return gs.Entity.RequiredSymbols()
+}
+
+// Eval is required by the Function interface but should not be called directly.
+// Use EvalWithLookup instead, which is called by the executor when it detects
+// a DatabaseFunction.
+func (gs *GetSomeFunction) Eval(bindings map[Symbol]interface{}) (interface{}, error) {
+	return nil, fmt.Errorf("get-some requires database access; use EvalWithLookup instead")
+}
+
+func (gs *GetSomeFunction) EvalWithLookup(bindings map[Symbol]interface{}, lookup EntityLookup) (interface{}, error) {
+	// Resolve entity
+	entityVal, ok := gs.Entity.Resolve(bindings)
+	if !ok {
+		return nil, fmt.Errorf("get-some: cannot resolve entity %s", gs.Entity)
+	}
+
+	// Convert to Identity
+	entity, err := toIdentity(entityVal)
+	if err != nil {
+		return nil, fmt.Errorf("get-some: %w", err)
+	}
+
+	// Try each attribute in order
+	for _, attr := range gs.Attrs {
+		if value, found := lookup.LookupAttribute(entity, attr); found {
+			return &GetSomeResult{Attr: attr, Value: value}, nil
+		}
+	}
+
+	// No attribute found - return nil (will cause tuple to be filtered out)
+	return nil, fmt.Errorf("get-some: no attribute found for entity")
+}
+
+func (gs *GetSomeFunction) ReturnType() string {
+	return "tuple" // Returns [attr value] pair
+}
+
+func (gs *GetSomeFunction) String() string {
+	attrs := ""
+	for i, attr := range gs.Attrs {
+		if i > 0 {
+			attrs += " "
+		}
+		attrs += attr.String()
+	}
+	return fmt.Sprintf("(get-some $ %s %s)", gs.Entity, attrs)
+}
+
+// Helper function to convert interface{} to Identity
+func toIdentity(val interface{}) (datalog.Identity, error) {
+	switch v := val.(type) {
+	case datalog.Identity:
+		return v, nil
+	case *datalog.Identity:
+		if v == nil {
+			return datalog.Identity{}, fmt.Errorf("nil identity pointer")
+		}
+		return *v, nil
+	case string:
+		// Allow string conversion for convenience
+		return datalog.NewIdentity(v), nil
+	default:
+		return datalog.Identity{}, fmt.Errorf("expected Identity, got %T", val)
+	}
+}
+
+// DatabaseFunctionPredicate wraps a DatabaseFunction for use as a filter predicate.
+// This is used when database functions like missing? are used without a binding,
+// e.g., [(missing? $ ?e :attr)] filters to rows where the condition is true.
+type DatabaseFunctionPredicate struct {
+	Function DatabaseFunction
+}
+
+// DatabasePredicateLookup is an interface that matchers can implement to provide
+// entity lookup capability for predicate evaluation.
+type DatabasePredicateLookup interface {
+	EntityLookup
+}
+
+// RequiredSymbols returns all symbols needed by the wrapped function
+func (p *DatabaseFunctionPredicate) RequiredSymbols() []Symbol {
+	return p.Function.RequiredSymbols()
+}
+
+// Eval is required by the Predicate interface but cannot be called without database access.
+// Use EvalWithLookup instead via the executor.
+func (p *DatabaseFunctionPredicate) Eval(bindings map[Symbol]interface{}) (bool, error) {
+	return false, fmt.Errorf("database function predicate requires database access; use EvalWithLookup instead")
+}
+
+// EvalWithLookup evaluates the predicate with database access
+func (p *DatabaseFunctionPredicate) EvalWithLookup(bindings map[Symbol]interface{}, lookup EntityLookup) (bool, error) {
+	result, err := p.Function.EvalWithLookup(bindings, lookup)
+	if err != nil {
+		return false, err
+	}
+	// The function should return a boolean
+	if b, ok := result.(bool); ok {
+		return b, nil
+	}
+	return false, fmt.Errorf("database function predicate expected boolean result, got %T", result)
+}
+
+// CanPushToStorage returns false - database function predicates cannot be pushed to storage
+func (p *DatabaseFunctionPredicate) CanPushToStorage() bool {
+	return false
+}
+
+// Selectivity returns an estimate of what fraction of tuples pass the predicate
+// Database function predicates typically filter most tuples, so return a low value
+func (p *DatabaseFunctionPredicate) Selectivity() float64 {
+	return 0.1 // Assume 10% of entities are missing the attribute
+}
+
+// clause implements the Clause interface marker method
+func (p *DatabaseFunctionPredicate) clause() {}
+
+func (p *DatabaseFunctionPredicate) String() string {
+	return p.Function.String()
+}

--- a/datalog/storage/database_function_integration_test.go
+++ b/datalog/storage/database_function_integration_test.go
@@ -1,0 +1,838 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// =============================================================================
+// get-else Integration Tests
+// =============================================================================
+
+func TestGetElseBasic(t *testing.T) {
+	dir, err := os.MkdirTemp("", "get-else-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Add test data - some entities have :person/nickname, some don't
+	tx := db.NewTransaction()
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	charlie := datalog.NewIdentity("charlie")
+
+	// Alice has both name and nickname
+	tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice Smith")
+	tx.Add(alice, datalog.NewKeyword(":person/nickname"), "Ali")
+
+	// Bob has name but no nickname
+	tx.Add(bob, datalog.NewKeyword(":person/name"), "Bob Jones")
+
+	// Charlie has name but no nickname
+	tx.Add(charlie, datalog.NewKeyword(":person/name"), "Charlie Brown")
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		query       string
+		wantCount   int
+		checkResult func(t *testing.T, results [][]interface{})
+	}{
+		{
+			name:      "get-else returns actual value when present",
+			query:     `[:find ?name ?nick :where [?e :person/name ?name] [(get-else $ ?e :person/nickname "No Nickname") ?nick]]`,
+			wantCount: 3,
+			checkResult: func(t *testing.T, results [][]interface{}) {
+				nameToNick := make(map[string]string)
+				for _, row := range results {
+					name := row[0].(string)
+					nick := row[1].(string)
+					nameToNick[name] = nick
+				}
+				if nameToNick["Alice Smith"] != "Ali" {
+					t.Errorf("Alice should have nickname 'Ali', got %q", nameToNick["Alice Smith"])
+				}
+				if nameToNick["Bob Jones"] != "No Nickname" {
+					t.Errorf("Bob should have default 'No Nickname', got %q", nameToNick["Bob Jones"])
+				}
+				if nameToNick["Charlie Brown"] != "No Nickname" {
+					t.Errorf("Charlie should have default 'No Nickname', got %q", nameToNick["Charlie Brown"])
+				}
+			},
+		},
+		{
+			name:      "get-else with empty string default",
+			query:     `[:find ?name ?nick :where [?e :person/name ?name] [(get-else $ ?e :person/nickname "") ?nick]]`,
+			wantCount: 3,
+			checkResult: func(t *testing.T, results [][]interface{}) {
+				nameToNick := make(map[string]string)
+				for _, row := range results {
+					name := row[0].(string)
+					nick := row[1].(string)
+					nameToNick[name] = nick
+				}
+				if nameToNick["Alice Smith"] != "Ali" {
+					t.Errorf("Alice should have nickname 'Ali', got %q", nameToNick["Alice Smith"])
+				}
+				if nameToNick["Bob Jones"] != "" {
+					t.Errorf("Bob should have empty default, got %q", nameToNick["Bob Jones"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := db.ExecuteQuery(tt.query)
+			if err != nil {
+				t.Fatalf("Query failed: %v", err)
+			}
+			if len(results) != tt.wantCount {
+				t.Errorf("Expected %d results, got %d", tt.wantCount, len(results))
+				for i, row := range results {
+					t.Logf("  Row %d: %v", i, row)
+				}
+			}
+			if tt.checkResult != nil {
+				tt.checkResult(t, results)
+			}
+		})
+	}
+}
+
+func TestGetElseNumericDefault(t *testing.T) {
+	dir, err := os.MkdirTemp("", "get-else-numeric-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	prod1 := datalog.NewIdentity("product-1")
+	prod2 := datalog.NewIdentity("product-2")
+
+	// Product 1 has a discount
+	tx.Add(prod1, datalog.NewKeyword(":product/name"), "Widget")
+	tx.Add(prod1, datalog.NewKeyword(":product/discount"), int64(10))
+
+	// Product 2 has no discount
+	tx.Add(prod2, datalog.NewKeyword(":product/name"), "Gadget")
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	results, err := db.ExecuteQuery(`[:find ?name ?discount :where [?e :product/name ?name] [(get-else $ ?e :product/discount 0) ?discount]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+
+	nameToDiscount := make(map[string]int64)
+	for _, row := range results {
+		name := row[0].(string)
+		discount, ok := row[1].(int64)
+		if !ok {
+			t.Errorf("Expected int64 for discount, got %T: %v", row[1], row[1])
+			continue
+		}
+		nameToDiscount[name] = discount
+	}
+
+	if nameToDiscount["Widget"] != 10 {
+		t.Errorf("Widget should have discount 10, got %d", nameToDiscount["Widget"])
+	}
+	if nameToDiscount["Gadget"] != 0 {
+		t.Errorf("Gadget should have default discount 0, got %d", nameToDiscount["Gadget"])
+	}
+}
+
+// =============================================================================
+// missing? Integration Tests
+// =============================================================================
+
+func TestMissingAsPredicate(t *testing.T) {
+	dir, err := os.MkdirTemp("", "missing-predicate-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	charlie := datalog.NewIdentity("charlie")
+
+	// Alice has email
+	tx.Add(alice, datalog.NewKeyword(":user/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":user/email"), "alice@example.com")
+
+	// Bob has no email
+	tx.Add(bob, datalog.NewKeyword(":user/name"), "Bob")
+
+	// Charlie has email
+	tx.Add(charlie, datalog.NewKeyword(":user/name"), "Charlie")
+	tx.Add(charlie, datalog.NewKeyword(":user/email"), "charlie@example.com")
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Find users WITHOUT email - should only return Bob
+	results, err := db.ExecuteQuery(`[:find ?name :where [?e :user/name ?name] [(missing? $ ?e :user/email)]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result (Bob), got %d", len(results))
+		for i, row := range results {
+			t.Logf("  Row %d: %v", i, row)
+		}
+		return
+	}
+
+	if results[0][0].(string) != "Bob" {
+		t.Errorf("Expected 'Bob', got %v", results[0][0])
+	}
+}
+
+func TestMissingAsExpression(t *testing.T) {
+	dir, err := os.MkdirTemp("", "missing-expr-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+
+	tx.Add(alice, datalog.NewKeyword(":user/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":user/verified"), true)
+
+	tx.Add(bob, datalog.NewKeyword(":user/name"), "Bob")
+	// Bob is not verified
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Get missing status as a boolean column
+	results, err := db.ExecuteQuery(`[:find ?name ?needs_verification :where [?e :user/name ?name] [(missing? $ ?e :user/verified) ?needs_verification]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+		for i, row := range results {
+			t.Logf("  Row %d: %v", i, row)
+		}
+		return
+	}
+
+	nameToMissing := make(map[string]bool)
+	for _, row := range results {
+		name := row[0].(string)
+		missing, ok := row[1].(bool)
+		if !ok {
+			t.Errorf("Expected bool for missing status, got %T: %v", row[1], row[1])
+			continue
+		}
+		nameToMissing[name] = missing
+	}
+
+	if nameToMissing["Alice"] != false {
+		t.Errorf("Alice has :user/verified, so missing? should be false")
+	}
+	if nameToMissing["Bob"] != true {
+		t.Errorf("Bob lacks :user/verified, so missing? should be true")
+	}
+}
+
+func TestMissingMultipleAttributes(t *testing.T) {
+	dir, err := os.MkdirTemp("", "missing-multi-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	p1 := datalog.NewIdentity("p1")
+	p2 := datalog.NewIdentity("p2")
+	p3 := datalog.NewIdentity("p3")
+	p4 := datalog.NewIdentity("p4")
+
+	// p1: has phone, no email
+	tx.Add(p1, datalog.NewKeyword(":contact/name"), "Person1")
+	tx.Add(p1, datalog.NewKeyword(":contact/phone"), "555-1111")
+
+	// p2: has email, no phone
+	tx.Add(p2, datalog.NewKeyword(":contact/name"), "Person2")
+	tx.Add(p2, datalog.NewKeyword(":contact/email"), "p2@example.com")
+
+	// p3: has both
+	tx.Add(p3, datalog.NewKeyword(":contact/name"), "Person3")
+	tx.Add(p3, datalog.NewKeyword(":contact/phone"), "555-3333")
+	tx.Add(p3, datalog.NewKeyword(":contact/email"), "p3@example.com")
+
+	// p4: has neither
+	tx.Add(p4, datalog.NewKeyword(":contact/name"), "Person4")
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Find contacts missing BOTH phone AND email
+	results, err := db.ExecuteQuery(`[:find ?name :where [?e :contact/name ?name] [(missing? $ ?e :contact/phone)] [(missing? $ ?e :contact/email)]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result (Person4), got %d", len(results))
+		for i, row := range results {
+			t.Logf("  Row %d: %v", i, row)
+		}
+		return
+	}
+
+	if results[0][0].(string) != "Person4" {
+		t.Errorf("Expected 'Person4', got %v", results[0][0])
+	}
+}
+
+// =============================================================================
+// get-some Integration Tests
+// =============================================================================
+
+func TestGetSomeBasic(t *testing.T) {
+	dir, err := os.MkdirTemp("", "get-some-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	user1 := datalog.NewIdentity("user1")
+	user2 := datalog.NewIdentity("user2")
+	user3 := datalog.NewIdentity("user3")
+
+	// User1 has nickname (should use nickname)
+	tx.Add(user1, datalog.NewKeyword(":user/id"), "U001")
+	tx.Add(user1, datalog.NewKeyword(":user/nickname"), "CoolGuy")
+	tx.Add(user1, datalog.NewKeyword(":user/fullname"), "John Doe")
+	tx.Add(user1, datalog.NewKeyword(":user/email"), "john@example.com")
+
+	// User2 has no nickname but has fullname (should use fullname)
+	tx.Add(user2, datalog.NewKeyword(":user/id"), "U002")
+	tx.Add(user2, datalog.NewKeyword(":user/fullname"), "Jane Smith")
+	tx.Add(user2, datalog.NewKeyword(":user/email"), "jane@example.com")
+
+	// User3 has only email (should use email)
+	tx.Add(user3, datalog.NewKeyword(":user/id"), "U003")
+	tx.Add(user3, datalog.NewKeyword(":user/email"), "anon@example.com")
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// get-some with three fallback options: nickname -> fullname -> email
+	results, err := db.ExecuteQuery(`[:find ?id ?display :where [?e :user/id ?id] [(get-some $ ?e :user/nickname :user/fullname :user/email) ?display]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Errorf("Expected 3 results, got %d", len(results))
+		for i, row := range results {
+			t.Logf("  Row %d: %v", i, row)
+		}
+		return
+	}
+
+	idToDisplay := make(map[string]string)
+	for _, row := range results {
+		id := row[0].(string)
+		// get-some returns a GetSomeResult struct, which contains the value
+		// The executor should extract just the value for the binding
+		display, ok := row[1].(string)
+		if !ok {
+			t.Logf("Row for id %s has display type %T: %v", id, row[1], row[1])
+			continue
+		}
+		idToDisplay[id] = display
+	}
+
+	if idToDisplay["U001"] != "CoolGuy" {
+		t.Errorf("User1 should display 'CoolGuy' (nickname), got %q", idToDisplay["U001"])
+	}
+	if idToDisplay["U002"] != "Jane Smith" {
+		t.Errorf("User2 should display 'Jane Smith' (fullname), got %q", idToDisplay["U002"])
+	}
+	if idToDisplay["U003"] != "anon@example.com" {
+		t.Errorf("User3 should display 'anon@example.com' (email), got %q", idToDisplay["U003"])
+	}
+}
+
+func TestGetSomeNoMatch(t *testing.T) {
+	dir, err := os.MkdirTemp("", "get-some-nomatch-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	user1 := datalog.NewIdentity("user1")
+	user2 := datalog.NewIdentity("user2")
+
+	// User1 has nickname
+	tx.Add(user1, datalog.NewKeyword(":user/id"), "U001")
+	tx.Add(user1, datalog.NewKeyword(":user/nickname"), "HasNick")
+
+	// User2 has NONE of the fallback attributes
+	tx.Add(user2, datalog.NewKeyword(":user/id"), "U002")
+	// No nickname, fullname, or displayname
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// get-some should filter out User2 since none of the attrs exist
+	results, err := db.ExecuteQuery(`[:find ?id ?display :where [?e :user/id ?id] [(get-some $ ?e :user/nickname :user/fullname :user/displayname) ?display]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	// Should only return User1
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result (only User1), got %d", len(results))
+		for i, row := range results {
+			t.Logf("  Row %d: %v", i, row)
+		}
+		return
+	}
+
+	if results[0][0].(string) != "U001" {
+		t.Errorf("Expected User1 (U001), got %v", results[0][0])
+	}
+}
+
+// =============================================================================
+// Combined Database Function Tests
+// =============================================================================
+
+func TestCombinedDatabaseFunctions(t *testing.T) {
+	dir, err := os.MkdirTemp("", "combined-db-func-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+
+	// Alice: has phone, no email
+	tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":person/phone"), "555-ALICE")
+	tx.Add(alice, datalog.NewKeyword(":person/priority"), int64(1))
+
+	// Bob: has email, no phone
+	tx.Add(bob, datalog.NewKeyword(":person/name"), "Bob")
+	tx.Add(bob, datalog.NewKeyword(":person/email"), "bob@example.com")
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Use get-else to get phone with default "N/A"
+	// AND check if email is missing
+	results, err := db.ExecuteQuery(`[:find ?name ?phone ?email_missing :where [?e :person/name ?name] [(get-else $ ?e :person/phone "N/A") ?phone] [(missing? $ ?e :person/email) ?email_missing]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+		for i, row := range results {
+			t.Logf("  Row %d: %v", i, row)
+		}
+		return
+	}
+
+	for _, row := range results {
+		name := row[0].(string)
+		phone := row[1].(string)
+		emailMissing := row[2].(bool)
+
+		switch name {
+		case "Alice":
+			if phone != "555-ALICE" {
+				t.Errorf("Alice's phone should be '555-ALICE', got %q", phone)
+			}
+			if !emailMissing {
+				t.Errorf("Alice's email should be missing (true), got %v", emailMissing)
+			}
+		case "Bob":
+			if phone != "N/A" {
+				t.Errorf("Bob's phone should be 'N/A' (default), got %q", phone)
+			}
+			if emailMissing {
+				t.Errorf("Bob's email should NOT be missing (false), got %v", emailMissing)
+			}
+		default:
+			t.Errorf("Unexpected name: %s", name)
+		}
+	}
+}
+
+func TestDatabaseFunctionWithAggregation(t *testing.T) {
+	dir, err := os.MkdirTemp("", "db-func-agg-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	for i := 1; i <= 5; i++ {
+		eid := datalog.NewIdentity("item-" + string(rune('0'+i)))
+		tx.Add(eid, datalog.NewKeyword(":item/name"), "Item"+string(rune('0'+i)))
+		// Only odd items have discount
+		if i%2 == 1 {
+			tx.Add(eid, datalog.NewKeyword(":item/discount"), int64(i*10))
+		}
+	}
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Sum of discounts, with 0 as default for items without discount
+	results, err := db.ExecuteQuery(`[:find (sum ?discount) :where [?e :item/name ?name] [(get-else $ ?e :item/discount 0) ?discount]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 aggregated result, got %d", len(results))
+	}
+
+	// Items 1, 3, 5 have discounts: 10 + 30 + 50 = 90
+	// Items 2, 4 get default 0
+	// Total: 90
+	sum, ok := results[0][0].(int64)
+	if !ok {
+		// Try float64 as some aggregations return float
+		if f, ok := results[0][0].(float64); ok {
+			sum = int64(f)
+		} else {
+			t.Fatalf("Expected numeric sum, got %T: %v", results[0][0], results[0][0])
+		}
+	}
+
+	if sum != 90 {
+		t.Errorf("Expected sum of 90, got %d", sum)
+	}
+}
+
+func TestDatabaseFunctionWithOrderBy(t *testing.T) {
+	dir, err := os.MkdirTemp("", "db-func-orderby-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	p1 := datalog.NewIdentity("p1")
+	p2 := datalog.NewIdentity("p2")
+	p3 := datalog.NewIdentity("p3")
+
+	tx.Add(p1, datalog.NewKeyword(":person/name"), "Alice")
+	tx.Add(p1, datalog.NewKeyword(":person/score"), int64(85))
+
+	tx.Add(p2, datalog.NewKeyword(":person/name"), "Bob")
+	// No score for Bob
+
+	tx.Add(p3, datalog.NewKeyword(":person/name"), "Charlie")
+	tx.Add(p3, datalog.NewKeyword(":person/score"), int64(95))
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Order by score descending (Bob gets 0 as default)
+	results, err := db.ExecuteQuery(`[:find ?name ?score :where [?e :person/name ?name] [(get-else $ ?e :person/score 0) ?score] :order-by [[?score :desc]]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("Expected 3 results, got %d", len(results))
+	}
+
+	// Order should be: Charlie (95), Alice (85), Bob (0)
+	expected := []string{"Charlie", "Alice", "Bob"}
+	for i, row := range results {
+		name := row[0].(string)
+		if name != expected[i] {
+			t.Errorf("Position %d: expected %s, got %s", i, expected[i], name)
+		}
+	}
+}
+
+// =============================================================================
+// Edge Cases and Error Handling
+// =============================================================================
+
+func TestGetElseWithNullishValues(t *testing.T) {
+	dir, err := os.MkdirTemp("", "get-else-null-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	e1 := datalog.NewIdentity("e1")
+	e2 := datalog.NewIdentity("e2")
+
+	// e1 has empty string as value
+	tx.Add(e1, datalog.NewKeyword(":entity/name"), "Entity1")
+	tx.Add(e1, datalog.NewKeyword(":entity/description"), "") // empty string IS a value
+
+	// e2 has no description at all
+	tx.Add(e2, datalog.NewKeyword(":entity/name"), "Entity2")
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// The empty string should be returned (not the default)
+	results, err := db.ExecuteQuery(`[:find ?name ?desc :where [?e :entity/name ?name] [(get-else $ ?e :entity/description "DEFAULT") ?desc]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+
+	for _, row := range results {
+		name := row[0].(string)
+		desc := row[1].(string)
+		switch name {
+		case "Entity1":
+			if desc != "" {
+				t.Errorf("Entity1 has empty string description, should return empty, got %q", desc)
+			}
+		case "Entity2":
+			if desc != "DEFAULT" {
+				t.Errorf("Entity2 has no description, should return DEFAULT, got %q", desc)
+			}
+		}
+	}
+}
+
+func TestDatabaseFunctionWithInputParameters(t *testing.T) {
+	dir, err := os.MkdirTemp("", "db-func-input-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+
+	tx.Add(alice, datalog.NewKeyword(":user/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":user/status"), "active")
+
+	tx.Add(bob, datalog.NewKeyword(":user/name"), "Bob")
+	// No status
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Use input parameter for default value
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?name ?status :in $ ?default-status :where [?e :user/name ?name] [(get-else $ ?e :user/status ?default-status) ?status]]`,
+		"pending",
+	)
+	if err != nil {
+		// This might fail because get-else expects a constant default, not a variable
+		// Let's verify this is the expected behavior
+		t.Logf("Query with variable default failed (expected): %v", err)
+		return
+	}
+
+	// If it succeeds, check results
+	t.Logf("Query with variable default succeeded (results: %d)", len(results))
+	for _, row := range results {
+		t.Logf("  %v", row)
+	}
+}
+
+func TestLookupAttributeDirectly(t *testing.T) {
+	// Test the LookupAttribute method directly on BadgerMatcher
+	dir, err := os.MkdirTemp("", "lookup-attr-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	alice := datalog.NewIdentity("alice")
+
+	tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice Smith")
+	tx.Add(alice, datalog.NewKeyword(":person/age"), int64(30))
+	tx.Add(alice, datalog.NewKeyword(":person/active"), true)
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	matcher := db.Matcher()
+	badgerMatcher, ok := matcher.(*BadgerMatcher)
+	if !ok {
+		t.Fatalf("Expected BadgerMatcher, got %T", matcher)
+	}
+
+	// Test string attribute
+	val, found := badgerMatcher.LookupAttribute(alice, datalog.NewKeyword(":person/name"))
+	if !found {
+		t.Error(":person/name should be found")
+	} else if val != "Alice Smith" {
+		t.Errorf("Expected 'Alice Smith', got %v", val)
+	}
+
+	// Test int64 attribute
+	val, found = badgerMatcher.LookupAttribute(alice, datalog.NewKeyword(":person/age"))
+	if !found {
+		t.Error(":person/age should be found")
+	} else if val != int64(30) {
+		t.Errorf("Expected 30, got %v", val)
+	}
+
+	// Test bool attribute
+	val, found = badgerMatcher.LookupAttribute(alice, datalog.NewKeyword(":person/active"))
+	if !found {
+		t.Error(":person/active should be found")
+	} else if val != true {
+		t.Errorf("Expected true, got %v", val)
+	}
+
+	// Test missing attribute
+	val, found = badgerMatcher.LookupAttribute(alice, datalog.NewKeyword(":person/email"))
+	if found {
+		t.Errorf(":person/email should NOT be found, got %v", val)
+	}
+
+	// Test non-existent entity
+	noone := datalog.NewIdentity("noone")
+	val, found = badgerMatcher.LookupAttribute(noone, datalog.NewKeyword(":person/name"))
+	if found {
+		t.Errorf("Non-existent entity should return not found, got %v", val)
+	}
+}

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -554,3 +554,46 @@ func indexName(idx IndexType) string {
 		return "UNKNOWN"
 	}
 }
+
+// LookupAttribute retrieves the value of an attribute for an entity.
+// This implements the query.EntityLookup interface for database functions
+// like get-else, missing?, and get-some.
+//
+// Returns (value, true) if the attribute exists, (nil, false) otherwise.
+// For multi-valued attributes, returns the first value found.
+func (m *BadgerMatcher) LookupAttribute(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool) {
+	// Convert to storage format
+	eBytes := entity.Bytes()
+	aStorage := ToStorageDatom(datalog.Datom{A: attr}).A
+
+	encoder := m.store.encoder
+
+	// Use AEVT index which orders by A, then E
+	// This gives us efficient lookup for (A, E) pairs
+	start, end := encoder.EncodePrefixRange(AEVT, aStorage[:], eBytes[:])
+
+	iter, err := m.store.ScanKeysOnly(AEVT, start, end)
+	if err != nil {
+		return nil, false
+	}
+	defer iter.Close()
+
+	// Look for first matching datom
+	for iter.Next() {
+		datom, err := iter.Datom()
+		if err != nil {
+			return nil, false
+		}
+
+		// Check transaction filter for as-of queries
+		if m.txID > 0 && datom.Tx > m.txID {
+			continue
+		}
+
+		// Found a match - return the value
+		return datom.V, true
+	}
+
+	// No datom found
+	return nil, false
+}


### PR DESCRIPTION
Add three database functions that provide attribute lookup with defaults and missing attribute detection:

- get-else: Returns attribute value or default if missing
  Syntax: [(get-else $ ?e :attr default) ?result]

- missing?: Tests if entity lacks an attribute (predicate or expression)
  Syntax: [(missing? $ ?e :attr)] or [(missing? $ ?e :attr) ?bool]

- get-some: Returns first existing attribute from fallback list
  Syntax: [(get-some $ ?e :attr1 :attr2 ...) ?result]

Implementation includes:
- DatabaseFunction interface with EvalWithLookup for database access
- EntityLookup interface implemented by BadgerMatcher
- Parser support in function_parser.go and predicate_parser.go
- Executor integration for both expressions and predicates
- Comprehensive parser and integration tests

Updated documentation in README.md and DATOMIC_COMPATIBILITY.md.