### PR TITLE
Fix subquery binding variables dropped when not in :find clause

### DIFF
--- a/datalog/planner/phase_reordering.go
+++ b/datalog/planner/phase_reordering.go
@@ -415,9 +415,32 @@ func updatePhaseSymbols(phases []Phase, findElements []query.FindElement, inputS
 
 			// Keep symbols needed for subqueries
 			for _, sq := range phases[j].Subqueries {
+				// Keep inputs to the subquery
 				for _, input := range sq.Inputs {
 					if available[input] {
 						keep[input] = true
+					}
+				}
+
+				// CRITICAL FIX: Also keep symbols that are OUTPUTS of the subquery
+				// if they already exist in the current phase. This enables the JOIN
+				// between existing values and subquery results.
+				//
+				// Example: If phase 1 has pattern [?task :task/status ?s ?maxTx] and
+				// phase 2 has subquery [(q [...] ?task) [[?maxTx]]], we need to keep
+				// ?maxTx so it can be joined with the subquery's output.
+				var bindingSyms []query.Symbol
+				switch b := sq.Subquery.Binding.(type) {
+				case query.TupleBinding:
+					bindingSyms = b.Variables
+				case query.RelationBinding:
+					bindingSyms = b.Variables
+				case query.CollectionBinding:
+					bindingSyms = []query.Symbol{b.Variable}
+				}
+				for _, sym := range bindingSyms {
+					if available[sym] {
+						keep[sym] = true
 					}
 				}
 			}

--- a/datalog/planner/planner_phases.go
+++ b/datalog/planner/planner_phases.go
@@ -526,6 +526,28 @@ func (p *Planner) determinePhaseKeepSymbols(phases []Phase, findVars []query.Sym
 						keep[input] = true
 					}
 				}
+
+				// CRITICAL FIX: Also keep symbols that are OUTPUTS of the subquery
+				// if they already exist in the current phase. This enables the JOIN
+				// between existing values and subquery results.
+				//
+				// Example: If phase 1 has pattern [?task :task/status ?s ?maxTx] and
+				// phase 2 has subquery [(q [...] ?task) [[?maxTx]]], we need to keep
+				// ?maxTx so it can be joined with the subquery's output.
+				var bindingSyms []query.Symbol
+				switch b := sq.Subquery.Binding.(type) {
+				case query.TupleBinding:
+					bindingSyms = b.Variables
+				case query.RelationBinding:
+					bindingSyms = b.Variables
+				case query.CollectionBinding:
+					bindingSyms = []query.Symbol{b.Variable}
+				}
+				for _, sym := range bindingSyms {
+					if available[sym] {
+						keep[sym] = true
+					}
+				}
 			}
 		}
 

--- a/datalog/storage/subquery_binding_not_in_find_bug_test.go
+++ b/datalog/storage/subquery_binding_not_in_find_bug_test.go
@@ -1,0 +1,198 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/planner"
+)
+
+// TestSubqueryBindingNotInFindBug reproduces a bug where a subquery binding variable
+// used in a subsequent where clause for filtering, but NOT included in :find, causes
+// the filter to be skipped entirely.
+//
+// Bug: When ?maxTx is not in :find, the planner appears to optimize away or skip
+// the final pattern that uses ?maxTx for filtering.
+//
+// Workaround: Include the subquery binding variable in :find even if not needed.
+func TestSubqueryBindingNotInFindBug(t *testing.T) {
+	dbPath := "/tmp/test-subquery-binding-not-in-find-" + t.Name()
+	defer os.RemoveAll(dbPath)
+
+	db, err := NewDatabase(dbPath)
+	assert.NoError(t, err)
+	defer db.Close()
+
+	// Create test entities
+	task1 := datalog.NewIdentity("task1")
+	scenario1 := datalog.NewIdentity("scenario1")
+	char1 := datalog.NewIdentity("char1")
+	completeStatus := datalog.NewKeyword(":status/complete")
+	invalidatedStatus := datalog.NewKeyword(":status/invalidated")
+
+	// Transaction 1: Create task with status=:status/complete
+	tx1 := db.NewTransaction()
+	assert.NoError(t, tx1.Add(scenario1, datalog.NewKeyword(":scenario/name"), "Test Scenario"))
+	assert.NoError(t, tx1.Add(char1, datalog.NewKeyword(":character/name"), "Alice"))
+	assert.NoError(t, tx1.Add(task1, datalog.NewKeyword(":task/scenario"), scenario1))
+	assert.NoError(t, tx1.Add(task1, datalog.NewKeyword(":task/type"), "combat"))
+	assert.NoError(t, tx1.Add(task1, datalog.NewKeyword(":task/character"), char1))
+	assert.NoError(t, tx1.Add(task1, datalog.NewKeyword(":task/status"), completeStatus))
+	_, err = tx1.Commit()
+	assert.NoError(t, err)
+
+	// Transaction 2: Update task status to :status/invalidated
+	// This creates a second datom for :task/status with a higher tx
+	tx2 := db.NewTransaction()
+	assert.NoError(t, tx2.Add(task1, datalog.NewKeyword(":task/status"), invalidatedStatus))
+	_, err = tx2.Commit()
+	assert.NoError(t, err)
+
+	t.Run("BrokenQuery_BindingNotInFind", func(t *testing.T) {
+		// This query does NOT include ?maxTx in :find
+		// Expected behavior: Should return 0 results because the max tx has status=invalidated
+		// Actual behavior (BUG): Returns the task because the filter is skipped
+		brokenQuery := `[:find ?charName ?type
+		 :in $ ?scenario ?completeStatus
+		 :where
+		 [?task :task/scenario ?scenario]
+		 [?task :task/type ?type]
+		 [?task :task/character ?char]
+		 [?char :character/name ?charName]
+		 [(q [:find (max ?tx) :in $ ?t :where [?t :task/status _ ?tx]] $ ?task) [[?maxTx]]]
+		 [?task :task/status ?completeStatus ?maxTx]]`
+
+		q, err := parser.ParseQuery(brokenQuery)
+		assert.NoError(t, err)
+
+		// Debug: Show the query plan
+		p := planner.NewPlanner(nil, DefaultPlannerOptions())
+		plan, err := p.Plan(q)
+		assert.NoError(t, err)
+		t.Logf("Query Plan for BROKEN query:\n%s", plan.String())
+
+		inputRels, err := db.convertInputsToRelations(q, []interface{}{scenario1, completeStatus})
+		assert.NoError(t, err)
+
+		exec := db.NewExecutor()
+		result, err := exec.ExecuteWithRelations(executor.NewContext(nil), q, inputRels)
+		assert.NoError(t, err)
+
+		results := collectResults(result)
+
+		// BUG: This should be 0 results, but due to the bug it returns 1
+		// When this test fails with "Expected 0 but got 1", the bug is present
+		// When this test passes, the bug is fixed
+		if len(results) != 0 {
+			t.Logf("BUG CONFIRMED: Query returned %d results when it should return 0", len(results))
+			t.Logf("The subquery binding ?maxTx is not in :find, causing the filter to be skipped")
+			for i, row := range results {
+				t.Logf("  Result %d: %v", i, row)
+			}
+		}
+		assert.Equal(t, 0, len(results), "Should return 0 results - max tx has status=invalidated, not complete")
+	})
+
+	t.Run("WorkingQuery_BindingInFind", func(t *testing.T) {
+		// This query INCLUDES ?maxTx in :find (workaround)
+		// This should correctly return 0 results
+		workingQuery := `[:find ?charName ?type ?maxTx
+		 :in $ ?scenario ?completeStatus
+		 :where
+		 [?task :task/scenario ?scenario]
+		 [?task :task/type ?type]
+		 [?task :task/character ?char]
+		 [?char :character/name ?charName]
+		 [(q [:find (max ?tx) :in $ ?t :where [?t :task/status _ ?tx]] $ ?task) [[?maxTx]]]
+		 [?task :task/status ?completeStatus ?maxTx]]`
+
+		q, err := parser.ParseQuery(workingQuery)
+		assert.NoError(t, err)
+
+		// Debug: Show the query plan
+		p := planner.NewPlanner(nil, DefaultPlannerOptions())
+		plan, err := p.Plan(q)
+		assert.NoError(t, err)
+		t.Logf("Query Plan for WORKING query:\n%s", plan.String())
+
+		inputRels, err := db.convertInputsToRelations(q, []interface{}{scenario1, completeStatus})
+		assert.NoError(t, err)
+
+		exec := db.NewExecutor()
+		result, err := exec.ExecuteWithRelations(executor.NewContext(nil), q, inputRels)
+		assert.NoError(t, err)
+
+		results := collectResults(result)
+
+		// With ?maxTx in :find, this correctly returns 0 results
+		assert.Equal(t, 0, len(results), "Should return 0 results - max tx has status=invalidated, not complete")
+	})
+
+	t.Run("VerifyDataSetup_LatestStatusIsInvalidated", func(t *testing.T) {
+		// Verify our test data is set up correctly:
+		// The task should have TWO status values, and the max tx should be for invalidated
+		verifyQuery := `[:find ?status ?tx
+		 :in $ ?task
+		 :where [?task :task/status ?status ?tx]]`
+
+		q, err := parser.ParseQuery(verifyQuery)
+		assert.NoError(t, err)
+
+		inputRels, err := db.convertInputsToRelations(q, []interface{}{task1})
+		assert.NoError(t, err)
+
+		exec := db.NewExecutor()
+		result, err := exec.ExecuteWithRelations(executor.NewContext(nil), q, inputRels)
+		assert.NoError(t, err)
+
+		results := collectResults(result)
+
+		t.Logf("Task status history:")
+		for _, row := range results {
+			t.Logf("  status=%v, tx=%v", row[0], row[1])
+		}
+
+		assert.Equal(t, 2, len(results), "Task should have 2 status values (complete and invalidated)")
+	})
+
+	t.Run("VerifySubqueryReturnsMaxTx", func(t *testing.T) {
+		// Verify the subquery correctly returns the max tx
+		subqueryTest := `[:find ?maxTx
+		 :in $ ?task
+		 :where [(q [:find (max ?tx) :in $ ?t :where [?t :task/status _ ?tx]] $ ?task) [[?maxTx]]]]`
+
+		q, err := parser.ParseQuery(subqueryTest)
+		assert.NoError(t, err)
+
+		inputRels, err := db.convertInputsToRelations(q, []interface{}{task1})
+		assert.NoError(t, err)
+
+		exec := db.NewExecutor()
+		result, err := exec.ExecuteWithRelations(executor.NewContext(nil), q, inputRels)
+		assert.NoError(t, err)
+
+		results := collectResults(result)
+
+		assert.Equal(t, 1, len(results), "Should return 1 result with max tx")
+		t.Logf("Max tx from subquery: %v", results[0][0])
+	})
+}
+
+// collectResults converts a Relation to [][]interface{}
+func collectResults(result executor.Relation) [][]interface{} {
+	results := make([][]interface{}, 0)
+	it := result.Iterator()
+	defer it.Close()
+	for it.Next() {
+		tuple := it.Tuple()
+		// Make a copy to avoid slice aliasing issues
+		row := make([]interface{}, len(tuple))
+		copy(row, tuple)
+		results = append(results, row)
+	}
+	return results
+}

--- a/docs/bugs/resolved/SUBQUERY_BINDING_NOT_IN_FIND_BUG.md
+++ b/docs/bugs/resolved/SUBQUERY_BINDING_NOT_IN_FIND_BUG.md
@@ -1,0 +1,107 @@
+# Bug: Subquery Binding Variable Not in Find Causes Filter to be Skipped
+
+**Status: FIXED** (2025-12-17)
+
+## Summary
+
+When a subquery binding variable is used in a subsequent where clause for filtering, but is NOT included in the `:find` clause, the filter appears to be optimized away. The query returns results that should have been filtered out.
+
+## Reproduction
+
+```datalog
+;; Setup: A task with two status values at different tx times
+;; - status=:status/complete at tx1
+;; - status=:status/invalidated at tx2 (tx2 > tx1)
+
+;; BROKEN QUERY: ?maxTx not in :find
+[:find ?charName ?type
+ :in $ ?scenario ?completeStatus
+ :where 
+ [?task :task/scenario ?scenario]
+ [?task :task/type ?type]
+ [?task :task/character ?char]
+ [?char :character/name ?charName]
+ [(q [:find (max ?tx) :in $ ?t :where [?t :task/status _ ?tx]] $ ?task) [[?maxTx]]]
+ [?task :task/status ?completeStatus ?maxTx]]
+
+;; Expected: 0 results (max tx has status=invalidated, not complete)
+;; Actual: Returns the task (filter is skipped)
+```
+
+```datalog
+;; WORKING QUERY: ?maxTx included in :find
+[:find ?charName ?type ?maxTx
+ :in $ ?scenario ?completeStatus
+ :where 
+ [?task :task/scenario ?scenario]
+ [?task :task/type ?type]
+ [?task :task/character ?char]
+ [?char :character/name ?charName]
+ [(q [:find (max ?tx) :in $ ?t :where [?t :task/status _ ?tx]] $ ?task) [[?maxTx]]]
+ [?task :task/status ?completeStatus ?maxTx]]
+
+;; Expected: 0 results
+;; Actual: 0 results (correct)
+```
+
+## Analysis
+
+The bug appears to be in the query planner/optimizer. When `?maxTx` is not in the `:find` clause:
+
+1. The planner sees `?maxTx` is only used internally
+2. It may incorrectly optimize away phases that depend on `?maxTx`
+3. The final pattern `[?task :task/status ?completeStatus ?maxTx]` is not properly evaluated with the subquery result
+
+When `?maxTx` IS in `:find`:
+1. The planner must project `?maxTx`
+2. All phases that produce `?maxTx` are properly evaluated
+3. The filter works correctly
+
+## Workaround
+
+Include the subquery binding variable in the `:find` clause, even if you don't need it in the result:
+
+```datalog
+[:find ?charName ?type ?maxTx  ;; Include ?maxTx even though we don't use it
+ ...]
+```
+
+Then ignore the extra column in the result.
+
+## Impact
+
+Any query that:
+1. Uses a subquery with a binding
+2. Uses that binding in a subsequent where clause for filtering
+3. Does NOT project the binding in `:find`
+
+...will silently return incorrect results (the filter is skipped).
+
+## Discovered
+
+2024-12-14, while implementing `GetCharacterTaskStatuses` in narrative-generators.
+
+## Root Cause
+
+The bug was in the planner's `Keep` calculation logic. When determining which symbols a phase needs to keep for later phases, the code correctly kept symbols that were **inputs** to subqueries, but did **not** keep symbols that were **outputs** of subqueries when those output symbols already existed in the current phase.
+
+When Phase 1 had a pattern `[?task :task/status ?completeStatus ?maxTx]` that bound `?maxTx`, and Phase 2 had a subquery that also produced `?maxTx`, the planner should have kept `?maxTx` in Phase 1's `Keep` list so it could be **joined** with the subquery's output in Phase 2.
+
+Without `?maxTx` in Keep, it was dropped between phases, so Phase 2's subquery output couldn't join with Phase 1's value.
+
+## Fix
+
+The fix was applied to two locations:
+1. `datalog/planner/planner_phases.go` - `determinePhaseKeepSymbols` function
+2. `datalog/planner/phase_reordering.go` - `updatePhaseSymbols` function
+
+Both locations now check if a subquery's output symbols (from TupleBinding, RelationBinding, or CollectionBinding) already exist in the current phase's available symbols, and if so, keep them.
+
+## Test
+
+See `datalog/storage/subquery_binding_not_in_find_bug_test.go` for the regression test.
+
+## Files Modified
+
+- `datalog/planner/planner_phases.go` - Added subquery output handling to Keep calculation
+- `datalog/planner/phase_reordering.go` - Same fix in `updatePhaseSymbols`


### PR DESCRIPTION
When a subquery binding variable (e.g., `?maxTx`) was used in a subsequent where clause for filtering but NOT included in the :find clause, the filter was silently skipped, returning incorrect results.

Root cause: The planner's `Keep` calculation logic determined which symbols a phase needs to preserve for later phases. It correctly kept symbols that were INPUTS to subqueries, but did NOT keep symbols that were OUTPUTS of subqueries when those output symbols already existed in the current phase.

Example of the bug:
```clojure
  [:find ?charName ?type          ; ?maxTx NOT in :find
   :where [?task :task/status ?completeStatus ?maxTx]  ; Phase 1 binds ?maxTx
          [(q [...] ?task) [[?maxTx]]]                 ; Phase 2 subquery outputs ?maxTx
   ...]
```

Phase 1's pattern bound `?maxTx`, and Phase 2's subquery also produced `?maxTx`. These should JOIN on `?maxTx`, but without `?maxTx` in Phase 1's Keep list, it was dropped between phases. Phase 2's subquery output had nothing to join with, so the filter was effectively skipped.

The fix adds logic to both Keep calculation locations:
- `determinePhaseKeepSymbols` in planner_phases.go
- `updatePhaseSymbols` in phase_reordering.go (called after phase reordering)

Both now check if a subquery's output symbols (`TupleBinding`, `RelationBinding`, or `CollectionBinding`) already exist in the current phase's available symbols, and if so, keep them to enable the join.

Includes regression test and updated bug documentation.