### PR TITLE
Implement Datomic-style Pull API for declarative entity retrieval

### DIFF
--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -6,10 +6,11 @@ This guide is for developers familiar with Datomic who want to understand what j
 
 Janus-datalog implements a pragmatic subset of Datomic's Datalog query language with:
 - ✅ Core query patterns, expressions, aggregations, and subqueries
+- ✅ Pull API with nested references and cycle detection
 - ✅ Time-based queries using transaction IDs
 - ✅ Database functions: `get-else`, `missing?`, `get-some`
 - ✅ BadgerDB persistent storage with EAVT model
-- ❌ No Pull API, rules, schema, or transaction functions
+- ❌ No rules, schema, or transaction functions
 - ❌ No NOT/OR clauses or entity API
 - ❌ Single-node only (no distributed queries)
 
@@ -205,25 +206,52 @@ Every datom includes a transaction ID for temporal queries.
 - Entity references via Identity type
 - Keywords as first-class values
 
-## Missing Datomic Features
+### 10. Pull API ✅
 
-### 1. Pull API ❌
+Declarative entity attribute retrieval with nested reference following:
 
-No support for pull patterns:
-
+**In-query pull:**
 ```clojure
-; NOT SUPPORTED:
-[:find (pull ?e [*])
- :where [?e :person/name "John"]]
+[:find (pull ?e [:person/name :person/age])
+ :where [?e :entity/type :type/person]]
 
-; Use explicit patterns instead:
-[:find ?name ?email ?age
- :where [?e :person/name "John"]
-        [?e :person/email ?email]
-        [?e :person/age ?age]]
+; Mixed with regular variables
+[:find ?type (pull ?e [:person/name])
+ :where [?e :entity/type ?type]]
 ```
 
-### 2. Rules ❌
+**Standalone API (Go):**
+```go
+// Single entity
+result, err := db.Pull(entityID, `[:user/name :user/age]`)
+// result: map[string]interface{}{"user/name": "Alice", "user/age": 30}
+
+// Multiple entities
+results, err := db.PullMany(entityIDs, `[:user/name]`)
+```
+
+**Supported pull patterns:**
+- Simple attributes: `[:attr1 :attr2]`
+- Wildcard: `[*]` (all attributes)
+- Nested references: `{:user/region [:region/code :region/name]}`
+- Default values: `(default :attr "fallback")`
+- Limit (parsed, cardinality-many not yet implemented): `(limit :attr 10)`
+
+**Key behaviors:**
+- Result keys omit leading colon: `"user/name"` not `":user/name"`
+- Missing attributes are omitted from results (not nil)
+- Cycle detection prevents infinite loops on circular references
+- Unlimited nesting depth
+
+**Performance characteristics:**
+- Uses optimized `EntityLookupMatcher` for direct index seeks
+- Each attribute lookup is a single AEVT index seek (no query parsing/planning)
+- Wildcard `[*]` uses single EAVT prefix scan
+- Far more efficient than equivalent application-level N+1 queries
+
+## Missing Datomic Features
+
+### 1. Rules ❌
 
 No rule definitions or recursive queries:
 
@@ -236,7 +264,7 @@ No rule definitions or recursive queries:
   (ancestor ?p ?d)]]
 ```
 
-### 3. NOT and OR Clauses ❌
+### 2. NOT and OR Clauses ❌
 
 No logical negation or disjunction:
 
@@ -248,7 +276,7 @@ No logical negation or disjunction:
 (or-join [?e] ...)
 ```
 
-### 4. Schema ❌
+### 3. Schema ❌
 
 No schema definitions or constraints:
 - No cardinality specifications (one/many)
@@ -257,7 +285,7 @@ No schema definitions or constraints:
 - No required attributes
 - All attributes effectively `:db.cardinality/one`
 
-### 5. Transaction Features ❌
+### 4. Transaction Features ❌
 
 Limited transaction support:
 - **No transaction functions**
@@ -266,7 +294,7 @@ Limited transaction support:
 - **No transaction metadata** beyond timestamp
 - **No transaction entities**
 
-### 6. Entity API ❌
+### 5. Entity API ❌
 
 No entity navigation:
 
@@ -277,7 +305,7 @@ No entity navigation:
 (touch entity)
 ```
 
-### 7. Advanced Query Features (Partial) ⚠️
+### 6. Advanced Query Features (Partial) ⚠️
 
 **Implemented:**
 - `get-else` - default values for missing attributes ✅
@@ -289,7 +317,7 @@ No entity navigation:
 - `keys` - no map results
 - `with` - no duplicate control
 
-### 8. Advanced Time Features ❌
+### 7. Advanced Time Features ❌
 
 Limited to as-of queries:
 - No `since` queries
@@ -297,7 +325,7 @@ Limited to as-of queries:
 - No tx-range queries
 - No full history API
 
-### 9. Database Features ❌
+### 8. Database Features ❌
 
 No advanced database operations:
 - No database branching/forking
@@ -305,7 +333,7 @@ No advanced database operations:
 - No database filters
 - No log API
 
-### 10. Other Missing Features ❌
+### 9. Other Missing Features ❌
 
 - **Nested expressions in predicates**: Cannot do `[(< (- ?t2 ?t1) 300)]`
 - **Distinct in aggregations**: No `(count-distinct ?x)`
@@ -351,9 +379,8 @@ No advanced database operations:
 - Time-based queries similar (using AsOf)
 
 **Require refactoring:**
-- Pull patterns → explicit patterns
 - Rules → inline the logic
-- Entity navigation → explicit joins
+- Entity navigation → explicit joins or Pull API
 - Schema validations → application layer
 
 **Not possible:**
@@ -363,16 +390,21 @@ No advanced database operations:
 
 ### Example Query Conversions
 
-**Datomic Pull API:**
+**Datomic Pull API (now supported!):**
 ```clojure
-[:find (pull ?e [:person/name 
-                  :person/email 
+; Works directly in janus-datalog:
+[:find (pull ?e [:person/name
+                  :person/email
                   {:person/friends [:person/name]}])
  :where [?e :person/age ?age]
         [(> ?age 21)]]
 ```
 
-**Janus-Datalog equivalent:**
+Note: Nested references like `{:person/friends [...]}` work when `:person/friends`
+stores an entity reference. Cardinality-many attributes are not yet supported,
+so only the first friend would be returned.
+
+**Alternative using explicit patterns:**
 ```clojure
 [:find ?name ?email ?friend-name
  :where [?e :person/age ?age]
@@ -414,21 +446,22 @@ These make it suitable for production workloads despite the simpler feature set.
 - OLAP/analytical queries on moderate datasets
 - Time-series data with temporal queries
 - Applications needing Datalog's expressiveness
+- Entity retrieval using Pull API
 - Single-node deployments
 
 **Consider alternatives for:**
-- Applications heavily using Pull API
 - Recursive/graph queries requiring rules
 - Strong schema enforcement needs
+- Cardinality-many attributes (not yet supported)
 - Distributed/multi-node requirements
 
 ## Getting Started
 
-For Datomic users, the transition is straightforward for basic queries:
+For Datomic users, the transition is straightforward:
 
-1. Write patterns instead of pull expressions
+1. Most queries port directly, including Pull expressions
 2. Use subqueries for complex aggregations
 3. Handle schema validation in your application
-4. Use explicit patterns for entity navigation
+4. Use Pull API or explicit patterns for entity navigation
 
 Most Datalog queries will work with minimal changes, making janus-datalog a practical choice for applications that need Datalog's power without Datomic's full complexity.

--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -9,6 +9,7 @@ The Janus Datalog engine delivers production-ready performance through architect
 
 ### Verified Performance Improvements
 - ✅ **New architecture** (clause-based planner + QueryExecutor): **2× faster** on complex OHLC queries (verified)
+- ✅ **Pull API**: **9× faster than equivalent queries**, linear scaling (verified 2025-12-17)
 - ✅ **Iterator composition**: **4.06× speedup** (1,259μs → 310μs, 89% memory reduction) (verified 2025-10-25)
 - ✅ **Streaming execution**: **2.22× faster** with low-selectivity filters (1,720ms → 774ms), 52% memory reduction (verified 2025-10-25)
 - ✅ **Parallel subquery execution**: **2.06× speedup** with 8 workers on M3 Max (730ms → 355ms) (verified 2025-10-25)
@@ -243,7 +244,65 @@ During development, benchmarks showed dramatic speedups (49-4802×) comparing li
 - After: Near-zero lock contention with atomic operations
 - Micro-benchmarks: 13-80× faster intern operations
 
-### 8. OHLC Query Performance (MEASURED 2025-10-25)
+### 8. Pull API Performance (MEASURED 2025-12-17)
+**Status**: ✅ Production-ready with comprehensive benchmarks
+**Performance**: **9× faster than equivalent queries**, linear scaling
+**Location**: `datalog/executor/pull.go`, `datalog/storage/database.go`
+
+**Why Pull is Fast**:
+- Direct index seeks via `EntityLookupMatcher` interface
+- No query parsing or planning overhead
+- Single AEVT index lookup per attribute
+- Wildcard uses single EAVT prefix scan
+
+**In-Memory Benchmarks** (Apple M4 Max):
+| Operation | Time | Allocs | Notes |
+|-----------|------|--------|-------|
+| Single Attribute | 554ns | 19 | Base case |
+| 5 Attributes | 2.3µs | 87 | ~470ns/attr |
+| Wildcard (5 attrs) | 1.7µs | 36 | **Faster than explicit** |
+| Nested (2 levels) | 2.1µs | 72 | +reference follow |
+| Deep (3 levels) | 2.6µs | 91 | Linear with depth |
+| PullMany (100 entities) | 102µs | 3601 | ~1µs/entity |
+
+**BadgerDB Storage Benchmarks** (Apple M4 Max):
+| Operation | Time | Allocs | Notes |
+|-----------|------|--------|-------|
+| Single Attribute | 1.1µs | 31 | 2× in-memory |
+| 5 Attributes | 6.2µs | 147 | ~1.2µs/attr |
+| Wildcard (5 attrs) | 2.8µs | 69 | **2.2× faster than explicit** |
+| Nested (2 levels) | 5.0µs | 120 | |
+| Standalone API | 4.3µs | 116 | Includes parse |
+| Cached Pattern | 3.5µs | 89 | Pre-parsed |
+| PullMany (100 entities) | 225µs | 6001 | ~2.2µs/entity |
+
+**Pull vs Query Comparison** (3 attributes, BadgerDB):
+| Method | Time | Speedup |
+|--------|------|---------|
+| Pull | 3.5µs | **9.2×** |
+| Query | 32.7µs | baseline |
+
+**Scaling Characteristics**:
+- **Per-attribute cost**: ~1.2µs (BadgerDB), ~470ns (in-memory)
+- **Per-entity cost**: ~2.5µs (BadgerDB), ~1µs (in-memory)
+- **Linear scaling**: Both attributes and entities scale linearly
+- **Pattern caching**: 20% speedup by pre-parsing patterns
+
+**Key Insight**: Wildcard `[*]` is 2× faster than explicit attribute lists because it performs one EAVT scan instead of N AEVT lookups.
+
+**Recommended Usage**:
+```go
+// For hot paths, cache the parsed pattern
+pattern, _ := parser.ParsePullPattern(`[:user/name :user/age]`)
+puller := executor.NewPullExecutor(db.Matcher())
+
+// Reuse pattern across calls
+for _, entity := range entities {
+    result, _ := puller.Pull(entity, pattern)
+}
+```
+
+### 9. OHLC Query Performance (MEASURED 2025-10-25)
 **Benchmark**: OHLC queries with subqueries and predicate pushdown
 
 **Subquery Performance** (BenchmarkOHLCSubqueries):
@@ -368,17 +427,18 @@ During development, benchmarks showed dramatic speedups (49-4802×) comparing li
 All items below are **measured** and **active** in production code:
 
 1. ✅ **New architecture** (clause-based planner + QueryExecutor) - **2× faster on complex queries** (verified 2025-10-24)
-2. ✅ **Iterator composition** - **4.06× faster, 89% memory reduction** (verified 2025-10-25)
-3. ✅ **Parallel subquery execution** - **2.06× speedup with 8 workers** (verified 2025-10-25)
-4. ✅ **Intern cache optimization** - **6.26× speedup with BadgerDB**
-5. ✅ **Query plan caching** - **3× speedup for repeated queries**
-6. ✅ **Time range optimization** - **4× speedup on hourly OHLC**
-7. ✅ **Semantic rewriting** - **2-6× on time-filtered queries**
-8. ✅ **Predicate pushdown** - **1.58-2.78× faster** (scales with dataset size), **up to 91.5% memory reduction** (verified 2025-10-25)
-9. ✅ **Streaming execution** - **2.22× on low-selectivity filters, 52% memory reduction** (verified 2025-10-25)
-10. ✅ **Hash join pre-sizing** - **24-32% faster, 24-30% less memory**
-11. ✅ **In-memory indexing** - Hash indices now default path throughout codebase
-12. ✅ **Relation collapsing algorithm** - **Prevents catastrophic Cartesian products**
+2. ✅ **Pull API** - **9× faster than equivalent queries**, linear scaling (verified 2025-12-17)
+3. ✅ **Iterator composition** - **4.06× faster, 89% memory reduction** (verified 2025-10-25)
+4. ✅ **Parallel subquery execution** - **2.06× speedup with 8 workers** (verified 2025-10-25)
+5. ✅ **Intern cache optimization** - **6.26× speedup with BadgerDB**
+6. ✅ **Query plan caching** - **3× speedup for repeated queries**
+7. ✅ **Time range optimization** - **4× speedup on hourly OHLC**
+8. ✅ **Semantic rewriting** - **2-6× on time-filtered queries**
+9. ✅ **Predicate pushdown** - **1.58-2.78× faster** (scales with dataset size), **up to 91.5% memory reduction** (verified 2025-10-25)
+10. ✅ **Streaming execution** - **2.22× on low-selectivity filters, 52% memory reduction** (verified 2025-10-25)
+11. ✅ **Hash join pre-sizing** - **24-32% faster, 24-30% less memory**
+12. ✅ **In-memory indexing** - Hash indices now default path throughout codebase
+13. ✅ **Relation collapsing algorithm** - **Prevents catastrophic Cartesian products**
 
 ### Potential Future Work 🎯
 These are **ideas**, not commitments. Would require benchmarking before implementation:
@@ -523,6 +583,18 @@ The engine is **production-ready for datasets up to 10M+ datoms**. All major opt
 ---
 
 ## Session History
+
+### 2025-12-17: Pull API Implementation & Benchmarking
+- Implemented Datomic-style Pull API with nested references and cycle detection
+- Created comprehensive benchmark suite for Pull performance
+- **Measured Results**:
+  - Pull vs Query: **9.2× faster** (3.5µs vs 32.7µs for 3 attributes)
+  - Wildcard: **2.2× faster** than explicit attributes (single scan vs N lookups)
+  - Per-attribute cost: ~1.2µs (BadgerDB), ~470ns (in-memory)
+  - Per-entity cost: ~2.5µs (BadgerDB), ~1µs (in-memory)
+  - Linear scaling with both attributes and entities
+- **Key Finding**: Pull avoids query parsing/planning overhead entirely
+- **Recommendation**: Cache parsed patterns for hot paths (20% speedup)
 
 ### 2025-10-25: Single-Use Iterator Semantics & Performance Verification (Sessions 1-2)
 **Session 1**: Initial benchmarking after single-use iterator semantics implementation

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
 - Subqueries with proper scoping (semantically correct)
 - Order-by clause with multi-column sorting
 - Time extraction functions
+- **Pull API with nested references and cycle detection**
 - **True streaming execution (2.22× speedup, 52% memory reduction, up to 91.5% on large datasets)**
 - **Iterator composition with lazy evaluation (4.06× speedup)**
 - **Parallel subquery execution (2.06× speedup with 8 workers)**
@@ -78,7 +79,7 @@ The engine is **functionally complete, semantically correct, and memory-efficien
 
 ### Major Features
 1. **Rules System**: Named, reusable query fragments
-2. **Pull Syntax**: Entity graph traversal
+2. ✅ **Pull Syntax**: Entity graph traversal - COMPLETED
 3. **Recursive Queries**: Graph algorithms
 4. **Transaction Functions**: Custom transaction logic
 

--- a/datalog/executor/pull.go
+++ b/datalog/executor/pull.go
@@ -1,0 +1,238 @@
+package executor
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// PullExecutor executes pull patterns against the database
+type PullExecutor struct {
+	matcher PatternMatcher
+}
+
+// NewPullExecutor creates a new pull executor
+func NewPullExecutor(matcher PatternMatcher) *PullExecutor {
+	return &PullExecutor{
+		matcher: matcher,
+	}
+}
+
+// Pull executes a pull pattern for a single entity
+// Uses cycle detection to handle circular references
+func (pe *PullExecutor) Pull(entity datalog.Identity, pattern *query.PullPattern) (map[string]interface{}, error) {
+	visited := make(map[[20]byte]bool)
+	return pe.pullWithVisited(entity, pattern, visited)
+}
+
+// pullWithVisited executes a pull pattern with cycle detection
+func (pe *PullExecutor) pullWithVisited(entity datalog.Identity, pattern *query.PullPattern, visited map[[20]byte]bool) (map[string]interface{}, error) {
+	if pattern == nil {
+		return nil, nil
+	}
+
+	// Check for cycle using entity hash
+	entityHash := entity.Hash()
+	if visited[entityHash] {
+		return nil, nil // Cycle detected, stop recursion
+	}
+	visited[entityHash] = true
+	defer delete(visited, entityHash) // Allow revisiting from different paths
+
+	result := make(map[string]interface{})
+
+	for _, spec := range pattern.Specs {
+		if err := pe.processSpec(entity, spec, result, visited); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
+// processSpec processes a single pull spec and adds results to the map
+func (pe *PullExecutor) processSpec(entity datalog.Identity, spec query.PullAttrSpec, result map[string]interface{}, visited map[[20]byte]bool) error {
+	switch s := spec.(type) {
+	case *query.PullAttribute:
+		// Simple attribute lookup
+		if val, ok := pe.lookupAttribute(entity, s.Attr); ok {
+			result[query.KeyName(s.Attr)] = val
+		}
+		// Missing attributes are omitted (not included as nil)
+
+	case *query.PullWildcard:
+		// Get all attributes for entity
+		datoms, err := pe.getAllAttributes(entity)
+		if err != nil {
+			return fmt.Errorf("wildcard pull failed: %w", err)
+		}
+		for _, datom := range datoms {
+			result[query.KeyName(datom.A)] = datom.V
+		}
+
+	case *query.PullMapSpec:
+		// Follow reference and pull nested pattern
+		if refVal, ok := pe.lookupAttribute(entity, s.Attr); ok {
+			if refEntity, ok := refVal.(datalog.Identity); ok {
+				nested, err := pe.pullWithVisited(refEntity, s.Pattern, visited)
+				if err != nil {
+					return fmt.Errorf("nested pull for %s failed: %w", s.Attr.String(), err)
+				}
+				if nested != nil {
+					result[query.KeyName(s.Attr)] = nested
+				}
+			}
+			// If value is not an Identity, it's not a reference - skip
+		}
+
+	case *query.PullLimitExpr:
+		// For cardinality-many (future), limit results
+		// Currently just lookup single value
+		if val, ok := pe.lookupAttribute(entity, s.Attr); ok {
+			result[query.KeyName(s.Attr)] = val
+		}
+
+	case *query.PullDefaultExpr:
+		// Lookup with default value
+		if val, ok := pe.lookupAttribute(entity, s.Attr); ok {
+			result[query.KeyName(s.Attr)] = val
+		} else {
+			result[query.KeyName(s.Attr)] = s.Default
+		}
+
+	default:
+		return fmt.Errorf("unknown pull spec type: %T", spec)
+	}
+
+	return nil
+}
+
+// lookupAttribute retrieves a single attribute value using the matcher
+func (pe *PullExecutor) lookupAttribute(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool) {
+	// Use EntityLookupMatcher interface if available
+	if lookupMatcher, ok := pe.matcher.(EntityLookupMatcher); ok {
+		return lookupMatcher.LookupAttribute(entity, attr)
+	}
+
+	// Fallback: use pattern matching
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: "?v"},
+		},
+	}
+
+	rel, err := pe.matcher.Match(pattern, nil)
+	if err != nil || rel == nil {
+		return nil, false
+	}
+
+	// Get the first result
+	// Note: Avoid calling rel.IsEmpty() as it may consume the first tuple
+	// in non-streaming mode. Instead, just try to iterate.
+	it := rel.Iterator()
+	defer it.Close()
+
+	if it.Next() {
+		tuple := it.Tuple()
+		// Find the value column
+		cols := rel.Columns()
+		for i, col := range cols {
+			if col == "?v" && i < len(tuple) {
+				return tuple[i], true
+			}
+		}
+	}
+
+	return nil, false
+}
+
+// getAllAttributes retrieves all datoms for an entity (for wildcard pull)
+func (pe *PullExecutor) getAllAttributes(entity datalog.Identity) ([]datalog.Datom, error) {
+	// Create pattern: [entity ?a ?v] - gets all attributes
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Variable{Name: "?a"},
+			query.Variable{Name: "?v"},
+		},
+	}
+
+	rel, err := pe.matcher.Match(pattern, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if rel == nil {
+		return nil, nil
+	}
+
+	// Note: Avoid calling rel.IsEmpty() as it may consume the first tuple
+	// in non-streaming mode. Empty results are handled naturally by the
+	// iteration loop below.
+
+	// Find column indices
+	cols := rel.Columns()
+	aIdx := -1
+	vIdx := -1
+	for i, col := range cols {
+		if col == "?a" {
+			aIdx = i
+		} else if col == "?v" {
+			vIdx = i
+		}
+	}
+
+	if aIdx < 0 || vIdx < 0 {
+		return nil, fmt.Errorf("missing expected columns in result")
+	}
+
+	// Collect datoms
+	var datoms []datalog.Datom
+	it := rel.Iterator()
+	defer it.Close()
+
+	for it.Next() {
+		tuple := it.Tuple()
+		if aIdx < len(tuple) && vIdx < len(tuple) {
+			// Handle both Keyword and *Keyword (BadgerMatcher may return pointers)
+			var attr datalog.Keyword
+			switch a := tuple[aIdx].(type) {
+			case datalog.Keyword:
+				attr = a
+			case *datalog.Keyword:
+				if a == nil {
+					continue
+				}
+				attr = *a
+			default:
+				continue
+			}
+			datoms = append(datoms, datalog.Datom{
+				E: entity,
+				A: attr,
+				V: tuple[vIdx],
+			})
+		}
+	}
+
+	return datoms, nil
+}
+
+// PullMany executes a pull pattern for multiple entities
+func (pe *PullExecutor) PullMany(entities []datalog.Identity, pattern *query.PullPattern) ([]map[string]interface{}, error) {
+	results := make([]map[string]interface{}, len(entities))
+	for i, entity := range entities {
+		result, err := pe.Pull(entity, pattern)
+		if err != nil {
+			return nil, fmt.Errorf("pull failed for entity %d: %w", i, err)
+		}
+		results[i] = result
+	}
+	return results, nil
+}

--- a/datalog/executor/pull_benchmark_test.go
+++ b/datalog/executor/pull_benchmark_test.go
@@ -1,0 +1,232 @@
+package executor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// BenchmarkPull_SingleAttribute measures single attribute lookup performance
+func BenchmarkPull_SingleAttribute(b *testing.B) {
+	// Create test data
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+	pattern, _ := parser.ParsePullPattern(`[:user/name]`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(alice, pattern)
+	}
+}
+
+// BenchmarkPull_MultipleAttributes measures multiple attribute lookup performance
+func BenchmarkPull_MultipleAttributes(b *testing.B) {
+	alice := datalog.NewIdentity("user:alice")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: datalog.NewKeyword(":user/name"), V: "Alice", Tx: 1},
+		{E: alice, A: datalog.NewKeyword(":user/age"), V: int64(30), Tx: 1},
+		{E: alice, A: datalog.NewKeyword(":user/email"), V: "alice@example.com", Tx: 1},
+		{E: alice, A: datalog.NewKeyword(":user/city"), V: "NYC", Tx: 1},
+		{E: alice, A: datalog.NewKeyword(":user/country"), V: "USA", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+	pattern, _ := parser.ParsePullPattern(`[:user/name :user/age :user/email :user/city :user/country]`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(alice, pattern)
+	}
+}
+
+// BenchmarkPull_Wildcard measures wildcard pull performance
+func BenchmarkPull_Wildcard(b *testing.B) {
+	alice := datalog.NewIdentity("user:alice")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: datalog.NewKeyword(":user/name"), V: "Alice", Tx: 1},
+		{E: alice, A: datalog.NewKeyword(":user/age"), V: int64(30), Tx: 1},
+		{E: alice, A: datalog.NewKeyword(":user/email"), V: "alice@example.com", Tx: 1},
+		{E: alice, A: datalog.NewKeyword(":user/city"), V: "NYC", Tx: 1},
+		{E: alice, A: datalog.NewKeyword(":user/country"), V: "USA", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+	pattern, _ := parser.ParsePullPattern(`[*]`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(alice, pattern)
+	}
+}
+
+// BenchmarkPull_NestedReference measures nested reference following performance
+func BenchmarkPull_NestedReference(b *testing.B) {
+	alice := datalog.NewIdentity("user:alice")
+	region := datalog.NewIdentity("region:us-west")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: datalog.NewKeyword(":user/name"), V: "Alice", Tx: 1},
+		{E: alice, A: datalog.NewKeyword(":user/region"), V: region, Tx: 1},
+		{E: region, A: datalog.NewKeyword(":region/code"), V: "US-W", Tx: 1},
+		{E: region, A: datalog.NewKeyword(":region/name"), V: "US West", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+	pattern, _ := parser.ParsePullPattern(`[:user/name {:user/region [:region/code :region/name]}]`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(alice, pattern)
+	}
+}
+
+// BenchmarkPull_DeepNesting measures deeply nested reference performance
+func BenchmarkPull_DeepNesting(b *testing.B) {
+	nation := datalog.NewIdentity("nation:usa")
+	region := datalog.NewIdentity("region:us-west")
+	entity := datalog.NewIdentity("entity:apple")
+
+	datoms := []datalog.Datom{
+		{E: nation, A: datalog.NewKeyword(":nation/name"), V: "United States", Tx: 1},
+		{E: region, A: datalog.NewKeyword(":region/code"), V: "US-W", Tx: 1},
+		{E: region, A: datalog.NewKeyword(":region/nation"), V: nation, Tx: 1},
+		{E: entity, A: datalog.NewKeyword(":entity/code"), V: "AAPL", Tx: 1},
+		{E: entity, A: datalog.NewKeyword(":entity/region"), V: region, Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+	pattern, _ := parser.ParsePullPattern(`[:entity/code {:entity/region [:region/code {:region/nation [:nation/name]}]}]`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(entity, pattern)
+	}
+}
+
+// BenchmarkPullMany measures batch pull performance
+func BenchmarkPullMany(b *testing.B) {
+	// Create 100 entities
+	var entities []datalog.Identity
+	var datoms []datalog.Datom
+
+	for i := 0; i < 100; i++ {
+		entity := datalog.NewIdentity(fmt.Sprintf("user:%d", i))
+		entities = append(entities, entity)
+		datoms = append(datoms,
+			datalog.Datom{E: entity, A: datalog.NewKeyword(":user/name"), V: fmt.Sprintf("User%d", i), Tx: 1},
+			datalog.Datom{E: entity, A: datalog.NewKeyword(":user/age"), V: int64(20 + i%50), Tx: 1},
+		)
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+	pattern, _ := parser.ParsePullPattern(`[:user/name :user/age]`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.PullMany(entities, pattern)
+	}
+}
+
+// BenchmarkPull_VsManualQuery compares Pull vs equivalent manual pattern matching
+func BenchmarkPull_VsManualQuery(b *testing.B) {
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+	ageAttr := datalog.NewKeyword(":user/age")
+	emailAttr := datalog.NewKeyword(":user/email")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+		{E: alice, A: ageAttr, V: int64(30), Tx: 1},
+		{E: alice, A: emailAttr, V: "alice@example.com", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+
+	b.Run("Pull", func(b *testing.B) {
+		puller := NewPullExecutor(matcher)
+		pattern, _ := parser.ParsePullPattern(`[:user/name :user/age :user/email]`)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = puller.Pull(alice, pattern)
+		}
+	})
+
+	b.Run("ManualPatternMatch", func(b *testing.B) {
+		// Simulate manual pattern matching for each attribute
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			result := make(map[string]interface{})
+
+			// Manual pattern match for each attribute
+			for _, attr := range []datalog.Keyword{nameAttr, ageAttr, emailAttr} {
+				pattern := &query.DataPattern{
+					Elements: []query.PatternElement{
+						query.Constant{Value: alice},
+						query.Constant{Value: attr},
+						query.Variable{Name: "?v"},
+					},
+				}
+				rel, err := matcher.Match(pattern, nil)
+				if err == nil && rel != nil {
+					it := rel.Iterator()
+					if it.Next() {
+						tuple := it.Tuple()
+						if len(tuple) > 0 {
+							result[attr.String()[1:]] = tuple[0] // strip leading colon
+						}
+					}
+					it.Close()
+				}
+			}
+			_ = result
+		}
+	})
+}
+
+// BenchmarkPull_ScalingWithAttributes measures how Pull scales with attribute count
+func BenchmarkPull_ScalingWithAttributes(b *testing.B) {
+	alice := datalog.NewIdentity("user:alice")
+
+	for _, numAttrs := range []int{1, 5, 10, 20, 50} {
+		var datoms []datalog.Datom
+		var patternAttrs string
+
+		for i := 0; i < numAttrs; i++ {
+			attr := datalog.NewKeyword(fmt.Sprintf(":user/attr%d", i))
+			datoms = append(datoms, datalog.Datom{E: alice, A: attr, V: fmt.Sprintf("value%d", i), Tx: 1})
+			if i > 0 {
+				patternAttrs += " "
+			}
+			patternAttrs += fmt.Sprintf(":user/attr%d", i)
+		}
+
+		matcher := NewMemoryPatternMatcher(datoms)
+		puller := NewPullExecutor(matcher)
+		pattern, _ := parser.ParsePullPattern(fmt.Sprintf("[%s]", patternAttrs))
+
+		b.Run(fmt.Sprintf("Attrs_%d", numAttrs), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = puller.Pull(alice, pattern)
+			}
+		})
+	}
+}

--- a/datalog/executor/pull_test.go
+++ b/datalog/executor/pull_test.go
@@ -1,0 +1,427 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+func TestPullExecutor_SimpleAttributes(t *testing.T) {
+	// Create test data
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+	ageAttr := datalog.NewKeyword(":user/age")
+	emailAttr := datalog.NewKeyword(":user/email")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+		{E: alice, A: ageAttr, V: int64(30), Tx: 1},
+		{E: alice, A: emailAttr, V: "alice@example.com", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Parse pull pattern
+	pattern, err := parser.ParsePullPattern(`[:user/name :user/age]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// Execute pull
+	result, err := puller.Pull(alice, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Check results - keys should be without colon
+	if result["user/name"] != "Alice" {
+		t.Errorf("expected name=Alice, got %v", result["user/name"])
+	}
+	if result["user/age"] != int64(30) {
+		t.Errorf("expected age=30, got %v", result["user/age"])
+	}
+
+	// Email should NOT be in result (not in pattern)
+	if _, exists := result["user/email"]; exists {
+		t.Error("email should not be in result")
+	}
+}
+
+func TestPullExecutor_Wildcard(t *testing.T) {
+	// Create test data
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+	ageAttr := datalog.NewKeyword(":user/age")
+	emailAttr := datalog.NewKeyword(":user/email")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+		{E: alice, A: ageAttr, V: int64(30), Tx: 1},
+		{E: alice, A: emailAttr, V: "alice@example.com", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Parse wildcard pattern
+	pattern, err := parser.ParsePullPattern(`[*]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// Execute pull
+	result, err := puller.Pull(alice, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// All attributes should be in result
+	if len(result) != 3 {
+		t.Errorf("expected 3 attributes, got %d: %v", len(result), result)
+	}
+
+	if result["user/name"] != "Alice" {
+		t.Errorf("expected name=Alice, got %v", result["user/name"])
+	}
+	if result["user/age"] != int64(30) {
+		t.Errorf("expected age=30, got %v", result["user/age"])
+	}
+	if result["user/email"] != "alice@example.com" {
+		t.Errorf("expected email=alice@example.com, got %v", result["user/email"])
+	}
+}
+
+func TestPullExecutor_NestedReference(t *testing.T) {
+	// Create test data with references
+	region := datalog.NewIdentity("region:us-west")
+	entity := datalog.NewIdentity("entity:apple")
+
+	regionCodeAttr := datalog.NewKeyword(":region/code")
+	regionNameAttr := datalog.NewKeyword(":region/name")
+	entityCodeAttr := datalog.NewKeyword(":entity/code")
+	entityNameAttr := datalog.NewKeyword(":entity/name")
+	entityRegionAttr := datalog.NewKeyword(":entity/region")
+
+	datoms := []datalog.Datom{
+		{E: region, A: regionCodeAttr, V: "US-W", Tx: 1},
+		{E: region, A: regionNameAttr, V: "US West", Tx: 1},
+		{E: entity, A: entityCodeAttr, V: "AAPL", Tx: 1},
+		{E: entity, A: entityNameAttr, V: "Apple Inc.", Tx: 1},
+		{E: entity, A: entityRegionAttr, V: region, Tx: 1}, // Reference to region
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Parse nested pattern
+	pattern, err := parser.ParsePullPattern(`[:entity/code :entity/name {:entity/region [:region/code :region/name]}]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// Execute pull
+	result, err := puller.Pull(entity, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Check top-level attributes
+	if result["entity/code"] != "AAPL" {
+		t.Errorf("expected entity/code=AAPL, got %v", result["entity/code"])
+	}
+	if result["entity/name"] != "Apple Inc." {
+		t.Errorf("expected entity/name=Apple Inc., got %v", result["entity/name"])
+	}
+
+	// Check nested region
+	nestedRegion, ok := result["entity/region"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nested map for entity/region, got %T", result["entity/region"])
+	}
+
+	if nestedRegion["region/code"] != "US-W" {
+		t.Errorf("expected region/code=US-W, got %v", nestedRegion["region/code"])
+	}
+	if nestedRegion["region/name"] != "US West" {
+		t.Errorf("expected region/name=US West, got %v", nestedRegion["region/name"])
+	}
+}
+
+func TestPullExecutor_CycleDetection(t *testing.T) {
+	// Create circular reference
+	entity1 := datalog.NewIdentity("entity:1")
+	entity2 := datalog.NewIdentity("entity:2")
+
+	nameAttr := datalog.NewKeyword(":entity/name")
+	nextAttr := datalog.NewKeyword(":entity/next")
+
+	datoms := []datalog.Datom{
+		{E: entity1, A: nameAttr, V: "Entity 1", Tx: 1},
+		{E: entity1, A: nextAttr, V: entity2, Tx: 1},
+		{E: entity2, A: nameAttr, V: "Entity 2", Tx: 1},
+		{E: entity2, A: nextAttr, V: entity1, Tx: 1}, // Circular reference back to entity1
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Parse pattern that would recurse infinitely without cycle detection
+	pattern, err := parser.ParsePullPattern(`[:entity/name {:entity/next [:entity/name {:entity/next [:entity/name]}]}]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// Execute pull - should NOT panic or loop forever
+	result, err := puller.Pull(entity1, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Check top-level
+	if result["entity/name"] != "Entity 1" {
+		t.Errorf("expected entity/name=Entity 1, got %v", result["entity/name"])
+	}
+
+	// Check first level nested
+	nested1, ok := result["entity/next"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nested map for entity/next, got %T", result["entity/next"])
+	}
+	if nested1["entity/name"] != "Entity 2" {
+		t.Errorf("expected nested entity/name=Entity 2, got %v", nested1["entity/name"])
+	}
+
+	// The second level nested should stop at the cycle (entity1 was already visited)
+	nested2, ok := nested1["entity/next"].(map[string]interface{})
+	if ok && nested2 != nil {
+		// Due to cycle detection, this should be nil or empty
+		// (entity1 is already in the visited set when we try to pull it again)
+		if nested2["entity/name"] != nil {
+			t.Logf("Note: Nested entity/next returned %v (may vary by implementation)", nested2)
+		}
+	}
+
+	t.Logf("Result structure: %+v", result)
+}
+
+func TestPullExecutor_MissingAttribute(t *testing.T) {
+	// Create test data with partial attributes
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+		// No age attribute
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Parse pattern requesting missing attribute
+	pattern, err := parser.ParsePullPattern(`[:user/name :user/age]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// Execute pull
+	result, err := puller.Pull(alice, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	// Name should be present
+	if result["user/name"] != "Alice" {
+		t.Errorf("expected name=Alice, got %v", result["user/name"])
+	}
+
+	// Age should be OMITTED (not present, not nil)
+	if _, exists := result["user/age"]; exists {
+		t.Error("missing attribute should be omitted, not included as nil")
+	}
+}
+
+func TestPullExecutor_DefaultValue(t *testing.T) {
+	// Create test data with partial attributes
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+		// No status attribute
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Parse pattern with default value
+	pattern, err := parser.ParsePullPattern(`[:user/name (default :user/status "inactive")]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// Execute pull
+	result, err := puller.Pull(alice, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	// Name should be present
+	if result["user/name"] != "Alice" {
+		t.Errorf("expected name=Alice, got %v", result["user/name"])
+	}
+
+	// Status should have default value
+	if result["user/status"] != "inactive" {
+		t.Errorf("expected status=inactive (default), got %v", result["user/status"])
+	}
+}
+
+func TestPullExecutor_NonExistentEntity(t *testing.T) {
+	// Create empty datoms
+	datoms := []datalog.Datom{}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Parse pattern
+	pattern, err := parser.ParsePullPattern(`[:user/name :user/age]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// Pull non-existent entity
+	nonExistent := datalog.NewIdentity("user:nonexistent")
+	result, err := puller.Pull(nonExistent, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	// Result should be nil for non-existent entity
+	if result != nil {
+		t.Errorf("expected nil result for non-existent entity, got %v", result)
+	}
+}
+
+func TestPullExecutor_PullMany(t *testing.T) {
+	// Create test data
+	alice := datalog.NewIdentity("user:alice")
+	bob := datalog.NewIdentity("user:bob")
+	nameAttr := datalog.NewKeyword(":user/name")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+		{E: bob, A: nameAttr, V: "Bob", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Parse pattern
+	pattern, err := parser.ParsePullPattern(`[:user/name]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// Pull many entities
+	results, err := puller.PullMany([]datalog.Identity{alice, bob}, pattern)
+	if err != nil {
+		t.Fatalf("pullMany failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	if results[0]["user/name"] != "Alice" {
+		t.Errorf("expected first result name=Alice, got %v", results[0]["user/name"])
+	}
+	if results[1]["user/name"] != "Bob" {
+		t.Errorf("expected second result name=Bob, got %v", results[1]["user/name"])
+	}
+}
+
+func TestPullExecutor_DeeplyNested(t *testing.T) {
+	// Create 3-level deep reference chain
+	nation := datalog.NewIdentity("nation:usa")
+	region := datalog.NewIdentity("region:us-west")
+	entity := datalog.NewIdentity("entity:apple")
+
+	nationNameAttr := datalog.NewKeyword(":nation/name")
+	regionCodeAttr := datalog.NewKeyword(":region/code")
+	regionNationAttr := datalog.NewKeyword(":region/nation")
+	entityCodeAttr := datalog.NewKeyword(":entity/code")
+	entityRegionAttr := datalog.NewKeyword(":entity/region")
+
+	datoms := []datalog.Datom{
+		{E: nation, A: nationNameAttr, V: "United States", Tx: 1},
+		{E: region, A: regionCodeAttr, V: "US-W", Tx: 1},
+		{E: region, A: regionNationAttr, V: nation, Tx: 1},
+		{E: entity, A: entityCodeAttr, V: "AAPL", Tx: 1},
+		{E: entity, A: entityRegionAttr, V: region, Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Parse 3-level nested pattern
+	pattern, err := parser.ParsePullPattern(`[:entity/code {:entity/region [:region/code {:region/nation [:nation/name]}]}]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// Execute pull
+	result, err := puller.Pull(entity, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	// Navigate to deeply nested nation
+	regionMap := result["entity/region"].(map[string]interface{})
+	nationMap := regionMap["region/nation"].(map[string]interface{})
+
+	if nationMap["nation/name"] != "United States" {
+		t.Errorf("expected nation/name=United States, got %v", nationMap["nation/name"])
+	}
+}
+
+func TestKeyName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{":entity/name", "entity/name"},
+		{":user/age", "user/age"},
+		{"nocolon", "nocolon"},
+		{":", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			kw := datalog.NewKeyword(tt.input)
+			result := query.KeyName(kw)
+			if result != tt.expected {
+				t.Errorf("KeyName(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -146,6 +146,9 @@ func (e *DefaultQueryExecutor) Execute(ctx Context, q *query.Query, inputs []Rel
 		// Simple projection to :find symbols
 		findSymbols := extractFindSymbols(q.Find)
 
+		// Check if we have pulls to execute
+		needsPulls := hasPulls(q.Find)
+
 		// Check if all :find symbols are available across the groups
 		// If symbols span multiple groups, we need to Product() them first
 		if len(groups) > 1 {
@@ -210,6 +213,13 @@ func (e *DefaultQueryExecutor) Execute(ctx Context, q *query.Query, inputs []Rel
 					if err != nil {
 						return nil, fmt.Errorf("projection failed: %w", err)
 					}
+					// Apply pulls if needed
+					if needsPulls {
+						projected, err = e.executePulls(projected, q.Find)
+						if err != nil {
+							return nil, err
+						}
+					}
 					return []Relation{projected}, nil
 				}
 			}
@@ -225,6 +235,13 @@ func (e *DefaultQueryExecutor) Execute(ctx Context, q *query.Query, inputs []Rel
 				if err != nil {
 					return nil, fmt.Errorf("projection failed after product: %w", err)
 				}
+				// Apply pulls if needed
+				if needsPulls {
+					projected, err = e.executePulls(projected, q.Find)
+					if err != nil {
+						return nil, err
+					}
+				}
 				return []Relation{projected}, nil
 			}
 		}
@@ -234,6 +251,13 @@ func (e *DefaultQueryExecutor) Execute(ctx Context, q *query.Query, inputs []Rel
 			projected, err := group.Project(findSymbols)
 			if err != nil {
 				return nil, fmt.Errorf("projection of group %d failed: %w", i, err)
+			}
+			// Apply pulls if needed
+			if needsPulls {
+				projected, err = e.executePulls(projected, q.Find)
+				if err != nil {
+					return nil, err
+				}
 			}
 			groups[i] = projected
 		}
@@ -745,7 +769,101 @@ func extractFindSymbols(find []query.FindElement) []query.Symbol {
 		case query.FindAggregate:
 			// For aggregates, include the argument variable
 			symbols = append(symbols, e.Arg)
+		case query.FindPull:
+			// For pulls, include the pulled variable
+			symbols = append(symbols, e.Variable)
 		}
 	}
 	return symbols
+}
+
+// hasPulls checks if any find element is a pull expression
+func hasPulls(find []query.FindElement) bool {
+	for _, elem := range find {
+		if _, ok := elem.(query.FindPull); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// executePulls executes pull expressions on a relation
+// For each tuple in the relation, it replaces entity values with pulled maps
+// based on the FindPull patterns in the find clause.
+func (e *DefaultQueryExecutor) executePulls(rel Relation, find []query.FindElement) (Relation, error) {
+	// Build mapping: column index -> pull pattern
+	columns := rel.Columns()
+	pullSpecs := make(map[int]query.FindPull)
+
+	for _, elem := range find {
+		if pull, ok := elem.(query.FindPull); ok {
+			// Find the column index for this pull variable
+			for i, col := range columns {
+				if col == pull.Variable {
+					pullSpecs[i] = pull
+					break
+				}
+			}
+		}
+	}
+
+	if len(pullSpecs) == 0 {
+		return rel, nil // No pulls to execute
+	}
+
+	// Create pull executor
+	puller := NewPullExecutor(e.matcher)
+
+	// Process tuples and execute pulls
+	var resultTuples []Tuple
+	it := rel.Iterator()
+	defer it.Close()
+
+	for it.Next() {
+		tuple := it.Tuple()
+		// Make a copy to modify
+		newTuple := make(Tuple, len(tuple))
+		copy(newTuple, tuple)
+
+		// Execute pulls for each pull column
+		for colIdx, pull := range pullSpecs {
+			if colIdx >= len(tuple) {
+				continue
+			}
+
+			// Get the entity value - handle both Identity and *Identity
+			var entity datalog.Identity
+			switch v := tuple[colIdx].(type) {
+			case datalog.Identity:
+				entity = v
+			case *datalog.Identity:
+				if v == nil {
+					continue
+				}
+				entity = *v
+			default:
+				// Value is not an entity - keep it as is
+				continue
+			}
+
+			// Execute pull
+			pulled, err := puller.Pull(entity, pull.Pattern)
+			if err != nil {
+				return nil, fmt.Errorf("pull failed for %s: %w", pull.Variable, err)
+			}
+
+			// Replace entity with pulled map (nil if entity not found)
+			newTuple[colIdx] = pulled
+		}
+
+		resultTuples = append(resultTuples, newTuple)
+	}
+
+	// Return relation without deduplication - pulled maps (map[string]interface{})
+	// are not comparable and would panic during deduplication
+	return &MaterializedRelation{
+		columns: columns,
+		tuples:  resultTuples,
+		options: rel.Options(),
+	}, nil
 }

--- a/datalog/parser/parser.go
+++ b/datalog/parser/parser.go
@@ -178,20 +178,31 @@ func parseFindElement(node *edn.Node) (query.FindElement, error) {
 		return query.FindVariable{Symbol: sym}, nil
 
 	case edn.NodeList:
-		// Aggregate function (sum ?x), (count ?x), etc.
-		if len(node.Nodes) != 2 {
-			return nil, fmt.Errorf("aggregate function must have exactly 2 elements: function and argument")
+		// Could be aggregate function or pull expression
+		if len(node.Nodes) < 2 {
+			return nil, fmt.Errorf("find list expression must have at least 2 elements")
 		}
 
 		if node.Nodes[0].Type != edn.NodeSymbol {
-			return nil, fmt.Errorf("aggregate function name must be a symbol")
+			return nil, fmt.Errorf("find list expression must start with a function name")
+		}
+
+		fn := node.Nodes[0].Value
+
+		// Check for pull expression: (pull ?e [...])
+		if fn == "pull" {
+			return parseFindPull(node)
+		}
+
+		// Otherwise, it's an aggregate function (sum ?x), (count ?x), etc.
+		if len(node.Nodes) != 2 {
+			return nil, fmt.Errorf("aggregate function must have exactly 2 elements: function and argument")
 		}
 
 		if node.Nodes[1].Type != edn.NodeSymbol {
 			return nil, fmt.Errorf("aggregate argument must be a symbol")
 		}
 
-		fn := node.Nodes[0].Value
 		argSym := query.Symbol(node.Nodes[1].Value)
 
 		if !argSym.IsVariable() {

--- a/datalog/parser/pull_parser.go
+++ b/datalog/parser/pull_parser.go
@@ -1,0 +1,220 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/edn"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// parseFindPull parses a pull expression in the find clause: (pull ?e [...])
+func parseFindPull(node *edn.Node) (query.FindPull, error) {
+	// Validate: (pull ?var [...])
+	if len(node.Nodes) != 3 {
+		return query.FindPull{}, fmt.Errorf("pull requires exactly 2 arguments: variable and pattern, got %d", len(node.Nodes)-1)
+	}
+
+	// First element is "pull" (already validated)
+
+	// Parse variable (second element)
+	if node.Nodes[1].Type != edn.NodeSymbol {
+		return query.FindPull{}, fmt.Errorf("pull first argument must be a variable, got %v", node.Nodes[1].Type)
+	}
+	varSym := query.Symbol(node.Nodes[1].Value)
+	if !varSym.IsVariable() {
+		return query.FindPull{}, fmt.Errorf("pull argument must be a variable (starting with ?), got %s", varSym)
+	}
+
+	// Parse pattern (third element)
+	if node.Nodes[2].Type != edn.NodeVector {
+		return query.FindPull{}, fmt.Errorf("pull pattern must be a vector [...], got %v", node.Nodes[2].Type)
+	}
+	pattern, err := parsePullPattern(&node.Nodes[2])
+	if err != nil {
+		return query.FindPull{}, fmt.Errorf("invalid pull pattern: %w", err)
+	}
+
+	return query.FindPull{
+		Variable: varSym,
+		Pattern:  pattern,
+	}, nil
+}
+
+// parsePullPattern parses a pull pattern vector: [:attr1 :attr2 {:ref [...]}]
+func parsePullPattern(node *edn.Node) (*query.PullPattern, error) {
+	if node.Type != edn.NodeVector {
+		return nil, fmt.Errorf("pull pattern must be a vector, got %v", node.Type)
+	}
+
+	specs := make([]query.PullAttrSpec, 0, len(node.Nodes))
+
+	for i := range node.Nodes {
+		spec, err := parsePullAttrSpec(&node.Nodes[i])
+		if err != nil {
+			return nil, fmt.Errorf("invalid pull spec at position %d: %w", i, err)
+		}
+		specs = append(specs, spec)
+	}
+
+	return &query.PullPattern{Specs: specs}, nil
+}
+
+// parsePullAttrSpec parses a single attribute specification in a pull pattern
+func parsePullAttrSpec(node *edn.Node) (query.PullAttrSpec, error) {
+	switch node.Type {
+	case edn.NodeKeyword:
+		// Simple attribute: :entity/name
+		return &query.PullAttribute{
+			Attr: datalog.NewKeyword(node.Value),
+		}, nil
+
+	case edn.NodeSymbol:
+		if node.Value == "*" {
+			// Wildcard: *
+			return &query.PullWildcard{}, nil
+		}
+		return nil, fmt.Errorf("invalid pull spec symbol: %s (expected * for wildcard)", node.Value)
+
+	case edn.NodeMap:
+		// Map spec: {:entity/region [...]}
+		return parsePullMapSpec(node)
+
+	case edn.NodeList:
+		// Function expression: (limit ...) or (default ...)
+		return parsePullExpr(node)
+
+	default:
+		return nil, fmt.Errorf("invalid pull spec type: %v (expected keyword, *, map, or expression)", node.Type)
+	}
+}
+
+// parsePullMapSpec parses a map specification: {:attr [...pattern...]}
+func parsePullMapSpec(node *edn.Node) (*query.PullMapSpec, error) {
+	// Map nodes have key-value pairs in Nodes slice: [key1, val1, key2, val2, ...]
+	// We expect exactly one key-value pair
+	if len(node.Nodes) != 2 {
+		return nil, fmt.Errorf("pull map spec must have exactly one attribute, got %d elements", len(node.Nodes)/2)
+	}
+
+	// Key must be keyword
+	if node.Nodes[0].Type != edn.NodeKeyword {
+		return nil, fmt.Errorf("pull map key must be a keyword, got %v", node.Nodes[0].Type)
+	}
+	attr := datalog.NewKeyword(node.Nodes[0].Value)
+
+	// Value must be pattern vector
+	if node.Nodes[1].Type != edn.NodeVector {
+		return nil, fmt.Errorf("pull map value must be a pattern vector [...], got %v", node.Nodes[1].Type)
+	}
+	pattern, err := parsePullPattern(&node.Nodes[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid nested pattern for %s: %w", attr.String(), err)
+	}
+
+	return &query.PullMapSpec{
+		Attr:    attr,
+		Pattern: pattern,
+	}, nil
+}
+
+// parsePullExpr parses a pull expression: (limit ...) or (default ...)
+func parsePullExpr(node *edn.Node) (query.PullAttrSpec, error) {
+	if len(node.Nodes) < 2 {
+		return nil, fmt.Errorf("pull expression requires at least 2 arguments")
+	}
+
+	if node.Nodes[0].Type != edn.NodeSymbol {
+		return nil, fmt.Errorf("pull expression must start with a function name, got %v", node.Nodes[0].Type)
+	}
+
+	fn := node.Nodes[0].Value
+	switch fn {
+	case "limit":
+		// (limit :attr N)
+		if len(node.Nodes) != 3 {
+			return nil, fmt.Errorf("limit requires exactly 2 arguments: attribute and count, got %d", len(node.Nodes)-1)
+		}
+		if node.Nodes[1].Type != edn.NodeKeyword {
+			return nil, fmt.Errorf("limit first argument must be a keyword, got %v", node.Nodes[1].Type)
+		}
+		if node.Nodes[2].Type != edn.NodeInt {
+			return nil, fmt.Errorf("limit second argument must be an integer, got %v", node.Nodes[2].Type)
+		}
+		limit, err := strconv.Atoi(node.Nodes[2].Value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid limit value: %w", err)
+		}
+		if limit < 0 {
+			return nil, fmt.Errorf("limit must be non-negative, got %d", limit)
+		}
+		return &query.PullLimitExpr{
+			Attr:  datalog.NewKeyword(node.Nodes[1].Value),
+			Limit: limit,
+		}, nil
+
+	case "default":
+		// (default :attr value)
+		if len(node.Nodes) != 3 {
+			return nil, fmt.Errorf("default requires exactly 2 arguments: attribute and value, got %d", len(node.Nodes)-1)
+		}
+		if node.Nodes[1].Type != edn.NodeKeyword {
+			return nil, fmt.Errorf("default first argument must be a keyword, got %v", node.Nodes[1].Type)
+		}
+		defaultVal, err := parseDefaultValue(&node.Nodes[2])
+		if err != nil {
+			return nil, fmt.Errorf("invalid default value: %w", err)
+		}
+		return &query.PullDefaultExpr{
+			Attr:    datalog.NewKeyword(node.Nodes[1].Value),
+			Default: defaultVal,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown pull expression: %s (expected 'limit' or 'default')", fn)
+	}
+}
+
+// parseDefaultValue parses a default value for (default ...) expressions
+func parseDefaultValue(node *edn.Node) (interface{}, error) {
+	switch node.Type {
+	case edn.NodeString:
+		return node.Value, nil
+	case edn.NodeInt:
+		val, err := strconv.ParseInt(node.Value, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid integer: %w", err)
+		}
+		return val, nil
+	case edn.NodeFloat:
+		val, err := strconv.ParseFloat(node.Value, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid float: %w", err)
+		}
+		return val, nil
+	case edn.NodeBool:
+		return node.Value == "true", nil
+	case edn.NodeKeyword:
+		return datalog.NewKeyword(node.Value), nil
+	case edn.NodeNil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported default value type: %v", node.Type)
+	}
+}
+
+// ParsePullPattern parses a standalone pull pattern string
+// Example: `[:entity/code :entity/name {:entity/region [...]}]`
+func ParsePullPattern(input string) (*query.PullPattern, error) {
+	node, err := edn.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("EDN parse error: %w", err)
+	}
+
+	if node.Type != edn.NodeVector {
+		return nil, fmt.Errorf("pull pattern must be a vector [...], got %v", node.Type)
+	}
+
+	return parsePullPattern(node)
+}

--- a/datalog/parser/pull_parser_test.go
+++ b/datalog/parser/pull_parser_test.go
@@ -1,0 +1,399 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+func TestParsePullPattern_SimpleAttributes(t *testing.T) {
+	input := `[:entity/code :entity/name :entity/score]`
+
+	pattern, err := ParsePullPattern(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pattern.Specs) != 3 {
+		t.Fatalf("expected 3 specs, got %d", len(pattern.Specs))
+	}
+
+	// Check each spec
+	expectedAttrs := []string{":entity/code", ":entity/name", ":entity/score"}
+	for i, spec := range pattern.Specs {
+		attr, ok := spec.(*query.PullAttribute)
+		if !ok {
+			t.Errorf("spec %d: expected PullAttribute, got %T", i, spec)
+			continue
+		}
+		if attr.Attr.String() != expectedAttrs[i] {
+			t.Errorf("spec %d: expected %s, got %s", i, expectedAttrs[i], attr.Attr.String())
+		}
+	}
+}
+
+func TestParsePullPattern_Wildcard(t *testing.T) {
+	input := `[*]`
+
+	pattern, err := ParsePullPattern(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pattern.Specs) != 1 {
+		t.Fatalf("expected 1 spec, got %d", len(pattern.Specs))
+	}
+
+	_, ok := pattern.Specs[0].(*query.PullWildcard)
+	if !ok {
+		t.Errorf("expected PullWildcard, got %T", pattern.Specs[0])
+	}
+}
+
+func TestParsePullPattern_MapSpec(t *testing.T) {
+	input := `[:entity/code {:entity/region [:region/code :region/name]}]`
+
+	pattern, err := ParsePullPattern(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pattern.Specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(pattern.Specs))
+	}
+
+	// First spec is simple attribute
+	attr, ok := pattern.Specs[0].(*query.PullAttribute)
+	if !ok {
+		t.Errorf("spec 0: expected PullAttribute, got %T", pattern.Specs[0])
+	} else if attr.Attr.String() != ":entity/code" {
+		t.Errorf("spec 0: expected :entity/code, got %s", attr.Attr.String())
+	}
+
+	// Second spec is map spec
+	mapSpec, ok := pattern.Specs[1].(*query.PullMapSpec)
+	if !ok {
+		t.Fatalf("spec 1: expected PullMapSpec, got %T", pattern.Specs[1])
+	}
+
+	if mapSpec.Attr.String() != ":entity/region" {
+		t.Errorf("map spec attr: expected :entity/region, got %s", mapSpec.Attr.String())
+	}
+
+	if len(mapSpec.Pattern.Specs) != 2 {
+		t.Fatalf("nested pattern: expected 2 specs, got %d", len(mapSpec.Pattern.Specs))
+	}
+
+	// Check nested pattern attributes
+	nestedExpected := []string{":region/code", ":region/name"}
+	for i, spec := range mapSpec.Pattern.Specs {
+		nestedAttr, ok := spec.(*query.PullAttribute)
+		if !ok {
+			t.Errorf("nested spec %d: expected PullAttribute, got %T", i, spec)
+			continue
+		}
+		if nestedAttr.Attr.String() != nestedExpected[i] {
+			t.Errorf("nested spec %d: expected %s, got %s", i, nestedExpected[i], nestedAttr.Attr.String())
+		}
+	}
+}
+
+func TestParsePullPattern_NestedMapSpecs(t *testing.T) {
+	input := `[:entity/name {:entity/region [:region/code {:region/nation [:nation/name]}]}]`
+
+	pattern, err := ParsePullPattern(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pattern.Specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(pattern.Specs))
+	}
+
+	// Navigate to deeply nested map spec
+	mapSpec, ok := pattern.Specs[1].(*query.PullMapSpec)
+	if !ok {
+		t.Fatalf("expected PullMapSpec, got %T", pattern.Specs[1])
+	}
+
+	if len(mapSpec.Pattern.Specs) != 2 {
+		t.Fatalf("nested pattern: expected 2 specs, got %d", len(mapSpec.Pattern.Specs))
+	}
+
+	nestedMap, ok := mapSpec.Pattern.Specs[1].(*query.PullMapSpec)
+	if !ok {
+		t.Fatalf("deeply nested: expected PullMapSpec, got %T", mapSpec.Pattern.Specs[1])
+	}
+
+	if nestedMap.Attr.String() != ":region/nation" {
+		t.Errorf("deeply nested attr: expected :region/nation, got %s", nestedMap.Attr.String())
+	}
+}
+
+func TestParsePullPattern_LimitExpr(t *testing.T) {
+	input := `[:entity/name (limit :entity/tags 10)]`
+
+	pattern, err := ParsePullPattern(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pattern.Specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(pattern.Specs))
+	}
+
+	limitExpr, ok := pattern.Specs[1].(*query.PullLimitExpr)
+	if !ok {
+		t.Fatalf("expected PullLimitExpr, got %T", pattern.Specs[1])
+	}
+
+	if limitExpr.Attr.String() != ":entity/tags" {
+		t.Errorf("limit attr: expected :entity/tags, got %s", limitExpr.Attr.String())
+	}
+
+	if limitExpr.Limit != 10 {
+		t.Errorf("limit value: expected 10, got %d", limitExpr.Limit)
+	}
+}
+
+func TestParsePullPattern_DefaultExpr(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		attr     string
+		expected interface{}
+	}{
+		{
+			name:     "string default",
+			input:    `[(default :entity/status "unknown")]`,
+			attr:     ":entity/status",
+			expected: "unknown",
+		},
+		{
+			name:     "int default",
+			input:    `[(default :entity/count 0)]`,
+			attr:     ":entity/count",
+			expected: int64(0),
+		},
+		{
+			name:     "bool default",
+			input:    `[(default :entity/active true)]`,
+			attr:     ":entity/active",
+			expected: true,
+		},
+		{
+			name:     "keyword default",
+			input:    `[(default :entity/type :type/unknown)]`,
+			attr:     ":entity/type",
+			expected: datalog.NewKeyword(":type/unknown"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pattern, err := ParsePullPattern(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(pattern.Specs) != 1 {
+				t.Fatalf("expected 1 spec, got %d", len(pattern.Specs))
+			}
+
+			defaultExpr, ok := pattern.Specs[0].(*query.PullDefaultExpr)
+			if !ok {
+				t.Fatalf("expected PullDefaultExpr, got %T", pattern.Specs[0])
+			}
+
+			if defaultExpr.Attr.String() != tt.attr {
+				t.Errorf("attr: expected %s, got %s", tt.attr, defaultExpr.Attr.String())
+			}
+
+			// For keywords, compare string representation
+			if kw, ok := tt.expected.(datalog.Keyword); ok {
+				actualKw, ok := defaultExpr.Default.(datalog.Keyword)
+				if !ok {
+					t.Errorf("expected Keyword default, got %T", defaultExpr.Default)
+				} else if actualKw.String() != kw.String() {
+					t.Errorf("default value: expected %v, got %v", kw.String(), actualKw.String())
+				}
+			} else if defaultExpr.Default != tt.expected {
+				t.Errorf("default value: expected %v (%T), got %v (%T)", tt.expected, tt.expected, defaultExpr.Default, defaultExpr.Default)
+			}
+		})
+	}
+}
+
+func TestParseFindPull_InQuery(t *testing.T) {
+	input := `[:find (pull ?e [:entity/code :entity/name])
+              :where [?e :entity/type :type/stock]]`
+
+	q, err := ParseQuery(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(q.Find) != 1 {
+		t.Fatalf("expected 1 find element, got %d", len(q.Find))
+	}
+
+	pull, ok := q.Find[0].(query.FindPull)
+	if !ok {
+		t.Fatalf("expected FindPull, got %T", q.Find[0])
+	}
+
+	if pull.Variable != "?e" {
+		t.Errorf("expected variable ?e, got %s", pull.Variable)
+	}
+
+	if len(pull.Pattern.Specs) != 2 {
+		t.Errorf("expected 2 pull specs, got %d", len(pull.Pattern.Specs))
+	}
+}
+
+func TestParseFindPull_MixedWithVariables(t *testing.T) {
+	input := `[:find ?type (pull ?e [:entity/code :entity/name {:entity/region [:region/name]}])
+              :where [?e :entity/type ?type]]`
+
+	q, err := ParseQuery(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(q.Find) != 2 {
+		t.Fatalf("expected 2 find elements, got %d", len(q.Find))
+	}
+
+	// First element is a variable
+	_, ok := q.Find[0].(query.FindVariable)
+	if !ok {
+		t.Errorf("find[0]: expected FindVariable, got %T", q.Find[0])
+	}
+
+	// Second element is a pull
+	pull, ok := q.Find[1].(query.FindPull)
+	if !ok {
+		t.Fatalf("find[1]: expected FindPull, got %T", q.Find[1])
+	}
+
+	if pull.Variable != "?e" {
+		t.Errorf("expected variable ?e, got %s", pull.Variable)
+	}
+
+	// Check nested map spec
+	if len(pull.Pattern.Specs) != 3 {
+		t.Fatalf("expected 3 pull specs, got %d", len(pull.Pattern.Specs))
+	}
+
+	mapSpec, ok := pull.Pattern.Specs[2].(*query.PullMapSpec)
+	if !ok {
+		t.Fatalf("spec[2]: expected PullMapSpec, got %T", pull.Pattern.Specs[2])
+	}
+
+	if mapSpec.Attr.String() != ":entity/region" {
+		t.Errorf("map spec attr: expected :entity/region, got %s", mapSpec.Attr.String())
+	}
+}
+
+func TestParsePullPattern_Errors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "not a vector",
+			input: `(:entity/code)`,
+		},
+		{
+			name:  "invalid symbol",
+			input: `[foo]`,
+		},
+		{
+			name:  "empty map spec",
+			input: `[{}]`,
+		},
+		{
+			name:  "map with non-keyword key",
+			input: `[{foo [:bar]}]`,
+		},
+		{
+			name:  "map with non-vector value",
+			input: `[{:foo :bar}]`,
+		},
+		{
+			name:  "limit missing args",
+			input: `[(limit :foo)]`,
+		},
+		{
+			name:  "limit non-integer",
+			input: `[(limit :foo "ten")]`,
+		},
+		{
+			name:  "default missing args",
+			input: `[(default :foo)]`,
+		},
+		{
+			name:  "unknown function",
+			input: `[(unknown :foo 1)]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePullPattern(tt.input)
+			if err == nil {
+				t.Errorf("expected error for input: %s", tt.input)
+			}
+		})
+	}
+}
+
+func TestParseFindPull_Errors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "pull missing pattern",
+			input: `[:find (pull ?e) :where [?e :foo :bar]]`,
+		},
+		{
+			name:  "pull non-variable",
+			input: `[:find (pull :entity [:foo]) :where [?e :foo :bar]]`,
+		},
+		{
+			name:  "pull non-vector pattern",
+			input: `[:find (pull ?e (:foo :bar)) :where [?e :foo :bar]]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseQuery(tt.input)
+			if err == nil {
+				t.Errorf("expected error for input: %s", tt.input)
+			}
+		})
+	}
+}
+
+func TestParsePullPattern_String(t *testing.T) {
+	input := `[:entity/code * {:entity/region [:region/name]} (limit :tags 5) (default :status "unknown")]`
+
+	pattern, err := ParsePullPattern(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	str := pattern.String()
+
+	// Verify string contains expected parts
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+
+	// The string should round-trip correctly through parsing
+	// (though order might differ for some implementations)
+	t.Logf("Pattern string: %s", str)
+}

--- a/datalog/query/pull.go
+++ b/datalog/query/pull.go
@@ -1,0 +1,117 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// PullPattern represents a pull specification: [:attr1 :attr2 {:ref [...]}]
+type PullPattern struct {
+	Specs []PullAttrSpec
+}
+
+// String returns the string representation of the pull pattern
+func (p *PullPattern) String() string {
+	if p == nil {
+		return "[]"
+	}
+	var parts []string
+	for _, spec := range p.Specs {
+		parts = append(parts, spec.String())
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+// PullAttrSpec is the interface for all pull attribute specification types
+type PullAttrSpec interface {
+	isPullAttrSpec()
+	String() string
+}
+
+// PullAttribute represents a simple attribute specification: :entity/name
+type PullAttribute struct {
+	Attr datalog.Keyword
+}
+
+func (p *PullAttribute) isPullAttrSpec() {}
+
+func (p *PullAttribute) String() string {
+	return p.Attr.String()
+}
+
+// PullWildcard represents a wildcard that pulls all attributes: *
+type PullWildcard struct{}
+
+func (p *PullWildcard) isPullAttrSpec() {}
+
+func (p *PullWildcard) String() string {
+	return "*"
+}
+
+// PullMapSpec represents a reference follow specification: {:entity/region [:region/code]}
+// This follows a reference attribute and pulls nested attributes from the referenced entity
+type PullMapSpec struct {
+	Attr    datalog.Keyword
+	Pattern *PullPattern
+}
+
+func (p *PullMapSpec) isPullAttrSpec() {}
+
+func (p *PullMapSpec) String() string {
+	return fmt.Sprintf("{%s %s}", p.Attr.String(), p.Pattern.String())
+}
+
+// PullLimitExpr represents a cardinality limit: (limit :entity/tags 10)
+// This limits the number of values returned for cardinality-many attributes
+type PullLimitExpr struct {
+	Attr  datalog.Keyword
+	Limit int
+}
+
+func (p *PullLimitExpr) isPullAttrSpec() {}
+
+func (p *PullLimitExpr) String() string {
+	return fmt.Sprintf("(limit %s %d)", p.Attr.String(), p.Limit)
+}
+
+// PullDefaultExpr represents a default value specification: (default :entity/status "unknown")
+// This provides a default value when an attribute is missing
+type PullDefaultExpr struct {
+	Attr    datalog.Keyword
+	Default interface{}
+}
+
+func (p *PullDefaultExpr) isPullAttrSpec() {}
+
+func (p *PullDefaultExpr) String() string {
+	return fmt.Sprintf("(default %s %v)", p.Attr.String(), p.Default)
+}
+
+// FindPull represents a pull expression in the find clause
+// Example: (pull ?e [:entity/code :entity/name {:entity/region [:region/code]}])
+type FindPull struct {
+	Variable Symbol       // The entity variable to pull (e.g., ?e)
+	Pattern  *PullPattern // The pull specification
+}
+
+// String returns the string representation of the FindPull
+func (f FindPull) String() string {
+	return fmt.Sprintf("(pull %s %s)", f.Variable, f.Pattern.String())
+}
+
+// IsAggregate returns false - pull is not an aggregate
+func (f FindPull) IsAggregate() bool {
+	return false
+}
+
+// KeyName returns the attribute name without the leading colon
+// e.g., ":entity/name" -> "entity/name"
+func KeyName(k datalog.Keyword) string {
+	s := k.String()
+	if len(s) > 0 && s[0] == ':' {
+		return s[1:]
+	}
+	return s
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -601,3 +601,66 @@ func relationToSlice(rel executor.Relation) [][]interface{} {
 
 	return rows
 }
+
+// Pull retrieves entity data according to a pull pattern
+// This provides Datomic-style entity attribute retrieval with nested reference following.
+//
+// The pattern syntax:
+//   - Simple attributes: [:entity/name :entity/code]
+//   - Wildcard: [*] - all attributes
+//   - Nested references: [{:entity/region [:region/code :region/name]}]
+//   - Default values: [(default :entity/status "unknown")]
+//   - Limits (for cardinality-many): [(limit :entity/tags 10)]
+//
+// Examples:
+//
+//	// Get name and code for an entity
+//	result, err := db.Pull(entityID, `[:entity/name :entity/code]`)
+//
+//	// Get all attributes
+//	result, err := db.Pull(entityID, `[*]`)
+//
+//	// Get attributes with nested reference
+//	result, err := db.Pull(entityID, `[:entity/name {:entity/region [:region/code]}]`)
+//
+// Returns nil if the entity does not exist.
+func (d *Database) Pull(entityID datalog.Identity, patternStr string) (map[string]interface{}, error) {
+	// Parse the pull pattern
+	pattern, err := parser.ParsePullPattern(patternStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pull pattern: %w", err)
+	}
+
+	// Create pull executor with database matcher
+	matcher := d.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+
+	// Execute pull
+	return puller.Pull(entityID, pattern)
+}
+
+// PullMany retrieves data for multiple entities using the same pull pattern
+// This is more efficient than calling Pull multiple times.
+//
+// Example:
+//
+//	results, err := db.PullMany(
+//	    []datalog.Identity{entity1, entity2, entity3},
+//	    `[:entity/name :entity/code]`,
+//	)
+//
+// Returns a slice of maps, one per entity. Nil entries indicate non-existent entities.
+func (d *Database) PullMany(entityIDs []datalog.Identity, patternStr string) ([]map[string]interface{}, error) {
+	// Parse the pull pattern
+	pattern, err := parser.ParsePullPattern(patternStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pull pattern: %w", err)
+	}
+
+	// Create pull executor with database matcher
+	matcher := d.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+
+	// Execute pull for all entities
+	return puller.PullMany(entityIDs, pattern)
+}

--- a/datalog/storage/pull_benchmark_test.go
+++ b/datalog/storage/pull_benchmark_test.go
@@ -1,0 +1,248 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+)
+
+// setupBenchmarkDB creates a temporary database with test data
+func setupBenchmarkDB(b *testing.B, numEntities, attrsPerEntity int) (*Database, []datalog.Identity) {
+	b.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "pull-bench-*")
+	if err != nil {
+		b.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	db, err := NewDatabase(tmpDir)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		b.Fatalf("failed to create database: %v", err)
+	}
+
+	// Create entities and add data
+	var entities []datalog.Identity
+	tx := db.NewTransaction()
+
+	for i := 0; i < numEntities; i++ {
+		entity := datalog.NewIdentity(fmt.Sprintf("entity:%d", i))
+		entities = append(entities, entity)
+
+		for j := 0; j < attrsPerEntity; j++ {
+			attr := datalog.NewKeyword(fmt.Sprintf(":entity/attr%d", j))
+			tx.Add(entity, attr, fmt.Sprintf("value_%d_%d", i, j))
+		}
+	}
+
+	if _, err := tx.Commit(); err != nil {
+		db.Close()
+		os.RemoveAll(tmpDir)
+		b.Fatalf("failed to commit: %v", err)
+	}
+
+	b.Cleanup(func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	})
+
+	return db, entities
+}
+
+// BenchmarkPullBadger_SingleAttribute measures single attribute lookup with BadgerDB
+func BenchmarkPullBadger_SingleAttribute(b *testing.B) {
+	db, entities := setupBenchmarkDB(b, 100, 5)
+	entity := entities[0]
+
+	pattern, _ := parser.ParsePullPattern(`[:entity/attr0]`)
+	matcher := db.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(entity, pattern)
+	}
+}
+
+// BenchmarkPullBadger_MultipleAttributes measures multiple attribute lookup with BadgerDB
+func BenchmarkPullBadger_MultipleAttributes(b *testing.B) {
+	db, entities := setupBenchmarkDB(b, 100, 5)
+	entity := entities[0]
+
+	pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1 :entity/attr2 :entity/attr3 :entity/attr4]`)
+	matcher := db.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(entity, pattern)
+	}
+}
+
+// BenchmarkPullBadger_Wildcard measures wildcard pull with BadgerDB
+func BenchmarkPullBadger_Wildcard(b *testing.B) {
+	db, entities := setupBenchmarkDB(b, 100, 5)
+	entity := entities[0]
+
+	pattern, _ := parser.ParsePullPattern(`[*]`)
+	matcher := db.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(entity, pattern)
+	}
+}
+
+// BenchmarkPullBadger_NestedReference measures nested reference with BadgerDB
+func BenchmarkPullBadger_NestedReference(b *testing.B) {
+	tmpDir, _ := os.MkdirTemp("", "pull-nested-bench-*")
+	db, _ := NewDatabase(tmpDir)
+
+	// Create entities with references
+	parent := datalog.NewIdentity("entity:parent")
+	child := datalog.NewIdentity("entity:child")
+
+	tx := db.NewTransaction()
+	tx.Add(parent, datalog.NewKeyword(":entity/name"), "Parent")
+	tx.Add(parent, datalog.NewKeyword(":entity/child"), child)
+	tx.Add(child, datalog.NewKeyword(":entity/name"), "Child")
+	tx.Add(child, datalog.NewKeyword(":entity/value"), "ChildValue")
+	tx.Commit()
+
+	b.Cleanup(func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	})
+
+	pattern, _ := parser.ParsePullPattern(`[:entity/name {:entity/child [:entity/name :entity/value]}]`)
+	matcher := db.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(parent, pattern)
+	}
+}
+
+// BenchmarkPullBadger_StandaloneAPI measures the high-level db.Pull() API
+func BenchmarkPullBadger_StandaloneAPI(b *testing.B) {
+	db, entities := setupBenchmarkDB(b, 100, 5)
+	entity := entities[0]
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = db.Pull(entity, `[:entity/attr0 :entity/attr1 :entity/attr2]`)
+	}
+}
+
+// BenchmarkPullBadger_StandaloneAPIWithParseCached measures Pull with pre-parsed pattern
+func BenchmarkPullBadger_StandaloneAPICached(b *testing.B) {
+	db, entities := setupBenchmarkDB(b, 100, 5)
+	entity := entities[0]
+
+	// Pre-parse to measure just execution
+	pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1 :entity/attr2]`)
+	matcher := db.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.Pull(entity, pattern)
+	}
+}
+
+// BenchmarkPullManyBadger measures batch pull with BadgerDB
+func BenchmarkPullManyBadger(b *testing.B) {
+	db, entities := setupBenchmarkDB(b, 100, 5)
+
+	pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1]`)
+	matcher := db.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = puller.PullMany(entities, pattern)
+	}
+}
+
+// BenchmarkPullBadger_ScalingWithEntities measures how Pull scales with entity count
+func BenchmarkPullBadger_ScalingWithEntities(b *testing.B) {
+	for _, numEntities := range []int{10, 100, 1000} {
+		db, entities := setupBenchmarkDB(b, numEntities, 5)
+
+		pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1]`)
+		matcher := db.Matcher()
+		puller := executor.NewPullExecutor(matcher)
+
+		b.Run(fmt.Sprintf("Entities_%d", numEntities), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = puller.PullMany(entities, pattern)
+			}
+		})
+	}
+}
+
+// BenchmarkPullBadger_ScalingWithAttributes measures how Pull scales with attribute count
+func BenchmarkPullBadger_ScalingWithAttributes(b *testing.B) {
+	for _, numAttrs := range []int{1, 5, 10, 20} {
+		db, entities := setupBenchmarkDB(b, 10, numAttrs)
+		entity := entities[0]
+
+		// Build pattern string
+		var patternStr string
+		for i := 0; i < numAttrs; i++ {
+			if i > 0 {
+				patternStr += " "
+			}
+			patternStr += fmt.Sprintf(":entity/attr%d", i)
+		}
+
+		pattern, _ := parser.ParsePullPattern(fmt.Sprintf("[%s]", patternStr))
+		matcher := db.Matcher()
+		puller := executor.NewPullExecutor(matcher)
+
+		b.Run(fmt.Sprintf("Attrs_%d", numAttrs), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = puller.Pull(entity, pattern)
+			}
+		})
+	}
+}
+
+// BenchmarkPullBadger_VsQuery compares Pull vs equivalent query
+func BenchmarkPullBadger_VsQuery(b *testing.B) {
+	db, entities := setupBenchmarkDB(b, 100, 5)
+	entity := entities[0]
+
+	b.Run("Pull", func(b *testing.B) {
+		pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1 :entity/attr2]`)
+		matcher := db.Matcher()
+		puller := executor.NewPullExecutor(matcher)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = puller.Pull(entity, pattern)
+		}
+	})
+
+	b.Run("Query", func(b *testing.B) {
+		// Equivalent query that fetches same data
+		queryStr := `[:find ?a0 ?a1 ?a2
+			:in $ ?e
+			:where [?e :entity/attr0 ?a0]
+			       [?e :entity/attr1 ?a1]
+			       [?e :entity/attr2 ?a2]]`
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = db.ExecuteQueryWithInputs(queryStr, entity)
+		}
+	})
+}

--- a/datalog/storage/pull_integration_test.go
+++ b/datalog/storage/pull_integration_test.go
@@ -1,0 +1,437 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+func TestPullIntegration_StandaloneAPI(t *testing.T) {
+	// Create temporary database
+	tmpDir, err := os.MkdirTemp("", "pull-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	db, err := NewDatabase(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create test entities
+	alice := datalog.NewIdentity("user:alice")
+	bob := datalog.NewIdentity("user:bob")
+	region := datalog.NewIdentity("region:us-west")
+
+	// Add data
+	tx := db.NewTransaction()
+	tx.Add(alice, datalog.NewKeyword(":user/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":user/age"), int64(30))
+	tx.Add(alice, datalog.NewKeyword(":user/email"), "alice@example.com")
+	tx.Add(alice, datalog.NewKeyword(":user/region"), region)
+
+	tx.Add(bob, datalog.NewKeyword(":user/name"), "Bob")
+	tx.Add(bob, datalog.NewKeyword(":user/age"), int64(25))
+
+	tx.Add(region, datalog.NewKeyword(":region/code"), "US-W")
+	tx.Add(region, datalog.NewKeyword(":region/name"), "US West")
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	// Test simple pull
+	t.Run("SimpleAttributes", func(t *testing.T) {
+		result, err := db.Pull(alice, `[:user/name :user/age]`)
+		if err != nil {
+			t.Fatalf("pull failed: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result["user/name"] != "Alice" {
+			t.Errorf("expected name=Alice, got %v", result["user/name"])
+		}
+		if result["user/age"] != int64(30) {
+			t.Errorf("expected age=30, got %v", result["user/age"])
+		}
+		// Email should NOT be present (not in pattern)
+		if _, ok := result["user/email"]; ok {
+			t.Error("email should not be in result")
+		}
+	})
+
+	// Test wildcard pull
+	t.Run("Wildcard", func(t *testing.T) {
+		result, err := db.Pull(alice, `[*]`)
+		if err != nil {
+			t.Fatalf("pull failed: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		// Should have all 4 attributes (name, age, email, region)
+		if len(result) != 4 {
+			t.Errorf("expected 4 attributes, got %d: %v", len(result), result)
+		}
+	})
+
+	// Test nested reference pull
+	t.Run("NestedReference", func(t *testing.T) {
+		result, err := db.Pull(alice, `[:user/name {:user/region [:region/code :region/name]}]`)
+		if err != nil {
+			t.Fatalf("pull failed: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result["user/name"] != "Alice" {
+			t.Errorf("expected name=Alice, got %v", result["user/name"])
+		}
+
+		// Check nested region
+		nestedRegion, ok := result["user/region"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected nested map for user/region, got %T", result["user/region"])
+		}
+		if nestedRegion["region/code"] != "US-W" {
+			t.Errorf("expected region/code=US-W, got %v", nestedRegion["region/code"])
+		}
+		if nestedRegion["region/name"] != "US West" {
+			t.Errorf("expected region/name=US West, got %v", nestedRegion["region/name"])
+		}
+	})
+
+	// Test default value
+	t.Run("DefaultValue", func(t *testing.T) {
+		result, err := db.Pull(alice, `[:user/name (default :user/status "active")]`)
+		if err != nil {
+			t.Fatalf("pull failed: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		// Status should have default value since it doesn't exist
+		if result["user/status"] != "active" {
+			t.Errorf("expected status=active (default), got %v", result["user/status"])
+		}
+	})
+
+	// Test non-existent entity
+	t.Run("NonExistentEntity", func(t *testing.T) {
+		nonExistent := datalog.NewIdentity("user:nonexistent")
+		result, err := db.Pull(nonExistent, `[:user/name]`)
+		if err != nil {
+			t.Fatalf("pull failed: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil for non-existent entity, got %v", result)
+		}
+	})
+
+	// Test PullMany
+	t.Run("PullMany", func(t *testing.T) {
+		results, err := db.PullMany([]datalog.Identity{alice, bob}, `[:user/name :user/age]`)
+		if err != nil {
+			t.Fatalf("pullMany failed: %v", err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(results))
+		}
+		if results[0]["user/name"] != "Alice" {
+			t.Errorf("expected first name=Alice, got %v", results[0]["user/name"])
+		}
+		if results[1]["user/name"] != "Bob" {
+			t.Errorf("expected second name=Bob, got %v", results[1]["user/name"])
+		}
+	})
+}
+
+// TestPullWildcardPatternMatching tests that the underlying pattern matching works
+// for entity-only patterns used by wildcard pull
+func TestPullWildcardPatternMatching(t *testing.T) {
+	// Create temporary database
+	tmpDir, err := os.MkdirTemp("", "pull-pattern-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	db, err := NewDatabase(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create test entity
+	alice := datalog.NewIdentity("user:alice")
+
+	// Add data
+	tx := db.NewTransaction()
+	tx.Add(alice, datalog.NewKeyword(":user/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":user/age"), int64(30))
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	// Test that we can query for all attributes of alice via standard query
+	t.Run("QueryAllAttributes", func(t *testing.T) {
+		results, err := db.ExecuteQueryWithInputs(`
+			[:find ?a ?v
+			 :in $ ?e
+			 :where [?e ?a ?v]]
+		`, alice)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		if len(results) != 2 {
+			t.Errorf("expected 2 results, got %d: %v", len(results), results)
+		}
+	})
+
+	// Test direct pattern matching using the matcher
+	t.Run("DirectPatternMatch", func(t *testing.T) {
+		matcher := db.Matcher()
+
+		// Create pattern: [alice ?a ?v]
+		pattern := &query.DataPattern{
+			Elements: []query.PatternElement{
+				query.Constant{Value: alice},
+				query.Variable{Name: "?a"},
+				query.Variable{Name: "?v"},
+			},
+		}
+
+		rel, err := matcher.Match(pattern, nil)
+		if err != nil {
+			t.Fatalf("Match failed: %v", err)
+		}
+		if rel == nil {
+			t.Fatal("expected non-nil relation")
+		}
+
+		// Iterate and count results
+		var count int
+		it := rel.Iterator()
+		for it.Next() {
+			count++
+			tuple := it.Tuple()
+			t.Logf("Found tuple: %v", tuple)
+		}
+		it.Close()
+
+		if count != 2 {
+			t.Errorf("expected 2 tuples, got %d", count)
+		}
+	})
+
+	// Test the same pattern matching but with column extraction as pull does
+	t.Run("PatternMatchWithColumnExtraction", func(t *testing.T) {
+		matcher := db.Matcher()
+
+		// Create pattern: [alice ?a ?v] - same as what getAllAttributes creates
+		pattern := &query.DataPattern{
+			Elements: []query.PatternElement{
+				query.Constant{Value: alice},
+				query.Variable{Name: "?a"},
+				query.Variable{Name: "?v"},
+			},
+		}
+
+		rel, err := matcher.Match(pattern, nil)
+		if err != nil {
+			t.Fatalf("Match failed: %v", err)
+		}
+		if rel == nil {
+			t.Fatal("expected non-nil relation")
+		}
+
+		// Check columns
+		cols := rel.Columns()
+		t.Logf("Columns: %v", cols)
+
+		// Find column indices like pull.go does
+		aIdx := -1
+		vIdx := -1
+		for i, col := range cols {
+			if col == "?a" {
+				aIdx = i
+			} else if col == "?v" {
+				vIdx = i
+			}
+		}
+		t.Logf("aIdx=%d, vIdx=%d", aIdx, vIdx)
+
+		if aIdx < 0 || vIdx < 0 {
+			t.Fatalf("missing expected columns: aIdx=%d, vIdx=%d", aIdx, vIdx)
+		}
+
+		// Iterate and build datoms like pull.go does
+		var datoms []datalog.Datom
+		it := rel.Iterator()
+		defer it.Close()
+
+		for it.Next() {
+			tuple := it.Tuple()
+			t.Logf("Tuple: %v (len=%d)", tuple, len(tuple))
+			if aIdx < len(tuple) && vIdx < len(tuple) {
+				// Handle both Keyword and *Keyword (BadgerMatcher may return pointers)
+				var attr datalog.Keyword
+				switch a := tuple[aIdx].(type) {
+				case datalog.Keyword:
+					attr = a
+				case *datalog.Keyword:
+					if a == nil {
+						continue
+					}
+					attr = *a
+				default:
+					t.Logf("tuple[%d] is not Keyword or *Keyword, got %T: %v", aIdx, tuple[aIdx], tuple[aIdx])
+					continue
+				}
+				datoms = append(datoms, datalog.Datom{
+					E: alice,
+					A: attr,
+					V: tuple[vIdx],
+				})
+				t.Logf("Created datom: E=%v, A=%v, V=%v", alice, attr, tuple[vIdx])
+			} else {
+				t.Logf("indices out of range: aIdx=%d, vIdx=%d, len(tuple)=%d", aIdx, vIdx, len(tuple))
+			}
+		}
+
+		if len(datoms) != 2 {
+			t.Errorf("expected 2 datoms, got %d", len(datoms))
+		}
+	})
+}
+
+func TestPullIntegration_InQuery(t *testing.T) {
+	// Create temporary database
+	tmpDir, err := os.MkdirTemp("", "pull-query-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	db, err := NewDatabase(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create test entities
+	alice := datalog.NewIdentity("person:alice")
+	bob := datalog.NewIdentity("person:bob")
+	personType := datalog.NewKeyword(":type/person")
+
+	// Add data
+	tx := db.NewTransaction()
+	tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":person/age"), int64(30))
+	tx.Add(alice, datalog.NewKeyword(":entity/type"), personType)
+
+	tx.Add(bob, datalog.NewKeyword(":person/name"), "Bob")
+	tx.Add(bob, datalog.NewKeyword(":person/age"), int64(25))
+	tx.Add(bob, datalog.NewKeyword(":entity/type"), personType)
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	// Test pull in query
+	t.Run("PullInFindClause", func(t *testing.T) {
+		results, err := db.ExecuteQuery(`
+			[:find (pull ?e [:person/name :person/age])
+			 :where [?e :entity/type :type/person]]
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(results))
+		}
+
+		// Results should be pulled maps
+		foundAlice := false
+		foundBob := false
+		for _, row := range results {
+			if len(row) != 1 {
+				t.Errorf("expected 1 column per row, got %d", len(row))
+				continue
+			}
+			pulled, ok := row[0].(map[string]interface{})
+			if !ok {
+				t.Errorf("expected map[string]interface{}, got %T", row[0])
+				continue
+			}
+			name := pulled["person/name"]
+			if name == "Alice" {
+				foundAlice = true
+				if pulled["person/age"] != int64(30) {
+					t.Errorf("Alice's age should be 30, got %v", pulled["person/age"])
+				}
+			} else if name == "Bob" {
+				foundBob = true
+				if pulled["person/age"] != int64(25) {
+					t.Errorf("Bob's age should be 25, got %v", pulled["person/age"])
+				}
+			}
+		}
+		if !foundAlice {
+			t.Error("Alice not found in results")
+		}
+		if !foundBob {
+			t.Error("Bob not found in results")
+		}
+	})
+
+	// Test mixed find clause (pull + regular variable)
+	t.Run("MixedFindClause", func(t *testing.T) {
+		results, err := db.ExecuteQuery(`
+			[:find ?type (pull ?e [:person/name])
+			 :where [?e :entity/type ?type]]
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(results))
+		}
+
+		// Each row should have [type, pulled_map]
+		for _, row := range results {
+			if len(row) != 2 {
+				t.Errorf("expected 2 columns, got %d", len(row))
+				continue
+			}
+
+			// First column should be the type keyword
+			typeKw, ok := row[0].(datalog.Keyword)
+			if !ok {
+				t.Errorf("expected Keyword for type, got %T", row[0])
+			} else if typeKw.String() != ":type/person" {
+				t.Errorf("expected type=:type/person, got %s", typeKw.String())
+			}
+
+			// Second column should be pulled map
+			pulled, ok := row[1].(map[string]interface{})
+			if !ok {
+				t.Errorf("expected map for pull, got %T", row[1])
+			} else {
+				name := pulled["person/name"]
+				if name != "Alice" && name != "Bob" {
+					t.Errorf("unexpected name: %v", name)
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
Add Pull syntax support for declarative entity attribute retrieval with nested reference following. This is a significant feature addition that brings janus-datalog closer to Datomic compatibility.

## Features

### In-Query Pull
```clojure
[:find (pull ?e [:person/name :person/age])
 :where [?e :entity/type :type/person]]

; Mixed with regular variables
[:find ?type (pull ?e [:person/name])
 :where [?e :entity/type ?type]]
```

### Standalone API
```go
result, _ := db.Pull(entityID, `[:user/name :user/age]`)
results, _ := db.PullMany(entityIDs, `[:user/name]`)
```

### Supported Pull Patterns
- Simple attributes: `[:attr1 :attr2]`
- Wildcard: `[*]` (all attributes)
- Nested references: `{:user/region [:region/code :region/name]}`
- Default values: `(default :attr "fallback")`
- Limit (parsed): `(limit :attr 10)`

## Design Decisions

| Decision | Choice |
|----------|--------|
| Result key format | Without colon: `"entity/name"` | | Missing attributes | Omitted from result map |
| Recursion handling | Unlimited depth with cycle detection | | Cardinality | Single-valued only (no schema) |

## Performance Benchmarks (Apple M4 Max)

### Pull vs Query (3 attributes, BadgerDB)
| Method | Time | Speedup |
|--------|------|---------|
| Pull | 3.5µs | **9.2×** |
| Query | 32.7µs | baseline |

### In-Memory Performance
| Operation | Time | Allocs |
|-----------|------|--------|
| Single Attribute | 554ns | 19 |
| 5 Attributes | 2.3µs | 87 |
| Wildcard (5 attrs) | 1.7µs | 36 |
| Nested (2 levels) | 2.1µs | 72 |
| Deep (3 levels) | 2.6µs | 91 |
| PullMany (100 entities) | 102µs | 3601 |

### BadgerDB Storage Performance
| Operation | Time | Allocs |
|-----------|------|--------|
| Single Attribute | 1.1µs | 31 |
| 5 Attributes | 6.2µs | 147 |
| Wildcard (5 attrs) | 2.8µs | 69 |
| Nested (2 levels) | 5.0µs | 120 |
| PullMany (100 entities) | 225µs | 6001 |

### Scaling Characteristics
- Per-attribute cost: ~1.2µs (BadgerDB), ~470ns (in-memory)
- Per-entity cost: ~2.5µs (BadgerDB), ~1µs (in-memory)
- Linear scaling with both attributes and entities

### Key Performance Insight
Wildcard `[*]` is **2× faster** than explicit attribute lists because it performs one EAVT prefix scan instead of N separate AEVT lookups.

## Implementation

### New Files
- `datalog/query/pull.go` - Pull pattern types (PullPattern, PullAttrSpec, etc.)
- `datalog/parser/pull_parser.go` - Pull pattern parser
- `datalog/executor/pull.go` - Pull executor with cycle detection

### Modified Files
- `datalog/parser/parser.go` - Integrate pull in parseFindElement()
- `datalog/executor/query_executor.go` - Handle FindPull in find clause
- `datalog/storage/database.go` - Add db.Pull() and db.PullMany() APIs

### Bug Fixes During Implementation
- Fixed `*datalog.Keyword` pointer type handling in getAllAttributes()
- Fixed `*datalog.Identity` handling in executePulls()
- Avoided map deduplication panic (maps are not comparable)
- Removed IsEmpty() calls that consumed first tuple in streaming mode

## Test Coverage
- Parser tests: `datalog/parser/pull_parser_test.go`
- Executor tests: `datalog/executor/pull_test.go`
- Integration tests: `datalog/storage/pull_integration_test.go`
- Benchmarks: `datalog/executor/pull_benchmark_test.go`, `datalog/storage/pull_benchmark_test.go`

## Documentation Updates
- DATOMIC_COMPATIBILITY.md: Added Pull API section, updated feature matrix
- PERFORMANCE_STATUS.md: Added Pull API benchmarks and session history
- TODO.md: Marked Pull Syntax as completed