### PR TITLE
Implement Datomic-compatible schema support for type validation and cardinality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,12 +139,13 @@ datalog/
 ├── types/       # Core type definitions
 ├── query/       # Query structures and types
 ├── symbolic/    # User-facing types (EntityID, Keyword, Datom)
-├── executor/    # Query execution with Relations
+├── executor/    # Query execution with Relations, Pull API
 ├── planner/     # Query planning and optimization
 ├── store/       # Storage abstraction and backends
 ├── index/       # Index implementations
 ├── codec/       # L85 and value encoding
 ├── edn/         # EDN lexer and parser
+├── schema/      # Schema support (types, cardinality, uniqueness)
 └── storage/     # Storage implementations (BadgerDB)
 ```
 
@@ -239,8 +240,10 @@ The storage layer connects the query engine to BadgerDB:
 17. **Table formatter** - Markdown table formatting using tablewriter library
 18. **Order-by clause** - Full implementation with multi-column sorting and direction control
 19. **Time comparison fix** - Proper time.Time comparison in aggregations and predicates
-20. **Datomic compatibility** - ~40-50% feature parity (see DATOMIC_COMPATIBILITY.md)
+20. **Datomic compatibility** - ~50-60% feature parity (see DATOMIC_COMPATIBILITY.md)
 21. **Relations migration** - Multi-value variable support throughout codebase
+22. **Pull API** - Declarative entity attribute retrieval with nested refs, cycle detection, wildcards (9× faster than queries)
+23. **Schema support** - Type validation, cardinality (one/many), uniqueness constraints; optional and additive
 
 ### 📋 TODO (Priority Order)
 
@@ -255,9 +258,8 @@ See `TODO.md` and `PERFORMANCE_STATUS.md` for detailed roadmap.
 6. **NOT/OR clauses** - Negation and disjunction support
 
 **Long Term**:
-7. **Schema management** - Attribute definitions and constraints
-8. **Statistics-based optimization** - Query planning with cardinality estimates
-9. **WASM build** - Browser deployment support
+7. **Statistics-based optimization** - Query planning with cardinality estimates
+8. **WASM build** - Browser deployment support
 
 ## Go Implementation Guidelines
 
@@ -479,12 +481,13 @@ Note: While our planner is explicit and feature-complete, the **information flow
 ## Important Documentation
 
 ### Core Documentation
-- **[DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md)** - Comprehensive compatibility guide for Datomic users (~40-50% feature parity)
+- **[DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md)** - Comprehensive compatibility guide for Datomic users (~50-60% feature parity)
 - **[PERFORMANCE_STATUS.md](PERFORMANCE_STATUS.md)** - Current performance status, active optimizations, and benchmarks
 - **[TODO.md](TODO.md)** - Active task tracking with completed and pending features
 - **[DOCUMENTATION_INDEX.md](DOCUMENTATION_INDEX.md)** - Complete documentation navigation
 
 ### Implementation Guides
+- **[docs/reference/SCHEMA.md](docs/reference/SCHEMA.md)** - Schema support: types, cardinality, uniqueness, Pull API integration
 - **[docs/INPUT_PARAMETER_SEMANTICS.md](docs/INPUT_PARAMETER_SEMANTICS.md)** - Comprehensive guide to input parameter handling
 - **[docs/reference/PLANNER_OPTIONS.md](docs/reference/PLANNER_OPTIONS.md)** - Complete planner options reference with performance guidance
 

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -10,7 +10,8 @@ Janus-datalog implements a pragmatic subset of Datomic's Datalog query language 
 - ✅ Time-based queries using transaction IDs
 - ✅ Database functions: `get-else`, `missing?`, `get-some`
 - ✅ BadgerDB persistent storage with EAVT model
-- ❌ No rules, schema, or transaction functions
+- ✅ Schema support: type validation, cardinality, uniqueness
+- ❌ No rules or transaction functions
 - ❌ No NOT/OR clauses or entity API
 - ❌ Single-node only (no distributed queries)
 
@@ -276,14 +277,53 @@ No logical negation or disjunction:
 (or-join [?e] ...)
 ```
 
-### 3. Schema ❌
+### 3. Schema ✅
 
-No schema definitions or constraints:
-- No cardinality specifications (one/many)
-- No type constraints at schema level
-- No uniqueness constraints
-- No required attributes
-- All attributes effectively `:db.cardinality/one`
+Schema support with Datomic-compatible attributes:
+
+**Supported schema features:**
+- `:db/valueType` - type constraints (string, long, double, boolean, instant, bytes, ref, keyword)
+- `:db/cardinality` - one or many
+- `:db/unique` - value uniqueness or identity
+- `:db/doc` - documentation strings
+
+**Schema definition via EDN:**
+```clojure
+{:person/name   {:db/valueType   :db.type/string
+                 :db/cardinality :db.cardinality/one}
+ :person/friends {:db/valueType   :db.type/ref
+                  :db/cardinality :db.cardinality/many}
+ :person/email  {:db/valueType   :db.type/string
+                 :db/unique      :db.unique/value}}
+```
+
+**Schema definition via Go API:**
+```go
+schema, _ := schema.NewBuilder().
+    Attribute(":person/name").Type(schema.TypeString).Add().
+    Attribute(":person/friends").Type(schema.TypeRef).Many().Add().
+    Attribute(":person/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+    Build()
+
+db, _ := storage.NewDatabaseWithSchema(path, schema)
+```
+
+**Schema behavior:**
+- Type validation enforced on transaction `Add()`
+- Uniqueness validation enforced on `Commit()`
+- Unknown attributes allowed (additive schema)
+- Pull API uses schema for cardinality-many handling
+- Schema is optional - existing behavior preserved without schema
+
+**Schema limitations vs Datomic:**
+- No `:db/isComponent` - component entity semantics not implemented
+- No `:db/index` - all attributes are indexed by default
+- No `:db/fulltext` - fulltext search not supported
+- No `:db/noHistory` - all datoms are retained
+- No upsert semantics - `:db.unique/identity` behaves like `:db.unique/value`
+- Schema not stored as datoms - schema is in-memory only
+
+**Performance (writes only):** Type validation adds <1% overhead at `Add()` time; uniqueness checking adds ~6% at `Commit()` time. Reads are unaffected. See `PERFORMANCE_STATUS.md` for benchmarks.
 
 ### 4. Transaction Features ❌
 
@@ -381,7 +421,6 @@ No advanced database operations:
 **Require refactoring:**
 - Rules → inline the logic
 - Entity navigation → explicit joins or Pull API
-- Schema validations → application layer
 
 **Not possible:**
 - Transaction functions
@@ -401,8 +440,9 @@ No advanced database operations:
 ```
 
 Note: Nested references like `{:person/friends [...]}` work when `:person/friends`
-stores an entity reference. Cardinality-many attributes are not yet supported,
-so only the first friend would be returned.
+stores an entity reference. With schema support, cardinality-many attributes return
+all values as an array. Use `ResolvePullPattern()` and `PullResolved()` for proper
+cardinality handling.
 
 **Alternative using explicit patterns:**
 ```clojure
@@ -451,8 +491,6 @@ These make it suitable for production workloads despite the simpler feature set.
 
 **Consider alternatives for:**
 - Recursive/graph queries requiring rules
-- Strong schema enforcement needs
-- Cardinality-many attributes (not yet supported)
 - Distributed/multi-node requirements
 
 ## Getting Started
@@ -461,7 +499,7 @@ For Datomic users, the transition is straightforward:
 
 1. Most queries port directly, including Pull expressions
 2. Use subqueries for complex aggregations
-3. Handle schema validation in your application
-4. Use Pull API or explicit patterns for entity navigation
+3. Define schema for type validation and cardinality-many support
+4. Use Pull API with resolved patterns for entity navigation
 
 Most Datalog queries will work with minimal changes, making janus-datalog a practical choice for applications that need Datalog's power without Datomic's full complexity.

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -18,6 +18,7 @@
 ## Reference Documentation
 
 Configuration and optimization guides in `docs/reference/`:
+- **[SCHEMA.md](docs/reference/SCHEMA.md)** - Schema support: types, cardinality, uniqueness, Pull API integration
 - **[PLANNER_OPTIONS.md](docs/reference/PLANNER_OPTIONS.md)** - Complete planner options reference with performance guidance
 
 ## Current Work in Progress
@@ -39,6 +40,7 @@ Implementation notes organized by package in `docs/dev-notes/`:
 - `datalog/storage/` - Persistent storage layer (BadgerDB)
 - `datalog/parser/` - EDN and query parsing
 - `datalog/query/` - Query types and structures
+- `datalog/schema/` - Schema support (types, cardinality, uniqueness)
 
 ### Support Packages
 - `datalog/codec/` - L85 encoding and value serialization

--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -1,15 +1,16 @@
-a
+# PERFORMANCE_STATUS.md
 
-**Last Updated**: 2025-10-25
-**Version**: Clause-based planner, QueryExecutor, streaming architecture, and single-use iterator semantics
+**Last Updated**: 2025-12-17
+**Version**: Clause-based planner, QueryExecutor, streaming architecture, Pull API, and schema support
 
 ## Executive Summary
 
-The Janus Datalog engine delivers production-ready performance through architectural improvements and targeted optimizations. All performance claims in this document are verified by actual benchmarks run on 2025-10-25.
+The Janus Datalog engine delivers production-ready performance through architectural improvements and targeted optimizations. All performance claims in this document are verified by actual benchmarks (last updated 2025-12-17).
 
 ### Verified Performance Improvements
 - ✅ **New architecture** (clause-based planner + QueryExecutor): **2× faster** on complex OHLC queries (verified)
 - ✅ **Pull API**: **9× faster than equivalent queries**, linear scaling (verified 2025-12-17)
+- ✅ **Schema validation**: **<1% overhead** for type checking, **~6% overhead** for uniqueness (verified 2025-12-17)
 - ✅ **Iterator composition**: **4.06× speedup** (1,259μs → 310μs, 89% memory reduction) (verified 2025-10-25)
 - ✅ **Streaming execution**: **2.22× faster** with low-selectivity filters (1,720ms → 774ms), 52% memory reduction (verified 2025-10-25)
 - ✅ **Parallel subquery execution**: **2.06× speedup** with 8 workers on M3 Max (730ms → 355ms) (verified 2025-10-25)
@@ -302,7 +303,52 @@ for _, entity := range entities {
 }
 ```
 
-### 9. OHLC Query Performance (MEASURED 2025-10-25)
+### 9. Schema Validation Performance (MEASURED 2025-12-17)
+**Status**: ✅ Negligible overhead for type validation, minimal overhead for uniqueness
+**Performance**: Type validation **<1% write overhead**, uniqueness checking **~6% write overhead**
+**Location**: `datalog/schema/`, `datalog/storage/database.go`
+
+**Note**: All schema overhead is on the **write path only**. Reads are completely unaffected.
+
+**Type Validation Overhead** (Apple M4 Max, write path):
+| Benchmark | ns/op | allocs | Overhead |
+|-----------|-------|--------|----------|
+| Add without schema | 25,771 | 223 | baseline |
+| Add with schema | 25,768 | 225 | **<0.2%** |
+
+**Uniqueness Checking Overhead** (write path):
+| Benchmark | ns/op | allocs | Overhead |
+|-----------|-------|--------|----------|
+| Add without schema | 25,771 | 223 | baseline |
+| Add with uniqueness | 27,236 | 292 | **~5.8%** |
+
+**Bulk Operations (100 items/transaction)**:
+| Benchmark | ns/op | allocs | Overhead |
+|-----------|-------|--------|----------|
+| Bulk without schema | 1,388,000 | 17,115 | baseline |
+| Bulk with schema | 1,408,000 | 17,117 | **~1.4%** |
+
+**Schema Resolution (one-time cost per Pull pattern)**:
+| Operation | ns/op | allocs |
+|-----------|-------|--------|
+| Resolve 5-attr pattern with nested refs | 225 | 10 |
+
+**Pull with Cardinality-Many** (10 values):
+| Cardinality | ns/op | allocs |
+|-------------|-------|--------|
+| Cardinality-one (1 value) | 1,117 | 31 |
+| Cardinality-many (10 values) | 3,679 | 96 |
+
+**Key Findings**:
+- **Type validation is essentially free** - just a map lookup and type switch (write path)
+- **Uniqueness checking adds ~6% to writes** - requires database query to check existing values
+- **Reads are unaffected** - schema validation only impacts the write path
+- **Schema resolution is negligible** - 225ns one-time cost per Pull pattern
+- **Cardinality-many scales linearly** - ~370ns per additional value in Pull results
+
+**Recommendation**: Enable schema validation freely for type safety. Uniqueness constraints are worth the 6% write overhead for data integrity.
+
+### 10. OHLC Query Performance (MEASURED 2025-10-25)
 **Benchmark**: OHLC queries with subqueries and predicate pushdown
 
 **Subquery Performance** (BenchmarkOHLCSubqueries):
@@ -428,17 +474,18 @@ All items below are **measured** and **active** in production code:
 
 1. ✅ **New architecture** (clause-based planner + QueryExecutor) - **2× faster on complex queries** (verified 2025-10-24)
 2. ✅ **Pull API** - **9× faster than equivalent queries**, linear scaling (verified 2025-12-17)
-3. ✅ **Iterator composition** - **4.06× faster, 89% memory reduction** (verified 2025-10-25)
-4. ✅ **Parallel subquery execution** - **2.06× speedup with 8 workers** (verified 2025-10-25)
-5. ✅ **Intern cache optimization** - **6.26× speedup with BadgerDB**
-6. ✅ **Query plan caching** - **3× speedup for repeated queries**
-7. ✅ **Time range optimization** - **4× speedup on hourly OHLC**
-8. ✅ **Semantic rewriting** - **2-6× on time-filtered queries**
-9. ✅ **Predicate pushdown** - **1.58-2.78× faster** (scales with dataset size), **up to 91.5% memory reduction** (verified 2025-10-25)
-10. ✅ **Streaming execution** - **2.22× on low-selectivity filters, 52% memory reduction** (verified 2025-10-25)
-11. ✅ **Hash join pre-sizing** - **24-32% faster, 24-30% less memory**
-12. ✅ **In-memory indexing** - Hash indices now default path throughout codebase
-13. ✅ **Relation collapsing algorithm** - **Prevents catastrophic Cartesian products**
+3. ✅ **Schema validation** - **<1% overhead** for type checking, **~6%** for uniqueness (verified 2025-12-17)
+4. ✅ **Iterator composition** - **4.06× faster, 89% memory reduction** (verified 2025-10-25)
+5. ✅ **Parallel subquery execution** - **2.06× speedup with 8 workers** (verified 2025-10-25)
+6. ✅ **Intern cache optimization** - **6.26× speedup with BadgerDB**
+7. ✅ **Query plan caching** - **3× speedup for repeated queries**
+8. ✅ **Time range optimization** - **4× speedup on hourly OHLC**
+9. ✅ **Semantic rewriting** - **2-6× on time-filtered queries**
+10. ✅ **Predicate pushdown** - **1.58-2.78× faster** (scales with dataset size), **up to 91.5% memory reduction** (verified 2025-10-25)
+11. ✅ **Streaming execution** - **2.22× on low-selectivity filters, 52% memory reduction** (verified 2025-10-25)
+12. ✅ **Hash join pre-sizing** - **24-32% faster, 24-30% less memory**
+13. ✅ **In-memory indexing** - Hash indices now default path throughout codebase
+14. ✅ **Relation collapsing algorithm** - **Prevents catastrophic Cartesian products**
 
 ### Potential Future Work 🎯
 These are **ideas**, not commitments. Would require benchmarking before implementation:
@@ -583,6 +630,20 @@ The engine is **production-ready for datasets up to 10M+ datoms**. All major opt
 ---
 
 ## Session History
+
+### 2025-12-17: Schema Support Implementation & Benchmarking
+- Implemented Datomic-compatible schema support with type validation, cardinality, and uniqueness
+- Schema definable via EDN file or Go builder API (same internal representation)
+- Added plan-time resolution for Pull patterns (schema lookup once per pattern, not per entity)
+- Created comprehensive benchmark suite for schema performance
+- **Measured Results**:
+  - Type validation overhead: **<0.2%** (essentially free)
+  - Uniqueness checking overhead: **~5.8%** (requires database query)
+  - Bulk operations with schema: **~1.4%** overhead
+  - Schema resolution: **225ns** one-time cost per pattern
+  - Cardinality-many: ~370ns per additional value (linear scaling)
+- **Key Finding**: Schema validation is essentially free; use freely for type safety
+- **Files created**: `datalog/schema/` package, `docs/reference/SCHEMA.md`, `examples/schema_demo.go`
 
 ### 2025-12-17: Pull API Implementation & Benchmarking
 - Implemented Datomic-style Pull API with nested references and cycle detection

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Available examples:
 - `subquery_ohlc_demo.go` - Financial OHLC queries with subqueries
 - `financial_time_demo.go` - Time-based queries and as-of queries
 - `expression_demo.go` - Expression clauses and arithmetic
+- `schema_demo.go` - Schema validation, cardinality, and uniqueness
+- `pull_demo.go` - Pull API for entity attribute retrieval
 - And many more in `examples/`
 
 ## Tutorial
@@ -233,6 +235,64 @@ When you need scoped aggregations:
 ```
 
 The `q` function runs a sub-query with its own `:find` and `:where` clauses. Results bind to the outer query.
+
+### Schema (Optional)
+
+Schema is **completely optional** but provides type safety and cardinality-many support:
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/schema"
+
+// Define schema with builder API
+s, _ := schema.NewBuilder().
+    Attribute(":user/name").Type(schema.TypeString).Add().
+    Attribute(":user/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+    Attribute(":user/tags").Type(schema.TypeString).Many().Add().
+    Build()
+
+// Create database with schema
+db, _ := storage.NewDatabaseWithSchema("my.db", s)
+```
+
+**What schema gives you:**
+- **Type validation** at `Add()` time – catch type errors immediately
+- **Uniqueness constraints** at `Commit()` time – enforce data integrity
+- **Cardinality-many** – Pull API returns arrays instead of single values
+
+**Performance:** <1% write overhead for type checking, ~6% for uniqueness. Reads unaffected.
+
+Or define schema via EDN file:
+
+```clojure
+{:user/name   {:db/valueType :db.type/string}
+ :user/email  {:db/valueType :db.type/string
+               :db/unique    :db.unique/value}
+ :user/tags   {:db/valueType   :db.type/string
+               :db/cardinality :db.cardinality/many}}
+```
+
+See [docs/reference/SCHEMA.md](docs/reference/SCHEMA.md) for complete documentation.
+
+### Pull API
+
+Retrieve entity attributes declaratively:
+
+```go
+// In queries
+[:find (pull ?user [:user/name :user/age])
+ :where [?user :user/active true]]
+
+// Standalone
+result, _ := db.Pull(userId, `[:user/name :user/email {:user/friends [:user/name]}]`)
+```
+
+**Features:**
+- Nested reference following with cycle detection
+- Wildcard `[*]` for all attributes
+- Default values: `(default :attr "fallback")`
+- **9× faster than equivalent queries**
+
+See [DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md) for Pull API details.
 
 ## What Makes Janus Different
 
@@ -565,7 +625,6 @@ We welcome contributions! Here's how to get started:
 
 **Areas where we'd love help:**
 
-- Schema management and constraints
 - Additional aggregation functions (e.g., distinct, median)
 - WASM build support
 - Query optimization with statistics (for SQL-style workloads)
@@ -575,7 +634,7 @@ We welcome contributions! Here's how to get started:
 
 ## Datomic Compatibility
 
-Janus implements **~40-50% of Datomic's feature set**, focusing on the most commonly used features:
+Janus implements **~50-60% of Datomic's feature set**, focusing on the most commonly used features:
 
 **Implemented:**
 - Core queries: Patterns, joins, variables
@@ -583,13 +642,14 @@ Janus implements **~40-50% of Datomic's feature set**, focusing on the most comm
 - Aggregations: sum, count, avg, min, max
 - Subqueries: Full q support
 - Time queries: as-of, time functions
+- Pull API: Nested references, cycle detection, wildcards
+- Schema: Type validation, cardinality, uniqueness constraints
 - Storage: Persistent BadgerDB backend
 
 **Not implemented:**
-- Pull API
-- Transactions with rules
+- Rules and recursive queries
+- NOT/OR clauses
 - Full-text search
-- Schema constraints
 - Distributed transactions
 
 See [DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md) for the complete compatibility matrix.
@@ -601,14 +661,15 @@ See [DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md) for the complete compat
 **Production Ready:**
 
 - Core query engine complete and tested
+- Pull API with nested references and cycle detection
+- Schema support: type validation, cardinality, uniqueness
 - Persistent storage with BadgerDB
 - Comprehensive test suite (1.28:1 test-to-code ratio)
 - Used in production for financial analysis
 
 **In Progress:**
 
-- Schema management and attribute constraints
-- Additional aggregation functions
+- Additional aggregation functions (distinct, median)
 
 **Future Work:**
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,8 @@
 - Subqueries with proper scoping (semantically correct)
 - Order-by clause with multi-column sorting
 - Time extraction functions
-- **Pull API with nested references and cycle detection**
+- **Pull API with nested references and cycle detection (9× faster than queries)**
+- **Schema support: type validation, cardinality, uniqueness (<1% write overhead)**
 - **True streaming execution (2.22× speedup, 52% memory reduction, up to 91.5% on large datasets)**
 - **Iterator composition with lazy evaluation (4.06× speedup)**
 - **Parallel subquery execution (2.06× speedup with 8 workers)**
@@ -93,9 +94,10 @@ The engine is **functionally complete, semantically correct, and memory-efficien
 
 These require fundamental architecture changes:
 - Full Datomic compatibility (different philosophy)
-- Schema enforcement (designed to be schema-less)
-- Time-travel queries (would need different storage)
+- Full history/time-travel queries (would need different storage model)
 - Lazy evaluation throughout (Go doesn't support well)
+
+**Note:** Schema support was added in Dec 2025 as an optional, additive feature. See `docs/reference/SCHEMA.md`.
 
 ## Success Metrics
 

--- a/datalog/executor/pull.go
+++ b/datalog/executor/pull.go
@@ -236,3 +236,221 @@ func (pe *PullExecutor) PullMany(entities []datalog.Identity, pattern *query.Pul
 	}
 	return results, nil
 }
+
+// ============================================================================
+// Resolved Pull Pattern Methods
+// ============================================================================
+//
+// These methods work with pre-resolved patterns that have cardinality/ref info
+// baked in from schema resolution.
+
+// PullResolved executes a resolved pull pattern for a single entity
+// Uses pre-resolved cardinality info for proper handling of many-valued attributes
+func (pe *PullExecutor) PullResolved(entity datalog.Identity, pattern *query.ResolvedPullPattern) (map[string]interface{}, error) {
+	visited := make(map[[20]byte]bool)
+	return pe.pullResolvedWithVisited(entity, pattern, visited)
+}
+
+// pullResolvedWithVisited executes a resolved pull pattern with cycle detection
+func (pe *PullExecutor) pullResolvedWithVisited(entity datalog.Identity, pattern *query.ResolvedPullPattern, visited map[[20]byte]bool) (map[string]interface{}, error) {
+	if pattern == nil {
+		return nil, nil
+	}
+
+	// Check for cycle using entity hash
+	entityHash := entity.Hash()
+	if visited[entityHash] {
+		return nil, nil // Cycle detected, stop recursion
+	}
+	visited[entityHash] = true
+	defer delete(visited, entityHash) // Allow revisiting from different paths
+
+	result := make(map[string]interface{})
+
+	for _, spec := range pattern.Specs {
+		if err := pe.processResolvedSpec(entity, spec, result, visited); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
+// processResolvedSpec processes a single resolved pull spec
+func (pe *PullExecutor) processResolvedSpec(entity datalog.Identity, spec query.ResolvedPullAttrSpec, result map[string]interface{}, visited map[[20]byte]bool) error {
+	switch s := spec.(type) {
+	case *query.ResolvedPullAttribute:
+		if s.IsMany {
+			// Cardinality-many: get all values as array
+			values := pe.lookupAllValues(entity, s.Attr)
+			if len(values) > 0 {
+				result[query.KeyName(s.Attr)] = values
+			}
+		} else {
+			// Cardinality-one: get single value
+			if val, ok := pe.lookupAttribute(entity, s.Attr); ok {
+				result[query.KeyName(s.Attr)] = val
+			}
+		}
+
+	case *query.ResolvedPullWildcard:
+		// Get all attributes for entity (same as unresolved)
+		datoms, err := pe.getAllAttributes(entity)
+		if err != nil {
+			return fmt.Errorf("wildcard pull failed: %w", err)
+		}
+		for _, datom := range datoms {
+			result[query.KeyName(datom.A)] = datom.V
+		}
+
+	case *query.ResolvedPullMapSpec:
+		if s.IsMany {
+			// Cardinality-many reference: follow all refs and pull nested
+			refs := pe.lookupAllValues(entity, s.Attr)
+			if len(refs) > 0 {
+				nestedResults := make([]interface{}, 0, len(refs))
+				for _, refVal := range refs {
+					if refEntity, ok := getIdentity(refVal); ok {
+						nested, err := pe.pullResolvedWithVisited(refEntity, s.Pattern, visited)
+						if err != nil {
+							return fmt.Errorf("nested pull for %s failed: %w", s.Attr.String(), err)
+						}
+						if nested != nil {
+							nestedResults = append(nestedResults, nested)
+						}
+					}
+				}
+				if len(nestedResults) > 0 {
+					result[query.KeyName(s.Attr)] = nestedResults
+				}
+			}
+		} else {
+			// Cardinality-one reference: follow single ref
+			if refVal, ok := pe.lookupAttribute(entity, s.Attr); ok {
+				if refEntity, ok := getIdentity(refVal); ok {
+					nested, err := pe.pullResolvedWithVisited(refEntity, s.Pattern, visited)
+					if err != nil {
+						return fmt.Errorf("nested pull for %s failed: %w", s.Attr.String(), err)
+					}
+					if nested != nil {
+						result[query.KeyName(s.Attr)] = nested
+					}
+				}
+			}
+		}
+
+	case *query.ResolvedPullLimitExpr:
+		if s.IsMany {
+			// Get all values and apply limit
+			values := pe.lookupAllValues(entity, s.Attr)
+			if len(values) > s.Limit {
+				values = values[:s.Limit]
+			}
+			if len(values) > 0 {
+				result[query.KeyName(s.Attr)] = values
+			}
+		} else {
+			// Cardinality-one: limit doesn't really apply
+			if val, ok := pe.lookupAttribute(entity, s.Attr); ok {
+				result[query.KeyName(s.Attr)] = val
+			}
+		}
+
+	case *query.ResolvedPullDefaultExpr:
+		if s.IsMany {
+			// Cardinality-many with default
+			values := pe.lookupAllValues(entity, s.Attr)
+			if len(values) > 0 {
+				result[query.KeyName(s.Attr)] = values
+			} else {
+				result[query.KeyName(s.Attr)] = s.Default
+			}
+		} else {
+			// Cardinality-one with default
+			if val, ok := pe.lookupAttribute(entity, s.Attr); ok {
+				result[query.KeyName(s.Attr)] = val
+			} else {
+				result[query.KeyName(s.Attr)] = s.Default
+			}
+		}
+
+	default:
+		return fmt.Errorf("unknown resolved pull spec type: %T", spec)
+	}
+
+	return nil
+}
+
+// lookupAllValues retrieves all values for a cardinality-many attribute
+func (pe *PullExecutor) lookupAllValues(entity datalog.Identity, attr datalog.Keyword) []interface{} {
+	// Create pattern: [entity attr ?v] - gets all values for this attribute
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: "?v"},
+		},
+	}
+
+	rel, err := pe.matcher.Match(pattern, nil)
+	if err != nil || rel == nil {
+		return nil
+	}
+
+	// Find value column index
+	cols := rel.Columns()
+	vIdx := -1
+	for i, col := range cols {
+		if col == "?v" {
+			vIdx = i
+			break
+		}
+	}
+
+	if vIdx < 0 {
+		return nil
+	}
+
+	// Collect all values
+	var values []interface{}
+	it := rel.Iterator()
+	defer it.Close()
+
+	for it.Next() {
+		tuple := it.Tuple()
+		if vIdx < len(tuple) {
+			values = append(values, tuple[vIdx])
+		}
+	}
+
+	return values
+}
+
+// PullResolvedMany executes a resolved pull pattern for multiple entities
+func (pe *PullExecutor) PullResolvedMany(entities []datalog.Identity, pattern *query.ResolvedPullPattern) ([]map[string]interface{}, error) {
+	results := make([]map[string]interface{}, len(entities))
+	for i, entity := range entities {
+		result, err := pe.PullResolved(entity, pattern)
+		if err != nil {
+			return nil, fmt.Errorf("pull failed for entity %d: %w", i, err)
+		}
+		results[i] = result
+	}
+	return results, nil
+}
+
+// getIdentity extracts an Identity from a value (handles both value and pointer types)
+func getIdentity(val interface{}) (datalog.Identity, bool) {
+	switch v := val.(type) {
+	case datalog.Identity:
+		return v, true
+	case *datalog.Identity:
+		if v != nil {
+			return *v, true
+		}
+	}
+	return datalog.Identity{}, false
+}

--- a/datalog/query/pull.go
+++ b/datalog/query/pull.go
@@ -115,3 +115,111 @@ func KeyName(k datalog.Keyword) string {
 	}
 	return s
 }
+
+// ============================================================================
+// Resolved Pull Types
+// ============================================================================
+//
+// These types represent pull patterns with cardinality/ref info pre-resolved
+// from schema. Schema lookups happen once when resolving the pattern, not
+// per-entity during execution.
+
+// ResolvedPullPattern has cardinality/ref info baked in from schema resolution
+type ResolvedPullPattern struct {
+	Specs []ResolvedPullAttrSpec
+}
+
+// String returns the string representation of the resolved pull pattern
+func (p *ResolvedPullPattern) String() string {
+	if p == nil {
+		return "[]"
+	}
+	var parts []string
+	for _, spec := range p.Specs {
+		parts = append(parts, spec.String())
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+// ResolvedPullAttrSpec is the interface for resolved pull attribute specifications
+type ResolvedPullAttrSpec interface {
+	isResolvedPullAttrSpec()
+	String() string
+}
+
+// ResolvedPullAttribute represents a resolved simple attribute with cardinality info
+type ResolvedPullAttribute struct {
+	Attr   datalog.Keyword
+	IsMany bool // From schema, or false if unknown
+	IsRef  bool // From schema, or detected from value type
+}
+
+func (r *ResolvedPullAttribute) isResolvedPullAttrSpec() {}
+
+func (r *ResolvedPullAttribute) String() string {
+	suffix := ""
+	if r.IsMany {
+		suffix += "[many]"
+	}
+	if r.IsRef {
+		suffix += "[ref]"
+	}
+	return r.Attr.String() + suffix
+}
+
+// ResolvedPullWildcard represents a resolved wildcard
+type ResolvedPullWildcard struct {
+	// No additional info needed - wildcard pulls all attributes
+	// Individual attributes will be resolved at execution time
+}
+
+func (r *ResolvedPullWildcard) isResolvedPullAttrSpec() {}
+
+func (r *ResolvedPullWildcard) String() string {
+	return "*"
+}
+
+// ResolvedPullMapSpec represents a resolved reference follow specification
+type ResolvedPullMapSpec struct {
+	Attr    datalog.Keyword
+	IsMany  bool                 // Cardinality of the ref attribute
+	Pattern *ResolvedPullPattern // Nested pattern, also resolved
+}
+
+func (r *ResolvedPullMapSpec) isResolvedPullAttrSpec() {}
+
+func (r *ResolvedPullMapSpec) String() string {
+	suffix := ""
+	if r.IsMany {
+		suffix = "[many]"
+	}
+	return fmt.Sprintf("{%s%s %s}", r.Attr.String(), suffix, r.Pattern.String())
+}
+
+// ResolvedPullLimitExpr represents a resolved limit expression
+type ResolvedPullLimitExpr struct {
+	Attr   datalog.Keyword
+	Limit  int
+	IsMany bool // From schema
+	IsRef  bool // From schema
+}
+
+func (r *ResolvedPullLimitExpr) isResolvedPullAttrSpec() {}
+
+func (r *ResolvedPullLimitExpr) String() string {
+	return fmt.Sprintf("(limit %s %d)", r.Attr.String(), r.Limit)
+}
+
+// ResolvedPullDefaultExpr represents a resolved default expression
+type ResolvedPullDefaultExpr struct {
+	Attr    datalog.Keyword
+	Default interface{}
+	IsMany  bool // From schema
+	IsRef   bool // From schema
+}
+
+func (r *ResolvedPullDefaultExpr) isResolvedPullAttrSpec() {}
+
+func (r *ResolvedPullDefaultExpr) String() string {
+	return fmt.Sprintf("(default %s %v)", r.Attr.String(), r.Default)
+}

--- a/datalog/schema/builder.go
+++ b/datalog/schema/builder.go
@@ -1,0 +1,107 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// Builder provides fluent schema construction
+//
+// Example usage:
+//
+//	schema, err := schema.NewBuilder().
+//	    Attribute(":person/name").Type(schema.TypeString).Add().
+//	    Attribute(":person/friends").Type(schema.TypeRef).Many().Add().
+//	    Attribute(":person/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+//	    Build()
+type Builder struct {
+	schema *Schema
+	errors []error
+}
+
+// NewBuilder creates a new schema builder
+func NewBuilder() *Builder {
+	return &Builder{
+		schema: NewSchema(),
+	}
+}
+
+// Attribute starts defining a new attribute
+func (b *Builder) Attribute(ident string) *AttributeBuilder {
+	return &AttributeBuilder{
+		parent: b,
+		def: &AttributeDefinition{
+			Ident:       datalog.NewKeyword(ident),
+			Cardinality: CardinalityOne, // Default
+		},
+	}
+}
+
+// Build finalizes and returns the schema
+// Returns error if any attribute definitions were invalid
+func (b *Builder) Build() (*Schema, error) {
+	if len(b.errors) > 0 {
+		return nil, fmt.Errorf("schema errors: %v", b.errors)
+	}
+	return b.schema, nil
+}
+
+// MustBuild is like Build but panics on error
+// Useful for static schema definitions
+func (b *Builder) MustBuild() *Schema {
+	s, err := b.Build()
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// AttributeBuilder provides fluent attribute construction
+type AttributeBuilder struct {
+	parent *Builder
+	def    *AttributeDefinition
+}
+
+// Type sets the value type for the attribute
+func (ab *AttributeBuilder) Type(t ValueType) *AttributeBuilder {
+	ab.def.ValueType = t
+	return ab
+}
+
+// One sets cardinality to one (default)
+func (ab *AttributeBuilder) One() *AttributeBuilder {
+	ab.def.Cardinality = CardinalityOne
+	return ab
+}
+
+// Many sets cardinality to many
+func (ab *AttributeBuilder) Many() *AttributeBuilder {
+	ab.def.Cardinality = CardinalityMany
+	return ab
+}
+
+// Unique sets the uniqueness constraint
+func (ab *AttributeBuilder) Unique(u Unique) *AttributeBuilder {
+	ab.def.Unique = u
+	return ab
+}
+
+// Doc sets the documentation string
+func (ab *AttributeBuilder) Doc(doc string) *AttributeBuilder {
+	ab.def.Doc = doc
+	return ab
+}
+
+// Add finalizes this attribute and adds it to the schema
+// Returns the builder for chaining more attributes
+func (ab *AttributeBuilder) Add() *Builder {
+	// Validate attribute definition
+	if ab.def.Ident.String() == "" {
+		ab.parent.errors = append(ab.parent.errors, fmt.Errorf("attribute ident is required"))
+		return ab.parent
+	}
+
+	ab.parent.schema.Add(ab.def)
+	return ab.parent
+}

--- a/datalog/schema/parser.go
+++ b/datalog/schema/parser.go
@@ -1,0 +1,194 @@
+package schema
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/edn"
+)
+
+// ParseSchema parses an EDN schema definition string
+//
+// Example input:
+//
+//	{:person/name   {:db/valueType   :db.type/string
+//	                 :db/cardinality :db.cardinality/one}
+//	 :person/friends {:db/valueType   :db.type/ref
+//	                  :db/cardinality :db.cardinality/many}}
+func ParseSchema(input string) (*Schema, error) {
+	node, err := edn.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("EDN parse error: %w", err)
+	}
+
+	return parseSchemaNode(node)
+}
+
+// ParseSchemaFile parses a schema from a file
+func ParseSchemaFile(path string) (*Schema, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read schema file: %w", err)
+	}
+	return ParseSchema(string(data))
+}
+
+// parseSchemaNode parses a schema from an EDN node
+func parseSchemaNode(node *edn.Node) (*Schema, error) {
+	if node.Type != edn.NodeMap {
+		return nil, fmt.Errorf("schema must be a map, got %v", node.Type)
+	}
+
+	schema := NewSchema()
+
+	// Map nodes have alternating key-value pairs in Nodes slice
+	if len(node.Nodes)%2 != 0 {
+		return nil, fmt.Errorf("schema map has odd number of elements")
+	}
+
+	for i := 0; i < len(node.Nodes); i += 2 {
+		keyNode := &node.Nodes[i]
+		valueNode := &node.Nodes[i+1]
+
+		if keyNode.Type != edn.NodeKeyword {
+			return nil, fmt.Errorf("attribute ident must be keyword at line %d, got %v",
+				keyNode.Line, keyNode.Type)
+		}
+
+		def, err := parseAttributeDefinition(keyNode.Value, valueNode)
+		if err != nil {
+			return nil, fmt.Errorf("invalid attribute %s at line %d: %w",
+				keyNode.Value, keyNode.Line, err)
+		}
+
+		schema.Add(def)
+	}
+
+	return schema, nil
+}
+
+// parseAttributeDefinition parses a single attribute definition from EDN
+func parseAttributeDefinition(ident string, node *edn.Node) (*AttributeDefinition, error) {
+	if node.Type != edn.NodeMap {
+		return nil, fmt.Errorf("attribute definition must be a map, got %v", node.Type)
+	}
+
+	def := &AttributeDefinition{
+		Ident:       datalog.NewKeyword(ident),
+		Cardinality: CardinalityOne, // Default
+	}
+
+	// Parse map entries
+	if len(node.Nodes)%2 != 0 {
+		return nil, fmt.Errorf("attribute definition map has odd number of elements")
+	}
+
+	for i := 0; i < len(node.Nodes); i += 2 {
+		keyNode := &node.Nodes[i]
+		valueNode := &node.Nodes[i+1]
+
+		if keyNode.Type != edn.NodeKeyword {
+			continue // Skip non-keyword keys
+		}
+
+		switch keyNode.Value {
+		case ":db/valueType":
+			vt, err := parseValueType(valueNode)
+			if err != nil {
+				return nil, fmt.Errorf(":db/valueType error: %w", err)
+			}
+			def.ValueType = vt
+
+		case ":db/cardinality":
+			card, err := parseCardinality(valueNode)
+			if err != nil {
+				return nil, fmt.Errorf(":db/cardinality error: %w", err)
+			}
+			def.Cardinality = card
+
+		case ":db/unique":
+			uniq, err := parseUnique(valueNode)
+			if err != nil {
+				return nil, fmt.Errorf(":db/unique error: %w", err)
+			}
+			def.Unique = uniq
+
+		case ":db/doc":
+			if valueNode.Type != edn.NodeString {
+				return nil, fmt.Errorf(":db/doc must be string, got %v", valueNode.Type)
+			}
+			def.Doc = valueNode.Value
+		}
+	}
+
+	return def, nil
+}
+
+// parseValueType parses a :db/valueType keyword
+func parseValueType(node *edn.Node) (ValueType, error) {
+	if node.Type != edn.NodeKeyword {
+		return "", fmt.Errorf("must be keyword, got %v", node.Type)
+	}
+
+	// Remove leading colon and convert to our format
+	val := strings.TrimPrefix(node.Value, ":")
+
+	switch val {
+	case "db.type/string":
+		return TypeString, nil
+	case "db.type/long":
+		return TypeLong, nil
+	case "db.type/double":
+		return TypeDouble, nil
+	case "db.type/boolean":
+		return TypeBoolean, nil
+	case "db.type/instant":
+		return TypeInstant, nil
+	case "db.type/bytes":
+		return TypeBytes, nil
+	case "db.type/ref":
+		return TypeRef, nil
+	case "db.type/keyword":
+		return TypeKeyword, nil
+	default:
+		return "", fmt.Errorf("unknown value type: %s", node.Value)
+	}
+}
+
+// parseCardinality parses a :db/cardinality keyword
+func parseCardinality(node *edn.Node) (Cardinality, error) {
+	if node.Type != edn.NodeKeyword {
+		return "", fmt.Errorf("must be keyword, got %v", node.Type)
+	}
+
+	val := strings.TrimPrefix(node.Value, ":")
+
+	switch val {
+	case "db.cardinality/one":
+		return CardinalityOne, nil
+	case "db.cardinality/many":
+		return CardinalityMany, nil
+	default:
+		return "", fmt.Errorf("unknown cardinality: %s", node.Value)
+	}
+}
+
+// parseUnique parses a :db/unique keyword
+func parseUnique(node *edn.Node) (Unique, error) {
+	if node.Type != edn.NodeKeyword {
+		return "", fmt.Errorf("must be keyword, got %v", node.Type)
+	}
+
+	val := strings.TrimPrefix(node.Value, ":")
+
+	switch val {
+	case "db.unique/value":
+		return UniqueValue, nil
+	case "db.unique/identity":
+		return UniqueIdentity, nil
+	default:
+		return "", fmt.Errorf("unknown unique constraint: %s", node.Value)
+	}
+}

--- a/datalog/schema/parser_test.go
+++ b/datalog/schema/parser_test.go
@@ -1,0 +1,221 @@
+package schema
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSchemaBasic(t *testing.T) {
+	input := `{:person/name {:db/valueType :db.type/string}}`
+
+	schema, err := ParseSchema(input)
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+
+	def := schema.GetAttribute(kw(":person/name"))
+	require.NotNil(t, def)
+	assert.Equal(t, TypeString, def.ValueType)
+	assert.Equal(t, CardinalityOne, def.Cardinality) // Default
+}
+
+func TestParseSchemaMultipleAttributes(t *testing.T) {
+	input := `{:person/name   {:db/valueType   :db.type/string
+                  :db/cardinality :db.cardinality/one}
+ :person/age    {:db/valueType   :db.type/long
+                  :db/cardinality :db.cardinality/one}
+ :person/friends {:db/valueType   :db.type/ref
+                   :db/cardinality :db.cardinality/many}}`
+
+	schema, err := ParseSchema(input)
+	require.NoError(t, err)
+	assert.Equal(t, 3, schema.Count())
+
+	// Check name
+	name := schema.GetAttribute(kw(":person/name"))
+	require.NotNil(t, name)
+	assert.Equal(t, TypeString, name.ValueType)
+	assert.Equal(t, CardinalityOne, name.Cardinality)
+
+	// Check age
+	age := schema.GetAttribute(kw(":person/age"))
+	require.NotNil(t, age)
+	assert.Equal(t, TypeLong, age.ValueType)
+
+	// Check friends
+	friends := schema.GetAttribute(kw(":person/friends"))
+	require.NotNil(t, friends)
+	assert.Equal(t, TypeRef, friends.ValueType)
+	assert.Equal(t, CardinalityMany, friends.Cardinality)
+	assert.True(t, schema.IsRef(kw(":person/friends")))
+	assert.True(t, schema.IsMany(kw(":person/friends")))
+}
+
+func TestParseSchemaAllTypes(t *testing.T) {
+	input := `{:test/string  {:db/valueType :db.type/string}
+ :test/long    {:db/valueType :db.type/long}
+ :test/double  {:db/valueType :db.type/double}
+ :test/boolean {:db/valueType :db.type/boolean}
+ :test/instant {:db/valueType :db.type/instant}
+ :test/bytes   {:db/valueType :db.type/bytes}
+ :test/ref     {:db/valueType :db.type/ref}
+ :test/keyword {:db/valueType :db.type/keyword}}`
+
+	schema, err := ParseSchema(input)
+	require.NoError(t, err)
+	assert.Equal(t, 8, schema.Count())
+
+	assert.Equal(t, TypeString, schema.GetAttribute(kw(":test/string")).ValueType)
+	assert.Equal(t, TypeLong, schema.GetAttribute(kw(":test/long")).ValueType)
+	assert.Equal(t, TypeDouble, schema.GetAttribute(kw(":test/double")).ValueType)
+	assert.Equal(t, TypeBoolean, schema.GetAttribute(kw(":test/boolean")).ValueType)
+	assert.Equal(t, TypeInstant, schema.GetAttribute(kw(":test/instant")).ValueType)
+	assert.Equal(t, TypeBytes, schema.GetAttribute(kw(":test/bytes")).ValueType)
+	assert.Equal(t, TypeRef, schema.GetAttribute(kw(":test/ref")).ValueType)
+	assert.Equal(t, TypeKeyword, schema.GetAttribute(kw(":test/keyword")).ValueType)
+}
+
+func TestParseSchemaWithUnique(t *testing.T) {
+	input := `{:user/email {:db/valueType :db.type/string
+                :db/unique :db.unique/value}
+ :user/id    {:db/valueType :db.type/string
+               :db/unique :db.unique/identity}}`
+
+	schema, err := ParseSchema(input)
+	require.NoError(t, err)
+
+	email := schema.GetAttribute(kw(":user/email"))
+	require.NotNil(t, email)
+	assert.Equal(t, UniqueValue, email.Unique)
+
+	id := schema.GetAttribute(kw(":user/id"))
+	require.NotNil(t, id)
+	assert.Equal(t, UniqueIdentity, id.Unique)
+}
+
+func TestParseSchemaWithDoc(t *testing.T) {
+	input := `{:person/name {:db/valueType :db.type/string
+                :db/doc "The person's full name"}}`
+
+	schema, err := ParseSchema(input)
+	require.NoError(t, err)
+
+	name := schema.GetAttribute(kw(":person/name"))
+	require.NotNil(t, name)
+	assert.Equal(t, "The person's full name", name.Doc)
+}
+
+func TestParseSchemaComplex(t *testing.T) {
+	// Real-world style schema
+	input := `{:user/id       {:db/valueType   :db.type/string
+                  :db/unique      :db.unique/identity
+                  :db/cardinality :db.cardinality/one
+                  :db/doc         "User identifier"}
+ :user/name     {:db/valueType   :db.type/string
+                  :db/cardinality :db.cardinality/one}
+ :user/email    {:db/valueType   :db.type/string
+                  :db/unique      :db.unique/value}
+ :user/friends  {:db/valueType   :db.type/ref
+                  :db/cardinality :db.cardinality/many
+                  :db/doc         "References to friend users"}
+ :user/created  {:db/valueType   :db.type/instant}}`
+
+	schema, err := ParseSchema(input)
+	require.NoError(t, err)
+	assert.Equal(t, 5, schema.Count())
+
+	id := schema.GetAttribute(kw(":user/id"))
+	assert.Equal(t, TypeString, id.ValueType)
+	assert.Equal(t, UniqueIdentity, id.Unique)
+	assert.Equal(t, "User identifier", id.Doc)
+
+	friends := schema.GetAttribute(kw(":user/friends"))
+	assert.True(t, schema.IsRef(kw(":user/friends")))
+	assert.True(t, schema.IsMany(kw(":user/friends")))
+	assert.Equal(t, "References to friend users", friends.Doc)
+}
+
+func TestParseSchemaErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "not a map",
+			input: `[:person/name]`,
+			want:  "must be a map",
+		},
+		{
+			name:  "non-keyword ident",
+			input: `{"person/name" {:db/valueType :db.type/string}}`,
+			want:  "must be keyword",
+		},
+		{
+			name:  "invalid value type",
+			input: `{:person/name {:db/valueType :db.type/invalid}}`,
+			want:  "unknown value type",
+		},
+		{
+			name:  "invalid cardinality",
+			input: `{:person/name {:db/cardinality :db.cardinality/invalid}}`,
+			want:  "unknown cardinality",
+		},
+		{
+			name:  "invalid unique",
+			input: `{:person/name {:db/unique :db.unique/invalid}}`,
+			want:  "unknown unique",
+		},
+		{
+			name:  "doc not string",
+			input: `{:person/name {:db/doc 123}}`,
+			want:  "must be string",
+		},
+		{
+			name:  "valueType not keyword",
+			input: `{:person/name {:db/valueType "string"}}`,
+			want:  "must be keyword",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSchema(tt.input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestParseSchemaFile(t *testing.T) {
+	// Create temp file
+	tmpDir := t.TempDir()
+	schemaFile := filepath.Join(tmpDir, "schema.edn")
+
+	content := `{:person/name {:db/valueType :db.type/string}
+ :person/age  {:db/valueType :db.type/long}}`
+
+	err := os.WriteFile(schemaFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	schema, err := ParseSchemaFile(schemaFile)
+	require.NoError(t, err)
+	assert.Equal(t, 2, schema.Count())
+	assert.Equal(t, TypeString, schema.GetAttribute(kw(":person/name")).ValueType)
+}
+
+func TestParseSchemaFileNotFound(t *testing.T) {
+	_, err := ParseSchemaFile("/nonexistent/path/schema.edn")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read schema file")
+}
+
+func TestParseSchemaEmptyMap(t *testing.T) {
+	schema, err := ParseSchema(`{}`)
+	require.NoError(t, err)
+	assert.False(t, schema.HasSchema())
+	assert.Equal(t, 0, schema.Count())
+}

--- a/datalog/schema/provider.go
+++ b/datalog/schema/provider.go
@@ -1,0 +1,24 @@
+package schema
+
+import (
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// SchemaProvider provides read-only access to schema information
+// This interface is consumed by Transaction validation, Pull API, etc.
+type SchemaProvider interface {
+	// GetAttribute returns the definition for an attribute, or nil if unknown
+	GetAttribute(attr datalog.Keyword) *AttributeDefinition
+
+	// HasSchema returns true if a schema is available
+	HasSchema() bool
+
+	// IsRef returns true if the attribute is a reference type
+	IsRef(attr datalog.Keyword) bool
+
+	// IsMany returns true if the attribute has cardinality many
+	IsMany(attr datalog.Keyword) bool
+}
+
+// Verify Schema implements SchemaProvider at compile time
+var _ SchemaProvider = (*Schema)(nil)

--- a/datalog/schema/resolve.go
+++ b/datalog/schema/resolve.go
@@ -1,0 +1,69 @@
+package schema
+
+import "github.com/wbrown/janus-datalog/datalog/query"
+
+// ResolvePullPattern annotates a PullPattern with schema info (cardinality, ref status)
+// Schema lookups happen once during resolution, not per-entity during execution.
+// If schema is nil or doesn't define an attribute, defaults are used (cardinality-one, not ref).
+func ResolvePullPattern(pattern *query.PullPattern, s SchemaProvider) *query.ResolvedPullPattern {
+	if pattern == nil {
+		return nil
+	}
+	resolved := &query.ResolvedPullPattern{
+		Specs: make([]query.ResolvedPullAttrSpec, 0, len(pattern.Specs)),
+	}
+	for _, spec := range pattern.Specs {
+		resolved.Specs = append(resolved.Specs, resolveSpec(spec, s))
+	}
+	return resolved
+}
+
+// resolveSpec converts a single PullAttrSpec to its resolved form
+func resolveSpec(spec query.PullAttrSpec, s SchemaProvider) query.ResolvedPullAttrSpec {
+	switch sp := spec.(type) {
+	case *query.PullAttribute:
+		isMany := s != nil && s.IsMany(sp.Attr)
+		isRef := s != nil && s.IsRef(sp.Attr)
+		return &query.ResolvedPullAttribute{
+			Attr:   sp.Attr,
+			IsMany: isMany,
+			IsRef:  isRef,
+		}
+
+	case *query.PullWildcard:
+		return &query.ResolvedPullWildcard{}
+
+	case *query.PullMapSpec:
+		isMany := s != nil && s.IsMany(sp.Attr)
+		// Map specs are always refs (they follow a reference)
+		return &query.ResolvedPullMapSpec{
+			Attr:    sp.Attr,
+			IsMany:  isMany,
+			Pattern: ResolvePullPattern(sp.Pattern, s),
+		}
+
+	case *query.PullLimitExpr:
+		isMany := s != nil && s.IsMany(sp.Attr)
+		isRef := s != nil && s.IsRef(sp.Attr)
+		return &query.ResolvedPullLimitExpr{
+			Attr:   sp.Attr,
+			Limit:  sp.Limit,
+			IsMany: isMany,
+			IsRef:  isRef,
+		}
+
+	case *query.PullDefaultExpr:
+		isMany := s != nil && s.IsMany(sp.Attr)
+		isRef := s != nil && s.IsRef(sp.Attr)
+		return &query.ResolvedPullDefaultExpr{
+			Attr:    sp.Attr,
+			Default: sp.Default,
+			IsMany:  isMany,
+			IsRef:   isRef,
+		}
+
+	default:
+		// Unknown spec type, return nil (shouldn't happen)
+		return nil
+	}
+}

--- a/datalog/schema/resolve_test.go
+++ b/datalog/schema/resolve_test.go
@@ -1,0 +1,204 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// kw helper is defined in schema_test.go
+
+func TestResolvePullPatternNilPattern(t *testing.T) {
+	schema, _ := NewBuilder().
+		Attribute(":person/name").Type(TypeString).Add().
+		Build()
+
+	resolved := ResolvePullPattern(nil, schema)
+	assert.Nil(t, resolved)
+}
+
+func TestResolvePullPatternNilSchema(t *testing.T) {
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: kw(":person/name")},
+			&query.PullAttribute{Attr: kw(":person/friends")},
+		},
+	}
+
+	// With nil schema, all attributes default to cardinality-one, not ref
+	resolved := ResolvePullPattern(pattern, nil)
+	require.NotNil(t, resolved)
+	require.Len(t, resolved.Specs, 2)
+
+	nameSpec := resolved.Specs[0].(*query.ResolvedPullAttribute)
+	assert.Equal(t, kw(":person/name"), nameSpec.Attr)
+	assert.False(t, nameSpec.IsMany)
+	assert.False(t, nameSpec.IsRef)
+
+	friendsSpec := resolved.Specs[1].(*query.ResolvedPullAttribute)
+	assert.Equal(t, kw(":person/friends"), friendsSpec.Attr)
+	assert.False(t, friendsSpec.IsMany)
+	assert.False(t, friendsSpec.IsRef)
+}
+
+func TestResolvePullPatternWithSchema(t *testing.T) {
+	schema, _ := NewBuilder().
+		Attribute(":person/name").Type(TypeString).Add().
+		Attribute(":person/friends").Type(TypeRef).Many().Add().
+		Attribute(":person/manager").Type(TypeRef).Add().
+		Build()
+
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: kw(":person/name")},
+			&query.PullAttribute{Attr: kw(":person/friends")},
+			&query.PullAttribute{Attr: kw(":person/manager")},
+			&query.PullAttribute{Attr: kw(":person/unknown")}, // Not in schema
+		},
+	}
+
+	resolved := ResolvePullPattern(pattern, schema)
+	require.NotNil(t, resolved)
+	require.Len(t, resolved.Specs, 4)
+
+	// :person/name - string, cardinality-one
+	nameSpec := resolved.Specs[0].(*query.ResolvedPullAttribute)
+	assert.False(t, nameSpec.IsMany)
+	assert.False(t, nameSpec.IsRef)
+
+	// :person/friends - ref, cardinality-many
+	friendsSpec := resolved.Specs[1].(*query.ResolvedPullAttribute)
+	assert.True(t, friendsSpec.IsMany)
+	assert.True(t, friendsSpec.IsRef)
+
+	// :person/manager - ref, cardinality-one
+	managerSpec := resolved.Specs[2].(*query.ResolvedPullAttribute)
+	assert.False(t, managerSpec.IsMany)
+	assert.True(t, managerSpec.IsRef)
+
+	// :person/unknown - not in schema, defaults to one/not-ref
+	unknownSpec := resolved.Specs[3].(*query.ResolvedPullAttribute)
+	assert.False(t, unknownSpec.IsMany)
+	assert.False(t, unknownSpec.IsRef)
+}
+
+func TestResolvePullPatternWildcard(t *testing.T) {
+	schema, _ := NewBuilder().
+		Attribute(":person/name").Type(TypeString).Add().
+		Build()
+
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullWildcard{},
+		},
+	}
+
+	resolved := ResolvePullPattern(pattern, schema)
+	require.NotNil(t, resolved)
+	require.Len(t, resolved.Specs, 1)
+
+	_, ok := resolved.Specs[0].(*query.ResolvedPullWildcard)
+	assert.True(t, ok)
+}
+
+func TestResolvePullPatternMapSpec(t *testing.T) {
+	schema, _ := NewBuilder().
+		Attribute(":person/friends").Type(TypeRef).Many().Add().
+		Attribute(":person/name").Type(TypeString).Add().
+		Build()
+
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullMapSpec{
+				Attr: kw(":person/friends"),
+				Pattern: &query.PullPattern{
+					Specs: []query.PullAttrSpec{
+						&query.PullAttribute{Attr: kw(":person/name")},
+					},
+				},
+			},
+		},
+	}
+
+	resolved := ResolvePullPattern(pattern, schema)
+	require.NotNil(t, resolved)
+	require.Len(t, resolved.Specs, 1)
+
+	mapSpec := resolved.Specs[0].(*query.ResolvedPullMapSpec)
+	assert.Equal(t, kw(":person/friends"), mapSpec.Attr)
+	assert.True(t, mapSpec.IsMany) // friends is cardinality-many
+
+	// Nested pattern should also be resolved
+	require.NotNil(t, mapSpec.Pattern)
+	require.Len(t, mapSpec.Pattern.Specs, 1)
+	nestedAttr := mapSpec.Pattern.Specs[0].(*query.ResolvedPullAttribute)
+	assert.Equal(t, kw(":person/name"), nestedAttr.Attr)
+	assert.False(t, nestedAttr.IsMany)
+	assert.False(t, nestedAttr.IsRef)
+}
+
+func TestResolvePullPatternLimitExpr(t *testing.T) {
+	schema, _ := NewBuilder().
+		Attribute(":person/tags").Type(TypeString).Many().Add().
+		Build()
+
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullLimitExpr{Attr: kw(":person/tags"), Limit: 5},
+		},
+	}
+
+	resolved := ResolvePullPattern(pattern, schema)
+	require.NotNil(t, resolved)
+	require.Len(t, resolved.Specs, 1)
+
+	limitSpec := resolved.Specs[0].(*query.ResolvedPullLimitExpr)
+	assert.Equal(t, kw(":person/tags"), limitSpec.Attr)
+	assert.Equal(t, 5, limitSpec.Limit)
+	assert.True(t, limitSpec.IsMany)
+	assert.False(t, limitSpec.IsRef)
+}
+
+func TestResolvePullPatternDefaultExpr(t *testing.T) {
+	schema, _ := NewBuilder().
+		Attribute(":person/status").Type(TypeString).Add().
+		Build()
+
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullDefaultExpr{Attr: kw(":person/status"), Default: "unknown"},
+		},
+	}
+
+	resolved := ResolvePullPattern(pattern, schema)
+	require.NotNil(t, resolved)
+	require.Len(t, resolved.Specs, 1)
+
+	defaultSpec := resolved.Specs[0].(*query.ResolvedPullDefaultExpr)
+	assert.Equal(t, kw(":person/status"), defaultSpec.Attr)
+	assert.Equal(t, "unknown", defaultSpec.Default)
+	assert.False(t, defaultSpec.IsMany)
+	assert.False(t, defaultSpec.IsRef)
+}
+
+func TestResolvePullPatternString(t *testing.T) {
+	schema, _ := NewBuilder().
+		Attribute(":person/friends").Type(TypeRef).Many().Add().
+		Build()
+
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: kw(":person/name")},
+			&query.PullAttribute{Attr: kw(":person/friends")},
+		},
+	}
+
+	resolved := ResolvePullPattern(pattern, schema)
+	str := resolved.String()
+
+	// String representation should show cardinality info
+	assert.Contains(t, str, ":person/name")
+	assert.Contains(t, str, ":person/friends[many][ref]")
+}

--- a/datalog/schema/schema_test.go
+++ b/datalog/schema/schema_test.go
@@ -1,0 +1,230 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+func kw(s string) datalog.Keyword {
+	return datalog.NewKeyword(s)
+}
+
+func TestSchemaBasic(t *testing.T) {
+	s := NewSchema()
+	assert.False(t, s.HasSchema())
+	assert.Equal(t, 0, s.Count())
+
+	s.Add(&AttributeDefinition{
+		Ident:       kw(":person/name"),
+		ValueType:   TypeString,
+		Cardinality: CardinalityOne,
+	})
+
+	assert.True(t, s.HasSchema())
+	assert.Equal(t, 1, s.Count())
+
+	def := s.GetAttribute(kw(":person/name"))
+	require.NotNil(t, def)
+	assert.Equal(t, TypeString, def.ValueType)
+	assert.Equal(t, CardinalityOne, def.Cardinality)
+}
+
+func TestSchemaIsRef(t *testing.T) {
+	s := NewSchema()
+	s.Add(&AttributeDefinition{
+		Ident:     kw(":person/friend"),
+		ValueType: TypeRef,
+	})
+	s.Add(&AttributeDefinition{
+		Ident:     kw(":person/name"),
+		ValueType: TypeString,
+	})
+
+	assert.True(t, s.IsRef(kw(":person/friend")))
+	assert.False(t, s.IsRef(kw(":person/name")))
+	assert.False(t, s.IsRef(kw(":unknown/attr")))
+}
+
+func TestSchemaIsMany(t *testing.T) {
+	s := NewSchema()
+	s.Add(&AttributeDefinition{
+		Ident:       kw(":person/friends"),
+		ValueType:   TypeRef,
+		Cardinality: CardinalityMany,
+	})
+	s.Add(&AttributeDefinition{
+		Ident:       kw(":person/name"),
+		ValueType:   TypeString,
+		Cardinality: CardinalityOne,
+	})
+
+	assert.True(t, s.IsMany(kw(":person/friends")))
+	assert.False(t, s.IsMany(kw(":person/name")))
+	assert.False(t, s.IsMany(kw(":unknown/attr")))
+}
+
+func TestSchemaDefaultCardinality(t *testing.T) {
+	s := NewSchema()
+	// Add without explicit cardinality
+	s.Add(&AttributeDefinition{
+		Ident:     kw(":person/name"),
+		ValueType: TypeString,
+	})
+
+	def := s.GetAttribute(kw(":person/name"))
+	require.NotNil(t, def)
+	assert.Equal(t, CardinalityOne, def.Cardinality)
+}
+
+func TestSchemaNil(t *testing.T) {
+	var s *Schema = nil
+
+	assert.False(t, s.HasSchema())
+	assert.Nil(t, s.GetAttribute(kw(":person/name")))
+	assert.False(t, s.IsRef(kw(":person/name")))
+	assert.False(t, s.IsMany(kw(":person/name")))
+	assert.Equal(t, 0, s.Count())
+	assert.Nil(t, s.Attributes())
+}
+
+func TestBuilderBasic(t *testing.T) {
+	schema, err := NewBuilder().
+		Attribute(":person/name").Type(TypeString).Add().
+		Attribute(":person/age").Type(TypeLong).Add().
+		Build()
+
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+	assert.Equal(t, 2, schema.Count())
+
+	name := schema.GetAttribute(kw(":person/name"))
+	require.NotNil(t, name)
+	assert.Equal(t, TypeString, name.ValueType)
+	assert.Equal(t, CardinalityOne, name.Cardinality)
+
+	age := schema.GetAttribute(kw(":person/age"))
+	require.NotNil(t, age)
+	assert.Equal(t, TypeLong, age.ValueType)
+}
+
+func TestBuilderWithCardinality(t *testing.T) {
+	schema, err := NewBuilder().
+		Attribute(":person/name").Type(TypeString).One().Add().
+		Attribute(":person/friends").Type(TypeRef).Many().Add().
+		Build()
+
+	require.NoError(t, err)
+
+	assert.False(t, schema.IsMany(kw(":person/name")))
+	assert.True(t, schema.IsMany(kw(":person/friends")))
+}
+
+func TestBuilderWithUnique(t *testing.T) {
+	schema, err := NewBuilder().
+		Attribute(":person/email").Type(TypeString).Unique(UniqueValue).Add().
+		Attribute(":person/id").Type(TypeString).Unique(UniqueIdentity).Add().
+		Build()
+
+	require.NoError(t, err)
+
+	email := schema.GetAttribute(kw(":person/email"))
+	require.NotNil(t, email)
+	assert.Equal(t, UniqueValue, email.Unique)
+
+	id := schema.GetAttribute(kw(":person/id"))
+	require.NotNil(t, id)
+	assert.Equal(t, UniqueIdentity, id.Unique)
+}
+
+func TestBuilderWithDoc(t *testing.T) {
+	schema, err := NewBuilder().
+		Attribute(":person/name").Type(TypeString).Doc("The person's full name").Add().
+		Build()
+
+	require.NoError(t, err)
+
+	name := schema.GetAttribute(kw(":person/name"))
+	require.NotNil(t, name)
+	assert.Equal(t, "The person's full name", name.Doc)
+}
+
+func TestBuilderMustBuild(t *testing.T) {
+	schema := NewBuilder().
+		Attribute(":person/name").Type(TypeString).Add().
+		MustBuild()
+
+	require.NotNil(t, schema)
+	assert.Equal(t, 1, schema.Count())
+}
+
+func TestBuilderAllTypes(t *testing.T) {
+	schema, err := NewBuilder().
+		Attribute(":test/string").Type(TypeString).Add().
+		Attribute(":test/long").Type(TypeLong).Add().
+		Attribute(":test/double").Type(TypeDouble).Add().
+		Attribute(":test/boolean").Type(TypeBoolean).Add().
+		Attribute(":test/instant").Type(TypeInstant).Add().
+		Attribute(":test/bytes").Type(TypeBytes).Add().
+		Attribute(":test/ref").Type(TypeRef).Add().
+		Attribute(":test/keyword").Type(TypeKeyword).Add().
+		Build()
+
+	require.NoError(t, err)
+	assert.Equal(t, 8, schema.Count())
+
+	// Verify each type
+	assert.Equal(t, TypeString, schema.GetAttribute(kw(":test/string")).ValueType)
+	assert.Equal(t, TypeLong, schema.GetAttribute(kw(":test/long")).ValueType)
+	assert.Equal(t, TypeDouble, schema.GetAttribute(kw(":test/double")).ValueType)
+	assert.Equal(t, TypeBoolean, schema.GetAttribute(kw(":test/boolean")).ValueType)
+	assert.Equal(t, TypeInstant, schema.GetAttribute(kw(":test/instant")).ValueType)
+	assert.Equal(t, TypeBytes, schema.GetAttribute(kw(":test/bytes")).ValueType)
+	assert.Equal(t, TypeRef, schema.GetAttribute(kw(":test/ref")).ValueType)
+	assert.Equal(t, TypeKeyword, schema.GetAttribute(kw(":test/keyword")).ValueType)
+}
+
+func TestBuilderChaining(t *testing.T) {
+	// Complex real-world example
+	schema, err := NewBuilder().
+		Attribute(":user/id").Type(TypeString).Unique(UniqueIdentity).Doc("User identifier").Add().
+		Attribute(":user/name").Type(TypeString).One().Add().
+		Attribute(":user/email").Type(TypeString).Unique(UniqueValue).Add().
+		Attribute(":user/friends").Type(TypeRef).Many().Doc("User's friends").Add().
+		Attribute(":user/created-at").Type(TypeInstant).Add().
+		Attribute(":user/settings").Type(TypeBytes).Add().
+		Build()
+
+	require.NoError(t, err)
+	assert.Equal(t, 6, schema.Count())
+
+	// Check specific attributes
+	id := schema.GetAttribute(kw(":user/id"))
+	assert.Equal(t, UniqueIdentity, id.Unique)
+	assert.Equal(t, "User identifier", id.Doc)
+
+	friends := schema.GetAttribute(kw(":user/friends"))
+	assert.True(t, schema.IsRef(kw(":user/friends")))
+	assert.True(t, schema.IsMany(kw(":user/friends")))
+	assert.Equal(t, "User's friends", friends.Doc)
+}
+
+func TestSchemaAttributes(t *testing.T) {
+	schema, _ := NewBuilder().
+		Attribute(":person/name").Type(TypeString).Add().
+		Attribute(":person/age").Type(TypeLong).Add().
+		Build()
+
+	attrs := schema.Attributes()
+	assert.Len(t, attrs, 2)
+
+	// Verify both attributes are present (order not guaranteed due to map)
+	idents := make(map[string]bool)
+	for _, attr := range attrs {
+		idents[attr.Ident.String()] = true
+	}
+	assert.True(t, idents[":person/name"])
+	assert.True(t, idents[":person/age"])
+}

--- a/datalog/schema/types.go
+++ b/datalog/schema/types.go
@@ -1,0 +1,118 @@
+package schema
+
+import (
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// ValueType represents the allowed types for attribute values
+// Uses Datomic-compatible naming conventions
+type ValueType string
+
+const (
+	TypeString  ValueType = "db.type/string"
+	TypeLong    ValueType = "db.type/long"    // int64
+	TypeDouble  ValueType = "db.type/double"  // float64
+	TypeBoolean ValueType = "db.type/boolean" // bool
+	TypeInstant ValueType = "db.type/instant" // time.Time
+	TypeBytes   ValueType = "db.type/bytes"   // []byte
+	TypeRef     ValueType = "db.type/ref"     // datalog.Identity
+	TypeKeyword ValueType = "db.type/keyword" // datalog.Keyword
+)
+
+// Cardinality represents how many values an attribute can have
+type Cardinality string
+
+const (
+	CardinalityOne  Cardinality = "db.cardinality/one"
+	CardinalityMany Cardinality = "db.cardinality/many"
+)
+
+// Unique represents uniqueness constraints on attribute values
+type Unique string
+
+const (
+	UniqueNone     Unique = ""                    // No uniqueness (default)
+	UniqueValue    Unique = "db.unique/value"     // Value must be globally unique
+	UniqueIdentity Unique = "db.unique/identity"  // Upsert behavior on conflict
+)
+
+// AttributeDefinition defines schema for a single attribute
+type AttributeDefinition struct {
+	Ident       datalog.Keyword // The attribute keyword (e.g., :person/name)
+	ValueType   ValueType       // Required for type validation
+	Cardinality Cardinality     // Required for Pull API (default: one)
+	Unique      Unique          // Optional uniqueness constraint
+	Doc         string          // Optional documentation
+}
+
+// Schema holds all attribute definitions
+// Thread-safe for concurrent reads after construction
+type Schema struct {
+	attributes map[datalog.Keyword]*AttributeDefinition
+}
+
+// NewSchema creates an empty schema
+func NewSchema() *Schema {
+	return &Schema{
+		attributes: make(map[datalog.Keyword]*AttributeDefinition),
+	}
+}
+
+// Add adds an attribute definition to the schema
+// Returns the schema for chaining
+func (s *Schema) Add(def *AttributeDefinition) *Schema {
+	if def == nil {
+		return s
+	}
+	// Set default cardinality if not specified
+	if def.Cardinality == "" {
+		def.Cardinality = CardinalityOne
+	}
+	s.attributes[def.Ident] = def
+	return s
+}
+
+// GetAttribute returns the definition for an attribute, or nil if unknown
+func (s *Schema) GetAttribute(attr datalog.Keyword) *AttributeDefinition {
+	if s == nil {
+		return nil
+	}
+	return s.attributes[attr]
+}
+
+// HasSchema returns true if a schema is available with at least one attribute
+func (s *Schema) HasSchema() bool {
+	return s != nil && len(s.attributes) > 0
+}
+
+// IsRef returns true if the attribute is a reference type
+func (s *Schema) IsRef(attr datalog.Keyword) bool {
+	def := s.GetAttribute(attr)
+	return def != nil && def.ValueType == TypeRef
+}
+
+// IsMany returns true if the attribute has cardinality many
+func (s *Schema) IsMany(attr datalog.Keyword) bool {
+	def := s.GetAttribute(attr)
+	return def != nil && def.Cardinality == CardinalityMany
+}
+
+// Attributes returns all attribute definitions in the schema
+func (s *Schema) Attributes() []*AttributeDefinition {
+	if s == nil {
+		return nil
+	}
+	result := make([]*AttributeDefinition, 0, len(s.attributes))
+	for _, def := range s.attributes {
+		result = append(result, def)
+	}
+	return result
+}
+
+// Count returns the number of attributes in the schema
+func (s *Schema) Count() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.attributes)
+}

--- a/datalog/schema/validation.go
+++ b/datalog/schema/validation.go
@@ -1,0 +1,98 @@
+package schema
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// ValidateValue checks if a value matches the expected type
+// Returns nil if valid, error if type mismatch
+func ValidateValue(value interface{}, expected ValueType) error {
+	if expected == "" {
+		return nil // No type constraint
+	}
+
+	var ok bool
+	var actualType string
+
+	switch expected {
+	case TypeString:
+		_, ok = value.(string)
+		actualType = "string"
+
+	case TypeLong:
+		switch value.(type) {
+		case int64, int, int32, int16, int8:
+			ok = true
+		}
+		actualType = "int64"
+
+	case TypeDouble:
+		switch value.(type) {
+		case float64, float32:
+			ok = true
+		}
+		actualType = "float64"
+
+	case TypeBoolean:
+		_, ok = value.(bool)
+		actualType = "bool"
+
+	case TypeInstant:
+		_, ok = value.(time.Time)
+		actualType = "time.Time"
+
+	case TypeBytes:
+		_, ok = value.([]byte)
+		actualType = "[]byte"
+
+	case TypeRef:
+		_, ok = value.(datalog.Identity)
+		if !ok {
+			// Also check for pointer type
+			_, ok = value.(*datalog.Identity)
+		}
+		actualType = "Identity"
+
+	case TypeKeyword:
+		_, ok = value.(datalog.Keyword)
+		if !ok {
+			// Also check for pointer type
+			_, ok = value.(*datalog.Keyword)
+		}
+		actualType = "Keyword"
+
+	default:
+		// Unknown type constraint, allow anything
+		return nil
+	}
+
+	if !ok {
+		return fmt.Errorf("expected %s (%s), got %T", expected, actualType, value)
+	}
+	return nil
+}
+
+// ValidateDatom validates a single attribute-value pair against schema
+// Returns nil if valid or if schema doesn't define the attribute
+func ValidateDatom(s SchemaProvider, attr datalog.Keyword, value interface{}) error {
+	if s == nil || !s.HasSchema() {
+		return nil // No schema = no validation
+	}
+
+	def := s.GetAttribute(attr)
+	if def == nil {
+		return nil // Unknown attribute = allow (additive schema)
+	}
+
+	// Type validation
+	if def.ValueType != "" {
+		if err := ValidateValue(value, def.ValueType); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/datalog/schema/validation_test.go
+++ b/datalog/schema/validation_test.go
@@ -1,0 +1,122 @@
+package schema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+func TestValidateValueString(t *testing.T) {
+	assert.NoError(t, ValidateValue("hello", TypeString))
+	assert.NoError(t, ValidateValue("", TypeString))
+	assert.Error(t, ValidateValue(123, TypeString))
+	assert.Error(t, ValidateValue(true, TypeString))
+}
+
+func TestValidateValueLong(t *testing.T) {
+	assert.NoError(t, ValidateValue(int64(42), TypeLong))
+	assert.NoError(t, ValidateValue(int(42), TypeLong))
+	assert.NoError(t, ValidateValue(int32(42), TypeLong))
+	assert.Error(t, ValidateValue("42", TypeLong))
+	assert.Error(t, ValidateValue(42.5, TypeLong))
+}
+
+func TestValidateValueDouble(t *testing.T) {
+	assert.NoError(t, ValidateValue(float64(3.14), TypeDouble))
+	assert.NoError(t, ValidateValue(float32(3.14), TypeDouble))
+	assert.Error(t, ValidateValue(int64(42), TypeDouble))
+	assert.Error(t, ValidateValue("3.14", TypeDouble))
+}
+
+func TestValidateValueBoolean(t *testing.T) {
+	assert.NoError(t, ValidateValue(true, TypeBoolean))
+	assert.NoError(t, ValidateValue(false, TypeBoolean))
+	assert.Error(t, ValidateValue(1, TypeBoolean))
+	assert.Error(t, ValidateValue("true", TypeBoolean))
+}
+
+func TestValidateValueInstant(t *testing.T) {
+	assert.NoError(t, ValidateValue(time.Now(), TypeInstant))
+	assert.NoError(t, ValidateValue(time.Time{}, TypeInstant))
+	assert.Error(t, ValidateValue("2023-01-01", TypeInstant))
+	assert.Error(t, ValidateValue(int64(1234567890), TypeInstant))
+}
+
+func TestValidateValueBytes(t *testing.T) {
+	assert.NoError(t, ValidateValue([]byte{1, 2, 3}, TypeBytes))
+	assert.NoError(t, ValidateValue([]byte{}, TypeBytes))
+	assert.Error(t, ValidateValue("bytes", TypeBytes))
+	assert.Error(t, ValidateValue([]int{1, 2, 3}, TypeBytes))
+}
+
+func TestValidateValueRef(t *testing.T) {
+	id := datalog.NewIdentity("test:entity")
+	assert.NoError(t, ValidateValue(id, TypeRef))
+	assert.NoError(t, ValidateValue(&id, TypeRef))
+	assert.Error(t, ValidateValue("test:entity", TypeRef))
+	assert.Error(t, ValidateValue(12345, TypeRef))
+}
+
+func TestValidateValueKeyword(t *testing.T) {
+	kw := datalog.NewKeyword(":test/keyword")
+	assert.NoError(t, ValidateValue(kw, TypeKeyword))
+	assert.NoError(t, ValidateValue(&kw, TypeKeyword))
+	assert.Error(t, ValidateValue(":test/keyword", TypeKeyword))
+	assert.Error(t, ValidateValue("keyword", TypeKeyword))
+}
+
+func TestValidateValueEmptyType(t *testing.T) {
+	// Empty type means no constraint
+	assert.NoError(t, ValidateValue("anything", ""))
+	assert.NoError(t, ValidateValue(123, ""))
+	assert.NoError(t, ValidateValue(nil, ""))
+}
+
+func TestValidateDatom(t *testing.T) {
+	schema, err := NewBuilder().
+		Attribute(":person/name").Type(TypeString).Add().
+		Attribute(":person/age").Type(TypeLong).Add().
+		Attribute(":person/friend").Type(TypeRef).Add().
+		Build()
+	require.NoError(t, err)
+
+	// Valid values
+	assert.NoError(t, ValidateDatom(schema, kw(":person/name"), "Alice"))
+	assert.NoError(t, ValidateDatom(schema, kw(":person/age"), int64(30)))
+	assert.NoError(t, ValidateDatom(schema, kw(":person/friend"), datalog.NewIdentity("bob")))
+
+	// Invalid values
+	err = ValidateDatom(schema, kw(":person/name"), 123)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected db.type/string")
+
+	err = ValidateDatom(schema, kw(":person/age"), "thirty")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected db.type/long")
+
+	// Unknown attribute - should pass (additive schema)
+	assert.NoError(t, ValidateDatom(schema, kw(":person/unknown"), "anything"))
+}
+
+func TestValidateDatomNilSchema(t *testing.T) {
+	// nil schema should allow everything
+	assert.NoError(t, ValidateDatom(nil, kw(":any/attr"), "any value"))
+	assert.NoError(t, ValidateDatom(nil, kw(":any/attr"), 123))
+}
+
+func TestValidateDatomEmptySchema(t *testing.T) {
+	schema := NewSchema()
+	// Empty schema should allow everything
+	assert.NoError(t, ValidateDatom(schema, kw(":any/attr"), "any value"))
+}
+
+func TestValidateValueErrorMessage(t *testing.T) {
+	err := ValidateValue(123, TypeString)
+	require.Error(t, err)
+	// Error message should include both expected type and actual type
+	assert.Contains(t, err.Error(), "db.type/string")
+	assert.Contains(t, err.Error(), "int")
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/parser"
 	"github.com/wbrown/janus-datalog/datalog/planner"
 	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
 // Database provides the main API for reading and writing datoms
@@ -20,8 +21,9 @@ type Database struct {
 	txCounter atomic.Uint64
 	mu        sync.RWMutex
 	activeTx  map[*Transaction]bool
-	useTimeTx bool               // Use time-based transaction IDs
-	planCache *planner.PlanCache // Shared query plan cache
+	useTimeTx bool                   // Use time-based transaction IDs
+	planCache *planner.PlanCache     // Shared query plan cache
+	schema    schema.SchemaProvider  // Optional schema for validation
 }
 
 // NewDatabase creates a new database with BadgerDB storage
@@ -47,6 +49,31 @@ func NewDatabaseWithTimeTx(path string) (*Database, error) {
 	}
 	db.useTimeTx = true
 	return db, nil
+}
+
+// NewDatabaseWithSchema creates a database with schema validation
+func NewDatabaseWithSchema(path string, s schema.SchemaProvider) (*Database, error) {
+	db, err := NewDatabase(path)
+	if err != nil {
+		return nil, err
+	}
+	db.schema = s
+	return db, nil
+}
+
+// Schema returns the current schema (may be nil)
+func (d *Database) Schema() schema.SchemaProvider {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.schema
+}
+
+// SetSchema sets or replaces the schema for validation
+// Schema changes take effect for new transactions
+func (d *Database) SetSchema(s schema.SchemaProvider) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.schema = s
 }
 
 // NewTransaction starts a new write transaction
@@ -178,11 +205,17 @@ func (d *Database) Store() *BadgerStore {
 
 // Close closes the database
 func (d *Database) Close() error {
+	// Copy active transactions while holding lock, then release before calling Rollback
+	// to avoid deadlock (Rollback also acquires d.mu)
 	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	// Rollback any active transactions
+	txs := make([]*Transaction, 0, len(d.activeTx))
 	for tx := range d.activeTx {
+		txs = append(txs, tx)
+	}
+	d.mu.Unlock()
+
+	// Rollback any active transactions (without holding d.mu)
+	for _, tx := range txs {
 		tx.Rollback()
 	}
 
@@ -301,6 +334,11 @@ func (t *Transaction) Add(e datalog.Identity, a datalog.Keyword, v interface{}) 
 		return fmt.Errorf("transaction is closed")
 	}
 
+	// Schema validation (if schema present)
+	if err := schema.ValidateDatom(t.db.Schema(), a, v); err != nil {
+		return fmt.Errorf("schema validation failed for %s: %w", a.String(), err)
+	}
+
 	t.datoms = append(t.datoms, datalog.Datom{
 		E:  e,
 		A:  a,
@@ -367,6 +405,11 @@ func (t *Transaction) Commit() (uint64, error) {
 		return 0, fmt.Errorf("transaction is closed")
 	}
 
+	// Validate uniqueness constraints before committing
+	if err := t.validateUniqueness(); err != nil {
+		return 0, err
+	}
+
 	// Get transaction ID (time-based or sequential)
 	var txID uint64
 	var txTime time.Time
@@ -430,6 +473,97 @@ func (t *Transaction) Commit() (uint64, error) {
 	t.db.mu.Unlock()
 
 	return txID, nil
+}
+
+// validateUniqueness checks uniqueness constraints for all datoms in the transaction
+func (t *Transaction) validateUniqueness() error {
+	s := t.db.Schema()
+	if s == nil || !s.HasSchema() {
+		return nil // No schema = no validation
+	}
+
+	// Track values seen in this transaction for within-transaction uniqueness
+	// Key: attribute + serialized value
+	seenInTx := make(map[string]datalog.Identity)
+
+	matcher := NewBadgerMatcher(t.db.store)
+
+	for _, d := range t.datoms {
+		def := s.GetAttribute(d.A)
+		if def == nil || def.Unique == "" {
+			continue // No uniqueness constraint
+		}
+
+		// Create a key for tracking this attr+value combination
+		txKey := fmt.Sprintf("%s:%v", d.A.String(), d.V)
+
+		// Check within transaction uniqueness
+		if existingEntity, ok := seenInTx[txKey]; ok {
+			if existingEntity != d.E {
+				return fmt.Errorf("uniqueness violation for %s: value %v already used by entity %s in this transaction",
+					d.A.String(), d.V, existingEntity.String())
+			}
+			// Same entity, same value - OK (idempotent update)
+			continue
+		}
+		seenInTx[txKey] = d.E
+
+		// Check database for existing value
+		// Create a pattern [?e :attr value _] to find entities with this value
+		pattern := &query.DataPattern{
+			Elements: []query.PatternElement{
+				query.Variable{Name: query.Symbol("?e")},    // Entity variable
+				query.Constant{Value: d.A},                  // Bound attribute
+				query.Constant{Value: d.V},                  // Bound value
+				query.Blank{},                               // Transaction wildcard
+			},
+		}
+
+		results, err := matcher.Match(pattern, nil)
+		if err != nil {
+			return fmt.Errorf("failed to check uniqueness for %s: %w", d.A.String(), err)
+		}
+
+		// Find the index of ?e in the result columns
+		columns := results.Columns()
+		eIndex := -1
+		for i, col := range columns {
+			if col == query.Symbol("?e") {
+				eIndex = i
+				break
+			}
+		}
+		if eIndex < 0 {
+			continue // No entity column in results (shouldn't happen)
+		}
+
+		// Check if any existing datoms have a different entity
+		iter := results.Iterator()
+		for iter.Next() {
+			tuple := iter.Tuple()
+			if eIndex >= len(tuple) {
+				continue
+			}
+			// Handle both value and pointer types for Identity
+			var existingEntity datalog.Identity
+			switch e := tuple[eIndex].(type) {
+			case datalog.Identity:
+				existingEntity = e
+			case *datalog.Identity:
+				existingEntity = *e
+			default:
+				continue
+			}
+			if !existingEntity.Equal(d.E) {
+				iter.Close()
+				return fmt.Errorf("uniqueness violation for %s: value %v already exists on entity %s",
+					d.A.String(), d.V, existingEntity.String())
+			}
+		}
+		iter.Close()
+	}
+
+	return nil
 }
 
 // Rollback aborts the transaction

--- a/datalog/storage/database_schema_test.go
+++ b/datalog/storage/database_schema_test.go
@@ -1,0 +1,287 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+func TestDatabaseWithSchema(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db-schema-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Attribute(":person/age").Type(schema.TypeLong).Add().
+		Build()
+	require.NoError(t, err)
+
+	// Create database with schema
+	db, err := NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	assert.NotNil(t, db.Schema())
+	assert.True(t, db.Schema().HasSchema())
+}
+
+func TestSchemaTypeValidation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db-type-validation-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema with type constraints
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Attribute(":person/age").Type(schema.TypeLong).Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+	age := datalog.NewKeyword(":person/age")
+
+	// Valid data
+	tx := db.NewTransaction()
+	err = tx.Add(alice, name, "Alice")
+	assert.NoError(t, err)
+	err = tx.Add(alice, age, int64(30))
+	assert.NoError(t, err)
+	_, err = tx.Commit()
+	assert.NoError(t, err)
+
+	// Invalid type: string instead of long
+	tx2 := db.NewTransaction()
+	err = tx2.Add(alice, age, "thirty") // Should fail - wrong type
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "schema validation failed")
+	assert.Contains(t, err.Error(), "db.type/long")
+
+	// Invalid type: int instead of string
+	tx3 := db.NewTransaction()
+	err = tx3.Add(alice, name, 123) // Should fail - wrong type
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "schema validation failed")
+	assert.Contains(t, err.Error(), "db.type/string")
+}
+
+func TestSchemaUnknownAttribute(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db-unknown-attr-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema with only name defined
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+
+	// Unknown attribute should be allowed (additive schema)
+	tx := db.NewTransaction()
+	err = tx.Add(alice, datalog.NewKeyword(":person/email"), "alice@example.com")
+	assert.NoError(t, err, "unknown attribute should be allowed")
+	_, err = tx.Commit()
+	assert.NoError(t, err)
+}
+
+func TestSchemaUniquenessValue(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db-unique-value-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema with unique value constraint
+	s, err := schema.NewBuilder().
+		Attribute(":user/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	email := datalog.NewKeyword(":user/email")
+
+	// First user with email
+	tx := db.NewTransaction()
+	err = tx.Add(alice, email, "alice@example.com")
+	require.NoError(t, err)
+	txid, err := tx.Commit()
+	require.NoError(t, err)
+	t.Logf("First commit txid: %d", txid)
+
+	// Verify data was written by querying directly
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: query.Symbol("?e")},
+			query.Constant{Value: email},
+			query.Constant{Value: "alice@example.com"},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err, "matcher.Match should succeed")
+	t.Logf("Result columns: %v", results.Columns())
+
+	iter := results.Iterator()
+	count := 0
+	for iter.Next() {
+		tuple := iter.Tuple()
+		t.Logf("Found tuple: %v", tuple)
+		if len(tuple) > 0 {
+			t.Logf("  tuple[0] type: %T, value: %v", tuple[0], tuple[0])
+			switch id := tuple[0].(type) {
+			case datalog.Identity:
+				t.Logf("  Is Identity (value): %s", id.String())
+			case *datalog.Identity:
+				t.Logf("  Is Identity (pointer): %s", id.String())
+			default:
+				t.Logf("  NOT an Identity type")
+			}
+		}
+		count++
+	}
+	iter.Close()
+	t.Logf("Total matches found: %d", count)
+	require.Greater(t, count, 0, "should find at least one existing datom")
+
+	// Second user with same email should fail
+	tx2 := db.NewTransaction()
+	err = tx2.Add(bob, email, "alice@example.com")
+	require.NoError(t, err) // Add succeeds (type check passes)
+	_, err = tx2.Commit()
+	require.Error(t, err, "should fail uniqueness check")
+	assert.Contains(t, err.Error(), "uniqueness violation")
+}
+
+func TestSchemaUniquenessWithinTransaction(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db-unique-tx-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema with unique value constraint
+	s, err := schema.NewBuilder().
+		Attribute(":user/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	email := datalog.NewKeyword(":user/email")
+
+	// Two different entities with same email in same transaction
+	tx := db.NewTransaction()
+	err = tx.Add(alice, email, "shared@example.com")
+	require.NoError(t, err)
+	err = tx.Add(bob, email, "shared@example.com")
+	require.NoError(t, err) // Add succeeds (checked at commit time for cross-entity)
+	_, err = tx.Commit()
+	assert.Error(t, err, "should fail uniqueness check within transaction")
+	assert.Contains(t, err.Error(), "uniqueness violation")
+	assert.Contains(t, err.Error(), "already used by entity")
+}
+
+func TestSchemaUniquenessIdempotent(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db-unique-idempotent-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema with unique value constraint
+	s, err := schema.NewBuilder().
+		Attribute(":user/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	email := datalog.NewKeyword(":user/email")
+
+	// First assertion
+	tx := db.NewTransaction()
+	err = tx.Add(alice, email, "alice@example.com")
+	require.NoError(t, err)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Same entity, same value should succeed (idempotent)
+	tx2 := db.NewTransaction()
+	err = tx2.Add(alice, email, "alice@example.com")
+	require.NoError(t, err)
+	_, err = tx2.Commit()
+	assert.NoError(t, err, "idempotent update should succeed")
+}
+
+func TestNoSchemaNoValidation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db-no-schema-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create database without schema
+	db, err := NewDatabase(tmpDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	assert.Nil(t, db.Schema())
+
+	// Should accept any data without validation
+	alice := datalog.NewIdentity("alice")
+	tx := db.NewTransaction()
+	err = tx.Add(alice, datalog.NewKeyword(":person/age"), "not a number")
+	assert.NoError(t, err)
+	_, err = tx.Commit()
+	assert.NoError(t, err, "without schema, any value should be accepted")
+}
+
+func TestSetSchema(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db-set-schema-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create database without schema
+	db, err := NewDatabase(tmpDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	assert.Nil(t, db.Schema())
+
+	// Add schema later
+	s, err := schema.NewBuilder().
+		Attribute(":person/age").Type(schema.TypeLong).Add().
+		Build()
+	require.NoError(t, err)
+
+	db.SetSchema(s)
+	assert.NotNil(t, db.Schema())
+
+	// Now validation should be enforced
+	alice := datalog.NewIdentity("alice")
+	tx := db.NewTransaction()
+	err = tx.Add(alice, datalog.NewKeyword(":person/age"), "not a number")
+	assert.Error(t, err, "schema should now be enforced")
+}

--- a/datalog/storage/schema_bench_test.go
+++ b/datalog/storage/schema_bench_test.go
@@ -1,0 +1,264 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// BenchmarkAddWithoutSchema measures Add() performance without schema validation
+func BenchmarkAddWithoutSchema(b *testing.B) {
+	tmpDir, _ := os.MkdirTemp("", "bench-no-schema")
+	defer os.RemoveAll(tmpDir)
+
+	db, _ := NewDatabase(tmpDir)
+	defer db.Close()
+
+	name := datalog.NewKeyword(":person/name")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tx := db.NewTransaction()
+		e := datalog.NewIdentity(fmt.Sprintf("entity-%d", i))
+		tx.Add(e, name, "Alice")
+		tx.Commit()
+	}
+}
+
+// BenchmarkAddWithSchema measures Add() performance with type validation
+func BenchmarkAddWithSchema(b *testing.B) {
+	tmpDir, _ := os.MkdirTemp("", "bench-with-schema")
+	defer os.RemoveAll(tmpDir)
+
+	s, _ := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Build()
+
+	db, _ := NewDatabaseWithSchema(tmpDir, s)
+	defer db.Close()
+
+	name := datalog.NewKeyword(":person/name")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tx := db.NewTransaction()
+		e := datalog.NewIdentity(fmt.Sprintf("entity-%d", i))
+		tx.Add(e, name, "Alice")
+		tx.Commit()
+	}
+}
+
+// BenchmarkAddWithSchemaUnique measures Add()+Commit() with uniqueness validation
+func BenchmarkAddWithSchemaUnique(b *testing.B) {
+	tmpDir, _ := os.MkdirTemp("", "bench-unique")
+	defer os.RemoveAll(tmpDir)
+
+	s, _ := schema.NewBuilder().
+		Attribute(":person/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+		Build()
+
+	db, _ := NewDatabaseWithSchema(tmpDir, s)
+	defer db.Close()
+
+	email := datalog.NewKeyword(":person/email")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tx := db.NewTransaction()
+		e := datalog.NewIdentity(fmt.Sprintf("entity-%d", i))
+		tx.Add(e, email, fmt.Sprintf("user%d@example.com", i))
+		tx.Commit()
+	}
+}
+
+// BenchmarkBulkAddWithoutSchema measures bulk inserts without schema
+func BenchmarkBulkAddWithoutSchema(b *testing.B) {
+	tmpDir, _ := os.MkdirTemp("", "bench-bulk-no-schema")
+	defer os.RemoveAll(tmpDir)
+
+	db, _ := NewDatabase(tmpDir)
+	defer db.Close()
+
+	name := datalog.NewKeyword(":person/name")
+	age := datalog.NewKeyword(":person/age")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tx := db.NewTransaction()
+		for j := 0; j < 100; j++ {
+			e := datalog.NewIdentity(fmt.Sprintf("entity-%d-%d", i, j))
+			tx.Add(e, name, "Alice")
+			tx.Add(e, age, int64(30))
+		}
+		tx.Commit()
+	}
+}
+
+// BenchmarkBulkAddWithSchema measures bulk inserts with type validation
+func BenchmarkBulkAddWithSchema(b *testing.B) {
+	tmpDir, _ := os.MkdirTemp("", "bench-bulk-with-schema")
+	defer os.RemoveAll(tmpDir)
+
+	s, _ := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Attribute(":person/age").Type(schema.TypeLong).Add().
+		Build()
+
+	db, _ := NewDatabaseWithSchema(tmpDir, s)
+	defer db.Close()
+
+	name := datalog.NewKeyword(":person/name")
+	age := datalog.NewKeyword(":person/age")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tx := db.NewTransaction()
+		for j := 0; j < 100; j++ {
+			e := datalog.NewIdentity(fmt.Sprintf("entity-%d-%d", i, j))
+			tx.Add(e, name, "Alice")
+			tx.Add(e, age, int64(30))
+		}
+		tx.Commit()
+	}
+}
+
+// BenchmarkBulkAddWithSchemaUnique measures bulk inserts with uniqueness checking
+func BenchmarkBulkAddWithSchemaUnique(b *testing.B) {
+	tmpDir, _ := os.MkdirTemp("", "bench-bulk-unique")
+	defer os.RemoveAll(tmpDir)
+
+	s, _ := schema.NewBuilder().
+		Attribute(":person/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+		Build()
+
+	db, _ := NewDatabaseWithSchema(tmpDir, s)
+	defer db.Close()
+
+	email := datalog.NewKeyword(":person/email")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tx := db.NewTransaction()
+		for j := 0; j < 100; j++ {
+			e := datalog.NewIdentity(fmt.Sprintf("entity-%d-%d", i, j))
+			tx.Add(e, email, fmt.Sprintf("user%d-%d@example.com", i, j))
+		}
+		tx.Commit()
+	}
+}
+
+// BenchmarkPullCardinalityOne measures Pull for cardinality-one attributes
+func BenchmarkPullCardinalityOne(b *testing.B) {
+	tmpDir, _ := os.MkdirTemp("", "bench-pull-one")
+	defer os.RemoveAll(tmpDir)
+
+	s, _ := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Build()
+
+	db, _ := NewDatabaseWithSchema(tmpDir, s)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	tx := db.NewTransaction()
+	tx.Add(alice, name, "Alice Smith")
+	tx.Commit()
+
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: name},
+		},
+	}
+	resolved := schema.ResolvePullPattern(pattern, s)
+
+	matcher := NewBadgerMatcher(db.Store())
+	puller := executor.NewPullExecutor(matcher)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		puller.PullResolved(alice, resolved)
+	}
+}
+
+// BenchmarkPullCardinalityMany measures Pull for cardinality-many attributes
+func BenchmarkPullCardinalityMany(b *testing.B) {
+	tmpDir, _ := os.MkdirTemp("", "bench-pull-many")
+	defer os.RemoveAll(tmpDir)
+
+	s, _ := schema.NewBuilder().
+		Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+		Build()
+
+	db, _ := NewDatabaseWithSchema(tmpDir, s)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	tags := datalog.NewKeyword(":person/tags")
+
+	tx := db.NewTransaction()
+	for i := 0; i < 10; i++ {
+		tx.Add(alice, tags, fmt.Sprintf("tag-%d", i))
+	}
+	tx.Commit()
+
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: tags},
+		},
+	}
+	resolved := schema.ResolvePullPattern(pattern, s)
+
+	matcher := NewBadgerMatcher(db.Store())
+	puller := executor.NewPullExecutor(matcher)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		puller.PullResolved(alice, resolved)
+	}
+}
+
+// BenchmarkSchemaResolution measures the cost of resolving a pull pattern
+func BenchmarkSchemaResolution(b *testing.B) {
+	s, _ := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Attribute(":person/age").Type(schema.TypeLong).Add().
+		Attribute(":person/email").Type(schema.TypeString).Add().
+		Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+		Attribute(":person/friends").Type(schema.TypeRef).Many().Add().
+		Build()
+
+	name := datalog.NewKeyword(":person/name")
+	age := datalog.NewKeyword(":person/age")
+	email := datalog.NewKeyword(":person/email")
+	tags := datalog.NewKeyword(":person/tags")
+	friends := datalog.NewKeyword(":person/friends")
+
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: name},
+			&query.PullAttribute{Attr: age},
+			&query.PullAttribute{Attr: email},
+			&query.PullAttribute{Attr: tags},
+			&query.PullMapSpec{
+				Attr: friends,
+				Pattern: &query.PullPattern{
+					Specs: []query.PullAttrSpec{
+						&query.PullAttribute{Attr: name},
+					},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		schema.ResolvePullPattern(pattern, s)
+	}
+}

--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -1,0 +1,277 @@
+# Schema Support
+
+This document describes janus-datalog's schema support for type validation, cardinality, and uniqueness constraints.
+
+## Overview
+
+Schema support is **optional and additive**:
+- Without schema: all existing behavior is preserved
+- With schema: type validation, cardinality-many, and uniqueness constraints are enforced
+- Unknown attributes are allowed (additive schema model)
+
+## Defining a Schema
+
+### Option 1: EDN File (Datomic-compatible)
+
+```clojure
+{:person/name   {:db/valueType   :db.type/string
+                 :db/cardinality :db.cardinality/one}
+ :person/age    {:db/valueType   :db.type/long}
+ :person/email  {:db/valueType   :db.type/string
+                 :db/unique      :db.unique/value}
+ :person/friends {:db/valueType   :db.type/ref
+                  :db/cardinality :db.cardinality/many
+                  :db/doc         "References to friend entities"}}
+```
+
+Load with:
+```go
+schema, err := schema.ParseSchemaFile("schema.edn")
+```
+
+### Option 2: Go Builder API
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/schema"
+
+s, err := schema.NewBuilder().
+    Attribute(":person/name").Type(schema.TypeString).Add().
+    Attribute(":person/age").Type(schema.TypeLong).Add().
+    Attribute(":person/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+    Attribute(":person/friends").Type(schema.TypeRef).Many().Doc("References to friends").Add().
+    Build()
+```
+
+## Using Schema with Database
+
+```go
+// Create database with schema
+db, err := storage.NewDatabaseWithSchema("/path/to/db", s)
+
+// Or add schema to existing database
+db, _ := storage.NewDatabase("/path/to/db")
+db.SetSchema(s)
+```
+
+## Supported Attributes
+
+### `:db/valueType`
+
+| Type | Go Type | Constant |
+|------|---------|----------|
+| `:db.type/string` | `string` | `schema.TypeString` |
+| `:db.type/long` | `int64`, `int`, `int32`, `int16`, `int8` | `schema.TypeLong` |
+| `:db.type/double` | `float64`, `float32` | `schema.TypeDouble` |
+| `:db.type/boolean` | `bool` | `schema.TypeBoolean` |
+| `:db.type/instant` | `time.Time` | `schema.TypeInstant` |
+| `:db.type/bytes` | `[]byte` | `schema.TypeBytes` |
+| `:db.type/ref` | `datalog.Identity` | `schema.TypeRef` |
+| `:db.type/keyword` | `datalog.Keyword` | `schema.TypeKeyword` |
+
+### `:db/cardinality`
+
+| Cardinality | Description | Constant |
+|-------------|-------------|----------|
+| `:db.cardinality/one` | Single value (default) | `schema.CardinalityOne` |
+| `:db.cardinality/many` | Multiple values | `schema.CardinalityMany` |
+
+### `:db/unique`
+
+| Unique | Description | Constant |
+|--------|-------------|----------|
+| (none) | No uniqueness constraint | `""` |
+| `:db.unique/value` | Value must be unique across entities | `schema.UniqueValue` |
+| `:db.unique/identity` | Value uniqueness (upsert semantics planned) | `schema.UniqueIdentity` |
+
+### `:db/doc`
+
+Documentation string for the attribute.
+
+## Validation Behavior
+
+### Type Validation
+
+Type validation occurs at `Transaction.Add()` time:
+
+```go
+tx := db.NewTransaction()
+
+// OK - string value for string attribute
+tx.Add(alice, kw(":person/name"), "Alice")
+
+// ERROR - int value for string attribute
+err := tx.Add(alice, kw(":person/name"), 123)
+// err: "schema validation failed for :person/name: expected db.type/string (string), got int"
+```
+
+### Uniqueness Validation
+
+Uniqueness validation occurs at `Transaction.Commit()` time:
+
+```go
+// First transaction succeeds
+tx1 := db.NewTransaction()
+tx1.Add(alice, kw(":person/email"), "alice@example.com")
+tx1.Commit()
+
+// Second transaction fails - email already exists
+tx2 := db.NewTransaction()
+tx2.Add(bob, kw(":person/email"), "alice@example.com")
+_, err := tx2.Commit()
+// err: "uniqueness violation for :person/email: value alice@example.com already exists on entity ..."
+```
+
+Uniqueness is also checked within a single transaction:
+
+```go
+tx := db.NewTransaction()
+tx.Add(alice, kw(":person/email"), "shared@example.com")
+tx.Add(bob, kw(":person/email"), "shared@example.com")
+_, err := tx.Commit()
+// err: "uniqueness violation for :person/email: value shared@example.com already used by entity ..."
+```
+
+### Idempotent Updates
+
+Asserting the same value for the same entity is allowed:
+
+```go
+tx1 := db.NewTransaction()
+tx1.Add(alice, kw(":person/email"), "alice@example.com")
+tx1.Commit()
+
+// OK - same entity, same value
+tx2 := db.NewTransaction()
+tx2.Add(alice, kw(":person/email"), "alice@example.com")
+tx2.Commit() // succeeds
+```
+
+## Pull API with Schema
+
+Schema enables proper cardinality-many handling in the Pull API.
+
+### Without Schema (default behavior)
+
+```go
+// Returns single value even if multiple exist
+result, _ := puller.Pull(alice, pattern)
+// result["person/tags"] = "developer"  // Only first value
+```
+
+### With Schema
+
+```go
+// Resolve pattern with schema
+resolved := schema.ResolvePullPattern(pattern, db.Schema())
+
+// Execute with resolved pattern
+result, _ := puller.PullResolved(alice, resolved)
+// result["person/tags"] = ["developer", "team-lead", "mentor"]  // All values
+```
+
+### Complete Example
+
+```go
+// Schema with cardinality-many
+s, _ := schema.NewBuilder().
+    Attribute(":person/name").Type(schema.TypeString).Add().
+    Attribute(":person/friends").Type(schema.TypeRef).Many().Add().
+    Build()
+
+db, _ := storage.NewDatabaseWithSchema(tmpDir, s)
+
+// Add data
+tx := db.NewTransaction()
+tx.Add(alice, kw(":person/name"), "Alice")
+tx.Add(alice, kw(":person/friends"), bob)
+tx.Add(alice, kw(":person/friends"), carol)
+tx.Commit()
+
+// Pull pattern with nested refs
+pattern := &query.PullPattern{
+    Specs: []query.PullAttrSpec{
+        &query.PullAttribute{Attr: kw(":person/name")},
+        &query.PullMapSpec{
+            Attr: kw(":person/friends"),
+            Pattern: &query.PullPattern{
+                Specs: []query.PullAttrSpec{
+                    &query.PullAttribute{Attr: kw(":person/name")},
+                },
+            },
+        },
+    },
+}
+
+// Resolve and execute
+resolved := schema.ResolvePullPattern(pattern, s)
+matcher := storage.NewBadgerMatcher(db.Store())
+puller := executor.NewPullExecutor(matcher)
+result, _ := puller.PullResolved(alice, resolved)
+
+// Result:
+// {
+//   "person/name": "Alice",
+//   "person/friends": [
+//     {"person/name": "Bob"},
+//     {"person/name": "Carol"}
+//   ]
+// }
+```
+
+## SchemaProvider Interface
+
+For custom schema implementations:
+
+```go
+type SchemaProvider interface {
+    GetAttribute(attr datalog.Keyword) *AttributeDefinition
+    HasSchema() bool
+    IsRef(attr datalog.Keyword) bool
+    IsMany(attr datalog.Keyword) bool
+}
+```
+
+## Performance
+
+Schema validation impacts **writes only**. Reads are completely unaffected.
+
+| Operation | Overhead | When |
+|-----------|----------|------|
+| Type validation | <0.2% | `Add()` time |
+| Uniqueness checking | ~6% | `Commit()` time |
+| Schema resolution | 225ns | Once per Pull pattern |
+
+**Recommendation**: Enable schema validation freely. The write overhead is minimal and provides valuable type safety and data integrity.
+
+See `PERFORMANCE_STATUS.md` for detailed benchmarks.
+
+## Limitations
+
+Current limitations compared to Datomic:
+
+1. **No `:db/isComponent`** - component entity semantics not implemented
+2. **No `:db/index`** - all attributes are indexed by default
+3. **No `:db/fulltext`** - fulltext search not supported
+4. **No `:db/noHistory`** - all datoms are retained
+5. **No upsert semantics** - `:db.unique/identity` currently behaves like `:db.unique/value`
+6. **Schema not stored as datoms** - schema is in-memory only
+
+## Package Reference
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/schema"
+
+// Types
+schema.ValueType      // string, long, double, boolean, instant, bytes, ref, keyword
+schema.Cardinality    // one, many
+schema.Unique         // value, identity
+
+// Functions
+schema.NewBuilder()                    // Start building a schema
+schema.NewSchema()                     // Create empty schema
+schema.ParseSchema(input string)       // Parse EDN schema string
+schema.ParseSchemaFile(path string)    // Parse EDN schema file
+schema.ResolvePullPattern(p, s)        // Resolve pull pattern with schema
+schema.ValidateValue(v, t)             // Validate value against type
+schema.ValidateDatom(s, attr, v)       // Validate datom against schema
+```

--- a/examples/schema_demo.go
+++ b/examples/schema_demo.go
@@ -1,0 +1,232 @@
+//go:build example
+// +build example
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+func main() {
+	// Create a temporary directory for the database
+	tmpDir, err := os.MkdirTemp("", "schema-demo")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fmt.Println("=== Schema Demo ===")
+	fmt.Println()
+
+	// =========================================================================
+	// Part 1: Define Schema
+	// =========================================================================
+	fmt.Println("1. Defining Schema")
+	fmt.Println("-------------------")
+
+	s, err := schema.NewBuilder().
+		// Simple string attribute
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		// Integer attribute
+		Attribute(":person/age").Type(schema.TypeLong).Add().
+		// Unique email
+		Attribute(":person/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+		// Cardinality-many tags
+		Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+		// Cardinality-many refs to friends
+		Attribute(":person/friends").Type(schema.TypeRef).Many().Doc("References to friend entities").Add().
+		Build()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Schema defined with attributes:")
+	fmt.Println("  :person/name    - string, cardinality-one")
+	fmt.Println("  :person/age     - long, cardinality-one")
+	fmt.Println("  :person/email   - string, unique")
+	fmt.Println("  :person/tags    - string, cardinality-many")
+	fmt.Println("  :person/friends - ref, cardinality-many")
+	fmt.Println()
+
+	// =========================================================================
+	// Part 2: Create Database with Schema
+	// =========================================================================
+	fmt.Println("2. Creating Database with Schema")
+	fmt.Println("---------------------------------")
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, s)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	fmt.Println("Database created with schema validation enabled")
+	fmt.Println()
+
+	// =========================================================================
+	// Part 3: Add Data with Type Validation
+	// =========================================================================
+	fmt.Println("3. Adding Data with Type Validation")
+	fmt.Println("------------------------------------")
+
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	carol := datalog.NewIdentity("carol")
+
+	name := datalog.NewKeyword(":person/name")
+	age := datalog.NewKeyword(":person/age")
+	email := datalog.NewKeyword(":person/email")
+	tags := datalog.NewKeyword(":person/tags")
+	friends := datalog.NewKeyword(":person/friends")
+
+	// Add Alice with multiple tags and friends
+	tx := db.NewTransaction()
+	tx.Add(alice, name, "Alice Smith")
+	tx.Add(alice, age, int64(30))
+	tx.Add(alice, email, "alice@example.com")
+	tx.Add(alice, tags, "developer")
+	tx.Add(alice, tags, "team-lead")
+	tx.Add(alice, tags, "mentor")
+	tx.Add(alice, friends, bob)
+	tx.Add(alice, friends, carol)
+
+	// Add Bob
+	tx.Add(bob, name, "Bob Jones")
+	tx.Add(bob, age, int64(25))
+	tx.Add(bob, email, "bob@example.com")
+	tx.Add(bob, tags, "developer")
+	tx.Add(bob, tags, "backend")
+
+	// Add Carol
+	tx.Add(carol, name, "Carol White")
+	tx.Add(carol, age, int64(28))
+	tx.Add(carol, email, "carol@example.com")
+	tx.Add(carol, tags, "designer")
+
+	_, err = tx.Commit()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Added 3 people with tags and friendships")
+	fmt.Println()
+
+	// =========================================================================
+	// Part 4: Demonstrate Type Validation Failure
+	// =========================================================================
+	fmt.Println("4. Type Validation (Failure Case)")
+	fmt.Println("----------------------------------")
+
+	tx2 := db.NewTransaction()
+	err = tx2.Add(alice, age, "not a number") // Wrong type!
+	if err != nil {
+		fmt.Printf("Type validation caught error: %v\n", err)
+	}
+	fmt.Println()
+
+	// =========================================================================
+	// Part 5: Demonstrate Uniqueness Validation
+	// =========================================================================
+	fmt.Println("5. Uniqueness Validation (Failure Case)")
+	fmt.Println("----------------------------------------")
+
+	dave := datalog.NewIdentity("dave")
+	tx3 := db.NewTransaction()
+	tx3.Add(dave, name, "Dave Brown")
+	tx3.Add(dave, email, "alice@example.com") // Duplicate email!
+	_, err = tx3.Commit()
+	if err != nil {
+		fmt.Printf("Uniqueness validation caught error: %v\n", err)
+	}
+	fmt.Println()
+
+	// =========================================================================
+	// Part 6: Pull API with Cardinality-Many
+	// =========================================================================
+	fmt.Println("6. Pull API with Cardinality-Many")
+	fmt.Println("----------------------------------")
+
+	// Create pull pattern
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: name},
+			&query.PullAttribute{Attr: age},
+			&query.PullAttribute{Attr: tags}, // cardinality-many
+			&query.PullMapSpec{
+				Attr: friends, // cardinality-many refs
+				Pattern: &query.PullPattern{
+					Specs: []query.PullAttrSpec{
+						&query.PullAttribute{Attr: name},
+					},
+				},
+			},
+		},
+	}
+
+	// Resolve pattern with schema (enables cardinality-many handling)
+	resolved := schema.ResolvePullPattern(pattern, s)
+
+	// Execute pull
+	matcher := storage.NewBadgerMatcher(db.Store())
+	puller := executor.NewPullExecutor(matcher)
+	result, err := puller.PullResolved(alice, resolved)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Pull result for Alice:")
+	fmt.Printf("  Name: %v\n", result["person/name"])
+	fmt.Printf("  Age: %v\n", result["person/age"])
+
+	// Tags should be an array
+	if tagsVal, ok := result["person/tags"].([]interface{}); ok {
+		fmt.Printf("  Tags: %v (array with %d items)\n", tagsVal, len(tagsVal))
+	}
+
+	// Friends should be an array of nested objects
+	if friendsVal, ok := result["person/friends"].([]interface{}); ok {
+		fmt.Printf("  Friends: %d friends\n", len(friendsVal))
+		for i, f := range friendsVal {
+			if friendMap, ok := f.(map[string]interface{}); ok {
+				fmt.Printf("    [%d] %v\n", i, friendMap["person/name"])
+			}
+		}
+	}
+	fmt.Println()
+
+	// =========================================================================
+	// Part 7: EDN Schema Parsing
+	// =========================================================================
+	fmt.Println("7. EDN Schema Parsing")
+	fmt.Println("---------------------")
+
+	ednSchema := `{:product/name   {:db/valueType   :db.type/string
+                      :db/cardinality :db.cardinality/one}
+ :product/price  {:db/valueType   :db.type/double}
+ :product/tags   {:db/valueType   :db.type/string
+                  :db/cardinality :db.cardinality/many}
+ :product/sku    {:db/valueType   :db.type/string
+                  :db/unique      :db.unique/identity
+                  :db/doc         "Stock keeping unit"}}`
+
+	parsedSchema, err := schema.ParseSchema(ednSchema)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Parsed EDN schema with attributes:")
+	fmt.Printf("  Count: %d attributes\n", parsedSchema.Count())
+	fmt.Printf("  :product/tags is many? %v\n", parsedSchema.IsMany(datalog.NewKeyword(":product/tags")))
+	fmt.Printf("  :product/name is many? %v\n", parsedSchema.IsMany(datalog.NewKeyword(":product/name")))
+	fmt.Println()
+
+	fmt.Println("=== Demo Complete ===")
+}

--- a/tests/pull_schema_test.go
+++ b/tests/pull_schema_test.go
@@ -1,0 +1,307 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+func TestPullResolvedCardinalityMany(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pull-schema-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema with cardinality-many attribute
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+	tags := datalog.NewKeyword(":person/tags")
+
+	// Add person with multiple tags
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	require.NoError(t, tx.Add(alice, tags, "developer"))
+	require.NoError(t, tx.Add(alice, tags, "team-lead"))
+	require.NoError(t, tx.Add(alice, tags, "mentor"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Create pull pattern
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: name},
+			&query.PullAttribute{Attr: tags},
+		},
+	}
+
+	// Resolve pattern with schema
+	resolved := schema.ResolvePullPattern(pattern, s)
+
+	// Execute pull with resolved pattern
+	matcher := storage.NewBadgerMatcher(db.Store())
+	puller := executor.NewPullExecutor(matcher)
+	result, err := puller.PullResolved(alice, resolved)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Name should be single value
+	assert.Equal(t, "Alice", result["person/name"])
+
+	// Tags should be array (cardinality-many)
+	tagsVal, ok := result["person/tags"].([]interface{})
+	require.True(t, ok, "tags should be []interface{}")
+	assert.Len(t, tagsVal, 3)
+
+	// Check all tags are present (order may vary)
+	tagStrings := make([]string, 0, len(tagsVal))
+	for _, v := range tagsVal {
+		tagStrings = append(tagStrings, v.(string))
+	}
+	assert.Contains(t, tagStrings, "developer")
+	assert.Contains(t, tagStrings, "team-lead")
+	assert.Contains(t, tagStrings, "mentor")
+}
+
+func TestPullResolvedCardinalityManyRefs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pull-refs-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema with cardinality-many refs
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Attribute(":person/friends").Type(schema.TypeRef).Many().Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	carol := datalog.NewIdentity("carol")
+	name := datalog.NewKeyword(":person/name")
+	friends := datalog.NewKeyword(":person/friends")
+
+	// Add people and friendships
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	require.NoError(t, tx.Add(bob, name, "Bob"))
+	require.NoError(t, tx.Add(carol, name, "Carol"))
+	require.NoError(t, tx.Add(alice, friends, bob))
+	require.NoError(t, tx.Add(alice, friends, carol))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Create pull pattern with nested ref
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: name},
+			&query.PullMapSpec{
+				Attr: friends,
+				Pattern: &query.PullPattern{
+					Specs: []query.PullAttrSpec{
+						&query.PullAttribute{Attr: name},
+					},
+				},
+			},
+		},
+	}
+
+	// Resolve pattern with schema
+	resolved := schema.ResolvePullPattern(pattern, s)
+
+	// Execute pull with resolved pattern
+	matcher := storage.NewBadgerMatcher(db.Store())
+	puller := executor.NewPullExecutor(matcher)
+	result, err := puller.PullResolved(alice, resolved)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Name should be single value
+	assert.Equal(t, "Alice", result["person/name"])
+
+	// Friends should be array of nested objects (cardinality-many refs)
+	friendsVal, ok := result["person/friends"].([]interface{})
+	require.True(t, ok, "friends should be []interface{}")
+	assert.Len(t, friendsVal, 2)
+
+	// Check friend names
+	friendNames := make([]string, 0)
+	for _, f := range friendsVal {
+		friendMap := f.(map[string]interface{})
+		if name, ok := friendMap["person/name"].(string); ok {
+			friendNames = append(friendNames, name)
+		}
+	}
+	assert.Contains(t, friendNames, "Bob")
+	assert.Contains(t, friendNames, "Carol")
+}
+
+func TestPullResolvedLimit(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pull-limit-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema with cardinality-many attribute
+	s, err := schema.NewBuilder().
+		Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	tags := datalog.NewKeyword(":person/tags")
+
+	// Add person with many tags
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(alice, tags, "tag1"))
+	require.NoError(t, tx.Add(alice, tags, "tag2"))
+	require.NoError(t, tx.Add(alice, tags, "tag3"))
+	require.NoError(t, tx.Add(alice, tags, "tag4"))
+	require.NoError(t, tx.Add(alice, tags, "tag5"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Create pull pattern with limit
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullLimitExpr{Attr: tags, Limit: 2},
+		},
+	}
+
+	// Resolve pattern with schema
+	resolved := schema.ResolvePullPattern(pattern, s)
+
+	// Execute pull with resolved pattern
+	matcher := storage.NewBadgerMatcher(db.Store())
+	puller := executor.NewPullExecutor(matcher)
+	result, err := puller.PullResolved(alice, resolved)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Tags should be limited to 2
+	tagsVal, ok := result["person/tags"].([]interface{})
+	require.True(t, ok, "tags should be []interface{}")
+	assert.Len(t, tagsVal, 2, "should be limited to 2 tags")
+}
+
+func TestPullResolvedDefault(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pull-default-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).Add().
+		Attribute(":person/status").Type(schema.TypeString).Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+	status := datalog.NewKeyword(":person/status")
+
+	// Add person without status
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Create pull pattern with default
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: name},
+			&query.PullDefaultExpr{Attr: status, Default: "unknown"},
+		},
+	}
+
+	// Resolve pattern with schema
+	resolved := schema.ResolvePullPattern(pattern, s)
+
+	// Execute pull with resolved pattern
+	matcher := storage.NewBadgerMatcher(db.Store())
+	puller := executor.NewPullExecutor(matcher)
+	result, err := puller.PullResolved(alice, resolved)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Name should be present
+	assert.Equal(t, "Alice", result["person/name"])
+
+	// Status should have default value
+	assert.Equal(t, "unknown", result["person/status"])
+}
+
+func TestPullResolvedWithoutSchema(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pull-no-schema-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create database without schema
+	db, err := storage.NewDatabase(tmpDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+	tags := datalog.NewKeyword(":person/tags")
+
+	// Add person with multiple tags (without schema, each is just another datom)
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	require.NoError(t, tx.Add(alice, tags, "developer"))
+	require.NoError(t, tx.Add(alice, tags, "team-lead"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Create pull pattern
+	pattern := &query.PullPattern{
+		Specs: []query.PullAttrSpec{
+			&query.PullAttribute{Attr: name},
+			&query.PullAttribute{Attr: tags},
+		},
+	}
+
+	// Resolve pattern without schema - all attributes default to cardinality-one
+	resolved := schema.ResolvePullPattern(pattern, nil)
+
+	// Execute pull with resolved pattern
+	matcher := storage.NewBadgerMatcher(db.Store())
+	puller := executor.NewPullExecutor(matcher)
+	result, err := puller.PullResolved(alice, resolved)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Both should be single values (default cardinality-one)
+	assert.Equal(t, "Alice", result["person/name"])
+
+	// Tags will only return one value (whichever is returned first)
+	// This is the expected behavior without schema
+	_, ok := result["person/tags"]
+	assert.True(t, ok, "tags should have some value")
+}


### PR DESCRIPTION
Add optional schema support with type validation, cardinality constraints, and uniqueness enforcement. This feature solves the cardinality-many problem for the Pull API and brings janus-datalog closer to Datomic compatibility (~50-60%).

## Features

### Schema Definition via Go Builder API
```go
schema, _ := schema.NewBuilder().
    Attribute(":person/name").Type(schema.TypeString).Add().
    Attribute(":person/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
    Attribute(":person/tags").Type(schema.TypeString).Many().Add().
    Attribute(":person/friends").Type(schema.TypeRef).Many().Doc("Friend refs").Add().
    Build()

db, _ := storage.NewDatabaseWithSchema("my.db", schema)
```

### Schema Definition via EDN (Datomic-compatible)
```clojure
{:person/name   {:db/valueType   :db.type/string
                 :db/cardinality :db.cardinality/one}
 :person/email  {:db/valueType   :db.type/string
                 :db/unique      :db.unique/value}
 :person/tags   {:db/valueType   :db.type/string
                 :db/cardinality :db.cardinality/many}}
```

### Supported Schema Attributes
- `:db/valueType` - string, long, double, boolean, instant, bytes, ref, keyword
- `:db/cardinality` - one (default), many
- `:db/unique` - value, identity
- `:db/doc` - documentation string

### Pull API with Cardinality-Many
```go
// Resolve pattern with schema (one-time, 225ns)
resolved := schema.ResolvePullPattern(pattern, db.Schema())

// Execute pull - cardinality-many returns arrays
result, _ := puller.PullResolved(alice, resolved)
// result["person/tags"] = ["developer", "team-lead", "mentor"]
// result["person/friends"] = [{...}, {...}]
```

## Design Decisions

| Decision | Choice |
|----------|--------|
| Schema storage | In-memory only (not as datoms) | | Unknown attributes | Allowed (additive schema model) | | Type validation | At `Add()` time |
| Uniqueness validation | At `Commit()` time |
| Schema resolution | Plan-time (once per pattern, not per entity) | | Backward compatibility | nil schema = existing behavior |

## Performance Benchmarks (Apple M4 Max)

### Write Overhead (all impacts are write-path only) | Operation | ns/op | Overhead |
|-----------|-------|----------|
| Add without schema | 25,771 | baseline |
| Add with type validation | 25,768 | **<0.2%** |
| Add with uniqueness | 27,236 | **~5.8%** |

### Bulk Operations (100 items/transaction)
| Operation | ns/op | Overhead |
|-----------|-------|----------|
| Bulk without schema | 1,388,000 | baseline |
| Bulk with schema | 1,408,000 | **~1.4%** |

### Schema Resolution & Pull
| Operation | Time |
|-----------|------|
| Resolve 5-attr pattern | 225ns |
| Pull cardinality-one | 1,117ns |
| Pull cardinality-many (10 values) | 3,679ns |

### Key Performance Insights
- **Reads are completely unaffected** by schema
- Type validation is essentially free (<0.2%)
- Uniqueness requires DB query (~6% overhead)
- Schema resolution is one-time per pattern (225ns)
- Cardinality-many scales linearly (~370ns per value)

## Implementation

### New Package: `datalog/schema/`
- `types.go` - ValueType, Cardinality, Unique, AttributeDefinition, Schema
- `provider.go` - SchemaProvider interface
- `builder.go` - Fluent builder API
- `parser.go` - EDN schema parser
- `validation.go` - Type validation functions
- `resolve.go` - Pull pattern resolution with schema

### Modified Files
- `datalog/storage/database.go` - Schema field, validation in Add/Commit
- `datalog/query/pull.go` - ResolvedPullPattern types
- `datalog/executor/pull.go` - PullResolved(), lookupAllValues()

### Bug Fixes During Implementation
- Fixed deadlock in Database.Close() when rolling back active transactions
- Fixed type assertion for `*datalog.Identity` vs `datalog.Identity`
- Fixed Identity comparison using `.Equal()` instead of `!=`
- Avoided import cycle by moving integration test to tests/ package

## Test Coverage
- Schema tests: `datalog/schema/*_test.go` (7 test files)
- Storage integration: `datalog/storage/database_schema_test.go`
- Pull with schema: `tests/pull_schema_test.go`
- Benchmarks: `datalog/storage/schema_bench_test.go`

## Documentation Updates
- `docs/reference/SCHEMA.md` - Comprehensive schema reference (NEW)
- `DATOMIC_COMPATIBILITY.md` - Updated to ~50-60%, added schema section
- `PERFORMANCE_STATUS.md` - Added schema benchmarks
- `README.md` - Added Schema and Pull API tutorial sections
- `CLAUDE.md` - Added schema package, updated feature list
- `TODO.md` - Moved schema from "Long Term" to "Working Well"
- `examples/schema_demo.go` - Working example (NEW)