### PR TITLE
Implement struct reflection API for Go struct ↔ datom conversion

### DIFF
--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -11,6 +11,7 @@ Janus-datalog implements a pragmatic subset of Datomic's Datalog query language 
 - ✅ Database functions: `get-else`, `missing?`, `get-some`
 - ✅ BadgerDB persistent storage with EAVT model
 - ✅ Schema support: type validation, cardinality, uniqueness
+- ✅ Struct reflection API: Go structs ↔ datoms with automatic schema generation
 - ❌ No rules or transaction functions
 - ❌ No NOT/OR clauses or entity API
 - ❌ Single-node only (no distributed queries)
@@ -249,6 +250,66 @@ results, err := db.PullMany(entityIDs, `[:user/name]`)
 - Each attribute lookup is a single AEVT index seek (no query parsing/planning)
 - Wildcard `[*]` uses single EAVT prefix scan
 - Far more efficient than equivalent application-level N+1 queries
+
+### 11. Struct Reflection API ✅
+
+**Go-specific feature** for ergonomic struct ↔ datom conversion:
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/reflect"
+
+// Define domain types with struct tags
+type Person struct {
+    ID      datalog.Identity `datalog:"-,id"`      // Entity identity
+    Name    string           `datalog:"name"`      // → :person/name
+    Age     int64            `datalog:"age"`       // → :person/age
+    Tags    []string         `datalog:"tags"`      // → :person/tags (many)
+    Manager *Person          `datalog:"manager"`   // → :person/manager (ref)
+}
+
+// Generate schema from struct
+schema, _ := reflect.SchemaFromStruct(Person{})
+db, _ := storage.NewDatabaseWithSchema(path, schema)
+
+// Write struct as datoms
+alice := &Person{Name: "Alice", Age: 30, Tags: []string{"dev"}}
+tx := db.NewTransaction()
+aliceID, _ := tx.AddStructAuto(alice)  // Auto-generate ID
+tx.Commit()
+
+// Read datoms into struct
+var loaded Person
+db.PullInto(aliceID, &loaded)
+// loaded.Name == "Alice", loaded.Tags == ["dev"]
+```
+
+**Key features:**
+- `SchemaFromStruct()` - Generate schema from Go struct definitions
+- `AddStructAuto()` - Write struct with auto-generated unique ID
+- `AddStruct()` - Write struct with explicit entity ID
+- `PullInto()` - Read entity into struct using Pull API
+- `PullIntoMany()` - Read multiple entities into slice
+
+**Tag format:**
+| Tag | Meaning |
+|-----|---------|
+| `datalog:"name"` | Attribute local name (namespace from struct) |
+| `datalog:"ns/name"` | Full attribute name |
+| `datalog:"-"` | Skip this field |
+| `datalog:"-,id"` | Entity identity field |
+
+**Namespace derivation:**
+- `Person` → `person`
+- `PersonInfo` → `person-info`
+- `HTTPServer` → `http-server`
+
+**Cardinality inference:**
+- Single values (`string`, `int64`, `*Person`) → cardinality-one
+- Slices (`[]string`, `[]*Person`) → cardinality-many
+
+**Note:** This is a Go-specific ergonomic feature not found in Datomic. It builds on the Pull API and Schema support to provide idiomatic Go development.
+
+See [docs/reference/REFLECT.md](docs/reference/REFLECT.md) for complete documentation.
 
 ## Missing Datomic Features
 
@@ -501,5 +562,8 @@ For Datomic users, the transition is straightforward:
 2. Use subqueries for complex aggregations
 3. Define schema for type validation and cardinality-many support
 4. Use Pull API with resolved patterns for entity navigation
+5. Use Struct Reflection API for idiomatic Go struct ↔ datom mapping
 
 Most Datalog queries will work with minimal changes, making janus-datalog a practical choice for applications that need Datalog's power without Datomic's full complexity.
+
+**For Go developers:** The Struct Reflection API (`datalog/reflect`) provides a particularly ergonomic way to work with the database using native Go structs instead of manual datom creation.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Available examples:
 - `expression_demo.go` - Expression clauses and arithmetic
 - `schema_demo.go` - Schema validation, cardinality, and uniqueness
 - `pull_demo.go` - Pull API for entity attribute retrieval
+- `reflect_demo.go` - Struct reflection API for Go structs ↔ datoms
 - And many more in `examples/`
 
 ## Tutorial
@@ -293,6 +294,49 @@ result, _ := db.Pull(userId, `[:user/name :user/email {:user/friends [:user/name
 - **9× faster than equivalent queries**
 
 See [DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md) for Pull API details.
+
+### Struct Reflection API
+
+For Go developers, janus-datalog provides a reflection-based API that maps structs directly to datoms:
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/reflect"
+
+// Define your domain type with struct tags
+type Person struct {
+    ID      datalog.Identity `datalog:"-,id"`     // Entity identity
+    Name    string           `datalog:"name"`     // → :person/name
+    Age     int64            `datalog:"age"`      // → :person/age
+    Tags    []string         `datalog:"tags"`     // → :person/tags (many)
+    Manager *Person          `datalog:"manager"`  // → :person/manager (ref)
+}
+
+// Generate schema from struct
+schema, _ := reflect.SchemaFromStruct(Person{})
+db, _ := storage.NewDatabaseWithSchema("my.db", schema)
+
+// Write structs directly
+alice := &Person{Name: "Alice", Age: 30, Tags: []string{"dev", "lead"}}
+tx := db.NewTransaction()
+aliceID, _ := tx.AddStructAuto(alice)  // ID auto-generated
+tx.Commit()
+// alice.ID is now populated
+
+// Read into structs
+var loaded Person
+db.PullInto(aliceID, &loaded)
+fmt.Println(loaded.Name)  // "Alice"
+fmt.Println(loaded.Tags)  // ["dev", "lead"]
+```
+
+**Features:**
+- Schema generation from struct definitions
+- Automatic namespace derivation: `type PersonInfo` → `:person-info/...`
+- Cardinality inference: slices become cardinality-many
+- Auto-generated unique IDs with crypto/rand
+- Reference handling via nested struct pointers
+
+See [docs/reference/REFLECT.md](docs/reference/REFLECT.md) for complete documentation.
 
 ## What Makes Janus Different
 

--- a/datalog/reflect/cache.go
+++ b/datalog/reflect/cache.go
@@ -1,0 +1,44 @@
+package reflect
+
+import (
+	"reflect"
+	"sync"
+)
+
+// structInfoCache stores parsed StructInfo by reflect.Type
+// Using sync.Map for concurrent read/write safety
+var structInfoCache sync.Map
+
+// GetStructInfo returns the StructInfo for a type, using cache
+func GetStructInfo(t reflect.Type) (*StructInfo, error) {
+	// Normalize to non-pointer type
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	// Check cache first
+	if cached, ok := structInfoCache.Load(t); ok {
+		return cached.(*StructInfo), nil
+	}
+
+	// Parse and cache
+	info, err := ParseStructInfo(t)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store in cache (LoadOrStore handles race conditions)
+	actual, _ := structInfoCache.LoadOrStore(t, info)
+	return actual.(*StructInfo), nil
+}
+
+// GetStructInfoFromValue returns the StructInfo for a value
+func GetStructInfoFromValue(v interface{}) (*StructInfo, error) {
+	t := reflect.TypeOf(v)
+	return GetStructInfo(t)
+}
+
+// ClearCache clears the struct info cache (useful for testing)
+func ClearCache() {
+	structInfoCache = sync.Map{}
+}

--- a/datalog/reflect/integration_test.go
+++ b/datalog/reflect/integration_test.go
@@ -1,0 +1,285 @@
+package reflect_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// Test types for integration testing
+type Person struct {
+	ID   datalog.Identity `datalog:"-,id"`
+	Name string           `datalog:"name"`
+	Age  int64            `datalog:"age"`
+}
+
+type PersonWithFriends struct {
+	ID      datalog.Identity    `datalog:"-,id"`
+	Name    string              `datalog:"name"`
+	Age     int64               `datalog:"age"`
+	Friends []*PersonWithFriends `datalog:"friends"`
+}
+
+type PersonWithTags struct {
+	ID   datalog.Identity `datalog:"-,id"`
+	Name string           `datalog:"name"`
+	Tags []string         `datalog:"tags"`
+}
+
+func TestSchemaFromStruct(t *testing.T) {
+	schema, err := dlreflect.SchemaFromStruct(Person{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check that attributes are defined
+	nameAttr := schema.GetAttribute(datalog.NewKeyword(":person/name"))
+	if nameAttr == nil {
+		t.Fatal("expected :person/name attribute")
+	}
+	if nameAttr.ValueType != "db.type/string" {
+		t.Errorf("expected name to be string, got %s", nameAttr.ValueType)
+	}
+
+	ageAttr := schema.GetAttribute(datalog.NewKeyword(":person/age"))
+	if ageAttr == nil {
+		t.Fatal("expected :person/age attribute")
+	}
+	if ageAttr.ValueType != "db.type/long" {
+		t.Errorf("expected age to be long, got %s", ageAttr.ValueType)
+	}
+}
+
+func TestAddStructAndPullInto_Simple(t *testing.T) {
+	// Create temp database
+	tmpDir, err := os.MkdirTemp("", "reflect-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Generate schema from struct
+	schema, err := dlreflect.SchemaFromStruct(Person{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	// Create database with schema
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create and write a person
+	alice := Person{Name: "Alice", Age: 30}
+	tx := db.NewTransaction()
+	aliceID, err := tx.AddStructAuto(&alice)
+	if err != nil {
+		t.Fatalf("failed to add struct: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	// Verify ID was set on struct
+	var zeroHash [20]byte
+	if alice.ID.Hash() == zeroHash {
+		t.Error("expected alice.ID to be set")
+	}
+
+	// Read back using PullInto
+	var loaded Person
+	if err := db.PullInto(aliceID, &loaded); err != nil {
+		t.Fatalf("failed to pull: %v", err)
+	}
+
+	// Verify values
+	if loaded.Name != "Alice" {
+		t.Errorf("expected Name=Alice, got %s", loaded.Name)
+	}
+	if loaded.Age != 30 {
+		t.Errorf("expected Age=30, got %d", loaded.Age)
+	}
+}
+
+func TestAddStructAndPullInto_CardinalityMany(t *testing.T) {
+	// Create temp database
+	tmpDir, err := os.MkdirTemp("", "reflect-test-many")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Generate schema from struct
+	schema, err := dlreflect.SchemaFromStruct(PersonWithTags{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	// Create database with schema
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create and write a person with tags
+	alice := PersonWithTags{
+		Name: "Alice",
+		Tags: []string{"developer", "team-lead", "mentor"},
+	}
+	tx := db.NewTransaction()
+	aliceID, err := tx.AddStructAuto(&alice)
+	if err != nil {
+		t.Fatalf("failed to add struct: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	// Read back using PullInto
+	var loaded PersonWithTags
+	if err := db.PullInto(aliceID, &loaded); err != nil {
+		t.Fatalf("failed to pull: %v", err)
+	}
+
+	// Verify values
+	if loaded.Name != "Alice" {
+		t.Errorf("expected Name=Alice, got %s", loaded.Name)
+	}
+	if len(loaded.Tags) != 3 {
+		t.Errorf("expected 3 tags, got %d", len(loaded.Tags))
+	}
+}
+
+func TestGeneratePullPattern(t *testing.T) {
+	pattern := dlreflect.GeneratePullPattern(Person{}, nil)
+	if pattern == "" {
+		t.Error("expected non-empty pattern")
+	}
+
+	// Should contain the attributes
+	expected := "[:person/name :person/age]"
+	if pattern != expected {
+		t.Errorf("expected pattern=%s, got %s", expected, pattern)
+	}
+}
+
+func TestGeneratePullPattern_Nested(t *testing.T) {
+	pattern := dlreflect.GeneratePullPattern(PersonWithFriends{}, nil)
+	if pattern == "" {
+		t.Error("expected non-empty pattern")
+	}
+
+	// Should contain nested pattern for friends
+	// Due to recursion handling, it should include the nested pattern
+	t.Logf("Generated pattern: %s", pattern)
+}
+
+func TestAddStruct_WithExistingID(t *testing.T) {
+	// Create temp database
+	tmpDir, err := os.MkdirTemp("", "reflect-test-existing-id")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	db, err := storage.NewDatabase(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create person with explicit ID
+	explicitID := datalog.NewIdentity("alice-unique-id")
+	alice := Person{
+		ID:   explicitID,
+		Name: "Alice",
+		Age:  30,
+	}
+
+	tx := db.NewTransaction()
+	returnedID, err := tx.AddStructAuto(&alice)
+	if err != nil {
+		t.Fatalf("failed to add struct: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	// Should use the existing ID
+	if returnedID.Hash() != explicitID.Hash() {
+		t.Error("expected returned ID to match explicit ID")
+	}
+}
+
+func TestPullIntoMany(t *testing.T) {
+	// Create temp database
+	tmpDir, err := os.MkdirTemp("", "reflect-test-many-entities")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(Person{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create multiple people
+	people := []Person{
+		{Name: "Alice", Age: 30},
+		{Name: "Bob", Age: 25},
+		{Name: "Carol", Age: 35},
+	}
+
+	var ids []datalog.Identity
+	tx := db.NewTransaction()
+	for i := range people {
+		id, err := tx.AddStructAuto(&people[i])
+		if err != nil {
+			t.Fatalf("failed to add struct: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	// Read back using PullIntoMany
+	var loaded []Person
+	if err := db.PullIntoMany(ids, &loaded); err != nil {
+		t.Fatalf("failed to pull many: %v", err)
+	}
+
+	// Verify all people loaded
+	if len(loaded) != 3 {
+		t.Fatalf("expected 3 people, got %d", len(loaded))
+	}
+
+	// Verify names
+	names := make(map[string]bool)
+	for i, p := range loaded {
+		if p.Name == "" {
+			t.Logf("person %d has empty name, Age=%d", i, p.Age)
+		}
+		names[p.Name] = true
+	}
+	if !names["Alice"] || !names["Bob"] || !names["Carol"] {
+		t.Errorf("expected to find all names, found: %v", names)
+		// Debug: check original data
+		for i, p := range people {
+			t.Logf("original person %d: Name=%q, Age=%d, ID=%s", i, p.Name, p.Age, p.ID.String()[:20])
+		}
+	}
+}

--- a/datalog/reflect/pattern.go
+++ b/datalog/reflect/pattern.go
@@ -1,0 +1,135 @@
+package reflect
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// GeneratePullPattern creates a pull pattern string from a struct type
+// The pattern includes all fields from the struct, with nested patterns
+// for reference fields.
+//
+// Example:
+//
+//	type Person struct {
+//	    ID      datalog.Identity `datalog:"-,id"`
+//	    Name    string           `datalog:"name"`
+//	    Age     int64            `datalog:"age"`
+//	    Friends []*Person        `datalog:"friends"`
+//	}
+//
+//	pattern := GeneratePullPattern(Person{}, nil)
+//	// Returns: "[:person/name :person/age {:person/friends [:person/name :person/age]}]"
+//
+// Note: To prevent infinite recursion with self-referential structs,
+// nested patterns only include one level of the same type.
+func GeneratePullPattern(v interface{}, s schema.SchemaProvider) string {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	visited := make(map[reflect.Type]bool)
+	return generatePullPatternRecursive(t, s, visited, 0, 3)
+}
+
+// GeneratePullPatternWithDepth creates a pull pattern with a maximum nesting depth
+func GeneratePullPatternWithDepth(v interface{}, s schema.SchemaProvider, maxDepth int) string {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	visited := make(map[reflect.Type]bool)
+	return generatePullPatternRecursive(t, s, visited, 0, maxDepth)
+}
+
+// generatePullPatternRecursive builds the pattern string recursively
+func generatePullPatternRecursive(t reflect.Type, s schema.SchemaProvider, visited map[reflect.Type]bool, depth, maxDepth int) string {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return ""
+	}
+
+	// Check for recursion limit
+	if depth >= maxDepth {
+		return ""
+	}
+
+	// Mark as visited for this path
+	if visited[t] {
+		return ""
+	}
+	visited[t] = true
+	defer func() { visited[t] = false }()
+
+	info, err := GetStructInfo(t)
+	if err != nil {
+		return ""
+	}
+
+	var specs []string
+
+	for _, field := range info.Fields {
+		// Check if this is a reference field with nested struct
+		elemType := ElementType(field.GoType)
+		if elemType.Kind() == reflect.Ptr {
+			elemType = elemType.Elem()
+		}
+
+		isNestedStruct := elemType.Kind() == reflect.Struct &&
+			elemType != timeType &&
+			elemType != identityType &&
+			elemType != keywordType
+
+		if isNestedStruct {
+			// Generate nested pattern
+			nestedPattern := generatePullPatternRecursive(elemType, s, visited, depth+1, maxDepth)
+			if nestedPattern != "" {
+				specs = append(specs, "{"+field.FullAttr+" "+nestedPattern+"}")
+			} else {
+				// No nested pattern (recursion limit), just include the attribute
+				specs = append(specs, field.FullAttr)
+			}
+		} else {
+			// Simple attribute
+			specs = append(specs, field.FullAttr)
+		}
+	}
+
+	if len(specs) == 0 {
+		return ""
+	}
+
+	return "[" + strings.Join(specs, " ") + "]"
+}
+
+// GenerateSimplePullPattern creates a flat pull pattern (no nested refs)
+// This is useful when you only want the direct attributes of an entity.
+func GenerateSimplePullPattern(v interface{}) string {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	info, err := GetStructInfo(t)
+	if err != nil {
+		return ""
+	}
+
+	var specs []string
+	for _, field := range info.Fields {
+		specs = append(specs, field.FullAttr)
+	}
+
+	if len(specs) == 0 {
+		return ""
+	}
+
+	return "[" + strings.Join(specs, " ") + "]"
+}

--- a/datalog/reflect/reader.go
+++ b/datalog/reflect/reader.go
@@ -1,0 +1,306 @@
+package reflect
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// StructReader handles pull result → struct conversion
+type StructReader struct {
+	info   *StructInfo
+	schema schema.SchemaProvider
+}
+
+// NewStructReader creates a reader for a struct type
+func NewStructReader(v interface{}, s schema.SchemaProvider) (*StructReader, error) {
+	info, err := GetStructInfoFromValue(v)
+	if err != nil {
+		return nil, err
+	}
+	return &StructReader{
+		info:   info,
+		schema: s,
+	}, nil
+}
+
+// Read populates struct from pull result map
+func (sr *StructReader) Read(result map[string]interface{}, v interface{}) error {
+	return sr.ReadWithDepth(result, v, 10) // Default max depth
+}
+
+// ReadWithDepth limits nested struct recursion
+func (sr *StructReader) ReadWithDepth(result map[string]interface{}, v interface{}, maxDepth int) error {
+	val := reflect.ValueOf(v)
+	if val.Kind() != reflect.Ptr {
+		return fmt.Errorf("Read requires pointer to struct")
+	}
+	if val.IsNil() {
+		return fmt.Errorf("cannot read into nil pointer")
+	}
+
+	structVal := val.Elem()
+	if structVal.Kind() != reflect.Struct {
+		return fmt.Errorf("expected pointer to struct, got pointer to %s", structVal.Kind())
+	}
+
+	return sr.readIntoStruct(result, structVal, 0, maxDepth)
+}
+
+// readIntoStruct populates a struct value from a result map
+func (sr *StructReader) readIntoStruct(result map[string]interface{}, structVal reflect.Value, depth, maxDepth int) error {
+	if depth >= maxDepth {
+		return nil
+	}
+
+	info, err := GetStructInfo(structVal.Type())
+	if err != nil {
+		return err
+	}
+
+	for _, field := range info.Fields {
+		// Pull results use keys without colon: "person/name" not ":person/name"
+		key := strings.TrimPrefix(field.FullAttr, ":")
+
+		value, ok := result[key]
+		if !ok {
+			// Field not in result, leave as zero value
+			continue
+		}
+
+		fieldVal := structVal.Field(field.Index)
+		if err := sr.setFieldValue(fieldVal, field, value, depth, maxDepth); err != nil {
+			return fmt.Errorf("field %s: %w", field.FieldName, err)
+		}
+	}
+
+	return nil
+}
+
+// setFieldValue sets a struct field from a pull result value
+func (sr *StructReader) setFieldValue(fieldVal reflect.Value, field *FieldInfo, value interface{}, depth, maxDepth int) error {
+	if value == nil {
+		return nil
+	}
+
+	fieldType := field.GoType
+
+	// Handle pointer fields
+	if fieldType.Kind() == reflect.Ptr {
+		// Create new value and set pointer
+		newVal := reflect.New(fieldType.Elem())
+		if err := sr.setSingleValue(newVal.Elem(), fieldType.Elem(), value, depth, maxDepth); err != nil {
+			return err
+		}
+		fieldVal.Set(newVal)
+		return nil
+	}
+
+	// Handle slice fields (cardinality-many)
+	if IsSliceType(fieldType) {
+		return sr.setSliceValue(fieldVal, field, value, depth, maxDepth)
+	}
+
+	// Single value
+	return sr.setSingleValue(fieldVal, fieldType, value, depth, maxDepth)
+}
+
+// setSliceValue handles cardinality-many fields
+func (sr *StructReader) setSliceValue(fieldVal reflect.Value, field *FieldInfo, value interface{}, depth, maxDepth int) error {
+	// Value should be a slice
+	valueSlice, ok := value.([]interface{})
+	if !ok {
+		// Single value - wrap in slice
+		valueSlice = []interface{}{value}
+	}
+
+	elemType := field.GoType.Elem()
+	sliceVal := reflect.MakeSlice(field.GoType, 0, len(valueSlice))
+
+	for _, elem := range valueSlice {
+		var newElem reflect.Value
+
+		if elemType.Kind() == reflect.Ptr {
+			// Pointer element
+			newElem = reflect.New(elemType.Elem())
+			if err := sr.setSingleValue(newElem.Elem(), elemType.Elem(), elem, depth, maxDepth); err != nil {
+				return err
+			}
+		} else {
+			// Value element
+			newElem = reflect.New(elemType).Elem()
+			if err := sr.setSingleValue(newElem, elemType, elem, depth, maxDepth); err != nil {
+				return err
+			}
+		}
+
+		sliceVal = reflect.Append(sliceVal, newElem)
+	}
+
+	fieldVal.Set(sliceVal)
+	return nil
+}
+
+// setSingleValue sets a single value (not slice) to a reflect.Value
+func (sr *StructReader) setSingleValue(fieldVal reflect.Value, fieldType reflect.Type, value interface{}, depth, maxDepth int) error {
+	// Handle pointer types by dereferencing the target type
+	if fieldType.Kind() == reflect.Ptr {
+		fieldType = fieldType.Elem()
+	}
+
+	// Handle nested struct (from pull result map or Identity)
+	if fieldType.Kind() == reflect.Struct &&
+		fieldType != timeType &&
+		fieldType != identityType &&
+		fieldType != keywordType {
+
+		// Could be a map (nested pull result) or Identity (ref without nested pattern)
+		switch v := value.(type) {
+		case map[string]interface{}:
+			nestedInfo, err := GetStructInfo(fieldType)
+			if err != nil {
+				return err
+			}
+			// Create temporary reader for nested struct
+			nestedReader := &StructReader{info: nestedInfo, schema: sr.schema}
+			return nestedReader.readIntoStruct(v, fieldVal, depth+1, maxDepth)
+
+		case datalog.Identity:
+			// Just an Identity ref - try to set the ID field if the struct has one
+			return sr.setNestedStructID(fieldVal, fieldType, v)
+
+		case *datalog.Identity:
+			// Pointer to Identity ref
+			if v != nil {
+				return sr.setNestedStructID(fieldVal, fieldType, *v)
+			}
+			return nil
+
+		default:
+			return fmt.Errorf("expected map or Identity for nested struct, got %T", value)
+		}
+	}
+
+	// Handle specific types
+	switch fieldType {
+	case timeType:
+		t, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("expected time.Time, got %T", value)
+		}
+		fieldVal.Set(reflect.ValueOf(t))
+		return nil
+
+	case identityType:
+		id, ok := value.(datalog.Identity)
+		if !ok {
+			return fmt.Errorf("expected Identity, got %T", value)
+		}
+		fieldVal.Set(reflect.ValueOf(id))
+		return nil
+
+	case keywordType:
+		kw, ok := value.(datalog.Keyword)
+		if !ok {
+			return fmt.Errorf("expected Keyword, got %T", value)
+		}
+		fieldVal.Set(reflect.ValueOf(kw))
+		return nil
+	}
+
+	// Handle basic types
+	switch fieldType.Kind() {
+	case reflect.String:
+		s, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("expected string, got %T", value)
+		}
+		fieldVal.SetString(s)
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		var i int64
+		switch v := value.(type) {
+		case int64:
+			i = v
+		case int:
+			i = int64(v)
+		case int32:
+			i = int64(v)
+		case float64:
+			i = int64(v)
+		default:
+			return fmt.Errorf("expected integer, got %T", value)
+		}
+		fieldVal.SetInt(i)
+
+	case reflect.Float32, reflect.Float64:
+		var f float64
+		switch v := value.(type) {
+		case float64:
+			f = v
+		case float32:
+			f = float64(v)
+		case int64:
+			f = float64(v)
+		default:
+			return fmt.Errorf("expected float, got %T", value)
+		}
+		fieldVal.SetFloat(f)
+
+	case reflect.Bool:
+		b, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("expected bool, got %T", value)
+		}
+		fieldVal.SetBool(b)
+
+	case reflect.Slice:
+		// []byte
+		if fieldType.Elem().Kind() == reflect.Uint8 {
+			b, ok := value.([]byte)
+			if !ok {
+				return fmt.Errorf("expected []byte, got %T", value)
+			}
+			fieldVal.SetBytes(b)
+		} else {
+			return fmt.Errorf("unsupported slice type: %s", fieldType)
+		}
+
+	default:
+		return fmt.Errorf("unsupported type: %s", fieldType)
+	}
+
+	return nil
+}
+
+// setNestedStructID sets just the ID field of a nested struct from an Identity
+func (sr *StructReader) setNestedStructID(fieldVal reflect.Value, fieldType reflect.Type, id datalog.Identity) error {
+	nestedInfo, err := GetStructInfo(fieldType)
+	if err != nil {
+		return err
+	}
+	if nestedInfo.IDField != nil {
+		idField := fieldVal.Field(nestedInfo.IDField.Index)
+		if nestedInfo.IDField.GoType.Kind() == reflect.Ptr {
+			newID := reflect.New(identityType)
+			newID.Elem().Set(reflect.ValueOf(id))
+			idField.Set(newID)
+		} else {
+			idField.Set(reflect.ValueOf(id))
+		}
+	}
+	return nil
+}
+
+// ReadStruct is a convenience function that creates a reader and populates the struct
+func ReadStruct(result map[string]interface{}, v interface{}, s schema.SchemaProvider) error {
+	reader, err := NewStructReader(v, s)
+	if err != nil {
+		return err
+	}
+	return reader.Read(result, v)
+}

--- a/datalog/reflect/schema.go
+++ b/datalog/reflect/schema.go
@@ -1,0 +1,99 @@
+package reflect
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// SchemaFromStruct generates a Schema from a struct type
+// The struct's fields are used to define attributes, with the struct name
+// providing the namespace.
+//
+// Example:
+//
+//	type Person struct {
+//	    ID      datalog.Identity `datalog:"-,id"`
+//	    Name    string           `datalog:"name"`
+//	    Age     int64            `datalog:"age"`
+//	    Friends []*Person        `datalog:"friends"`
+//	}
+//
+//	schema, err := reflect.SchemaFromStruct(Person{})
+//	// Produces:
+//	// :person/name   → TypeString, CardinalityOne
+//	// :person/age    → TypeLong, CardinalityOne
+//	// :person/friends → TypeRef, CardinalityMany
+func SchemaFromStruct(v interface{}) (*schema.Schema, error) {
+	return SchemaFromStructs(v)
+}
+
+// SchemaFromStructs generates a Schema from multiple struct types
+// This is useful when your data model spans multiple struct types.
+//
+// Example:
+//
+//	schema, err := reflect.SchemaFromStructs(Person{}, Company{}, Address{})
+func SchemaFromStructs(vs ...interface{}) (*schema.Schema, error) {
+	builder := schema.NewBuilder()
+
+	for _, v := range vs {
+		if err := addStructToBuilder(builder, v); err != nil {
+			return nil, err
+		}
+	}
+
+	return builder.Build()
+}
+
+// addStructToBuilder adds all fields from a struct to a schema builder
+func addStructToBuilder(builder *schema.Builder, v interface{}) error {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	info, err := GetStructInfo(t)
+	if err != nil {
+		return fmt.Errorf("parsing struct %s: %w", t.Name(), err)
+	}
+
+	for _, field := range info.Fields {
+		valueType, err := GoTypeToSchemaType(field.GoType)
+		if err != nil {
+			return fmt.Errorf("field %s.%s: %w", t.Name(), field.FieldName, err)
+		}
+
+		cardinality := InferCardinality(field.GoType)
+
+		ab := builder.Attribute(field.FullAttr).Type(valueType)
+
+		if cardinality == schema.CardinalityMany {
+			ab.Many()
+		}
+
+		ab.Add()
+	}
+
+	return nil
+}
+
+// MustSchemaFromStruct is like SchemaFromStruct but panics on error
+// Useful for static schema definitions
+func MustSchemaFromStruct(v interface{}) *schema.Schema {
+	s, err := SchemaFromStruct(v)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// MustSchemaFromStructs is like SchemaFromStructs but panics on error
+func MustSchemaFromStructs(vs ...interface{}) *schema.Schema {
+	s, err := SchemaFromStructs(vs...)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}

--- a/datalog/reflect/tags.go
+++ b/datalog/reflect/tags.go
@@ -1,0 +1,194 @@
+// Package reflect provides reflection-based utilities for converting
+// Go structs to/from datoms, making the database more ergonomic to use.
+package reflect
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+// FieldInfo contains parsed tag information for a struct field
+type FieldInfo struct {
+	FieldName string       // Go field name
+	AttrName  string       // Attribute local name (from tag or field name)
+	FullAttr  string       // Full attribute with namespace: ":person/name"
+	IsID      bool         // This field holds entity Identity
+	Skip      bool         // Skip this field entirely
+	Index     int          // Field index in struct
+	GoType    reflect.Type // Go type of field
+}
+
+// StructInfo contains metadata about a struct type
+type StructInfo struct {
+	Name      string                // Struct name: "Person"
+	Namespace string                // Derived namespace: "person"
+	Fields    []*FieldInfo          // All mapped fields (non-ID, non-skipped)
+	IDField   *FieldInfo            // The identity field (if any)
+	FieldMap  map[string]*FieldInfo // FullAttr → FieldInfo for quick lookup
+	Type      reflect.Type          // The underlying reflect.Type
+}
+
+// GetField returns the FieldInfo for a given full attribute name
+func (si *StructInfo) GetField(fullAttr string) *FieldInfo {
+	return si.FieldMap[fullAttr]
+}
+
+// GetFieldByName returns the FieldInfo for a given attribute local name
+func (si *StructInfo) GetFieldByName(attrName string) *FieldInfo {
+	fullAttr := ":" + si.Namespace + "/" + attrName
+	return si.FieldMap[fullAttr]
+}
+
+// ParseStructInfo parses a struct type and extracts tag information
+func ParseStructInfo(t reflect.Type) (*StructInfo, error) {
+	// Handle pointer to struct
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected struct type, got %s", t.Kind())
+	}
+
+	info := &StructInfo{
+		Name:      t.Name(),
+		Namespace: toNamespace(t.Name()),
+		Fields:    make([]*FieldInfo, 0),
+		FieldMap:  make(map[string]*FieldInfo),
+		Type:      t,
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		fieldInfo, err := parseFieldTag(field, i, info.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("field %s: %w", field.Name, err)
+		}
+
+		// Handle ID field
+		if fieldInfo.IsID {
+			if info.IDField != nil {
+				return nil, fmt.Errorf("multiple ID fields: %s and %s", info.IDField.FieldName, fieldInfo.FieldName)
+			}
+			info.IDField = fieldInfo
+			continue
+		}
+
+		// Skip explicitly skipped fields
+		if fieldInfo.Skip {
+			continue
+		}
+
+		info.Fields = append(info.Fields, fieldInfo)
+		info.FieldMap[fieldInfo.FullAttr] = fieldInfo
+	}
+
+	return info, nil
+}
+
+// parseFieldTag parses the datalog tag from a struct field
+func parseFieldTag(field reflect.StructField, index int, namespace string) (*FieldInfo, error) {
+	info := &FieldInfo{
+		FieldName: field.Name,
+		Index:     index,
+		GoType:    field.Type,
+	}
+
+	tag := field.Tag.Get("datalog")
+
+	// No tag - use field name converted to kebab-case
+	if tag == "" {
+		info.AttrName = toKebabCase(field.Name)
+		info.FullAttr = ":" + namespace + "/" + info.AttrName
+		return info, nil
+	}
+
+	// Parse tag parts
+	parts := strings.Split(tag, ",")
+	name := strings.TrimSpace(parts[0])
+
+	// Check for modifiers
+	for _, part := range parts[1:] {
+		part = strings.TrimSpace(part)
+		switch part {
+		case "id":
+			info.IsID = true
+		}
+	}
+
+	// Handle skip marker
+	if name == "-" {
+		if info.IsID {
+			// "-,id" means this is the ID field (skip as regular attribute)
+			info.Skip = false
+		} else {
+			info.Skip = true
+		}
+		return info, nil
+	}
+
+	// Check if full attribute provided (contains /)
+	if strings.Contains(name, "/") {
+		// Full attribute - ensure it starts with :
+		if !strings.HasPrefix(name, ":") {
+			name = ":" + name
+		}
+		info.FullAttr = name
+		// Extract local name
+		idx := strings.LastIndex(name, "/")
+		info.AttrName = name[idx+1:]
+	} else {
+		// Local name only - add namespace
+		info.AttrName = name
+		info.FullAttr = ":" + namespace + "/" + name
+	}
+
+	return info, nil
+}
+
+// toNamespace converts a struct name to a namespace
+// PersonInfo → person-info
+func toNamespace(name string) string {
+	return toKebabCase(name)
+}
+
+// toKebabCase converts CamelCase to kebab-case
+// PersonInfo → person-info
+// HTTPServer → http-server
+func toKebabCase(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	var result strings.Builder
+	result.Grow(len(s) + 4) // Pre-allocate with some buffer for hyphens
+
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			// Add hyphen before uppercase (except at start)
+			if i > 0 {
+				// Check if previous char was lowercase or if next char is lowercase
+				// This handles cases like "HTTPServer" → "http-server"
+				prev := rune(s[i-1])
+				if unicode.IsLower(prev) {
+					result.WriteRune('-')
+				} else if i+1 < len(s) && unicode.IsLower(rune(s[i+1])) {
+					result.WriteRune('-')
+				}
+			}
+			result.WriteRune(unicode.ToLower(r))
+		} else {
+			result.WriteRune(r)
+		}
+	}
+
+	return result.String()
+}

--- a/datalog/reflect/tags_test.go
+++ b/datalog/reflect/tags_test.go
@@ -1,0 +1,176 @@
+package reflect
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// Test types for tag parsing
+type SimpleStruct struct {
+	ID   datalog.Identity `datalog:"-,id"`
+	Name string           `datalog:"name"`
+	Age  int64            `datalog:"age"`
+}
+
+type StructWithDefaults struct {
+	ID          datalog.Identity `datalog:"-,id"`
+	FirstName   string           // Uses field name converted to kebab-case
+	LastName    string           // Uses field name converted to kebab-case
+	EmailAddr   string           `datalog:"email"` // Explicit name
+	unexported  string           // Should be ignored
+	SkipMe      string           `datalog:"-"` // Explicit skip
+}
+
+type StructWithFullAttr struct {
+	ID     datalog.Identity `datalog:"-,id"`
+	Name   string           `datalog:"custom/name"`   // Full attribute name
+	Other  string           `datalog:":other/value"`  // Full attribute with colon
+}
+
+func TestParseStructInfo_Simple(t *testing.T) {
+	info, err := ParseStructInfo(reflect.TypeOf(SimpleStruct{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.Name != "SimpleStruct" {
+		t.Errorf("expected Name=SimpleStruct, got %s", info.Name)
+	}
+	if info.Namespace != "simple-struct" {
+		t.Errorf("expected Namespace=simple-struct, got %s", info.Namespace)
+	}
+	if info.IDField == nil {
+		t.Fatal("expected IDField to be set")
+	}
+	if !info.IDField.IsID {
+		t.Error("expected IDField.IsID to be true")
+	}
+	if len(info.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(info.Fields))
+	}
+
+	// Check Name field
+	nameField := info.GetFieldByName("name")
+	if nameField == nil {
+		t.Fatal("expected to find name field")
+	}
+	if nameField.FullAttr != ":simple-struct/name" {
+		t.Errorf("expected FullAttr=:simple-struct/name, got %s", nameField.FullAttr)
+	}
+
+	// Check Age field
+	ageField := info.GetFieldByName("age")
+	if ageField == nil {
+		t.Fatal("expected to find age field")
+	}
+	if ageField.FullAttr != ":simple-struct/age" {
+		t.Errorf("expected FullAttr=:simple-struct/age, got %s", ageField.FullAttr)
+	}
+}
+
+func TestParseStructInfo_Defaults(t *testing.T) {
+	info, err := ParseStructInfo(reflect.TypeOf(StructWithDefaults{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have 3 fields (FirstName, LastName, EmailAddr)
+	// unexported and SkipMe should be excluded
+	if len(info.Fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(info.Fields))
+	}
+
+	// Check FirstName field - uses field name converted to kebab-case
+	firstNameField := info.GetFieldByName("first-name")
+	if firstNameField == nil {
+		t.Fatal("expected to find first-name field")
+	}
+	if firstNameField.FullAttr != ":struct-with-defaults/first-name" {
+		t.Errorf("expected FullAttr=:struct-with-defaults/first-name, got %s", firstNameField.FullAttr)
+	}
+
+	// Check explicit email field
+	emailField := info.GetFieldByName("email")
+	if emailField == nil {
+		t.Fatal("expected to find email field")
+	}
+}
+
+func TestParseStructInfo_FullAttr(t *testing.T) {
+	info, err := ParseStructInfo(reflect.TypeOf(StructWithFullAttr{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check custom/name
+	nameField := info.GetField(":custom/name")
+	if nameField == nil {
+		t.Fatal("expected to find :custom/name field")
+	}
+
+	// Check :other/value
+	otherField := info.GetField(":other/value")
+	if otherField == nil {
+		t.Fatal("expected to find :other/value field")
+	}
+}
+
+func TestParseStructInfo_Pointer(t *testing.T) {
+	// Should handle pointer to struct
+	info, err := ParseStructInfo(reflect.TypeOf(&SimpleStruct{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.Name != "SimpleStruct" {
+		t.Errorf("expected Name=SimpleStruct, got %s", info.Name)
+	}
+}
+
+func TestToKebabCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Person", "person"},
+		{"PersonInfo", "person-info"},
+		{"HTTPServer", "http-server"},
+		{"XMLParser", "xml-parser"},
+		{"ID", "id"},
+		{"userID", "user-id"},
+		{"firstName", "first-name"},
+		{"", ""},
+		{"A", "a"},
+		{"AB", "ab"},
+		{"ABC", "abc"},
+	}
+
+	for _, tt := range tests {
+		result := toKebabCase(tt.input)
+		if result != tt.expected {
+			t.Errorf("toKebabCase(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+// Test error cases
+type StructWithMultipleIDs struct {
+	ID1 datalog.Identity `datalog:"-,id"`
+	ID2 datalog.Identity `datalog:"-,id"`
+}
+
+func TestParseStructInfo_MultipleIDs(t *testing.T) {
+	_, err := ParseStructInfo(reflect.TypeOf(StructWithMultipleIDs{}))
+	if err == nil {
+		t.Error("expected error for multiple ID fields")
+	}
+}
+
+func TestParseStructInfo_NonStruct(t *testing.T) {
+	_, err := ParseStructInfo(reflect.TypeOf(42))
+	if err == nil {
+		t.Error("expected error for non-struct type")
+	}
+}

--- a/datalog/reflect/types.go
+++ b/datalog/reflect/types.go
@@ -1,0 +1,143 @@
+package reflect
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// Well-known types for comparison
+var (
+	timeType     = reflect.TypeOf(time.Time{})
+	identityType = reflect.TypeOf(datalog.Identity{})
+	keywordType  = reflect.TypeOf(datalog.Keyword{})
+)
+
+// GoTypeToSchemaType maps a Go reflect.Type to a schema.ValueType
+func GoTypeToSchemaType(t reflect.Type) (schema.ValueType, error) {
+	// Handle pointers by dereferencing
+	if t.Kind() == reflect.Ptr {
+		return GoTypeToSchemaType(t.Elem())
+	}
+
+	switch t.Kind() {
+	case reflect.String:
+		return schema.TypeString, nil
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return schema.TypeLong, nil
+
+	case reflect.Float32, reflect.Float64:
+		return schema.TypeDouble, nil
+
+	case reflect.Bool:
+		return schema.TypeBoolean, nil
+
+	case reflect.Slice:
+		// []byte is TypeBytes
+		if t.Elem().Kind() == reflect.Uint8 {
+			return schema.TypeBytes, nil
+		}
+		// Slice of other types = cardinality-many, recurse on element type
+		return GoTypeToSchemaType(t.Elem())
+
+	case reflect.Struct:
+		// Check well-known types
+		if t == timeType {
+			return schema.TypeInstant, nil
+		}
+		if t == identityType {
+			return schema.TypeRef, nil
+		}
+		if t == keywordType {
+			return schema.TypeKeyword, nil
+		}
+		// Other struct = nested reference
+		return schema.TypeRef, nil
+	}
+
+	return "", fmt.Errorf("unsupported type: %s", t)
+}
+
+// InferCardinality determines cardinality from a Go type
+// Slices (except []byte) are cardinality-many, everything else is one
+func InferCardinality(t reflect.Type) schema.Cardinality {
+	// Handle pointers
+	if t.Kind() == reflect.Ptr {
+		return InferCardinality(t.Elem())
+	}
+
+	if t.Kind() == reflect.Slice && t.Elem().Kind() != reflect.Uint8 {
+		return schema.CardinalityMany
+	}
+	return schema.CardinalityOne
+}
+
+// IsRefType checks if a Go type represents a reference to another entity
+func IsRefType(t reflect.Type) bool {
+	// Handle pointers
+	if t.Kind() == reflect.Ptr {
+		return IsRefType(t.Elem())
+	}
+
+	// Direct Identity type
+	if t == identityType {
+		return true
+	}
+
+	// Slice of Identity
+	if t.Kind() == reflect.Slice && t.Elem() == identityType {
+		return true
+	}
+
+	// Struct (other than well-known types) = nested entity reference
+	if t.Kind() == reflect.Struct {
+		if t == timeType || t == keywordType {
+			return false
+		}
+		return true
+	}
+
+	// Slice of structs (nested entity references)
+	if t.Kind() == reflect.Slice {
+		elem := t.Elem()
+		if elem.Kind() == reflect.Ptr {
+			elem = elem.Elem()
+		}
+		if elem.Kind() == reflect.Struct {
+			if elem == timeType || elem == keywordType || elem == identityType {
+				return false
+			}
+			return true
+		}
+	}
+
+	return false
+}
+
+// ElementType returns the element type for slices/pointers, or the type itself
+func ElementType(t reflect.Type) reflect.Type {
+	if t.Kind() == reflect.Ptr {
+		return ElementType(t.Elem())
+	}
+	if t.Kind() == reflect.Slice {
+		return t.Elem()
+	}
+	return t
+}
+
+// IsPointerType checks if a type is a pointer (indicating optional)
+func IsPointerType(t reflect.Type) bool {
+	return t.Kind() == reflect.Ptr
+}
+
+// IsSliceType checks if a type is a slice (indicating cardinality-many)
+func IsSliceType(t reflect.Type) bool {
+	if t.Kind() == reflect.Ptr {
+		return IsSliceType(t.Elem())
+	}
+	return t.Kind() == reflect.Slice && t.Elem().Kind() != reflect.Uint8
+}

--- a/datalog/reflect/writer.go
+++ b/datalog/reflect/writer.go
@@ -1,0 +1,297 @@
+package reflect
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// generateUniqueID creates a unique entity ID using timestamp + random bytes
+func generateUniqueID() datalog.Identity {
+	// 8 random bytes gives us 64 bits of entropy
+	var randomBytes [8]byte
+	rand.Read(randomBytes[:])
+	randomHex := hex.EncodeToString(randomBytes[:])
+	return datalog.NewIdentity(fmt.Sprintf("e%d-%s", time.Now().UnixNano(), randomHex))
+}
+
+// TransactionAdder is the interface required for adding datoms
+// This is implemented by storage.Transaction
+type TransactionAdder interface {
+	Add(e datalog.Identity, a datalog.Keyword, v interface{}) error
+}
+
+// StructWriter handles struct → datom conversion
+type StructWriter struct {
+	info   *StructInfo
+	schema schema.SchemaProvider
+}
+
+// NewStructWriter creates a writer for a struct type
+func NewStructWriter(v interface{}, s schema.SchemaProvider) (*StructWriter, error) {
+	info, err := GetStructInfoFromValue(v)
+	if err != nil {
+		return nil, err
+	}
+	return &StructWriter{
+		info:   info,
+		schema: s,
+	}, nil
+}
+
+// Write adds all fields from struct to transaction
+func (sw *StructWriter) Write(tx TransactionAdder, entity datalog.Identity, v interface{}) error {
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return fmt.Errorf("cannot write nil struct")
+		}
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return fmt.Errorf("expected struct, got %s", val.Kind())
+	}
+
+	for _, field := range sw.info.Fields {
+		fieldVal := val.Field(field.Index)
+
+		// Handle pointer fields (optional)
+		if field.GoType.Kind() == reflect.Ptr {
+			if fieldVal.IsNil() {
+				// Skip nil optional fields
+				continue
+			}
+			fieldVal = fieldVal.Elem()
+		}
+
+		// Get the keyword for this attribute
+		kw := datalog.NewKeyword(field.FullAttr)
+
+		// Handle different field types
+		if err := sw.writeField(tx, entity, kw, field, fieldVal); err != nil {
+			return fmt.Errorf("field %s: %w", field.FieldName, err)
+		}
+	}
+
+	return nil
+}
+
+// writeField writes a single field value to the transaction
+func (sw *StructWriter) writeField(tx TransactionAdder, entity datalog.Identity, kw datalog.Keyword, field *FieldInfo, val reflect.Value) error {
+	// Handle slice fields (cardinality-many)
+	if IsSliceType(field.GoType) {
+		return sw.writeSliceField(tx, entity, kw, field, val)
+	}
+
+	// Get the value to write
+	writeVal, err := sw.extractValue(field, val)
+	if err != nil {
+		return err
+	}
+
+	// Skip zero values for optional types
+	if writeVal == nil {
+		return nil
+	}
+
+	return tx.Add(entity, kw, writeVal)
+}
+
+// writeSliceField handles cardinality-many fields
+func (sw *StructWriter) writeSliceField(tx TransactionAdder, entity datalog.Identity, kw datalog.Keyword, field *FieldInfo, val reflect.Value) error {
+	if val.Kind() != reflect.Slice {
+		return fmt.Errorf("expected slice, got %s", val.Kind())
+	}
+
+	for i := 0; i < val.Len(); i++ {
+		elem := val.Index(i)
+
+		// Handle pointer elements
+		if elem.Kind() == reflect.Ptr {
+			if elem.IsNil() {
+				continue
+			}
+			elem = elem.Elem()
+		}
+
+		writeVal, err := sw.extractSingleValue(elem)
+		if err != nil {
+			return fmt.Errorf("element %d: %w", i, err)
+		}
+
+		if writeVal == nil {
+			continue
+		}
+
+		if err := tx.Add(entity, kw, writeVal); err != nil {
+			return fmt.Errorf("element %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// extractValue extracts a value from a reflect.Value for storage
+func (sw *StructWriter) extractValue(field *FieldInfo, val reflect.Value) (interface{}, error) {
+	return sw.extractSingleValue(val)
+}
+
+// extractSingleValue extracts a single value from a reflect.Value
+func (sw *StructWriter) extractSingleValue(val reflect.Value) (interface{}, error) {
+	// Handle pointer
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil, nil
+		}
+		val = val.Elem()
+	}
+
+	// Get interface value
+	if !val.CanInterface() {
+		return nil, fmt.Errorf("cannot get interface for unexported field")
+	}
+
+	v := val.Interface()
+
+	// Handle specific types
+	switch typedVal := v.(type) {
+	case string:
+		return typedVal, nil
+	case int64:
+		return typedVal, nil
+	case int:
+		return int64(typedVal), nil
+	case int32:
+		return int64(typedVal), nil
+	case int16:
+		return int64(typedVal), nil
+	case int8:
+		return int64(typedVal), nil
+	case float64:
+		return typedVal, nil
+	case float32:
+		return float64(typedVal), nil
+	case bool:
+		return typedVal, nil
+	case time.Time:
+		return typedVal, nil
+	case []byte:
+		return typedVal, nil
+	case datalog.Identity:
+		return typedVal, nil
+	case datalog.Keyword:
+		return typedVal, nil
+	default:
+		// Check if it's a nested struct (reference)
+		if val.Kind() == reflect.Struct {
+			// Try to get the ID field from the nested struct
+			nestedInfo, err := GetStructInfo(val.Type())
+			if err != nil {
+				return nil, fmt.Errorf("cannot get info for nested struct %s: %w", val.Type().Name(), err)
+			}
+			if nestedInfo.IDField == nil {
+				return nil, fmt.Errorf("nested struct %s has no ID field", val.Type().Name())
+			}
+			idVal := val.Field(nestedInfo.IDField.Index)
+			if idVal.Kind() == reflect.Ptr {
+				if idVal.IsNil() {
+					return nil, fmt.Errorf("nested struct %s has nil ID", val.Type().Name())
+				}
+				idVal = idVal.Elem()
+			}
+			id, ok := idVal.Interface().(datalog.Identity)
+			if !ok {
+				return nil, fmt.Errorf("nested struct %s ID field is not Identity", val.Type().Name())
+			}
+			return id, nil
+		}
+		return nil, fmt.Errorf("unsupported type: %T", v)
+	}
+}
+
+// WriteAuto generates entity ID if not set, returns the ID
+// If the struct has an ID field and it's set, use that
+// If the struct has an ID field and it's zero, generate and set it
+// If the struct has no ID field, generate an ID
+func (sw *StructWriter) WriteAuto(tx TransactionAdder, v interface{}) (datalog.Identity, error) {
+	val := reflect.ValueOf(v)
+
+	// Must be pointer to struct for setting ID
+	if val.Kind() != reflect.Ptr {
+		return datalog.Identity{}, fmt.Errorf("WriteAuto requires pointer to struct")
+	}
+	if val.IsNil() {
+		return datalog.Identity{}, fmt.Errorf("cannot write nil struct")
+	}
+
+	structVal := val.Elem()
+	if structVal.Kind() != reflect.Struct {
+		return datalog.Identity{}, fmt.Errorf("expected pointer to struct, got pointer to %s", structVal.Kind())
+	}
+
+	var entity datalog.Identity
+
+	// Check for existing ID
+	if sw.info.IDField != nil {
+		idField := structVal.Field(sw.info.IDField.Index)
+
+		// Handle pointer ID field
+		if sw.info.IDField.GoType.Kind() == reflect.Ptr {
+			if !idField.IsNil() {
+				entity = idField.Elem().Interface().(datalog.Identity)
+			}
+		} else {
+			entity = idField.Interface().(datalog.Identity)
+		}
+
+		// Check if ID is zero (all zeros in the hash)
+		var zeroHash [20]byte
+		if entity.Hash() == zeroHash {
+			// Generate new unique ID
+			entity = generateUniqueID()
+
+			// Set the ID field
+			if sw.info.IDField.GoType.Kind() == reflect.Ptr {
+				newID := reflect.New(identityType)
+				newID.Elem().Set(reflect.ValueOf(entity))
+				idField.Set(newID)
+			} else {
+				idField.Set(reflect.ValueOf(entity))
+			}
+		}
+	} else {
+		// No ID field, generate a unique ID
+		entity = generateUniqueID()
+	}
+
+	// Write the struct
+	if err := sw.Write(tx, entity, v); err != nil {
+		return datalog.Identity{}, err
+	}
+
+	return entity, nil
+}
+
+// WriteStruct is a convenience function that creates a writer and writes the struct
+func WriteStruct(tx TransactionAdder, entity datalog.Identity, v interface{}, s schema.SchemaProvider) error {
+	writer, err := NewStructWriter(v, s)
+	if err != nil {
+		return err
+	}
+	return writer.Write(tx, entity, v)
+}
+
+// WriteStructAuto is a convenience function that creates a writer and writes the struct with auto ID
+func WriteStructAuto(tx TransactionAdder, v interface{}, s schema.SchemaProvider) (datalog.Identity, error) {
+	writer, err := NewStructWriter(v, s)
+	if err != nil {
+		return datalog.Identity{}, err
+	}
+	return writer.WriteAuto(tx, v)
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/parser"
 	"github.com/wbrown/janus-datalog/datalog/planner"
 	"github.com/wbrown/janus-datalog/datalog/query"
+	dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -394,6 +395,34 @@ func (t *Transaction) AddMap(attrs map[string]interface{}) (datalog.Identity, er
 	}
 
 	return e, nil
+}
+
+// AddStruct adds all fields from a struct as datoms for the given entity.
+// The struct fields are mapped to attributes based on datalog struct tags.
+//
+// Example:
+//
+//	type Person struct {
+//	    ID   datalog.Identity `datalog:"-,id"`
+//	    Name string           `datalog:"name"`
+//	    Age  int64            `datalog:"age"`
+//	}
+//	tx.AddStruct(entityID, &person)
+func (t *Transaction) AddStruct(entity datalog.Identity, v interface{}) error {
+	return dlreflect.WriteStruct(t, entity, v, t.db.Schema())
+}
+
+// AddStructAuto adds all fields from a struct as datoms, auto-generating an entity ID if needed.
+// If the struct has an ID field (tagged with `datalog:"-,id"`) and it's empty, a new ID is generated.
+// The generated or existing ID is returned and also set on the struct's ID field.
+//
+// Example:
+//
+//	person := Person{Name: "Alice", Age: 30}
+//	id, err := tx.AddStructAuto(&person)
+//	// person.ID is now set to the generated identity
+func (t *Transaction) AddStructAuto(v interface{}) (datalog.Identity, error) {
+	return dlreflect.WriteStructAuto(t, v, t.db.Schema())
 }
 
 // Commit commits the transaction
@@ -797,4 +826,125 @@ func (d *Database) PullMany(entityIDs []datalog.Identity, patternStr string) ([]
 
 	// Execute pull for all entities
 	return puller.PullMany(entityIDs, pattern)
+}
+
+// PullInto retrieves entity data and populates the provided struct.
+// The struct fields are mapped to attributes based on datalog struct tags.
+// A pull pattern is automatically generated from the struct definition.
+// Schema is used to properly handle cardinality-many attributes.
+//
+// Example:
+//
+//	type Person struct {
+//	    ID      datalog.Identity `datalog:"-,id"`
+//	    Name    string           `datalog:"name"`
+//	    Age     int64            `datalog:"age"`
+//	    Friends []*Person        `datalog:"friends"`
+//	}
+//	var person Person
+//	err := db.PullInto(entityID, &person)
+func (d *Database) PullInto(entityID datalog.Identity, v interface{}) error {
+	// Generate pull pattern from struct
+	patternStr := dlreflect.GeneratePullPattern(v, d.Schema())
+	if patternStr == "" {
+		return fmt.Errorf("could not generate pull pattern for %T", v)
+	}
+
+	// Parse the pattern
+	pattern, err := parser.ParsePullPattern(patternStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse pull pattern: %w", err)
+	}
+
+	// Resolve with schema for proper cardinality handling
+	resolved := schema.ResolvePullPattern(pattern, d.Schema())
+
+	// Create pull executor and execute
+	matcher := d.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+	result, err := puller.PullResolved(entityID, resolved)
+	if err != nil {
+		return err
+	}
+
+	// Populate struct from result
+	return dlreflect.ReadStruct(result, v, d.Schema())
+}
+
+// PullIntoMany retrieves data for multiple entities and populates the provided slice.
+// The slice must be a pointer to a slice of structs (e.g., *[]Person or *[]*Person).
+// Schema is used to properly handle cardinality-many attributes.
+//
+// Example:
+//
+//	var people []Person
+//	err := db.PullIntoMany(entityIDs, &people)
+func (d *Database) PullIntoMany(entityIDs []datalog.Identity, v interface{}) error {
+	// Get the slice element type
+	sliceVal := reflect.ValueOf(v)
+	if sliceVal.Kind() != reflect.Ptr {
+		return fmt.Errorf("PullIntoMany requires pointer to slice")
+	}
+	sliceVal = sliceVal.Elem()
+	if sliceVal.Kind() != reflect.Slice {
+		return fmt.Errorf("PullIntoMany requires pointer to slice, got pointer to %s", sliceVal.Kind())
+	}
+
+	elemType := sliceVal.Type().Elem()
+	isPtr := elemType.Kind() == reflect.Ptr
+	if isPtr {
+		elemType = elemType.Elem()
+	}
+
+	// Create a sample struct to generate pattern
+	sampleStruct := reflect.New(elemType).Interface()
+	patternStr := dlreflect.GeneratePullPattern(sampleStruct, d.Schema())
+	if patternStr == "" {
+		return fmt.Errorf("could not generate pull pattern for %s", elemType.Name())
+	}
+
+	// Parse the pattern
+	pattern, err := parser.ParsePullPattern(patternStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse pull pattern: %w", err)
+	}
+
+	// Resolve with schema for proper cardinality handling
+	resolved := schema.ResolvePullPattern(pattern, d.Schema())
+
+	// Create pull executor and execute
+	matcher := d.Matcher()
+	puller := executor.NewPullExecutor(matcher)
+	results, err := puller.PullResolvedMany(entityIDs, resolved)
+	if err != nil {
+		return err
+	}
+
+	// Populate slice from results
+	newSlice := reflect.MakeSlice(sliceVal.Type(), 0, len(results))
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+
+		var newElem reflect.Value
+		if isPtr {
+			newElem = reflect.New(elemType)
+		} else {
+			newElem = reflect.New(elemType)
+		}
+
+		if err := dlreflect.ReadStruct(result, newElem.Interface(), d.Schema()); err != nil {
+			return err
+		}
+
+		if isPtr {
+			newSlice = reflect.Append(newSlice, newElem)
+		} else {
+			newSlice = reflect.Append(newSlice, newElem.Elem())
+		}
+	}
+
+	sliceVal.Set(newSlice)
+	return nil
 }

--- a/docs/reference/REFLECT.md
+++ b/docs/reference/REFLECT.md
@@ -1,0 +1,337 @@
+# Struct Reflection API
+
+This document describes janus-datalog's struct reflection API for mapping Go structs to/from datoms.
+
+## Overview
+
+The reflection API provides a more ergonomic way to work with the database:
+
+- **`SchemaFromStruct()`** - Generate schema from struct definitions
+- **`AddStruct()`** / **`AddStructAuto()`** - Write structs as datoms
+- **`PullInto()`** / **`PullIntoMany()`** - Read datoms into structs
+
+## Struct Tags
+
+Use the `datalog` tag to control field mapping:
+
+```go
+type Person struct {
+    ID      datalog.Identity `datalog:"-,id"`      // Entity identity field
+    Name    string           `datalog:"name"`      // → :person/name
+    Age     int64            `datalog:"age"`       // → :person/age
+    Bio     *string          `datalog:"bio"`       // Optional field (pointer)
+    Tags    []string         `datalog:"tags"`      // Cardinality-many
+    Manager *Person          `datalog:"manager"`   // Ref to another entity
+    Friends []*Person        `datalog:"friends"`   // Many refs
+    Skip    string           `datalog:"-"`         // Explicit skip
+    private string           // Unexported = ignored
+}
+```
+
+### Tag Format
+
+| Tag | Meaning |
+|-----|---------|
+| `datalog:"name"` | Attribute local name (namespace from struct) |
+| `datalog:"namespace/name"` | Full attribute name |
+| `datalog:"-"` | Skip this field |
+| `datalog:"-,id"` | This field holds the entity Identity |
+
+### Namespace Derivation
+
+The namespace is derived from the struct name using kebab-case:
+
+| Struct Type | Namespace |
+|-------------|-----------|
+| `Person` | `person` |
+| `PersonInfo` | `person-info` |
+| `HTTPServer` | `http-server` |
+
+### Cardinality Inference
+
+Cardinality is determined by schema (authoritative) or Go type (fallback):
+
+| Go Type | Inferred Cardinality |
+|---------|---------------------|
+| `string`, `int64`, etc. | one |
+| `*T` (pointer) | one (optional) |
+| `[]T` (slice) | many |
+| `[]*T` (slice of pointers) | many |
+
+## Generating Schema
+
+### From Single Struct
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/reflect"
+
+schema, err := reflect.SchemaFromStruct(Person{})
+```
+
+### From Multiple Structs
+
+```go
+schema, err := reflect.SchemaFromStructs(Person{}, Company{}, Order{})
+```
+
+### Using Generated Schema
+
+```go
+db, err := storage.NewDatabaseWithSchema(path, schema)
+```
+
+## Writing Structs
+
+### With Auto-Generated ID
+
+```go
+person := &Person{
+    Name:  "Alice",
+    Age:   30,
+    Tags:  []string{"developer", "team-lead"},
+}
+
+tx := db.NewTransaction()
+id, err := tx.AddStructAuto(person)  // ID auto-generated
+tx.Commit()
+
+// person.ID is now set to the generated identity
+fmt.Println(person.ID)  // e1234567890-a1b2c3d4...
+```
+
+### With Explicit ID
+
+```go
+person := &Person{
+    ID:   datalog.NewIdentity("alice-unique-id"),
+    Name: "Alice",
+    Age:  30,
+}
+
+tx := db.NewTransaction()
+tx.AddStruct(person.ID, person)
+tx.Commit()
+```
+
+### With Pre-Set ID
+
+```go
+person := &Person{
+    ID:   datalog.NewIdentity("alice"),  // Pre-set ID
+    Name: "Alice",
+}
+
+tx := db.NewTransaction()
+id, err := tx.AddStructAuto(person)  // Uses existing ID
+// id == person.ID
+```
+
+## Reading Structs
+
+### Single Entity
+
+```go
+var person Person
+err := db.PullInto(entityID, &person)
+
+fmt.Println(person.Name)  // "Alice"
+fmt.Println(person.Tags)  // ["developer", "team-lead"]
+```
+
+### Multiple Entities
+
+```go
+var people []Person
+err := db.PullIntoMany(entityIDs, &people)
+
+for _, p := range people {
+    fmt.Println(p.Name)
+}
+```
+
+### With Pointer Slice
+
+```go
+var people []*Person
+err := db.PullIntoMany(entityIDs, &people)
+```
+
+## Reference Handling
+
+### Writing References
+
+References to other entities use the `datalog.Identity` type:
+
+```go
+// Create manager
+manager := &Person{Name: "Carol", Age: 35}
+tx := db.NewTransaction()
+managerID, _ := tx.AddStructAuto(manager)
+
+// Create employee with manager reference
+employee := &Person{
+    Name:    "Alice",
+    Manager: &Person{ID: managerID},  // Just need the ID set
+}
+tx.AddStructAuto(employee)
+tx.Commit()
+```
+
+Or add references separately:
+
+```go
+tx.Add(employeeID, datalog.NewKeyword(":person/manager"), managerID)
+```
+
+### Reading References
+
+When reading, reference fields contain only the ID (not full nested data) unless nested patterns are generated:
+
+```go
+var person Person
+db.PullInto(aliceID, &person)
+
+// person.Manager has only the ID field populated
+if person.Manager != nil {
+    // Load manager's data separately
+    var manager Person
+    db.PullInto(person.Manager.ID, &manager)
+}
+```
+
+## Type Mapping
+
+### Go Types to Schema Types
+
+| Go Type | Schema ValueType |
+|---------|-----------------|
+| `string` | `db.type/string` |
+| `int64`, `int`, `int32`, etc. | `db.type/long` |
+| `float64`, `float32` | `db.type/double` |
+| `bool` | `db.type/boolean` |
+| `time.Time` | `db.type/instant` |
+| `[]byte` | `db.type/bytes` |
+| `datalog.Identity` | `db.type/ref` |
+| `datalog.Keyword` | `db.type/keyword` |
+| `*OtherStruct` | `db.type/ref` |
+
+## Pattern Generation
+
+The API automatically generates pull patterns from struct definitions:
+
+```go
+// Generate pattern for debugging
+pattern := reflect.GeneratePullPattern(Person{}, schema)
+// Returns: "[:person/name :person/age :person/email :person/tags ...]"
+
+// Simple (flat) pattern without nested refs
+simple := reflect.GenerateSimplePullPattern(Person{})
+```
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/wbrown/janus-datalog/datalog"
+    "github.com/wbrown/janus-datalog/datalog/reflect"
+    "github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+type Person struct {
+    ID      datalog.Identity `datalog:"-,id"`
+    Name    string           `datalog:"name"`
+    Age     int64            `datalog:"age"`
+    Tags    []string         `datalog:"tags"`
+}
+
+func main() {
+    tmpDir, _ := os.MkdirTemp("", "example")
+    defer os.RemoveAll(tmpDir)
+
+    // Generate schema from struct
+    schema, _ := reflect.SchemaFromStruct(Person{})
+    db, _ := storage.NewDatabaseWithSchema(tmpDir, schema)
+    defer db.Close()
+
+    // Write
+    alice := &Person{
+        Name: "Alice",
+        Age:  30,
+        Tags: []string{"developer", "mentor"},
+    }
+    tx := db.NewTransaction()
+    aliceID, _ := tx.AddStructAuto(alice)
+    tx.Commit()
+
+    fmt.Printf("Created: %s\n", alice.ID.String()[:20])
+
+    // Read
+    var loaded Person
+    db.PullInto(aliceID, &loaded)
+
+    fmt.Printf("Name: %s\n", loaded.Name)
+    fmt.Printf("Age: %d\n", loaded.Age)
+    fmt.Printf("Tags: %v\n", loaded.Tags)
+}
+```
+
+## Performance
+
+- **StructInfo caching**: Struct metadata is cached using `sync.Map` for O(1) lookups after first parse
+- **Reflection overhead**: ~100ns per field access (Go reflection cost)
+- **Schema resolution**: Uses resolved pull patterns for proper cardinality-many handling
+- **Bulk operations**: `AddStruct` calls `Add()` per field (same overhead as manual datom creation)
+
+## Limitations
+
+1. **Self-referential structs**: Pull patterns for self-referential types (e.g., `Friends []*Person`) generate flat patterns to prevent infinite recursion
+2. **Circular references on write**: Caller is responsible for ensuring entities exist before referencing them
+3. **Unexported fields**: Always ignored (Go reflection limitation)
+4. **Interface fields**: Not supported - use concrete types
+
+## Package Reference
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/reflect"
+
+// Schema generation
+reflect.SchemaFromStruct(v interface{}) (*schema.Schema, error)
+reflect.SchemaFromStructs(vs ...interface{}) (*schema.Schema, error)
+reflect.MustSchemaFromStruct(v interface{}) *schema.Schema
+
+// Pattern generation
+reflect.GeneratePullPattern(v interface{}, s schema.SchemaProvider) string
+reflect.GenerateSimplePullPattern(v interface{}) string
+
+// Writing (usually use Transaction methods instead)
+reflect.WriteStruct(tx TransactionAdder, entity Identity, v interface{}, s SchemaProvider) error
+reflect.WriteStructAuto(tx TransactionAdder, v interface{}, s SchemaProvider) (Identity, error)
+
+// Reading (usually use Database methods instead)
+reflect.ReadStruct(result map[string]interface{}, v interface{}, s SchemaProvider) error
+```
+
+### Transaction Methods
+
+```go
+// Write struct with explicit entity ID
+tx.AddStruct(entityID datalog.Identity, v interface{}) error
+
+// Write struct with auto-generated entity ID
+tx.AddStructAuto(v interface{}) (datalog.Identity, error)
+```
+
+### Database Methods
+
+```go
+// Read entity into struct
+db.PullInto(entityID datalog.Identity, v interface{}) error
+
+// Read multiple entities into slice
+db.PullIntoMany(entityIDs []datalog.Identity, v interface{}) error
+```

--- a/examples/reflect_demo.go
+++ b/examples/reflect_demo.go
@@ -1,0 +1,292 @@
+//go:build example
+// +build example
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/reflect"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// ============================================================================
+// Define your domain types with struct tags
+// ============================================================================
+
+// Person represents a person in our domain.
+// The `datalog` tag maps struct fields to database attributes.
+type Person struct {
+	// ID field marked with "-,id" - holds the entity identity
+	ID datalog.Identity `datalog:"-,id"`
+
+	// Simple attributes - namespace derived from struct name (person)
+	Name  string `datalog:"name"`  // → :person/name
+	Age   int64  `datalog:"age"`   // → :person/age
+	Email string `datalog:"email"` // → :person/email
+
+	// Cardinality-many: slice of strings
+	Tags []string `datalog:"tags"` // → :person/tags (many)
+
+	// Reference to another entity
+	Manager *Person `datalog:"manager"` // → :person/manager (ref)
+
+	// Cardinality-many references
+	Friends []*Person `datalog:"friends"` // → :person/friends (many refs)
+}
+
+// Company demonstrates a different namespace
+type Company struct {
+	ID       datalog.Identity `datalog:"-,id"`
+	Name     string           `datalog:"name"`     // → :company/name
+	Industry string           `datalog:"industry"` // → :company/industry
+}
+
+func main() {
+	// Create a temporary directory for the database
+	tmpDir, err := os.MkdirTemp("", "reflect-demo")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fmt.Println("=== Struct Reflection API Demo ===")
+	fmt.Println()
+
+	// =========================================================================
+	// Part 1: Generate Schema from Structs
+	// =========================================================================
+	fmt.Println("1. Generating Schema from Structs")
+	fmt.Println("----------------------------------")
+
+	// Generate schema from one struct
+	schema, err := reflect.SchemaFromStruct(Person{})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Schema generated from Person struct:")
+	fmt.Println("  :person/name    → string, one")
+	fmt.Println("  :person/age     → long, one")
+	fmt.Println("  :person/email   → string, one")
+	fmt.Println("  :person/tags    → string, many")
+	fmt.Println("  :person/manager → ref, one")
+	fmt.Println("  :person/friends → ref, many")
+	fmt.Println()
+
+	// Can also generate from multiple structs
+	_, err = reflect.SchemaFromStructs(Person{}, Company{})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Combined schema generated from Person and Company")
+	fmt.Println()
+
+	// =========================================================================
+	// Part 2: Create Database with Schema
+	// =========================================================================
+	fmt.Println("2. Creating Database with Schema")
+	fmt.Println("---------------------------------")
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	fmt.Println("Database created with schema validation")
+	fmt.Println()
+
+	// =========================================================================
+	// Part 3: Write Structs to Database
+	// =========================================================================
+	fmt.Println("3. Writing Structs to Database")
+	fmt.Println("-------------------------------")
+
+	// Create some people
+	alice := &Person{
+		Name:  "Alice",
+		Age:   30,
+		Email: "alice@example.com",
+		Tags:  []string{"developer", "team-lead", "mentor"},
+	}
+
+	bob := &Person{
+		Name:  "Bob",
+		Age:   25,
+		Email: "bob@example.com",
+		Tags:  []string{"developer", "junior"},
+	}
+
+	carol := &Person{
+		Name:  "Carol",
+		Age:   35,
+		Email: "carol@example.com",
+		Tags:  []string{"manager", "senior"},
+	}
+
+	// Write using AddStructAuto - generates ID automatically
+	tx := db.NewTransaction()
+
+	aliceID, err := tx.AddStructAuto(alice)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Added Alice with auto-generated ID: %s\n", aliceID.String()[:20]+"...")
+
+	bobID, err := tx.AddStructAuto(bob)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Added Bob with auto-generated ID: %s\n", bobID.String()[:20]+"...")
+
+	carolID, err := tx.AddStructAuto(carol)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Added Carol with auto-generated ID: %s\n", carolID.String()[:20]+"...")
+
+	// Commit the transaction
+	if _, err := tx.Commit(); err != nil {
+		panic(err)
+	}
+
+	// The struct's ID field is now populated
+	fmt.Printf("\nAlice's ID field was set: %v\n", alice.ID.Hash() != [20]byte{})
+	fmt.Println()
+
+	// =========================================================================
+	// Part 4: Add Relationships
+	// =========================================================================
+	fmt.Println("4. Adding Relationships")
+	fmt.Println("------------------------")
+
+	// Update Alice to have Bob and Carol as friends
+	tx = db.NewTransaction()
+
+	// Add friend relationships manually (or could update struct and re-add)
+	tx.Add(aliceID, datalog.NewKeyword(":person/friends"), bobID)
+	tx.Add(aliceID, datalog.NewKeyword(":person/friends"), carolID)
+
+	// Set Carol as Alice's manager
+	tx.Add(aliceID, datalog.NewKeyword(":person/manager"), carolID)
+
+	if _, err := tx.Commit(); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Added Alice's friends (Bob, Carol) and manager (Carol)")
+	fmt.Println()
+
+	// =========================================================================
+	// Part 5: Read Structs from Database
+	// =========================================================================
+	fmt.Println("5. Reading Structs from Database")
+	fmt.Println("---------------------------------")
+
+	// PullInto reads entity into a struct
+	var loadedAlice Person
+	if err := db.PullInto(aliceID, &loadedAlice); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Loaded Alice:\n")
+	fmt.Printf("  Name:  %s\n", loadedAlice.Name)
+	fmt.Printf("  Age:   %d\n", loadedAlice.Age)
+	fmt.Printf("  Email: %s\n", loadedAlice.Email)
+	fmt.Printf("  Tags:  %v\n", loadedAlice.Tags)
+	fmt.Println()
+
+	// =========================================================================
+	// Part 6: Read Multiple Structs
+	// =========================================================================
+	fmt.Println("6. Reading Multiple Structs")
+	fmt.Println("----------------------------")
+
+	var allPeople []Person
+	if err := db.PullIntoMany([]datalog.Identity{aliceID, bobID, carolID}, &allPeople); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Loaded %d people:\n", len(allPeople))
+	for _, p := range allPeople {
+		fmt.Printf("  - %s (age %d): %v\n", p.Name, p.Age, p.Tags)
+	}
+	fmt.Println()
+
+	// =========================================================================
+	// Part 7: Using Explicit Entity IDs
+	// =========================================================================
+	fmt.Println("7. Using Explicit Entity IDs")
+	fmt.Println("-----------------------------")
+
+	// You can provide your own IDs
+	dave := &Person{
+		ID:    datalog.NewIdentity("dave-unique-id"),
+		Name:  "Dave",
+		Age:   40,
+		Email: "dave@example.com",
+		Tags:  []string{"architect"},
+	}
+
+	tx = db.NewTransaction()
+	returnedID, err := tx.AddStructAuto(dave)
+	if err != nil {
+		panic(err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		panic(err)
+	}
+
+	// The returned ID matches the one we provided
+	fmt.Printf("Dave's explicit ID was used: %v\n", returnedID.Hash() == dave.ID.Hash())
+	fmt.Println()
+
+	// =========================================================================
+	// Part 8: Pattern Generation
+	// =========================================================================
+	fmt.Println("8. Pattern Generation")
+	fmt.Println("----------------------")
+
+	// You can see what pull pattern is generated from a struct
+	pattern := reflect.GeneratePullPattern(Person{}, schema)
+	fmt.Printf("Generated pull pattern for Person:\n  %s\n", pattern)
+
+	// For nested structs with refs, patterns include nested attributes
+	simplePattern := reflect.GenerateSimplePullPattern(Person{})
+	fmt.Printf("Simple (flat) pull pattern:\n  %s\n", simplePattern)
+	fmt.Println()
+
+	// =========================================================================
+	// Part 9: Struct Tag Reference
+	// =========================================================================
+	fmt.Println("9. Struct Tag Reference")
+	fmt.Println("------------------------")
+	fmt.Println(`
+Tag format: datalog:"name" or datalog:"namespace/name"
+
+Special tags:
+  datalog:"-"      Skip this field
+  datalog:"-,id"   This field holds the entity Identity
+
+Namespace derivation:
+  type Person → namespace "person"
+  type HTTPServer → namespace "http-server"
+
+Cardinality inference:
+  string         → cardinality one
+  []string       → cardinality many
+  *Person        → cardinality one (optional)
+  []*Person      → cardinality many refs
+
+Examples:
+  Name string           → :person/name (string, one)
+  Tags []string         → :person/tags (string, many)
+  Manager *Person       → :person/manager (ref, one)
+  Friends []*Person     → :person/friends (ref, many)
+`)
+
+	fmt.Println("=== Demo Complete ===")
+}


### PR DESCRIPTION
Add reflection-based APIs for mapping Go structs to/from datoms, making the database much more ergonomic to use. This feature builds on Schema and Pull API to provide idiomatic Go development without manual datom creation.

## Features

### Struct Definition with Tags
```go
type Person struct {
    ID      datalog.Identity `datalog:"-,id"`      // Entity identity
    Name    string           `datalog:"name"`      // → :person/name
    Age     int64            `datalog:"age"`       // → :person/age
    Tags    []string         `datalog:"tags"`      // → :person/tags (many)
    Manager *Person          `datalog:"manager"`   // → :person/manager (ref)
}
```

### Schema Generation from Structs
```go
// Generate schema from struct definition
schema, _ := reflect.SchemaFromStruct(Person{})
db, _ := storage.NewDatabaseWithSchema("my.db", schema)

// Or from multiple structs
schema, _ := reflect.SchemaFromStructs(Person{}, Company{}, Order{})
```

### Write Structs to Database
```go
alice := &Person{Name: "Alice", Age: 30, Tags: []string{"dev", "lead"}}
tx := db.NewTransaction()
aliceID, _ := tx.AddStructAuto(alice)  // Auto-generate unique ID
tx.Commit()
// alice.ID is now populated with the generated identity
```

### Read Structs from Database
```go
var loaded Person
db.PullInto(aliceID, &loaded)
// loaded.Name == "Alice", loaded.Tags == ["dev", "lead"]

// Multiple entities
var people []Person
db.PullIntoMany(entityIDs, &people)
```

## Design Decisions

| Decision | Choice |
|----------|--------|
| Tag name | `datalog` (not `db` or `datomic`) |
| Namespace derivation | From struct name: `PersonInfo` → `person-info` | | Package location | `datalog/reflect/` (new package) | | Cardinality source | Schema authoritative, Go type as fallback | | ID generation | crypto/rand + timestamp for uniqueness | | StructInfo caching | sync.Map for O(1) lookups after first parse |

## Tag Format

| Tag | Meaning |
|-----|---------|
| `datalog:"name"` | Attribute local name (namespace from struct) | | `datalog:"ns/name"` | Full attribute name |
| `datalog:"-"` | Skip this field |
| `datalog:"-,id"` | Entity identity field |

## Type Mapping

| Go Type | Schema ValueType |
|---------|-----------------|
| `string` | `db.type/string` |
| `int64`, `int`, etc. | `db.type/long` |
| `float64`, `float32` | `db.type/double` |
| `bool` | `db.type/boolean` |
| `time.Time` | `db.type/instant` |
| `[]byte` | `db.type/bytes` |
| `*OtherStruct` | `db.type/ref` |

## Implementation

### New Package: `datalog/reflect/`
- `tags.go` - Tag parsing, StructInfo, FieldInfo
- `types.go` - Go type → schema type mapping
- `cache.go` - StructInfo caching with sync.Map
- `schema.go` - SchemaFromStruct implementation
- `writer.go` - Struct → datoms conversion
- `reader.go` - Pull result → struct conversion
- `pattern.go` - Pull pattern generation from struct

### Modified Files
- `datalog/storage/database.go` - AddStruct, AddStructAuto, PullInto, PullIntoMany

### Bug Fixes During Implementation
- Fixed cardinality-many returning only first value (use PullResolved)
- Fixed reader expecting map but Pull returns Identity for refs
- Fixed reader not handling *datalog.Identity (pointer case)
- Fixed flaky test with duplicate IDs (switched to crypto/rand)

## Test Coverage
- Tag parsing: `datalog/reflect/tags_test.go`
- Integration: `datalog/reflect/integration_test.go`
  - Simple struct roundtrip
  - Cardinality-many fields
  - Existing ID preservation
  - Multiple entity PullIntoMany

## Documentation
- `docs/reference/REFLECT.md` - Complete API reference (NEW)
- `examples/reflect_demo.go` - Working demonstration (NEW)
- `README.md` - Added Struct Reflection API section
- `DATOMIC_COMPATIBILITY.md` - Added Section 11 for Go-specific feature