### PR TITLE
Resolve Identity input matching bug as false positive

### DIFF
--- a/docs/bugs/resolved/IDENTITY_INPUT_MATCHING_BUG.md
+++ b/docs/bugs/resolved/IDENTITY_INPUT_MATCHING_BUG.md
@@ -1,0 +1,125 @@
+# Identity Input Parameter Matching Bug
+
+## Status: RESOLVED (False Positive)
+
+## Resolution
+
+**This was NOT a bug in the query engine.** The test incorrectly used Go's struct equality (`!=`) to compare Identity values, which compares ALL fields of the struct. Identity structs loaded from storage have different auxiliary fields (`str`, `l85`, `l85Computed`) than the original Identities, causing struct comparison to fail even when the hash (the actual identity) matches.
+
+**The Fix:** Use `Identity.Equal()` method instead of struct equality `==`/`!=`:
+```go
+// WRONG - compares all struct fields
+if foundID != expectedID { ... }
+
+// CORRECT - compares only the hash
+if !foundID.Equal(expectedID) { ... }
+```
+
+The query engine correctly filters by Identity values in reference attributes. The `ValuesEqual()` function and all internal comparisons use hash-based comparison.
+
+## Original Summary (Incorrect)
+
+When an `Identity` value is passed as an input parameter to a Datalog query, the constraint `[?e :attr ?inputIdentity]` does NOT correctly filter to entities where `:attr` equals the input Identity. Instead, it returns arbitrary entities that happen to have that attribute, regardless of the attribute's actual value.
+
+## Original Impact Assessment (Incorrect)
+
+**Critical** - This breaks ALL entity queries that filter by a reference attribute:
+- `:entity/map` (finding entities belonging to a specific map)
+- `:entity/region` (finding entities in a specific region)
+- Any reference-type attribute used as a filter
+
+## Original Reproduction
+
+### Minimal Test Case
+
+```go
+func TestIdentityQueryMatching(t *testing.T) {
+    db, cleanup := createTestDB(t)
+    defer cleanup()
+
+    // Define attributes
+    refAttr := datalog.NewKeyword(":test/ref")
+    codeAttr := datalog.NewKeyword(":test/code")
+
+    // Create two different "parent" entities
+    parent1 := datalog.NewIdentity(generateUUID())
+    parent2 := datalog.NewIdentity(generateUUID())
+
+    // Create child1 referencing parent1
+    child1 := datalog.NewIdentity(generateUUID())
+    db.Assert([]datalog.Datom{
+        {E: child1, A: refAttr, V: parent1},
+        {E: child1, A: codeAttr, V: "child1"},
+    })
+
+    // Create child2 referencing parent2
+    child2 := datalog.NewIdentity(generateUUID())
+    db.Assert([]datalog.Datom{
+        {E: child2, A: refAttr, V: parent2},
+        {E: child2, A: codeAttr, V: "child2"},
+    })
+
+    // Query: find children of parent1
+    tuples, _ := db.store.ExecuteQueryWithInputs(
+        `[:find ?c ?code :in $ ?parent :where [?c :test/ref ?parent] [?c :test/code ?code]]`,
+        parent1,
+    )
+
+    // EXPECTED: 1 result - child1 with code "child1"
+    // ACTUAL: 1 result - but it's the WRONG entity with a DIFFERENT ref value
+}
+```
+
+### Observed Behavior
+
+```
+parent1: B-v@]gL{QHZOR754fsJj
+parent2: e]ffS4,nc`g8G/yfL(j$
+child1: 3$b@N<B:f;28=a.8J;0A (refs parent1)
+child2: wV!x%p8W=SB<{({La}N: (refs parent2)
+
+Query for parent1's children returned 1 results:
+  Result 0: ID=b:Ic<JFVFBc[;0jc6IKa_/C9, Code=child1
+
+BUG: Wrong child returned:
+  expected: 3$b@N<B:f;28=a.8J;0A
+  got:      b:Ic<JFVFBc[;0jc6IKa_/C9,
+
+Found entity's ref: 9s4PW66]2[:i&&3&OdO%e(j$T
+Our parent1: B-v@]gL{QHZOR754fsJj
+Refs equal: false
+```
+
+Key observations:
+1. Query correctly returns 1 result (not 2)
+2. But the returned entity has a **completely different** `:test/ref` value
+3. The entity ID returned doesn't match either child we created
+4. The ref attribute of the found entity doesn't match our input `parent1`
+
+## Root Cause Investigation
+
+The bug appears to be in how `Identity` values are matched when passed as query input parameters. Possible areas to investigate:
+
+1. **Value encoding/decoding**: Identity values may not be encoded/decoded consistently when used as inputs vs. when stored
+2. **Input binding**: The input parameter binding may not correctly propagate Identity values to the pattern matcher
+3. **Comparison**: Identity comparison in the matcher may have a bug
+
+## Workaround
+
+None known. The fundamental operation of "find entities where ref = X" is broken for Identity values.
+
+## Test Location
+
+- Bug reproduction test: `tests/identity_input_matching_bug_test.go`
+- Original discovery: `narrative-generators/pkg/scenario/identity_bug_test.go`
+
+## Related Issues
+
+This may be related to other input parameter handling issues:
+- `BUG_STRING_PREDICATES_CANT_USE_PARAMETERS.md` (resolved)
+- `BUG_PARAMETERIZED_QUERY_CARTESIAN_PRODUCT.md` (resolved)
+
+## Date Discovered
+
+2024-12-17
+

--- a/tests/identity_comparison_test.go
+++ b/tests/identity_comparison_test.go
@@ -1,0 +1,99 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// TestIdentityComparisonBestPractices demonstrates the correct way to compare
+// Identity values in query results.
+//
+// IMPORTANT: Use .Equal() to compare Identities, NOT == or !=
+//
+// Identity structs contain multiple fields:
+// - value: [20]byte - the actual SHA1 hash (the true identity)
+// - l85: string - lazily computed L85 encoding
+// - str: string - original string (if known)
+// - l85Computed: bool
+//
+// Identities loaded from storage have different auxiliary fields than the
+// original Identities created in code. Struct equality compares ALL fields,
+// so it will fail even when the hashes match.
+func TestIdentityComparisonBestPractices(t *testing.T) {
+	dir, err := os.MkdirTemp("", "identity-comparison-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := storage.NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	refAttr := datalog.NewKeyword(":test/ref")
+	codeAttr := datalog.NewKeyword(":test/code")
+
+	// Create entities
+	parent := datalog.NewIdentity(generateUUID())
+	child := datalog.NewIdentity(generateUUID())
+
+	tx := db.NewTransaction()
+	tx.Add(child, refAttr, parent)
+	tx.Add(child, codeAttr, "child1")
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Query to find the child
+	tuples, err := db.ExecuteQueryWithInputs(
+		`[:find ?c :in $ ?parent :where [?c :test/ref ?parent]]`,
+		parent,
+	)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(tuples) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(tuples))
+	}
+
+	// Get the returned entity
+	var foundID datalog.Identity
+	if id, ok := tuples[0][0].(datalog.Identity); ok {
+		foundID = id
+	} else if ptr, ok := tuples[0][0].(*datalog.Identity); ok && ptr != nil {
+		foundID = *ptr
+	} else {
+		t.Fatalf("Result is not an Identity: %T", tuples[0][0])
+	}
+
+	// WRONG: struct equality (compares all fields including str, l85)
+	// This will FAIL even when the identities represent the same entity!
+	if foundID == child {
+		t.Log("Struct equality (==) matched - this is luck, not guaranteed!")
+	} else {
+		// This is the EXPECTED case - struct fields differ
+		t.Log("Struct equality (==) did NOT match - expected behavior")
+		t.Logf("  original child.str: %q", child.String())
+		t.Logf("  returned foundID:   %q (from storage, no original string)", foundID.String())
+	}
+
+	// CORRECT: use .Equal() which compares only the hash
+	if foundID.Equal(child) {
+		t.Log("Hash equality (.Equal()) matched - CORRECT!")
+	} else {
+		t.Errorf("Hash equality (.Equal()) failed - this indicates a real bug!")
+	}
+
+	// Also correct: compare hashes directly
+	if foundID.Hash() == child.Hash() {
+		t.Log("Direct hash comparison matched - also correct")
+	} else {
+		t.Errorf("Direct hash comparison failed - this indicates a real bug!")
+	}
+}

--- a/tests/identity_input_matching_bug_test.go
+++ b/tests/identity_input_matching_bug_test.go
@@ -1,0 +1,227 @@
+package tests
+
+import (
+	"crypto/rand"
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/codec"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// generateUUID generates an L85-encoded binary UUID.
+func generateUUID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return codec.EncodeL85(b)
+}
+
+// TestIdentityInputMatchingBug demonstrates a bug where Identity values passed as
+// query input parameters don't correctly filter results.
+//
+// Bug: When querying [?e :attr ?inputIdentity] where ?inputIdentity is bound to
+// a specific Identity value, the query returns entities whose :attr value is
+// NOT equal to the input Identity.
+//
+// See: docs/bugs/active/IDENTITY_INPUT_MATCHING_BUG.md
+func TestIdentityInputMatchingBug(t *testing.T) {
+	// Create temporary directory for test database
+	dir, err := os.MkdirTemp("", "identity-input-bug-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Create database
+	db, err := storage.NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Define attributes
+	refAttr := datalog.NewKeyword(":test/ref")
+	codeAttr := datalog.NewKeyword(":test/code")
+
+	// Create two different "parent" entities
+	parent1 := datalog.NewIdentity(generateUUID())
+	parent2 := datalog.NewIdentity(generateUUID())
+
+	t.Logf("parent1: %v", parent1)
+	t.Logf("parent2: %v", parent2)
+
+	// Create child1 referencing parent1
+	child1 := datalog.NewIdentity(generateUUID())
+	tx1 := db.NewTransaction()
+	tx1.Add(child1, refAttr, parent1)
+	tx1.Add(child1, codeAttr, "child1")
+	if _, err := tx1.Commit(); err != nil {
+		t.Fatalf("Failed to commit child1: %v", err)
+	}
+
+	// Create child2 referencing parent2
+	child2 := datalog.NewIdentity(generateUUID())
+	tx2 := db.NewTransaction()
+	tx2.Add(child2, refAttr, parent2)
+	tx2.Add(child2, codeAttr, "child2")
+	if _, err := tx2.Commit(); err != nil {
+		t.Fatalf("Failed to commit child2: %v", err)
+	}
+
+	t.Logf("child1: %v (refs parent1)", child1)
+	t.Logf("child2: %v (refs parent2)", child2)
+
+	// Query: find children of parent1
+	tuples, err := db.ExecuteQueryWithInputs(
+		`[:find ?c ?code :in $ ?parent :where [?c :test/ref ?parent] [?c :test/code ?code]]`,
+		parent1,
+	)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	t.Logf("Query for parent1's children returned %d results:", len(tuples))
+	for i, tuple := range tuples {
+		t.Logf("  Result %d: ID=%v Code=%v", i, tuple[0], tuple[1])
+	}
+
+	// We should find exactly 1 child: child1 with code "child1"
+	if len(tuples) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(tuples))
+		if len(tuples) == 2 {
+			t.Error("Identity input not filtering correctly - matching both children")
+		}
+		if len(tuples) == 0 {
+			t.Error("Identity input not matching at all")
+		}
+		return
+	}
+
+	// Verify we got the RIGHT child
+	foundID, ok := tuples[0][0].(datalog.Identity)
+	if !ok {
+		if ptr, ok := tuples[0][0].(*datalog.Identity); ok && ptr != nil {
+			foundID = *ptr
+		} else {
+			t.Fatalf("Result is not an Identity: %T", tuples[0][0])
+		}
+	}
+
+	// IMPORTANT: Use .Equal() to compare Identities by hash, not struct equality!
+	// Identity structs from storage have different l85/str fields than the originals
+	if !foundID.Equal(child1) {
+		t.Errorf("Wrong child returned:\n  expected hash: %x\n  got hash:      %x\n  expected L85: %v\n  got L85:      %v",
+			child1.Hash(), foundID.Hash(), child1.L85(), foundID.L85())
+
+		// Debug: what is the actual ref of the found entity?
+		refs, _ := db.ExecuteQueryWithInputs(
+			`[:find ?ref :in $ ?e :where [?e :test/ref ?ref]]`,
+			foundID,
+		)
+		if len(refs) > 0 {
+			t.Logf("Found entity's actual ref (L85): %v", refs[0][0])
+			t.Logf("Our parent1 (L85):               %v", parent1.L85())
+			if refID, ok := refs[0][0].(datalog.Identity); ok {
+				t.Logf("Refs equal (by hash): %v", refID.Equal(parent1))
+				t.Logf("Refs hash match: expected=%x got=%x", parent1.Hash(), refID.Hash())
+			} else if refPtr, ok := refs[0][0].(*datalog.Identity); ok && refPtr != nil {
+				t.Logf("Refs equal (by hash): %v", refPtr.Equal(parent1))
+				t.Logf("Refs hash match: expected=%x got=%x", parent1.Hash(), refPtr.Hash())
+			}
+		}
+	}
+
+	code, ok := tuples[0][1].(string)
+	if !ok || code != "child1" {
+		t.Errorf("Wrong code: expected 'child1', got %v", tuples[0][1])
+	}
+}
+
+// TestIdentityInputMatchingWithMultipleConstraints tests Identity matching with
+// additional constraints (similar to real-world entity queries).
+func TestIdentityInputMatchingWithMultipleConstraints(t *testing.T) {
+	// Create temporary directory for test database
+	dir, err := os.MkdirTemp("", "identity-input-multi-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Create database
+	db, err := storage.NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Define attributes (simulating a real entity schema)
+	mapAttr := datalog.NewKeyword(":entity/map")
+	codeAttr := datalog.NewKeyword(":entity/code")
+	typeAttr := datalog.NewKeyword(":entity/type")
+	dungeonType := datalog.NewKeyword(":entity.type/dungeon")
+
+	// Create a map entity
+	mapID := datalog.NewIdentity(generateUUID())
+	tx := db.NewTransaction()
+	tx.Add(mapID, datalog.NewKeyword(":map/id"), mapID.L85())
+	if _, err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a dungeon entity belonging to this map
+	dungeonID := datalog.NewIdentity(generateUUID())
+	tx2 := db.NewTransaction()
+	tx2.Add(dungeonID, typeAttr, dungeonType)
+	tx2.Add(dungeonID, codeAttr, "POI A")
+	tx2.Add(dungeonID, mapAttr, mapID)
+	if _, err := tx2.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Created map: %v", mapID)
+	t.Logf("Created dungeon: %v with map=%v", dungeonID, mapID)
+
+	// Query: find dungeon by map, code, and type
+	tuples, err := db.ExecuteQueryWithInputs(
+		`[:find ?e :in $ ?map ?code :where [?e :entity/map ?map] [?e :entity/code ?code] [?e :entity/type :entity.type/dungeon]]`,
+		mapID, "POI A",
+	)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	t.Logf("Query returned %d results", len(tuples))
+
+	if len(tuples) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(tuples))
+		return
+	}
+
+	foundID, ok := tuples[0][0].(datalog.Identity)
+	if !ok {
+		if ptr, ok := tuples[0][0].(*datalog.Identity); ok && ptr != nil {
+			foundID = *ptr
+		} else {
+			t.Fatalf("Result is not an Identity: %T", tuples[0][0])
+		}
+	}
+
+	t.Logf("Found ID (L85): %v", foundID.L85())
+
+	// IMPORTANT: Use .Equal() to compare Identities by hash, not struct equality!
+	if !foundID.Equal(dungeonID) {
+		t.Errorf("Wrong entity returned:\n  expected hash: %x\n  got hash:      %x", dungeonID.Hash(), foundID.Hash())
+
+		// Debug: what are the actual attributes of the found entity?
+		attrs, _ := db.ExecuteQueryWithInputs(
+			`[:find ?a ?v :in $ ?e :where [?e ?a ?v]]`,
+			foundID,
+		)
+		t.Logf("Found entity attributes:")
+		for _, attr := range attrs {
+			t.Logf("  %v = %v", attr[0], attr[1])
+		}
+	}
+}
+


### PR DESCRIPTION
Investigation Summary:
The reported bug claimed that Identity values passed as query input parameters did not correctly filter results. Testing showed queries returning "wrong" entities even though the code attribute matched.

Root Cause Analysis:
The bug was in the TEST CODE, not the query engine. The tests used Go's struct equality (!=) to compare Identity values:

    if foundID != expectedID { // WRONG }

Identity structs contain multiple fields:
- value: [20]byte - the SHA1 hash (the actual identity)
- l85: string - lazily computed L85 encoding
- str: string - original string (if known)
- l85Computed: bool

Identities loaded from storage have different auxiliary fields than originals created in code:
- Original: str="uuid-string", l85="", l85Computed=false
- From storage: str="", l85="encoded-hash", l85Computed=true

Struct equality compares ALL fields, so it fails even when the underlying hash (the true identity) matches perfectly.

The Fix:
Use Identity.Equal() which compares only the hash bytes:

    if !foundID.Equal(expectedID) { // CORRECT }

Verification:
- Query engine correctly uses hash-based comparison internally
- ValuesEqual() in datalog/compare.go uses id1.value == id2.value
- All pattern matching and join operations work correctly
- The "wrong" entities in test output actually HAD the correct hash

Changes:
- tests/identity_input_matching_bug_test.go: Fix comparisons to use .Equal() method instead of struct equality
- tests/identity_comparison_test.go: New test demonstrating correct Identity comparison patterns as documentation
- docs/bugs/resolved/IDENTITY_INPUT_MATCHING_BUG.md: Move from active/ and document resolution

Lesson Learned:
When comparing complex types with cached/derived fields, always use the type's equality method rather than Go's struct equality operator.