### PR TITLE
Consolidate struct API to SaveStruct with upsert semantics

### DIFF
--- a/datalog/reflect/integration_test.go
+++ b/datalog/reflect/integration_test.go
@@ -53,7 +53,7 @@ func TestSchemaFromStruct(t *testing.T) {
 	}
 }
 
-func TestAddStructAndPullInto_Simple(t *testing.T) {
+func TestSaveStructAndPullInto_Simple(t *testing.T) {
 	// Create temp database
 	tmpDir, err := os.MkdirTemp("", "reflect-test")
 	if err != nil {
@@ -77,7 +77,7 @@ func TestAddStructAndPullInto_Simple(t *testing.T) {
 	// Create and write a person
 	alice := Person{Name: "Alice", Age: 30}
 	tx := db.NewTransaction()
-	aliceID, err := tx.AddStructAuto(&alice)
+	aliceID, err := tx.SaveStruct(&alice)
 	if err != nil {
 		t.Fatalf("failed to add struct: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestAddStructAndPullInto_Simple(t *testing.T) {
 	}
 }
 
-func TestAddStructAndPullInto_CardinalityMany(t *testing.T) {
+func TestSaveStructAndPullInto_CardinalityMany(t *testing.T) {
 	// Create temp database
 	tmpDir, err := os.MkdirTemp("", "reflect-test-many")
 	if err != nil {
@@ -133,7 +133,7 @@ func TestAddStructAndPullInto_CardinalityMany(t *testing.T) {
 		Tags: []string{"developer", "team-lead", "mentor"},
 	}
 	tx := db.NewTransaction()
-	aliceID, err := tx.AddStructAuto(&alice)
+	aliceID, err := tx.SaveStruct(&alice)
 	if err != nil {
 		t.Fatalf("failed to add struct: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestGeneratePullPattern_Nested(t *testing.T) {
 	t.Logf("Generated pattern: %s", pattern)
 }
 
-func TestAddStruct_WithExistingID(t *testing.T) {
+func TestSaveStruct_WithExistingID(t *testing.T) {
 	// Create temp database
 	tmpDir, err := os.MkdirTemp("", "reflect-test-existing-id")
 	if err != nil {
@@ -203,7 +203,7 @@ func TestAddStruct_WithExistingID(t *testing.T) {
 	}
 
 	tx := db.NewTransaction()
-	returnedID, err := tx.AddStructAuto(&alice)
+	returnedID, err := tx.SaveStruct(&alice)
 	if err != nil {
 		t.Fatalf("failed to add struct: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestPullIntoMany(t *testing.T) {
 	var ids []datalog.Identity
 	tx := db.NewTransaction()
 	for i := range people {
-		id, err := tx.AddStructAuto(&people[i])
+		id, err := tx.SaveStruct(&people[i])
 		if err != nil {
 			t.Fatalf("failed to add struct: %v", err)
 		}
@@ -281,5 +281,397 @@ func TestPullIntoMany(t *testing.T) {
 		for i, p := range people {
 			t.Logf("original person %d: Name=%q, Age=%d, ID=%s", i, p.Name, p.Age, p.ID.String()[:20])
 		}
+	}
+}
+
+func TestSaveStructCardinalityOne(t *testing.T) {
+	// Create temp database
+	tmpDir, err := os.MkdirTemp("", "reflect-test-update")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(Person{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create initial person
+	alice := Person{Name: "Alice", Age: 30}
+
+	tx := db.NewTransaction()
+	id, err := tx.SaveStruct(&alice)
+	if err != nil {
+		t.Fatalf("failed to add struct: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	t.Logf("Created person with ID: %s", id.L85())
+
+	// Verify initial state
+	var loaded Person
+	if err := db.PullInto(id, &loaded); err != nil {
+		t.Fatalf("failed to pull: %v", err)
+	}
+	if loaded.Name != "Alice" || loaded.Age != 30 {
+		t.Fatalf("initial load failed: got Name=%q Age=%d", loaded.Name, loaded.Age)
+	}
+
+	// Update the person
+	alice.Age = 31
+	alice.Name = "Alice Smith"
+
+	tx2 := db.NewTransaction()
+	if _, err := tx2.SaveStruct(&alice); err != nil {
+		t.Fatalf("failed to save struct: %v", err)
+	}
+	if _, err := tx2.Commit(); err != nil {
+		t.Fatalf("failed to commit update: %v", err)
+	}
+
+	// Verify updated state
+	var updated Person
+	if err := db.PullInto(id, &updated); err != nil {
+		t.Fatalf("failed to pull updated: %v", err)
+	}
+
+	if updated.Name != "Alice Smith" {
+		t.Errorf("expected Name='Alice Smith', got %q", updated.Name)
+	}
+	if updated.Age != 31 {
+		t.Errorf("expected Age=31, got %d", updated.Age)
+	}
+
+	// Verify there's only ONE age value (not both 30 and 31)
+	// Query for all age values of this entity
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?age :in $ ?e :where [?e :person/age ?age]]`,
+		id,
+	)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 age value, got %d: %v", len(results), results)
+	}
+}
+
+func TestSaveStructCardinalityMany(t *testing.T) {
+	// Create temp database
+	tmpDir, err := os.MkdirTemp("", "reflect-test-update-many")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(PersonWithTags{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create initial person with tags
+	alice := PersonWithTags{Name: "Alice", Tags: []string{"developer", "golang"}}
+
+	tx := db.NewTransaction()
+	id, err := tx.SaveStruct(&alice)
+	if err != nil {
+		t.Fatalf("failed to add struct: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	// Verify initial tags
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?tag :in $ ?e :where [?e :person-with-tags/tags ?tag]]`,
+		id,
+	)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 tags initially, got %d", len(results))
+	}
+
+	// Update - should replace all tags (diff-based)
+	alice.Tags = []string{"architect", "rust"}
+
+	tx2 := db.NewTransaction()
+	if _, err := tx2.SaveStruct(&alice); err != nil {
+		t.Fatalf("failed to save struct: %v", err)
+	}
+	if _, err := tx2.Commit(); err != nil {
+		t.Fatalf("failed to commit update: %v", err)
+	}
+
+	// Verify only new tags exist
+	results, err = db.ExecuteQueryWithInputs(
+		`[:find ?tag :in $ ?e :where [?e :person-with-tags/tags ?tag]]`,
+		id,
+	)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 tags after replace, got %d", len(results))
+	}
+
+	// Check we have the right tags
+	tags := make(map[string]bool)
+	for _, r := range results {
+		if s, ok := r[0].(string); ok {
+			tags[s] = true
+		}
+	}
+	if !tags["architect"] || !tags["rust"] {
+		t.Errorf("expected architect and rust tags, got: %v", tags)
+	}
+	if tags["developer"] || tags["golang"] {
+		t.Errorf("old tags should have been removed, got: %v", tags)
+	}
+}
+
+
+// TestNilVsEmptySliceSemantics verifies that nil slices are skipped (leave existing)
+// while empty slices clear existing values.
+func TestNilVsEmptySliceSemantics(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "reflect-test-nil-empty")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(PersonWithTags{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create person with tags
+	alice := PersonWithTags{Name: "Alice", Tags: []string{"developer", "golang"}}
+	tx := db.NewTransaction()
+	id, err := tx.SaveStruct(&alice)
+	if err != nil {
+		t.Fatalf("SaveStruct failed: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	// Test 1: Nil slice should leave existing tags alone
+	partialUpdate := PersonWithTags{ID: id, Name: "Alice Smith", Tags: nil}
+	tx2 := db.NewTransaction()
+	if _, err := tx2.SaveStruct(&partialUpdate); err != nil {
+		t.Fatalf("SaveStruct with nil tags failed: %v", err)
+	}
+	if _, err := tx2.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	// Verify tags unchanged
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?tag :in $ ?e :where [?e :person-with-tags/tags ?tag]]`,
+		id,
+	)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("nil slice should leave tags unchanged, expected 2, got %d: %v", len(results), results)
+	}
+
+	// Test 2: Empty slice (not nil) should clear all tags
+	emptyTags := make([]string, 0) // Empty but not nil
+	clearUpdate := PersonWithTags{ID: id, Name: "Alice Smith", Tags: emptyTags}
+	tx3 := db.NewTransaction()
+	if _, err := tx3.SaveStruct(&clearUpdate); err != nil {
+		t.Fatalf("SaveStruct with empty tags failed: %v", err)
+	}
+	if _, err := tx3.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	// Verify tags cleared
+	results, err = db.ExecuteQueryWithInputs(
+		`[:find ?tag :in $ ?e :where [?e :person-with-tags/tags ?tag]]`,
+		id,
+	)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("empty slice should clear tags, expected 0, got %d: %v", len(results), results)
+	}
+}
+
+// TestSaveStructUpsertSemantics verifies that SaveStruct uses upsert semantics
+// so calling it twice on the same entity properly updates values instead of duplicating.
+func TestSaveStructUpsertSemantics(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "reflect-test-upsert")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(Person{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// First add
+	alice := Person{Name: "Alice", Age: 30}
+	tx := db.NewTransaction()
+	id, err := tx.SaveStruct(&alice)
+	if err != nil {
+		t.Fatalf("first SaveStruct failed: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("first commit failed: %v", err)
+	}
+
+	// Modify and add again (using the same ID)
+	alice.Name = "Alice Smith"
+	alice.Age = 31
+	// alice.ID should already be set from first SaveStruct
+
+	tx2 := db.NewTransaction()
+	id2, err := tx2.SaveStruct(&alice)
+	if err != nil {
+		t.Fatalf("second SaveStruct failed: %v", err)
+	}
+	if _, err := tx2.Commit(); err != nil {
+		t.Fatalf("second commit failed: %v", err)
+	}
+
+	// Verify same ID was used
+	if !id.Equal(id2) {
+		t.Errorf("expected same ID, got different: %s vs %s", id.L85(), id2.L85())
+	}
+
+	// Verify updated values
+	var loaded Person
+	if err := db.PullInto(id, &loaded); err != nil {
+		t.Fatalf("PullInto failed: %v", err)
+	}
+
+	if loaded.Name != "Alice Smith" {
+		t.Errorf("expected Name='Alice Smith', got %q", loaded.Name)
+	}
+	if loaded.Age != 31 {
+		t.Errorf("expected Age=31, got %d", loaded.Age)
+	}
+
+	// Verify only one value for each attribute (no duplicates)
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?age :in $ ?e :where [?e :person/age ?age]]`,
+		id,
+	)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 age value (upsert), got %d: %v", len(results), results)
+	}
+}
+
+// TestLookupAttributeWithStructAPI verifies that LookupAttribute works with
+// entities and attributes created via the struct reflection API.
+// This test validates the integration between SaveStruct and LookupAttribute.
+func TestLookupAttributeWithStructAPI(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "reflect-test-lookup")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(Person{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create person via struct API
+	alice := Person{Name: "Alice", Age: 30}
+	tx := db.NewTransaction()
+	id, err := tx.SaveStruct(&alice)
+	if err != nil {
+		t.Fatalf("failed to add struct: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	t.Logf("Created entity with ID: %s", id.L85())
+
+	// Test LookupAttribute
+	matcher := storage.NewBadgerMatcher(db.Store())
+
+	// Lookup name
+	nameAttr := datalog.NewKeyword(":person/name")
+	val, found := matcher.LookupAttribute(id, nameAttr)
+	if !found {
+		t.Errorf("LookupAttribute failed to find :person/name for entity %s", id.L85())
+	} else {
+		t.Logf("Found name: %v (type: %T)", val, val)
+		if val != "Alice" {
+			t.Errorf("expected name='Alice', got %v", val)
+		}
+	}
+
+	// Lookup age
+	ageAttr := datalog.NewKeyword(":person/age")
+	val, found = matcher.LookupAttribute(id, ageAttr)
+	if !found {
+		t.Errorf("LookupAttribute failed to find :person/age for entity %s", id.L85())
+	} else {
+		t.Logf("Found age: %v (type: %T)", val, val)
+		if val != int64(30) {
+			t.Errorf("expected age=30, got %v", val)
+		}
+	}
+
+	// Verify query also works (sanity check)
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?name ?age :in $ ?e :where [?e :person/name ?name] [?e :person/age ?age]]`,
+		id,
+	)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 query result, got %d", len(results))
+	} else {
+		t.Logf("Query result: name=%v age=%v", results[0][0], results[0][1])
 	}
 }

--- a/datalog/reflect/writer.go
+++ b/datalog/reflect/writer.go
@@ -26,6 +26,40 @@ type TransactionAdder interface {
 	Add(e datalog.Identity, a datalog.Keyword, v interface{}) error
 }
 
+// TransactionUpdater extends TransactionAdder with retract capability
+// This is implemented by storage.Transaction
+type TransactionUpdater interface {
+	TransactionAdder
+	Retract(e datalog.Identity, a datalog.Keyword, v interface{}) error
+}
+
+// EntityLookup provides lookup of existing entity attributes
+// This is used for upsert operations to find existing values to retract
+type EntityLookup interface {
+	// LookupAttribute returns the current value of an attribute for an entity
+	// Returns (value, true) if found, (nil, false) if not found
+	LookupAttribute(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool)
+
+	// LookupAllAttributes returns all values for a cardinality-many attribute
+	// Returns empty slice if attribute not found
+	LookupAllAttributes(entity datalog.Identity, attr datalog.Keyword) []interface{}
+}
+
+// UpdateMode controls how cardinality-many fields are updated
+type UpdateMode int
+
+const (
+	// UpdateModeAdd uses union semantics: adds new values to existing set
+	// Values already present are not duplicated
+	UpdateModeAdd UpdateMode = iota
+
+	// UpdateModeReplace uses set assignment semantics: slice IS the new complete state
+	// - Retracts values in existing but not in new
+	// - Adds values in new but not in existing
+	// - Values present in both are left unchanged
+	UpdateModeReplace
+)
+
 // StructWriter handles struct → datom conversion
 type StructWriter struct {
 	info   *StructInfo
@@ -76,6 +110,165 @@ func (sw *StructWriter) Write(tx TransactionAdder, entity datalog.Identity, v in
 		// Handle different field types
 		if err := sw.writeField(tx, entity, kw, field, fieldVal); err != nil {
 			return fmt.Errorf("field %s: %w", field.FieldName, err)
+		}
+	}
+
+	return nil
+}
+
+// Update performs an upsert operation: retracts changed values and adds new ones.
+// For cardinality-one fields: if the value has changed, retracts the old value and adds the new one.
+// For cardinality-many fields: behavior depends on the UpdateMode.
+//
+// This requires both a TransactionUpdater (for retract capability) and an EntityLookup
+// (to find existing values to compare/retract).
+func (sw *StructWriter) Update(tx TransactionUpdater, lookup EntityLookup, entity datalog.Identity, v interface{}, mode UpdateMode) error {
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return fmt.Errorf("cannot update nil struct")
+		}
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return fmt.Errorf("expected struct, got %s", val.Kind())
+	}
+
+	for _, field := range sw.info.Fields {
+		fieldVal := val.Field(field.Index)
+
+		// Handle pointer fields (optional)
+		if field.GoType.Kind() == reflect.Ptr {
+			if fieldVal.IsNil() {
+				// For nil optional fields in update mode, we could optionally retract existing
+				// For now, skip nil fields (don't change existing value)
+				continue
+			}
+			fieldVal = fieldVal.Elem()
+		}
+
+		// Get the keyword for this attribute
+		kw := datalog.NewKeyword(field.FullAttr)
+
+		// Handle different field types
+		if err := sw.updateField(tx, lookup, entity, kw, field, fieldVal, mode); err != nil {
+			return fmt.Errorf("field %s: %w", field.FieldName, err)
+		}
+	}
+
+	return nil
+}
+
+// updateField updates a single field with upsert semantics
+func (sw *StructWriter) updateField(tx TransactionUpdater, lookup EntityLookup, entity datalog.Identity, kw datalog.Keyword, field *FieldInfo, val reflect.Value, mode UpdateMode) error {
+	// Handle slice fields (cardinality-many)
+	if IsSliceType(field.GoType) {
+		return sw.updateSliceField(tx, lookup, entity, kw, field, val, mode)
+	}
+
+	// Get the new value to write
+	newVal, err := sw.extractValue(field, val)
+	if err != nil {
+		return err
+	}
+
+	// Skip zero values for optional types
+	if newVal == nil {
+		return nil
+	}
+
+	// Look up existing value
+	existingVal, found := lookup.LookupAttribute(entity, kw)
+
+	if found {
+		// Compare values - if same, no action needed
+		if datalog.ValuesEqual(existingVal, newVal) {
+			return nil
+		}
+		// Different value - retract old, add new
+		if err := tx.Retract(entity, kw, existingVal); err != nil {
+			return fmt.Errorf("retract failed: %w", err)
+		}
+	}
+
+	return tx.Add(entity, kw, newVal)
+}
+
+// containsValue checks if a value exists in a slice using ValuesEqual
+func containsValue(vals []interface{}, target interface{}) bool {
+	for _, v := range vals {
+		if datalog.ValuesEqual(v, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// updateSliceField handles cardinality-many field updates
+// Nil slice means "don't touch existing values" - skip entirely.
+// Empty slice (not nil) means "clear all values".
+// Non-empty slice means "set to exactly these values" (diff-based).
+func (sw *StructWriter) updateSliceField(tx TransactionUpdater, lookup EntityLookup, entity datalog.Identity, kw datalog.Keyword, field *FieldInfo, val reflect.Value, mode UpdateMode) error {
+	if val.Kind() != reflect.Slice {
+		return fmt.Errorf("expected slice, got %s", val.Kind())
+	}
+
+	// Nil slice = "I didn't set this field" → leave existing values alone
+	if val.IsNil() {
+		return nil
+	}
+
+	// Extract new values (empty slice is valid - means "clear all")
+	var newVals []interface{}
+	for i := 0; i < val.Len(); i++ {
+		elem := val.Index(i)
+		if elem.Kind() == reflect.Ptr {
+			if elem.IsNil() {
+				continue
+			}
+			elem = elem.Elem()
+		}
+		writeVal, err := sw.extractSingleValue(elem)
+		if err != nil {
+			return fmt.Errorf("element %d: %w", i, err)
+		}
+		if writeVal != nil {
+			newVals = append(newVals, writeVal)
+		}
+	}
+
+	if mode == UpdateModeReplace {
+		// Diff-based set assignment: slice IS the new complete state
+		existingVals := lookup.LookupAllAttributes(entity, kw)
+
+		// Retract values in existing but not in new
+		for _, existing := range existingVals {
+			if !containsValue(newVals, existing) {
+				if err := tx.Retract(entity, kw, existing); err != nil {
+					return fmt.Errorf("retract failed: %w", err)
+				}
+			}
+		}
+
+		// Add values in new but not in existing
+		for _, newVal := range newVals {
+			if !containsValue(existingVals, newVal) {
+				if err := tx.Add(entity, kw, newVal); err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		// UpdateModeAdd - union semantics: add new values to existing set
+		// Only add values that don't already exist
+		existingVals := lookup.LookupAllAttributes(entity, kw)
+		for _, newVal := range newVals {
+			if !containsValue(existingVals, newVal) {
+				if err := tx.Add(entity, kw, newVal); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -278,20 +471,79 @@ func (sw *StructWriter) WriteAuto(tx TransactionAdder, v interface{}) (datalog.I
 	return entity, nil
 }
 
-// WriteStruct is a convenience function that creates a writer and writes the struct
-func WriteStruct(tx TransactionAdder, entity datalog.Identity, v interface{}, s schema.SchemaProvider) error {
-	writer, err := NewStructWriter(v, s)
-	if err != nil {
-		return err
+// UpdateAuto generates entity ID if not set, then performs upsert with the given mode.
+// This combines ID generation with update semantics.
+func (sw *StructWriter) UpdateAuto(tx TransactionUpdater, lookup EntityLookup, v interface{}, mode UpdateMode) (datalog.Identity, error) {
+	val := reflect.ValueOf(v)
+
+	// Must be pointer to struct for setting ID
+	if val.Kind() != reflect.Ptr {
+		return datalog.Identity{}, fmt.Errorf("UpdateAuto requires pointer to struct")
 	}
-	return writer.Write(tx, entity, v)
+	if val.IsNil() {
+		return datalog.Identity{}, fmt.Errorf("cannot update nil struct")
+	}
+
+	structVal := val.Elem()
+	if structVal.Kind() != reflect.Struct {
+		return datalog.Identity{}, fmt.Errorf("expected pointer to struct, got pointer to %s", structVal.Kind())
+	}
+
+	var entity datalog.Identity
+
+	// Check for existing ID
+	if sw.info.IDField != nil {
+		idField := structVal.Field(sw.info.IDField.Index)
+
+		// Handle pointer ID field
+		if sw.info.IDField.GoType.Kind() == reflect.Ptr {
+			if !idField.IsNil() {
+				entity = idField.Elem().Interface().(datalog.Identity)
+			}
+		} else {
+			entity = idField.Interface().(datalog.Identity)
+		}
+
+		// Check if ID is zero (all zeros in the hash)
+		var zeroHash [20]byte
+		if entity.Hash() == zeroHash {
+			// Generate new unique ID
+			entity = generateUniqueID()
+
+			// Set the ID field
+			if sw.info.IDField.GoType.Kind() == reflect.Ptr {
+				newID := reflect.New(identityType)
+				newID.Elem().Set(reflect.ValueOf(entity))
+				idField.Set(newID)
+			} else {
+				idField.Set(reflect.ValueOf(entity))
+			}
+		}
+	} else {
+		// No ID field, generate a unique ID
+		entity = generateUniqueID()
+	}
+
+	// Update the struct with upsert semantics
+	if err := sw.Update(tx, lookup, entity, v, mode); err != nil {
+		return datalog.Identity{}, err
+	}
+
+	return entity, nil
 }
 
-// WriteStructAuto is a convenience function that creates a writer and writes the struct with auto ID
-func WriteStructAuto(tx TransactionAdder, v interface{}, s schema.SchemaProvider) (datalog.Identity, error) {
+// SaveStruct persists a struct with upsert semantics.
+// Generates entity ID if not set, returns the ID.
+//
+// Upsert behavior:
+//   - Cardinality-one fields: retracts old value if different, adds new value
+//   - Cardinality-many fields (nil slice): leaves existing values unchanged
+//   - Cardinality-many fields (empty slice): clears all existing values
+//   - Cardinality-many fields (non-empty): diff-based update
+func SaveStruct(tx TransactionUpdater, lookup EntityLookup, v interface{}, s schema.SchemaProvider) (datalog.Identity, error) {
 	writer, err := NewStructWriter(v, s)
 	if err != nil {
 		return datalog.Identity{}, err
 	}
-	return writer.WriteAuto(tx, v)
+	return writer.UpdateAuto(tx, lookup, v, UpdateModeReplace)
 }

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -86,13 +86,54 @@ func (s *BadgerStore) Retract(datoms []datalog.Datom) error {
 }
 
 // retractDatom removes a single datom from all indices
+// NOTE: The Tx field in the passed datom is ignored. We find the actual stored
+// datom(s) matching E+A+V and delete those, regardless of their Tx.
 func (s *BadgerStore) retractDatom(txn *badger.Txn, d *datalog.Datom) error {
-	// Remove from all indices
-	indices := []IndexType{EAVT, AEVT, AVET, VAET, TAEV}
-	for _, idx := range indices {
-		key := s.encoder.EncodeKey(idx, d)
-		if err := txn.Delete(key); err != nil && err != badger.ErrKeyNotFound {
-			return fmt.Errorf("failed to delete from %v index: %w", idx, err)
+	// Convert to storage format for prefix scanning
+	sd := ToStorageDatom(*d)
+
+	// Use EAVT index to find matching datoms (E+A+V, any Tx)
+	// Build prefix: index byte + E + A + V (without Tx)
+	prefix := []byte{byte(EAVT)}
+	vType := byte(datalog.Type(sd.V))
+	vData := datalog.ValueBytes(sd.V)
+	vBytes := append([]byte{vType}, vData...)
+	searchPrefix := concatBytes(prefix, sd.E[:], sd.A[:], vBytes)
+
+	// Iterate to find matching keys with their actual Tx values
+	opts := badger.DefaultIteratorOptions
+	opts.PrefetchValues = false // Keys only for faster iteration
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	var keysToDelete [][]byte
+	for it.Seek(searchPrefix); it.ValidForPrefix(searchPrefix); it.Next() {
+		// Found a matching key - save it for deletion
+		key := it.Item().KeyCopy(nil)
+		keysToDelete = append(keysToDelete, key)
+	}
+
+	if len(keysToDelete) == 0 {
+		// No matching datom found - not an error, just nothing to retract
+		return nil
+	}
+
+	// For each matching EAVT key, decode it and delete from all indices
+	for _, eavtKey := range keysToDelete {
+		// Decode the EAVT key to get the full datom including Tx
+		// DatomFromKey handles all the complexity of decoding components
+		storedDatom, err := DatomFromKey(EAVT, eavtKey, s.encoder)
+		if err != nil {
+			return fmt.Errorf("failed to decode key for retraction: %w", err)
+		}
+
+		// Delete from all indices using the actual stored Tx
+		indices := []IndexType{EAVT, AEVT, AVET, VAET, TAEV}
+		for _, idx := range indices {
+			key := s.encoder.EncodeKey(idx, storedDatom)
+			if err := txn.Delete(key); err != nil && err != badger.ErrKeyNotFound {
+				return fmt.Errorf("failed to delete from %v index: %w", idx, err)
+			}
 		}
 	}
 

--- a/datalog/storage/badger_store_test.go
+++ b/datalog/storage/badger_store_test.go
@@ -198,6 +198,74 @@ func TestBadgerStore(t *testing.T) {
 	})
 }
 
+// TestRetractWithDifferentTx tests that retraction works even when the caller
+// specifies a different Tx than what was used when the datom was asserted.
+// This is the common case when retracting during an update operation, where
+// the caller doesn't know the original transaction ID.
+func TestRetractWithDifferentTx(t *testing.T) {
+	dir, err := os.MkdirTemp("", "badger-retract-tx-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	encoder := NewKeyEncoder(BinaryStrategy)
+	store, err := NewBadgerStore(dir, encoder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// Create entity and attribute
+	alice := datalog.NewIdentity("alice-retract-tx")
+	nameAttr := datalog.NewKeyword(":person/name")
+	originalTx := uint64(100)
+	differentTx := uint64(999) // Different from originalTx
+
+	// Assert a datom with originalTx
+	err = store.Assert([]datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: originalTx},
+	})
+	if err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	// Verify it was stored
+	aliceHash := alice.Hash()
+	attr := NewAttribute(":person/name")
+	start, end := encoder.EncodePrefixRange(EAVT, aliceHash[:], attr[:])
+	it, err := store.Scan(EAVT, start, end)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if !it.Next() {
+		t.Fatal("Expected to find Alice's name datom")
+	}
+	it.Close()
+
+	// Now retract with a DIFFERENT Tx value
+	// This simulates what happens in UpdateStruct where we lookup a value
+	// and try to retract it, but we don't know the original Tx
+	err = store.Retract([]datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: differentTx},
+	})
+	if err != nil {
+		t.Fatalf("Retract failed: %v", err)
+	}
+
+	// Verify the datom was actually retracted
+	it, err = store.Scan(EAVT, start, end)
+	if err != nil {
+		t.Fatalf("Scan after retract failed: %v", err)
+	}
+	defer it.Close()
+
+	if it.Next() {
+		datom, _ := it.Datom()
+		t.Errorf("Datom should have been retracted but found: %v", datom)
+	}
+}
+
 func TestKeyOnlyScanning(t *testing.T) {
 	// Create temporary directory
 	dir, err := os.MkdirTemp("", "badger-keyonly-test-*")

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -397,32 +397,28 @@ func (t *Transaction) AddMap(attrs map[string]interface{}) (datalog.Identity, er
 	return e, nil
 }
 
-// AddStruct adds all fields from a struct as datoms for the given entity.
-// The struct fields are mapped to attributes based on datalog struct tags.
-//
-// Example:
-//
-//	type Person struct {
-//	    ID   datalog.Identity `datalog:"-,id"`
-//	    Name string           `datalog:"name"`
-//	    Age  int64            `datalog:"age"`
-//	}
-//	tx.AddStruct(entityID, &person)
-func (t *Transaction) AddStruct(entity datalog.Identity, v interface{}) error {
-	return dlreflect.WriteStruct(t, entity, v, t.db.Schema())
-}
-
-// AddStructAuto adds all fields from a struct as datoms, auto-generating an entity ID if needed.
+// SaveStruct persists a struct to the database with upsert semantics.
 // If the struct has an ID field (tagged with `datalog:"-,id"`) and it's empty, a new ID is generated.
 // The generated or existing ID is returned and also set on the struct's ID field.
+//
+// Upsert behavior:
+//   - Cardinality-one fields: retracts old value if different, adds new value
+//   - Cardinality-many fields (nil slice): leaves existing values unchanged
+//   - Cardinality-many fields (empty slice): clears all existing values
+//   - Cardinality-many fields (non-empty): diff-based update (only changes what's different)
 //
 // Example:
 //
 //	person := Person{Name: "Alice", Age: 30}
-//	id, err := tx.AddStructAuto(&person)
+//	id, err := tx.SaveStruct(&person)
 //	// person.ID is now set to the generated identity
-func (t *Transaction) AddStructAuto(v interface{}) (datalog.Identity, error) {
-	return dlreflect.WriteStructAuto(t, v, t.db.Schema())
+//
+//	// Later, modify and save again
+//	person.Name = "Alice Smith"
+//	id, err = tx.SaveStruct(&person)  // Updates name, age unchanged
+func (t *Transaction) SaveStruct(v interface{}) (datalog.Identity, error) {
+	matcher := NewBadgerMatcher(t.db.Store())
+	return dlreflect.SaveStruct(t, matcher, v, t.db.Schema())
 }
 
 // Commit commits the transaction

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -597,3 +597,39 @@ func (m *BadgerMatcher) LookupAttribute(entity datalog.Identity, attr datalog.Ke
 	// No datom found
 	return nil, false
 }
+
+// LookupAllAttributes retrieves all values of a cardinality-many attribute for an entity.
+// Returns all matching values, or empty slice if none found.
+func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalog.Keyword) []interface{} {
+	// Convert to storage format
+	eBytes := entity.Bytes()
+	aStorage := ToStorageDatom(datalog.Datom{A: attr}).A
+
+	encoder := m.store.encoder
+
+	// Use AEVT index which orders by A, then E
+	start, end := encoder.EncodePrefixRange(AEVT, aStorage[:], eBytes[:])
+
+	iter, err := m.store.ScanKeysOnly(AEVT, start, end)
+	if err != nil {
+		return nil
+	}
+	defer iter.Close()
+
+	var values []interface{}
+	for iter.Next() {
+		datom, err := iter.Datom()
+		if err != nil {
+			continue
+		}
+
+		// Check transaction filter for as-of queries
+		if m.txID > 0 && datom.Tx > m.txID {
+			continue
+		}
+
+		values = append(values, datom.V)
+	}
+
+	return values
+}

--- a/docs/reference/REFLECT.md
+++ b/docs/reference/REFLECT.md
@@ -7,7 +7,7 @@ This document describes janus-datalog's struct reflection API for mapping Go str
 The reflection API provides a more ergonomic way to work with the database:
 
 - **`SchemaFromStruct()`** - Generate schema from struct definitions
-- **`AddStruct()`** / **`AddStructAuto()`** - Write structs as datoms
+- **`SaveStruct()`** - Write/update structs with upsert semantics
 - **`PullInto()`** / **`PullIntoMany()`** - Read datoms into structs
 
 ## Struct Tags
@@ -82,6 +82,8 @@ db, err := storage.NewDatabaseWithSchema(path, schema)
 
 ## Writing Structs
 
+`SaveStruct` provides unified upsert semantics - it creates new entities or updates existing ones.
+
 ### With Auto-Generated ID
 
 ```go
@@ -92,7 +94,7 @@ person := &Person{
 }
 
 tx := db.NewTransaction()
-id, err := tx.AddStructAuto(person)  // ID auto-generated
+id, err := tx.SaveStruct(person)  // ID auto-generated
 tx.Commit()
 
 // person.ID is now set to the generated identity
@@ -109,21 +111,99 @@ person := &Person{
 }
 
 tx := db.NewTransaction()
-tx.AddStruct(person.ID, person)
+id, err := tx.SaveStruct(person)  // Uses provided ID
 tx.Commit()
 ```
 
-### With Pre-Set ID
+## Updating Structs
+
+`SaveStruct` provides upsert semantics - calling it on an entity that already exists will update it.
+
+### Cardinality-One Fields
+
+For single-value fields, `SaveStruct` automatically:
+1. Looks up the existing value
+2. If different, retracts the old value
+3. Adds the new value
 
 ```go
-person := &Person{
-    ID:   datalog.NewIdentity("alice"),  // Pre-set ID
-    Name: "Alice",
-}
+// Original: Alice, age 30
+alice.Name = "Alice Smith"
+alice.Age = 31
 
 tx := db.NewTransaction()
-id, err := tx.AddStructAuto(person)  // Uses existing ID
-// id == person.ID
+tx.SaveStruct(&alice)
+tx.Commit()
+// Now: Alice Smith, age 31 (old values retracted)
+```
+
+### Cardinality-Many Fields
+
+For slice fields, `SaveStruct` uses diff-based updates:
+- Retracts values in existing but not in new
+- Adds values in new but not in existing
+- Values present in both are unchanged
+
+```go
+// Original tags: ["developer", "golang"]
+alice.Tags = []string{"developer", "rust", "architect"}
+
+tx := db.NewTransaction()
+tx.SaveStruct(&alice)
+tx.Commit()
+// Result: ["developer", "rust", "architect"]
+// "golang" retracted, "rust" and "architect" added, "developer" unchanged
+```
+
+### Nil vs Empty Slice Semantics
+
+For cardinality-many fields, `nil` and empty slices have different meanings:
+
+| Value | Behavior |
+|-------|----------|
+| `nil` | Skip field (leave existing values unchanged) |
+| `[]T{}` (empty) | Clear all existing values |
+| `[]T{"a", "b"}` | Replace with diff-based update |
+
+```go
+// Load entity - alice has tags ["go", "rust"]
+var alice Person
+db.PullInto(aliceID, &alice)
+
+// Partial update - only change name, leave tags alone
+update := Person{ID: aliceID, Name: "Alice Smith", Tags: nil}
+tx := db.NewTransaction()
+tx.SaveStruct(&update)
+tx.Commit()
+// tags still ["go", "rust"]
+
+// Clear all tags
+clear := Person{ID: aliceID, Name: "Alice Smith", Tags: []string{}}
+tx2 := db.NewTransaction()
+tx2.SaveStruct(&clear)
+tx2.Commit()
+// tags now empty
+```
+
+### Complete Update Example
+
+```go
+// Load existing entity
+var person Person
+db.PullInto(personID, &person)
+
+// Modify fields
+person.Name = "Alice Smith"
+person.Age = 31
+person.Tags = []string{"senior-developer", "team-lead"}
+
+// Save with upsert semantics
+tx := db.NewTransaction()
+_, err := tx.SaveStruct(&person)
+if err != nil {
+    return err
+}
+tx.Commit()
 ```
 
 ## Reading Structs
@@ -166,14 +246,14 @@ References to other entities use the `datalog.Identity` type:
 // Create manager
 manager := &Person{Name: "Carol", Age: 35}
 tx := db.NewTransaction()
-managerID, _ := tx.AddStructAuto(manager)
+managerID, _ := tx.SaveStruct(manager)
 
 // Create employee with manager reference
 employee := &Person{
     Name:    "Alice",
     Manager: &Person{ID: managerID},  // Just need the ID set
 }
-tx.AddStructAuto(employee)
+tx.SaveStruct(employee)
 tx.Commit()
 ```
 
@@ -258,14 +338,14 @@ func main() {
     db, _ := storage.NewDatabaseWithSchema(tmpDir, schema)
     defer db.Close()
 
-    // Write
+    // Create
     alice := &Person{
         Name: "Alice",
         Age:  30,
         Tags: []string{"developer", "mentor"},
     }
     tx := db.NewTransaction()
-    aliceID, _ := tx.AddStructAuto(alice)
+    aliceID, _ := tx.SaveStruct(alice)
     tx.Commit()
 
     fmt.Printf("Created: %s\n", alice.ID.String()[:20])
@@ -277,6 +357,19 @@ func main() {
     fmt.Printf("Name: %s\n", loaded.Name)
     fmt.Printf("Age: %d\n", loaded.Age)
     fmt.Printf("Tags: %v\n", loaded.Tags)
+
+    // Update
+    loaded.Age = 31
+    loaded.Tags = []string{"developer", "mentor", "architect"}
+    tx2 := db.NewTransaction()
+    tx2.SaveStruct(&loaded)
+    tx2.Commit()
+
+    // Verify update
+    var updated Person
+    db.PullInto(aliceID, &updated)
+    fmt.Printf("Updated Age: %d\n", updated.Age)
+    fmt.Printf("Updated Tags: %v\n", updated.Tags)
 }
 ```
 
@@ -285,7 +378,7 @@ func main() {
 - **StructInfo caching**: Struct metadata is cached using `sync.Map` for O(1) lookups after first parse
 - **Reflection overhead**: ~100ns per field access (Go reflection cost)
 - **Schema resolution**: Uses resolved pull patterns for proper cardinality-many handling
-- **Bulk operations**: `AddStruct` calls `Add()` per field (same overhead as manual datom creation)
+- **Bulk operations**: `SaveStruct` calls `Add()` per field (same overhead as manual datom creation)
 
 ## Limitations
 
@@ -308,9 +401,8 @@ reflect.MustSchemaFromStruct(v interface{}) *schema.Schema
 reflect.GeneratePullPattern(v interface{}, s schema.SchemaProvider) string
 reflect.GenerateSimplePullPattern(v interface{}) string
 
-// Writing (usually use Transaction methods instead)
-reflect.WriteStruct(tx TransactionAdder, entity Identity, v interface{}, s SchemaProvider) error
-reflect.WriteStructAuto(tx TransactionAdder, v interface{}, s SchemaProvider) (Identity, error)
+// Writing/Updating (usually use Transaction methods instead)
+reflect.SaveStruct(tx TransactionUpdater, lookup EntityLookup, v interface{}, s SchemaProvider) (Identity, error)
 
 // Reading (usually use Database methods instead)
 reflect.ReadStruct(result map[string]interface{}, v interface{}, s SchemaProvider) error
@@ -319,11 +411,9 @@ reflect.ReadStruct(result map[string]interface{}, v interface{}, s SchemaProvide
 ### Transaction Methods
 
 ```go
-// Write struct with explicit entity ID
-tx.AddStruct(entityID datalog.Identity, v interface{}) error
-
-// Write struct with auto-generated entity ID
-tx.AddStructAuto(v interface{}) (datalog.Identity, error)
+// Save struct with upsert semantics (creates or updates)
+// If ID field is empty, generates a new ID; otherwise uses existing ID
+tx.SaveStruct(v interface{}) (datalog.Identity, error)
 ```
 
 ### Database Methods


### PR DESCRIPTION
Replace AddStruct/AddStructAuto/UpdateStruct with unified SaveStruct:
- SaveStruct provides upsert semantics for both create and update
- If struct has no ID, generates one; otherwise uses existing
- Diff-based updates for cardinality-many fields

Key changes:
- Nil slice = skip field (leave existing values unchanged)
- Empty slice = clear all existing values
- Non-empty slice = diff-based replace

Fix retractDatom to scan for E+A+V regardless of Tx:
- Key encoding includes Tx, so deletion must find actual stored keys
- Now scans EAVT index for matching E+A+V and deletes actual keys

Documentation updated to reflect simplified API.