### PR TITLE
Implement Datomic-style history mode for full audit trail queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,11 @@ This is **standard database query optimization** (similar to Selinger's algorith
 - **Unbounded values**: Stored last with 2-byte size prefix and 1-byte type
 - **L85 encoding**: Custom Base85 variant preserving sort order (see below)
 - **Multiple indices**: EAVT, AEVT, AVET, VAET, TAEV for different access patterns
+- **History indices**: EAVT_HISTORY, AEVT_HISTORY, AVET_HISTORY, VAET_HISTORY, TAEV_HISTORY (opt-in with `RetractHistory` mode)
 - **Keyword interning**: Keywords hashed once and reused
 - **RefValues**: 20-byte entity references are L85-encoded like E/Tx components
 - **Attribute size**: Increased from 20 to 32 bytes to support longer attribute names (e.g., `:option/open-interest`)
+- **Retract modes**: `RetractDelete` (default, hard delete) vs `RetractHistory` (preserves audit trail)
 
 ### L85 Encoding Details
 
@@ -244,6 +246,7 @@ The storage layer connects the query engine to BadgerDB:
 21. **Relations migration** - Multi-value variable support throughout codebase
 22. **Pull API** - Declarative entity attribute retrieval with nested refs, cycle detection, wildcards (9× faster than queries)
 23. **Schema support** - Type validation, cardinality (one/many), uniqueness constraints; optional and additive
+24. **History mode** - Datomic-style retractions with `RetractHistory` mode; full audit trail via `ExecuteHistoryQuery`; 5-element patterns `[?e ?a ?v ?tx ?op]`
 
 ### 📋 TODO (Priority Order)
 

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -418,13 +418,34 @@ No entity navigation:
 - `keys` - no map results
 - `with` - no duplicate control
 
-### 7. Advanced Time Features ❌
+### 7. Time and History Features ⚠️
 
-Limited to as-of queries:
+**Supported:**
+- As-of queries via `db.AsOf(txID)`
+- **History database** via `db.History()` (opt-in with `RetractHistory` mode)
+- 5-element patterns `[?e ?a ?v ?tx ?op]` for history queries
+- Full audit trail: see all assertions and retractions
+
+**History Query API:**
+```go
+// Create database with history mode enabled
+db, _ := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+    Path:        "/path/to/db",
+    RetractMode: storage.RetractHistory,
+})
+
+// Query current state (uses current-state indices, value was retracted)
+results, _ := db.ExecuteQuery(`[:find ?name :where [?e :person/name ?name]]`)
+
+// Query history (uses history indices, sees all assertions AND retractions)
+// 5-element pattern: [?e ?a ?v ?tx ?op] where ?op is true=assert, false=retract
+history, _ := db.ExecuteHistoryQuery(`[:find ?name ?tx ?op :where [?e :person/name ?name ?tx ?op]]`)
+// Returns: [["Alice" 1 true] ["Alice" 2 false]]  -- assertion then retraction
+```
+
+**Not supported:**
 - No `since` queries
-- No `history` database
 - No tx-range queries
-- No full history API
 
 ### 8. Database Features ❌
 
@@ -485,7 +506,6 @@ No advanced database operations:
 
 **Not possible:**
 - Transaction functions
-- History queries beyond as-of
 - Distributed queries
 
 ### Example Query Conversions

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Most databases make you choose:
 
 **Janus gives you all three:**
 
-- **Datomic-style queries**: Joins, aggregations, subqueries, time-travel
+- **Datomic-style queries**: Joins, aggregations, subqueries, time-travel, history
 - **Single Go binary**: No JVM, no external dependencies, just `go get`
 - **No surprises**: Greedy planning without statistics, explicit error handling, predictable performance
 
@@ -219,6 +219,41 @@ Or extract time components:
 ```
 
 Time functions: `year`, `month`, `day`, `hour`, `minute`, `second`
+
+### History Queries (Audit Trail)
+
+Track every change with full history mode:
+
+```go
+// Create database with history mode enabled
+db, _ := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+    Path:        "my.db",
+    RetractMode: storage.RetractHistory,
+})
+
+// Make changes
+tx := db.NewTransaction()
+tx.Add(alice, datalog.NewKeyword(":user/name"), "Alice")
+tx.Commit()  // tx 1: assert "Alice"
+
+tx2 := db.NewTransaction()
+tx2.Retract(alice, datalog.NewKeyword(":user/name"), "Alice")
+tx2.Commit()  // tx 2: retract "Alice"
+
+// Query current state - returns nothing (value was retracted)
+db.ExecuteQuery(`[:find ?name :where [_ :user/name ?name]]`)
+
+// Query history - see ALL changes with 5-element pattern [?e ?a ?v ?tx ?op]
+db.ExecuteHistoryQuery(`[:find ?name ?tx ?op :where [_ :user/name ?name ?tx ?op]]`)
+// Returns: [["Alice" 1 true] ["Alice" 2 false]]
+// op=true means assertion, op=false means retraction
+```
+
+**Key concepts:**
+- `RetractHistory` mode preserves full audit trail (default `RetractDelete` just deletes)
+- Current-state queries (`ExecuteQuery`) see only current truth
+- History queries (`ExecuteHistoryQuery`) see all assertions AND retractions
+- 5-element patterns: `[?e ?a ?v ?tx ?op]` where `?op` is true=assert, false=retract
 
 ### Subqueries
 
@@ -686,6 +721,7 @@ Janus implements **~50-60% of Datomic's feature set**, focusing on the most comm
 - Aggregations: sum, count, avg, min, max
 - Subqueries: Full q support
 - Time queries: as-of, time functions
+- History queries: Full audit trail with `ExecuteHistoryQuery`
 - Pull API: Nested references, cycle detection, wildcards
 - Schema: Type validation, cardinality, uniqueness constraints
 - Storage: Persistent BadgerDB backend

--- a/datalog/parser/parser.go
+++ b/datalog/parser/parser.go
@@ -264,8 +264,11 @@ func parsePattern(node *edn.Node) (query.Clause, error) {
 	}
 
 	// Otherwise it's a data pattern
-	if len(node.Nodes) < 3 || len(node.Nodes) > 4 {
-		return nil, fmt.Errorf("data pattern must have 3 or 4 elements, got %d", len(node.Nodes))
+	// 3 elements: [e a v]
+	// 4 elements: [e a v tx]
+	// 5 elements: [e a v tx op] (history queries)
+	if len(node.Nodes) < 3 || len(node.Nodes) > 5 {
+		return nil, fmt.Errorf("data pattern must have 3, 4, or 5 elements, got %d", len(node.Nodes))
 	}
 
 	pattern := &query.DataPattern{

--- a/datalog/parser/parser_test.go
+++ b/datalog/parser/parser_test.go
@@ -206,7 +206,7 @@ func TestParseErrors(t *testing.T) {
 		{
 			name:  "invalid pattern length",
 			input: `[:find ?e :where [?e ?a]]`,
-			error: "pattern must have 3 or 4 elements",
+			error: "pattern must have 3, 4, or 5 elements",
 		},
 		{
 			name:  "non-vector pattern",

--- a/datalog/query/types.go
+++ b/datalog/query/types.go
@@ -203,6 +203,15 @@ func (p DataPattern) GetT() PatternElement {
 	return nil
 }
 
+// GetOp returns the operation element if it exists (for history queries)
+// This is position 4 in a 5-element pattern [?e ?a ?v ?tx ?op]
+func (p DataPattern) GetOp() PatternElement {
+	if len(p.Elements) > 4 {
+		return p.Elements[4]
+	}
+	return nil
+}
+
 // Symbols returns the symbols (variables) bound by this pattern
 // In relational theory, these become the attributes of the resulting relation
 func (p *DataPattern) Symbols() []Symbol {
@@ -245,6 +254,22 @@ func (p *DataPattern) Symbols() []Symbol {
 	// Check T position if present
 	if len(p.Elements) > 3 {
 		if v, ok := p.GetT().(Variable); ok {
+			found := false
+			for _, sym := range symbols {
+				if sym == v.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				symbols = append(symbols, v.Name)
+			}
+		}
+	}
+
+	// Check Op position if present (5-element history patterns)
+	if len(p.Elements) > 4 {
+		if v, ok := p.GetOp().(Variable); ok {
 			found := false
 			for _, sym := range symbols {
 				if sym == v.Name {
@@ -561,6 +586,57 @@ func DatomToTuple(datom datalog.Datom, pattern *DataPattern, columns []Symbol) T
 	if len(pattern.Elements) > 3 {
 		if v, ok := pattern.GetT().(Variable); ok {
 			values[v.Name] = datom.Tx
+		}
+	}
+
+	// Build tuple in column order
+	tuple := make(Tuple, len(columns))
+	for i, col := range columns {
+		if val, found := values[col]; found {
+			tuple[i] = val
+		}
+	}
+
+	return tuple
+}
+
+// HistoryDatomToTuple converts a datom and Op to a tuple for history queries.
+// This is used by the HistoryMatcher to include the Op in query results.
+// The op parameter is true for assertions, false for retractions.
+func HistoryDatomToTuple(datom datalog.Datom, op bool, pattern *DataPattern, columns []Symbol) Tuple {
+	if len(columns) == 0 {
+		return nil
+	}
+
+	// Build column to value mapping
+	values := make(map[Symbol]interface{})
+
+	// Map E position
+	if v, ok := pattern.GetE().(Variable); ok {
+		values[v.Name] = datom.E
+	}
+
+	// Map A position
+	if v, ok := pattern.GetA().(Variable); ok {
+		values[v.Name] = datom.A
+	}
+
+	// Map V position
+	if v, ok := pattern.GetV().(Variable); ok {
+		values[v.Name] = datom.V
+	}
+
+	// Map T position
+	if len(pattern.Elements) > 3 {
+		if v, ok := pattern.GetT().(Variable); ok {
+			values[v.Name] = datom.Tx
+		}
+	}
+
+	// Map Op position (for history queries)
+	if len(pattern.Elements) > 4 {
+		if v, ok := pattern.GetOp().(Variable); ok {
+			values[v.Name] = op
 		}
 	}
 

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -10,12 +10,19 @@ import (
 
 // BadgerStore implements Store using BadgerDB
 type BadgerStore struct {
-	db      *badger.DB
-	encoder KeyEncoder
+	db          *badger.DB
+	encoder     KeyEncoder
+	retractMode RetractMode // Controls how retractions are handled
 }
 
 // NewBadgerStore creates a new BadgerDB-backed store with the specified encoder
+// Uses RetractDelete mode (current behavior) by default
 func NewBadgerStore(path string, encoder KeyEncoder) (*BadgerStore, error) {
+	return NewBadgerStoreWithRetractMode(path, encoder, RetractDelete)
+}
+
+// NewBadgerStoreWithRetractMode creates a new BadgerDB-backed store with specified retract mode
+func NewBadgerStoreWithRetractMode(path string, encoder KeyEncoder, retractMode RetractMode) (*BadgerStore, error) {
 	opts := badger.DefaultOptions(path)
 	opts.Logger = nil // Disable BadgerDB logs for now
 
@@ -38,9 +45,15 @@ func NewBadgerStore(path string, encoder KeyEncoder) (*BadgerStore, error) {
 	}
 
 	return &BadgerStore{
-		db:      db,
-		encoder: encoder,
+		db:          db,
+		encoder:     encoder,
+		retractMode: retractMode,
 	}, nil
+}
+
+// RetractMode returns the store's retract mode
+func (s *BadgerStore) RetractMode() RetractMode {
+	return s.retractMode
 }
 
 // Assert adds datoms to the store
@@ -61,15 +74,38 @@ func (s *BadgerStore) assertDatom(txn *badger.Txn, d *datalog.Datom) error {
 	sd := ToStorageDatom(*d)
 	value := sd.Bytes()
 
-	// Write to all indices
-	indices := []IndexType{EAVT, AEVT, AVET, VAET, TAEV}
-	for _, idx := range indices {
+	// Write to all current-state indices
+	for _, idx := range CurrentStateIndices {
 		key := s.encoder.EncodeKey(idx, d)
 		if err := txn.Set(key, value); err != nil {
 			return fmt.Errorf("failed to write to %v index: %w", idx, err)
 		}
 	}
 
+	// If history mode, also write to history indices with Op=true
+	if s.retractMode == RetractHistory {
+		if err := s.writeToHistoryIndices(txn, d, OpAssert); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeToHistoryIndices writes a datom to all history indices with the given Op
+func (s *BadgerStore) writeToHistoryIndices(txn *badger.Txn, d *datalog.Datom, op Op) error {
+	// Value is just the Op byte - all other data is in the key
+	value := []byte{0x00}
+	if op {
+		value[0] = 0x01
+	}
+
+	for _, idx := range HistoryIndices {
+		key := s.encoder.EncodeHistoryKey(idx, d, op)
+		if err := txn.Set(key, value); err != nil {
+			return fmt.Errorf("failed to write to %v history index: %w", idx, err)
+		}
+	}
 	return nil
 }
 
@@ -85,9 +121,11 @@ func (s *BadgerStore) Retract(datoms []datalog.Datom) error {
 	})
 }
 
-// retractDatom removes a single datom from all indices
-// NOTE: The Tx field in the passed datom is ignored. We find the actual stored
-// datom(s) matching E+A+V and delete those, regardless of their Tx.
+// retractDatom removes a single datom from current-state indices and optionally
+// records the retraction in history indices.
+// NOTE: The Tx field in the passed datom is ignored for finding stored datoms.
+// We find the actual stored datom(s) matching E+A+V and delete those.
+// In history mode, the Tx from the passed datom is used for the retraction record.
 func (s *BadgerStore) retractDatom(txn *badger.Txn, d *datalog.Datom) error {
 	// Convert to storage format for prefix scanning
 	sd := ToStorageDatom(*d)
@@ -118,7 +156,7 @@ func (s *BadgerStore) retractDatom(txn *badger.Txn, d *datalog.Datom) error {
 		return nil
 	}
 
-	// For each matching EAVT key, decode it and delete from all indices
+	// For each matching EAVT key, decode it and delete from current-state indices
 	for _, eavtKey := range keysToDelete {
 		// Decode the EAVT key to get the full datom including Tx
 		// DatomFromKey handles all the complexity of decoding components
@@ -127,12 +165,25 @@ func (s *BadgerStore) retractDatom(txn *badger.Txn, d *datalog.Datom) error {
 			return fmt.Errorf("failed to decode key for retraction: %w", err)
 		}
 
-		// Delete from all indices using the actual stored Tx
-		indices := []IndexType{EAVT, AEVT, AVET, VAET, TAEV}
-		for _, idx := range indices {
+		// Delete from all current-state indices using the actual stored Tx
+		for _, idx := range CurrentStateIndices {
 			key := s.encoder.EncodeKey(idx, storedDatom)
 			if err := txn.Delete(key); err != nil && err != badger.ErrKeyNotFound {
 				return fmt.Errorf("failed to delete from %v index: %w", idx, err)
+			}
+		}
+
+		// If history mode, write retraction to history indices
+		// Use the Tx from the passed datom (the retraction transaction)
+		if s.retractMode == RetractHistory {
+			retractDatom := &datalog.Datom{
+				E:  storedDatom.E,
+				A:  storedDatom.A,
+				V:  storedDatom.V,
+				Tx: d.Tx, // Use the retraction Tx, not the original assertion Tx
+			}
+			if err := s.writeToHistoryIndices(txn, retractDatom, OpRetract); err != nil {
+				return err
 			}
 		}
 	}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -62,6 +62,49 @@ func NewDatabaseWithSchema(path string, s schema.SchemaProvider) (*Database, err
 	return db, nil
 }
 
+// DatabaseOptions configures database creation
+type DatabaseOptions struct {
+	Path        string               // Path to the database directory
+	UseTimeTx   bool                 // Use time-based transaction IDs
+	RetractMode RetractMode          // How retractions are handled
+	Schema      schema.SchemaProvider // Optional schema for validation
+}
+
+// NewDatabaseWithOptions creates a database with the specified options.
+// This is the most flexible constructor, supporting all configuration options.
+//
+// Options:
+//   - Path: Required. Directory for BadgerDB storage.
+//   - UseTimeTx: If true, use nanosecond timestamps as transaction IDs.
+//   - RetractMode: RetractDelete (default) deletes data; RetractHistory preserves full audit trail.
+//   - Schema: Optional schema for validation.
+//
+// Example:
+//
+//	db, err := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+//	    Path:        "/path/to/db",
+//	    RetractMode: storage.RetractHistory,
+//	})
+//	// Now db.History() returns a PatternMatcher for querying all changes
+func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
+	if opts.Path == "" {
+		return nil, fmt.Errorf("database path is required")
+	}
+
+	store, err := NewBadgerStoreWithRetractMode(opts.Path, NewKeyEncoder(BinaryStrategy), opts.RetractMode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create store: %w", err)
+	}
+
+	return &Database{
+		store:     store,
+		activeTx:  make(map[*Transaction]bool),
+		planCache: planner.NewPlanCache(1000, 0),
+		useTimeTx: opts.UseTimeTx,
+		schema:    opts.Schema,
+	}, nil
+}
+
 // Schema returns the current schema (may be nil)
 func (d *Database) Schema() schema.SchemaProvider {
 	d.mu.RLock()
@@ -136,6 +179,48 @@ func (d *Database) AsOf(txID uint64) executor.PatternMatcher {
 		IndexNestedLoopThreshold:        opts.IndexNestedLoopThreshold,
 	}
 	return NewBadgerMatcherWithOptions(d.store, execOpts).AsOf(txID)
+}
+
+// History returns a PatternMatcher for querying the full history of the database.
+// This includes all assertions and retractions with the Op (operation) field.
+// History queries can use 5-element patterns: [?e ?a ?v ?tx ?op]
+//
+// Returns nil if the database was not created with RetractHistory mode.
+// In RetractHistory mode, all assertions and retractions are preserved in history indices.
+//
+// Example:
+//
+//	historyMatcher := db.History()
+//	if historyMatcher == nil {
+//	    // Database doesn't support history queries
+//	}
+//	// Query all changes to an entity
+//	// Pattern: [entity-id ?a ?v ?tx ?op]
+func (d *Database) History() executor.PatternMatcher {
+	if d.store.RetractMode() != RetractHistory {
+		return nil
+	}
+	opts := DefaultPlannerOptions()
+	execOpts := executor.ExecutorOptions{
+		EnableIteratorComposition:       opts.EnableIteratorComposition,
+		EnableTrueStreaming:             opts.EnableTrueStreaming,
+		EnableSymmetricHashJoin:         opts.EnableSymmetricHashJoin,
+		EnableParallelSubqueries:        opts.EnableParallelSubqueries,
+		MaxSubqueryWorkers:              opts.MaxSubqueryWorkers,
+		EnableStreamingJoins:            opts.EnableStreamingJoins,
+		EnableStreamingAggregation:      opts.EnableStreamingAggregation,
+		EnableStreamingAggregationDebug: opts.EnableStreamingAggregationDebug,
+		EnableDebugLogging:              opts.EnableDebugLogging,
+		IndexNestedLoopThreshold:        opts.IndexNestedLoopThreshold,
+	}
+	return NewHistoryMatcherWithOptions(d.store, execOpts)
+}
+
+// RetractMode returns the retraction mode of the database.
+// RetractDelete means retractions delete data from current-state indices.
+// RetractHistory means retractions are preserved in history indices for audit trails.
+func (d *Database) RetractMode() RetractMode {
+	return d.store.RetractMode()
 }
 
 // DefaultPlannerOptions returns the default planner and executor options for the database
@@ -296,6 +381,52 @@ func (d *Database) ExecuteQueryWithInputs(queryStr string, inputs ...interface{}
 	result, err := exec.ExecuteWithRelations(executor.NewContext(nil), q, inputRelations)
 	if err != nil {
 		return nil, fmt.Errorf("query execution failed: %w", err)
+	}
+
+	// Convert result to [][]interface{}
+	return relationToSlice(result), nil
+}
+
+// ExecuteHistoryQuery executes a Datalog query against the history database
+// This requires the database to be created with RetractHistory mode
+//
+// History queries support 5-element patterns: [?e ?a ?v ?tx ?op]
+// where ?op is true for assertions and false for retractions
+//
+// Example:
+//
+//	results, err := db.ExecuteHistoryQuery(`[:find ?v ?tx ?op :where [?e :person/name ?v ?tx ?op]]`)
+func (d *Database) ExecuteHistoryQuery(queryStr string) ([][]interface{}, error) {
+	return d.ExecuteHistoryQueryWithInputs(queryStr)
+}
+
+// ExecuteHistoryQueryWithInputs executes a parameterized query against the history database
+// This is the history equivalent of ExecuteQueryWithInputs
+func (d *Database) ExecuteHistoryQueryWithInputs(queryStr string, inputs ...interface{}) ([][]interface{}, error) {
+	historyMatcher := d.History()
+	if historyMatcher == nil {
+		return nil, fmt.Errorf("history queries require RetractHistory mode (database was created with RetractDelete mode)")
+	}
+
+	// Parse the query
+	q, err := parser.ParseQuery(queryStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	// Convert inputs to Relations based on :in clause
+	inputRelations, err := d.convertInputsToRelations(q, inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute the query using the history matcher
+	opts := DefaultPlannerOptions()
+	opts.Cache = d.planCache
+	exec := executor.NewExecutorWithOptions(historyMatcher, opts)
+	result, err := exec.ExecuteWithRelations(executor.NewContext(nil), q, inputRelations)
+	if err != nil {
+		return nil, fmt.Errorf("history query execution failed: %w", err)
 	}
 
 	// Convert result to [][]interface{}

--- a/datalog/storage/datom_decoder.go
+++ b/datalog/storage/datom_decoder.go
@@ -91,6 +91,73 @@ func DatomFromKey(index IndexType, key []byte, encoder KeyEncoder) (*datalog.Dat
 	}, nil
 }
 
+// DatomFromHistoryKey reconstructs a datom and Op from a history index key
+func DatomFromHistoryKey(index IndexType, key []byte, encoder KeyEncoder) (*datalog.Datom, Op, error) {
+	// DecodeHistoryKey handles history indices and returns Op
+	eBytes, aBytes, vBytes, txBytes, op, err := encoder.DecodeHistoryKey(index, key)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to decode history key: %w", err)
+	}
+
+	// Create storage datom from the decoded components
+	var sd StorageDatom
+
+	// Entity (20 bytes)
+	if len(eBytes) != 20 {
+		return nil, false, fmt.Errorf("invalid entity size: %d", len(eBytes))
+	}
+	copy(sd.E[:], eBytes)
+
+	// Attribute (32 bytes)
+	if len(aBytes) != 32 {
+		return nil, false, fmt.Errorf("invalid attribute size: %d", len(aBytes))
+	}
+	copy(sd.A[:], aBytes)
+
+	// Value (variable length) - first byte is type, rest is data
+	if len(vBytes) < 1 {
+		return nil, false, fmt.Errorf("value bytes too short: %d", len(vBytes))
+	}
+	vType := datalog.ValueType(vBytes[0])
+	vData := vBytes[1:]
+
+	// Special handling for references which might be L85-encoded
+	if vType == datalog.TypeReference && len(vData) == 25 {
+		// L85-encoded reference - decode it first
+		if refBytes, err := codec.DecodeFixed20(string(vData)); err == nil {
+			vData = refBytes[:]
+		}
+	}
+
+	v, err := datalog.ValueFromBytes(vType, vData)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to decode value: %w", err)
+	}
+	sd.V = v
+
+	// Transaction (20 bytes)
+	if len(txBytes) != 20 {
+		return nil, false, fmt.Errorf("invalid tx size: %d", len(txBytes))
+	}
+	copy(sd.Tx[:], txBytes)
+
+	// Use cached attribute string
+	var attrString string
+	if cached, ok := attrStringCache.Load(sd.A); ok {
+		attrString = cached.(string)
+	} else {
+		attrString = string(bytes.TrimRight(aBytes, "\x00"))
+		attrStringCache.Store(sd.A, attrString)
+	}
+
+	return &datalog.Datom{
+		E:  *datalog.InternIdentityFromHash(sd.E),
+		A:  *datalog.InternKeyword(attrString),
+		V:  sd.V,
+		Tx: sd.Tx.Uint64(),
+	}, op, nil
+}
+
 // KeyOnlyIterator wraps a BadgerIterator to decode datoms from keys
 // This avoids fetching values entirely
 type KeyOnlyIterator struct {
@@ -120,6 +187,73 @@ func NewKeyOnlyIterator(store *BadgerStore, index IndexType, start, end []byte) 
 		},
 		encoder: store.encoder,
 	}, nil
+}
+
+// HistoryKeyOnlyIterator is like KeyOnlyIterator but for history indices
+type HistoryKeyOnlyIterator struct {
+	*BadgerIterator
+	encoder      KeyEncoder
+	currentDatom *datalog.Datom
+	currentOp    Op
+	currentError error
+}
+
+// NewHistoryKeyOnlyIterator creates an iterator for history indices
+func NewHistoryKeyOnlyIterator(store *BadgerStore, index IndexType, start, end []byte) (*HistoryKeyOnlyIterator, error) {
+	txn := store.db.NewTransaction(false)
+
+	opts := badger.DefaultIteratorOptions
+	opts.PrefetchSize = 10000
+	opts.PrefetchValues = false
+
+	it := txn.NewIterator(opts)
+
+	return &HistoryKeyOnlyIterator{
+		BadgerIterator: &BadgerIterator{
+			txn:   txn,
+			it:    it,
+			start: start,
+			end:   end,
+			index: index,
+		},
+		encoder: store.encoder,
+	}, nil
+}
+
+// Next advances the history iterator
+func (i *HistoryKeyOnlyIterator) Next() bool {
+	i.currentDatom = nil
+	i.currentError = nil
+
+	hasNext := i.BadgerIterator.Next()
+	if !hasNext {
+		return false
+	}
+
+	key := i.it.Item().Key()
+	i.currentDatom, i.currentOp, i.currentError = DatomFromHistoryKey(i.index, key, i.encoder)
+
+	if i.currentError != nil {
+		return false
+	}
+
+	return true
+}
+
+// Datom returns the current datom
+func (i *HistoryKeyOnlyIterator) Datom() (*datalog.Datom, error) {
+	if i.currentError != nil {
+		return nil, i.currentError
+	}
+	if i.currentDatom == nil {
+		return nil, fmt.Errorf("no current datom")
+	}
+	return i.currentDatom, nil
+}
+
+// Op returns the current Op (true=assert, false=retract)
+func (i *HistoryKeyOnlyIterator) Op() Op {
+	return i.currentOp
 }
 
 // Next advances the iterator

--- a/datalog/storage/history_matcher.go
+++ b/datalog/storage/history_matcher.go
@@ -1,0 +1,199 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// HistoryMatcher implements PatternMatcher for querying history indices.
+// It reads from the history index set which contains all assertions and retractions
+// with Op (operation) included. This enables full audit trail queries.
+//
+// History patterns can have 5 elements: [?e ?a ?v ?tx ?op]
+// When ?op is bound, results are filtered by that value.
+// When ?op is unbound, it's included in the result relation.
+type HistoryMatcher struct {
+	store   *BadgerStore
+	txID    uint64 // For as-of on history (0 = all history)
+	options executor.ExecutorOptions
+}
+
+// NewHistoryMatcher creates a new history pattern matcher
+func NewHistoryMatcher(store *BadgerStore) *HistoryMatcher {
+	return &HistoryMatcher{store: store}
+}
+
+// NewHistoryMatcherWithOptions creates a new history pattern matcher with options
+func NewHistoryMatcherWithOptions(store *BadgerStore, opts executor.ExecutorOptions) *HistoryMatcher {
+	return &HistoryMatcher{store: store, options: opts}
+}
+
+// AsOf creates a history matcher limited to transactions up to txID
+func (m *HistoryMatcher) AsOf(txID uint64) *HistoryMatcher {
+	return &HistoryMatcher{store: m.store, txID: txID, options: m.options}
+}
+
+var _ executor.PatternMatcher = (*HistoryMatcher)(nil)
+
+// Match implements PatternMatcher.Match for history queries
+func (m *HistoryMatcher) Match(pattern *query.DataPattern, bindings executor.Relations) (executor.Relation, error) {
+	columns := pattern.Symbols()
+
+	// Extract constraints from pattern
+	e, a, v, tx, op := m.extractPatternValues(pattern)
+
+	// Choose history index based on bound values (same logic as current-state)
+	index := m.chooseHistoryIndex(e, a, v, tx)
+
+	// Build prefix for scan range
+	start, end := m.buildScanRange(index, e, a, v, tx)
+
+	// Scan history index using specialized history iterator
+	histKeyIter, err := NewHistoryKeyOnlyIterator(m.store, index, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("history scan failed: %w", err)
+	}
+
+	// Create iterator that filters and builds tuples
+	histIter := &historyIterator{
+		matcher:  m,
+		index:    index,
+		histIter: histKeyIter,
+		pattern:  pattern,
+		columns:  columns,
+		e:        e,
+		a:        a,
+		v:        v,
+		tx:       tx,
+		op:       op,
+	}
+
+	return executor.NewStreamingRelationWithOptions(columns, histIter, m.options), nil
+}
+
+func (m *HistoryMatcher) extractPatternValues(pattern *query.DataPattern) (e, a, v, tx, op interface{}) {
+	extract := func(elem query.PatternElement) interface{} {
+		if c, ok := elem.(query.Constant); ok {
+			return c.Value
+		}
+		return nil
+	}
+	if elem := pattern.GetE(); elem != nil {
+		e = extract(elem)
+	}
+	if elem := pattern.GetA(); elem != nil {
+		a = extract(elem)
+	}
+	if elem := pattern.GetV(); elem != nil {
+		v = extract(elem)
+	}
+	if elem := pattern.GetT(); elem != nil {
+		tx = extract(elem)
+	}
+	if elem := pattern.GetOp(); elem != nil {
+		op = extract(elem)
+	}
+	return
+}
+
+func (m *HistoryMatcher) chooseHistoryIndex(e, a, v, tx interface{}) IndexType {
+	if e != nil {
+		return EAVT_HISTORY
+	} else if a != nil {
+		if v != nil {
+			return AVET_HISTORY
+		}
+		return AEVT_HISTORY
+	} else if v != nil {
+		return VAET_HISTORY
+	} else if tx != nil {
+		return TAEV_HISTORY
+	}
+	return EAVT_HISTORY
+}
+
+func (m *HistoryMatcher) buildScanRange(index IndexType, e, a, v, tx interface{}) ([]byte, []byte) {
+	encoder := m.store.encoder
+
+	// Build prefix parts based on what's bound
+	var parts [][]byte
+
+	switch index {
+	case EAVT_HISTORY:
+		if eId, ok := e.(datalog.Identity); ok {
+			parts = append(parts, eId.Bytes()[:])
+		}
+	case AEVT_HISTORY, AVET_HISTORY:
+		if aKw, ok := a.(datalog.Keyword); ok {
+			aStorage := ToStorageDatom(datalog.Datom{A: aKw}).A
+			parts = append(parts, aStorage[:])
+		}
+	case VAET_HISTORY:
+		if v != nil {
+			sDatom := ToStorageDatom(datalog.Datom{V: v})
+			vType := byte(datalog.Type(sDatom.V))
+			vData := datalog.ValueBytes(sDatom.V)
+			parts = append(parts, append([]byte{vType}, vData...))
+		}
+	case TAEV_HISTORY:
+		if txID, ok := tx.(uint64); ok {
+			storageTx := NewTxFromUint(txID)
+			parts = append(parts, storageTx[:])
+		}
+	}
+
+	return encoder.EncodePrefixRange(index, parts...)
+}
+
+// historyIterator iterates over history index results
+type historyIterator struct {
+	matcher             *HistoryMatcher
+	index               IndexType
+	histIter            *HistoryKeyOnlyIterator
+	pattern             *query.DataPattern
+	columns             []query.Symbol
+	e, a, v, tx, op     interface{}
+	current             executor.Tuple
+	done                bool
+}
+
+func (i *historyIterator) Next() bool {
+	if i.done {
+		return false
+	}
+
+	for i.histIter.Next() {
+		datom, err := i.histIter.Datom()
+		if err != nil {
+			i.done = true
+			return false
+		}
+
+		opBool := i.histIter.Op() == OpAssert
+
+		// Filter by txID if as-of is set
+		if i.matcher.txID > 0 && datom.Tx > i.matcher.txID {
+			continue
+		}
+
+		// Filter by Op if bound
+		if i.op != nil {
+			if opConst, ok := i.op.(bool); ok && opBool != opConst {
+				continue
+			}
+		}
+
+		// Build tuple including Op
+		i.current = query.HistoryDatomToTuple(*datom, opBool, i.pattern, i.columns)
+		return true
+	}
+
+	i.done = true
+	return false
+}
+
+func (i *historyIterator) Tuple() executor.Tuple { return i.current }
+func (i *historyIterator) Close() error          { return i.histIter.Close() }

--- a/datalog/storage/history_test.go
+++ b/datalog/storage/history_test.go
@@ -1,0 +1,129 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+func TestHistoryMode(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "history-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create database with history mode
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:        tmpDir,
+		RetractMode: RetractHistory,
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Verify history mode
+	if db.RetractMode() != RetractHistory {
+		t.Fatal("expected RetractHistory mode")
+	}
+
+	// Create entity and add initial value
+	entity := datalog.NewIdentity("user:1")
+	nameAttr := datalog.NewKeyword(":user/name")
+
+	tx1 := db.NewTransaction()
+	if err := tx1.Add(entity, nameAttr, "Alice"); err != nil {
+		t.Fatalf("failed to add: %v", err)
+	}
+	txID1, err := tx1.Commit()
+	if err != nil {
+		t.Fatalf("failed to commit tx1: %v", err)
+	}
+	t.Logf("Committed assertion at tx %d", txID1)
+
+	// Retract the value
+	tx2 := db.NewTransaction()
+	if err := tx2.Retract(entity, nameAttr, "Alice"); err != nil {
+		t.Fatalf("failed to retract: %v", err)
+	}
+	txID2, err := tx2.Commit()
+	if err != nil {
+		t.Fatalf("failed to commit tx2: %v", err)
+	}
+	t.Logf("Committed retraction at tx %d", txID2)
+
+	// Query current state using Query API - should be empty (value was retracted)
+	currentResults, err := db.ExecuteQuery(`[:find ?v :where [_ :user/name ?v]]`)
+	if err != nil {
+		t.Fatalf("current state query failed: %v", err)
+	}
+	if len(currentResults) != 0 {
+		t.Errorf("expected empty current state, got %v", currentResults)
+	}
+	t.Logf("Current state: %d results (expected 0)", len(currentResults))
+
+	// Query history using Query API - should see both assertion and retraction
+	// 5-element pattern: [?e ?a ?v ?tx ?op]
+	historyResults, err := db.ExecuteHistoryQuery(`[:find ?v ?tx ?op :where [_ :user/name ?v ?tx ?op]]`)
+	if err != nil {
+		t.Fatalf("history query failed: %v", err)
+	}
+
+	t.Logf("History results: %d entries", len(historyResults))
+	for _, row := range historyResults {
+		t.Logf("  value=%q tx=%v op=%v", row[0], row[1], row[2])
+	}
+
+	// Should have 2 history entries
+	if len(historyResults) != 2 {
+		t.Errorf("expected 2 history entries, got %d", len(historyResults))
+	}
+
+	// Verify we have both assertion (op=true) and retraction (op=false)
+	hasAssert := false
+	hasRetract := false
+	for _, row := range historyResults {
+		if op, ok := row[2].(bool); ok {
+			if op {
+				hasAssert = true
+			} else {
+				hasRetract = true
+			}
+		}
+	}
+
+	if !hasAssert {
+		t.Error("missing assertion in history")
+	}
+	if !hasRetract {
+		t.Error("missing retraction in history")
+	}
+}
+
+func TestDefaultRetractMode(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "default-retract-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create default database
+	db, err := NewDatabase(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Default mode should be RetractDelete
+	if db.RetractMode() != RetractDelete {
+		t.Errorf("expected RetractDelete mode, got %v", db.RetractMode())
+	}
+
+	// History() should return nil for non-history database
+	if db.History() != nil {
+		t.Error("History() should return nil for RetractDelete database")
+	}
+}

--- a/datalog/storage/key_encoder_binary.go
+++ b/datalog/storage/key_encoder_binary.go
@@ -153,3 +153,77 @@ func (e *BinaryKeyEncoder) EncodePrefixRange(index IndexType, parts ...[]byte) (
 
 	return start, end
 }
+
+// historyIndexToBase maps history index types to their base current-state equivalents
+func historyIndexToBase(index IndexType) IndexType {
+	switch index {
+	case EAVT_HISTORY:
+		return EAVT
+	case AEVT_HISTORY:
+		return AEVT
+	case AVET_HISTORY:
+		return AVET
+	case VAET_HISTORY:
+		return VAET
+	case TAEV_HISTORY:
+		return TAEV
+	default:
+		return index
+	}
+}
+
+// EncodeHistoryKey creates a binary index key with Op appended for history indices
+func (e *BinaryKeyEncoder) EncodeHistoryKey(index IndexType, d *datalog.Datom, op Op) []byte {
+	// Convert to storage datom first
+	sd := ToStorageDatom(*d)
+
+	// Use the history index byte as prefix
+	prefix := []byte{byte(index)}
+
+	// Get value bytes with type prefix (1 byte type + variable length data)
+	vType := byte(datalog.Type(sd.V))
+	vData := datalog.ValueBytes(sd.V)
+	vBytes := append([]byte{vType}, vData...)
+
+	// Op encoding: 0x01 = assert (true), 0x00 = retract (false)
+	opByte := byte(0x00)
+	if op {
+		opByte = 0x01
+	}
+
+	// Build key based on base index type, then append Op
+	baseIndex := historyIndexToBase(index)
+	switch baseIndex {
+	case EAVT:
+		return concatBytes(prefix, sd.E[:], sd.A[:], vBytes, sd.Tx[:], []byte{opByte})
+	case AEVT:
+		return concatBytes(prefix, sd.A[:], sd.E[:], vBytes, sd.Tx[:], []byte{opByte})
+	case AVET:
+		return concatBytes(prefix, sd.A[:], vBytes, sd.E[:], sd.Tx[:], []byte{opByte})
+	case VAET:
+		return concatBytes(prefix, vBytes, sd.A[:], sd.E[:], sd.Tx[:], []byte{opByte})
+	case TAEV:
+		return concatBytes(prefix, sd.Tx[:], sd.A[:], sd.E[:], vBytes, []byte{opByte})
+	default:
+		panic(fmt.Sprintf("unknown history index type: %v", index))
+	}
+}
+
+// DecodeHistoryKey extracts components including Op from a binary history index key
+func (e *BinaryKeyEncoder) DecodeHistoryKey(index IndexType, key []byte) (entity, attr, value, tx []byte, op Op, err error) {
+	if len(key) < 2 { // At minimum: prefix + op
+		return nil, nil, nil, nil, false, fmt.Errorf("history key too short")
+	}
+
+	// Op is the last byte
+	opByte := key[len(key)-1]
+	op = opByte == 0x01
+
+	// Decode the rest as a normal key (without the Op byte)
+	keyWithoutOp := key[:len(key)-1]
+
+	// Use the base index type for decoding
+	baseIndex := historyIndexToBase(index)
+	entity, attr, value, tx, err = e.DecodeKey(baseIndex, keyWithoutOp)
+	return entity, attr, value, tx, op, err
+}

--- a/datalog/storage/key_encoder_interface.go
+++ b/datalog/storage/key_encoder_interface.go
@@ -6,10 +6,10 @@ import (
 
 // KeyEncoder builds and parses index keys from datoms
 type KeyEncoder interface {
-	// EncodeKey creates an index key from a datom
+	// EncodeKey creates an index key from a datom (for current-state indices)
 	EncodeKey(index IndexType, d *datalog.Datom) []byte
 
-	// DecodeKey extracts components from an index key
+	// DecodeKey extracts components from an index key (for current-state indices)
 	DecodeKey(index IndexType, key []byte) (e, a, v, tx []byte, err error)
 
 	// EncodePrefix creates a prefix key for range scans
@@ -17,6 +17,12 @@ type KeyEncoder interface {
 
 	// EncodePrefixRange creates start and end keys for a prefix scan
 	EncodePrefixRange(index IndexType, parts ...[]byte) (start, end []byte)
+
+	// EncodeHistoryKey creates an index key with Op for history indices
+	EncodeHistoryKey(index IndexType, d *datalog.Datom, op Op) []byte
+
+	// DecodeHistoryKey extracts components including Op from a history index key
+	DecodeHistoryKey(index IndexType, key []byte) (e, a, v, tx []byte, op Op, err error)
 }
 
 // KeyEncodingStrategy represents different encoding strategies

--- a/datalog/storage/key_encoder_l85.go
+++ b/datalog/storage/key_encoder_l85.go
@@ -292,3 +292,89 @@ func (e *L85KeyEncoder) EncodePrefixRange(index IndexType, parts ...[]byte) (sta
 
 	return start, end
 }
+
+// l85HistoryIndexToBase maps history index types to their base current-state equivalents
+func l85HistoryIndexToBase(index IndexType) IndexType {
+	switch index {
+	case EAVT_HISTORY:
+		return EAVT
+	case AEVT_HISTORY:
+		return AEVT
+	case AVET_HISTORY:
+		return AVET
+	case VAET_HISTORY:
+		return VAET
+	case TAEV_HISTORY:
+		return TAEV
+	default:
+		return index
+	}
+}
+
+// EncodeHistoryKey creates an L85-encoded index key with Op appended for history indices
+func (e *L85KeyEncoder) EncodeHistoryKey(index IndexType, d *datalog.Datom, op Op) []byte {
+	// Convert to storage datom first
+	sd := ToStorageDatom(*d)
+
+	// Use the history index byte as prefix
+	prefix := []byte{byte(index)}
+
+	// Encode the components to L85
+	eL85 := codec.EncodeFixed20(sd.E)
+	aL85 := codec.EncodeFixed32(sd.A)
+	txL85 := codec.EncodeFixed20(sd.Tx)
+
+	// Get value bytes with type prefix
+	vType := byte(datalog.Type(sd.V))
+	var vBytes []byte
+	if datalog.Type(sd.V) == datalog.TypeReference {
+		var vArr [20]byte
+		copy(vArr[:], datalog.ValueBytes(sd.V))
+		vBytes = append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
+	} else {
+		vData := datalog.ValueBytes(sd.V)
+		vBytes = append([]byte{vType}, vData...)
+	}
+
+	// Op encoding: 0x01 = assert (true), 0x00 = retract (false)
+	opByte := byte(0x00)
+	if op {
+		opByte = 0x01
+	}
+
+	// Build key based on base index type, then append Op
+	baseIndex := l85HistoryIndexToBase(index)
+	switch baseIndex {
+	case EAVT:
+		return concatBytes(prefix, []byte(eL85), []byte(aL85), vBytes, []byte(txL85), []byte{opByte})
+	case AEVT:
+		return concatBytes(prefix, []byte(aL85), []byte(eL85), vBytes, []byte(txL85), []byte{opByte})
+	case AVET:
+		return concatBytes(prefix, []byte(aL85), vBytes, []byte(eL85), []byte(txL85), []byte{opByte})
+	case VAET:
+		return concatBytes(prefix, vBytes, []byte(aL85), []byte(eL85), []byte(txL85), []byte{opByte})
+	case TAEV:
+		return concatBytes(prefix, []byte(txL85), []byte(aL85), []byte(eL85), vBytes, []byte{opByte})
+	default:
+		panic(fmt.Sprintf("unknown history index type: %v", index))
+	}
+}
+
+// DecodeHistoryKey extracts components including Op from an L85-encoded history index key
+func (e *L85KeyEncoder) DecodeHistoryKey(index IndexType, key []byte) (entity, attr, value, tx []byte, op Op, err error) {
+	if len(key) < 2 { // At minimum: prefix + op
+		return nil, nil, nil, nil, false, fmt.Errorf("history key too short")
+	}
+
+	// Op is the last byte
+	opByte := key[len(key)-1]
+	op = opByte == 0x01
+
+	// Decode the rest as a normal key (without the Op byte)
+	keyWithoutOp := key[:len(key)-1]
+
+	// Use the base index type for decoding
+	baseIndex := l85HistoryIndexToBase(index)
+	entity, attr, value, tx, err = e.DecodeKey(baseIndex, keyWithoutOp)
+	return entity, attr, value, tx, op, err
+}

--- a/datalog/storage/store.go
+++ b/datalog/storage/store.go
@@ -13,6 +13,37 @@ const (
 	AVET                  // Attribute-Value-Entity-Tx
 	VAET                  // Value-Attribute-Entity-Tx
 	TAEV                  // Tx-Attribute-Entity-Value
+	// History indices (only used in RetractHistory mode)
+	// These mirror the current-state indices but include Op and are append-only
+	EAVT_HISTORY // Entity-Attribute-Value-Tx-Op
+	AEVT_HISTORY // Attribute-Entity-Value-Tx-Op
+	AVET_HISTORY // Attribute-Value-Entity-Tx-Op
+	VAET_HISTORY // Value-Attribute-Entity-Tx-Op
+	TAEV_HISTORY // Tx-Attribute-Entity-Value-Op
+)
+
+// CurrentStateIndices are the indices used for current-state queries
+var CurrentStateIndices = []IndexType{EAVT, AEVT, AVET, VAET, TAEV}
+
+// HistoryIndices are the indices used for history queries (include Op)
+var HistoryIndices = []IndexType{EAVT_HISTORY, AEVT_HISTORY, AVET_HISTORY, VAET_HISTORY, TAEV_HISTORY}
+
+// Op represents the operation type for a datom (assert or retract)
+type Op bool
+
+const (
+	OpAssert  Op = true  // Datom was asserted
+	OpRetract Op = false // Datom was retracted
+)
+
+// RetractMode controls how retractions are handled
+type RetractMode int
+
+const (
+	// RetractDelete removes datoms from the store (default, current behavior)
+	RetractDelete RetractMode = iota
+	// RetractHistory keeps full history - retractions append Op=false to history indices
+	RetractHistory
 )
 
 // Store is the interface for datom storage


### PR DESCRIPTION
Add opt-in history mode that preserves all assertions and retractions, enabling full audit trail queries. This brings janus-datalog closer to Datomic's temporal database capabilities.

## Architecture: Dual Index Sets

One database, two index sets:

| Index Set | Contents | On Retract |
|-----------|----------|------------|
| Current-State (existing) | Only currently-true facts | Delete entry | | History (new) | All assertions + retractions with Op | Append Op=false |

Query routing:
- `db.ExecuteQuery()` → Current-state indices (fast)
- `db.ExecuteHistoryQuery()` → History indices (complete audit trail)

## Database Modes

| Mode | On Assert | On Retract |
|------|-----------|------------|
| `RetractDelete` (default) | Add to current-state | Delete from current-state | | `RetractHistory` | Add to both | Delete from current-state, append to history |

## API

### Creating a History-Enabled Database
```go
db, _ := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
    Path:        "/path/to/db",
    RetractMode: storage.RetractHistory,
})
```

### Querying History
```go
// 5-element pattern: [?e ?a ?v ?tx ?op]
// ?op is true for assertions, false for retractions
results, _ := db.ExecuteHistoryQuery(`
    [:find ?name ?tx ?op
     :where [?e :person/name ?name ?tx ?op]]
`)
// Returns: [["Alice" 1 true] ["Alice" 2 false]]
```

## Implementation Details

### New Types
- `Op` - Boolean type (true=assert, false=retract)
- `RetractMode` - Enum (RetractDelete, RetractHistory)

### New Index Types
- EAVT_HISTORY, AEVT_HISTORY, AVET_HISTORY, VAET_HISTORY, TAEV_HISTORY

### Key Encoding
History keys include Op byte at the end:
- Key format: `[Index][E][A][V][Tx][Op]`
- Op encoding: 0x01=assert, 0x00=retract

### New Files
- `datalog/storage/history_matcher.go` - HistoryMatcher for querying history indices
- `datalog/storage/history_test.go` - Tests using Query API

### Modified Files
- `store.go` - Op type, RetractMode, history index constants
- `badger_store.go` - writeToHistoryIndices, retractMode field
- `key_encoder_*.go` - EncodeHistoryKey, DecodeHistoryKey methods
- `datom_decoder.go` - DatomFromHistoryKey, HistoryKeyOnlyIterator
- `database.go` - DatabaseOptions, ExecuteHistoryQuery, History()
- `parser.go` - Accept 5-element patterns
- `query/types.go` - GetOp(), HistoryDatomToTuple()

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Default mode | RetractDelete | Backward compatible, no overhead | | History storage | Same DB, separate indices | Single file, atomic transactions | | Op representation | Boolean in key | Compact, sortable | | Query API | ExecuteHistoryQuery() | Clear separation from current-state |