### PR TITLE
Fix StructReader to handle both Identity and *Identity values

### DIFF
--- a/datalog/reflect/reader.go
+++ b/datalog/reflect/reader.go
@@ -196,11 +196,16 @@ func (sr *StructReader) setSingleValue(fieldVal reflect.Value, fieldType reflect
 		return nil
 
 	case identityType:
-		id, ok := value.(datalog.Identity)
-		if !ok {
+		switch v := value.(type) {
+		case datalog.Identity:
+			fieldVal.Set(reflect.ValueOf(v))
+		case *datalog.Identity:
+			if v != nil {
+				fieldVal.Set(reflect.ValueOf(*v))
+			}
+		default:
 			return fmt.Errorf("expected Identity, got %T", value)
 		}
-		fieldVal.Set(reflect.ValueOf(id))
 		return nil
 
 	case keywordType:


### PR DESCRIPTION
The setSingleValue function was only handling datalog.Identity values, but some code paths pass *datalog.Identity pointers. This caused type assertion failures when reading structs with Identity fields.

Change the type assertion to a type switch that handles both cases:
- datalog.Identity: set directly
- *datalog.Identity: dereference and set (if non-nil)