### PR TITLE
Add annotation coverage for Pull API and reflection code

### DIFF
--- a/datalog/annotations/types.go
+++ b/datalog/annotations/types.go
@@ -45,6 +45,26 @@ const (
 	// Aggregation operations
 	AggregationExecuted = "aggregation/executed"
 
+	// Pull API operations
+	PullBegin           = "pull/begin"
+	PullComplete        = "pull/complete"
+	PullEntityBegin     = "pull/entity.begin"
+	PullEntityComplete  = "pull/entity.complete"
+	PullAttributeLookup = "pull/attr.lookup"
+	PullAllAttributes   = "pull/attr.wildcard"
+	PullManyValues      = "pull/attr.many"
+	PullNestedBegin     = "pull/nested.begin"
+	PullNestedComplete  = "pull/nested.complete"
+	PullCycleDetected   = "pull/cycle.detected"
+
+	// Reflection operations
+	ReflectReadBegin     = "reflect/read.begin"
+	ReflectReadComplete  = "reflect/read.complete"
+	ReflectWriteBegin    = "reflect/write.begin"
+	ReflectWriteComplete = "reflect/write.complete"
+	ReflectUpdateBegin   = "reflect/update.begin"
+	ReflectUpdateComplete = "reflect/update.complete"
+
 	// Errors
 	ErrorQueryParsing  = "error/query.parsing"
 	ErrorQueryBinding  = "error/query.binding"

--- a/datalog/executor/pull.go
+++ b/datalog/executor/pull.go
@@ -4,30 +4,56 @@ import (
 	"fmt"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
 // PullExecutor executes pull patterns against the database
 type PullExecutor struct {
 	matcher PatternMatcher
+	ctx     PullContext
 }
 
 // NewPullExecutor creates a new pull executor
 func NewPullExecutor(matcher PatternMatcher) *PullExecutor {
 	return &PullExecutor{
 		matcher: matcher,
+		ctx:     &BasePullContext{},
 	}
+}
+
+// NewPullExecutorWithHandler creates a new pull executor with annotation support
+func NewPullExecutorWithHandler(matcher PatternMatcher, handler annotations.Handler) *PullExecutor {
+	return &PullExecutor{
+		matcher: matcher,
+		ctx:     NewPullContext(handler),
+	}
+}
+
+// SetHandler configures the annotation handler
+func (pe *PullExecutor) SetHandler(handler annotations.Handler) {
+	pe.ctx = NewPullContext(handler)
 }
 
 // Pull executes a pull pattern for a single entity
 // Uses cycle detection to handle circular references
 func (pe *PullExecutor) Pull(entity datalog.Identity, pattern *query.PullPattern) (map[string]interface{}, error) {
+	pe.ctx.PullBegin(entity, len(pattern.Specs), false)
+
 	visited := make(map[[20]byte]bool)
-	return pe.pullWithVisited(entity, pattern, visited)
+	result, err := pe.pullWithVisited(entity, pattern, visited, 0)
+
+	attrCount := 0
+	if result != nil {
+		attrCount = len(result)
+	}
+	pe.ctx.PullComplete(entity, attrCount, false, err)
+
+	return result, err
 }
 
 // pullWithVisited executes a pull pattern with cycle detection
-func (pe *PullExecutor) pullWithVisited(entity datalog.Identity, pattern *query.PullPattern, visited map[[20]byte]bool) (map[string]interface{}, error) {
+func (pe *PullExecutor) pullWithVisited(entity datalog.Identity, pattern *query.PullPattern, visited map[[20]byte]bool, depth int) (map[string]interface{}, error) {
 	if pattern == nil {
 		return nil, nil
 	}
@@ -35,18 +61,23 @@ func (pe *PullExecutor) pullWithVisited(entity datalog.Identity, pattern *query.
 	// Check for cycle using entity hash
 	entityHash := entity.Hash()
 	if visited[entityHash] {
+		pe.ctx.CycleDetected(entity, depth)
 		return nil, nil // Cycle detected, stop recursion
 	}
 	visited[entityHash] = true
 	defer delete(visited, entityHash) // Allow revisiting from different paths
 
+	pe.ctx.EntityBegin(entity, depth, len(pattern.Specs))
+
 	result := make(map[string]interface{})
 
 	for _, spec := range pattern.Specs {
-		if err := pe.processSpec(entity, spec, result, visited); err != nil {
+		if err := pe.processSpec(entity, spec, result, visited, depth); err != nil {
 			return nil, err
 		}
 	}
+
+	pe.ctx.EntityComplete(entity, depth, len(result))
 
 	if len(result) == 0 {
 		return nil, nil
@@ -55,7 +86,7 @@ func (pe *PullExecutor) pullWithVisited(entity datalog.Identity, pattern *query.
 }
 
 // processSpec processes a single pull spec and adds results to the map
-func (pe *PullExecutor) processSpec(entity datalog.Identity, spec query.PullAttrSpec, result map[string]interface{}, visited map[[20]byte]bool) error {
+func (pe *PullExecutor) processSpec(entity datalog.Identity, spec query.PullAttrSpec, result map[string]interface{}, visited map[[20]byte]bool, depth int) error {
 	switch s := spec.(type) {
 	case *query.PullAttribute:
 		// Simple attribute lookup
@@ -78,7 +109,16 @@ func (pe *PullExecutor) processSpec(entity datalog.Identity, spec query.PullAttr
 		// Follow reference and pull nested pattern
 		if refVal, ok := pe.lookupAttribute(entity, s.Attr); ok {
 			if refEntity, ok := refVal.(datalog.Identity); ok {
-				nested, err := pe.pullWithVisited(refEntity, s.Pattern, visited)
+				pe.ctx.NestedBegin(entity, s.Attr, refEntity, depth+1, false)
+
+				nested, err := pe.pullWithVisited(refEntity, s.Pattern, visited, depth+1)
+
+				attrCount := 0
+				if nested != nil {
+					attrCount = len(nested)
+				}
+				pe.ctx.NestedComplete(entity, s.Attr, refEntity, depth+1, attrCount, err)
+
 				if err != nil {
 					return fmt.Errorf("nested pull for %s failed: %w", s.Attr.String(), err)
 				}
@@ -115,10 +155,25 @@ func (pe *PullExecutor) processSpec(entity datalog.Identity, spec query.PullAttr
 func (pe *PullExecutor) lookupAttribute(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool) {
 	// Use EntityLookupMatcher interface if available
 	if lookupMatcher, ok := pe.matcher.(EntityLookupMatcher); ok {
-		return lookupMatcher.LookupAttribute(entity, attr)
+		var val interface{}
+		var found bool
+		pe.ctx.AttributeLookup(entity, attr, found, "direct", func() {
+			val, found = lookupMatcher.LookupAttribute(entity, attr)
+		})
+		return val, found
 	}
 
 	// Fallback: use pattern matching
+	var val interface{}
+	var found bool
+	pe.ctx.AttributeLookup(entity, attr, found, "pattern", func() {
+		val, found = pe.lookupAttributeViaPattern(entity, attr)
+	})
+	return val, found
+}
+
+// lookupAttributeViaPattern is the fallback path using pattern matching
+func (pe *PullExecutor) lookupAttributeViaPattern(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool) {
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
 			query.Constant{Value: entity},
@@ -133,14 +188,11 @@ func (pe *PullExecutor) lookupAttribute(entity datalog.Identity, attr datalog.Ke
 	}
 
 	// Get the first result
-	// Note: Avoid calling rel.IsEmpty() as it may consume the first tuple
-	// in non-streaming mode. Instead, just try to iterate.
 	it := rel.Iterator()
 	defer it.Close()
 
 	if it.Next() {
 		tuple := it.Tuple()
-		// Find the value column
 		cols := rel.Columns()
 		for i, col := range cols {
 			if col == "?v" && i < len(tuple) {
@@ -154,7 +206,19 @@ func (pe *PullExecutor) lookupAttribute(entity datalog.Identity, attr datalog.Ke
 
 // getAllAttributes retrieves all datoms for an entity (for wildcard pull)
 func (pe *PullExecutor) getAllAttributes(entity datalog.Identity) ([]datalog.Datom, error) {
-	// Create pattern: [entity ?a ?v] - gets all attributes
+	var datoms []datalog.Datom
+	var err error
+
+	pe.ctx.AllAttributes(entity, func() int {
+		datoms, err = pe.getAllAttributesInternal(entity)
+		return len(datoms)
+	})
+
+	return datoms, err
+}
+
+// getAllAttributesInternal is the actual implementation
+func (pe *PullExecutor) getAllAttributesInternal(entity datalog.Identity) ([]datalog.Datom, error) {
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
 			query.Constant{Value: entity},
@@ -171,10 +235,6 @@ func (pe *PullExecutor) getAllAttributes(entity datalog.Identity) ([]datalog.Dat
 	if rel == nil {
 		return nil, nil
 	}
-
-	// Note: Avoid calling rel.IsEmpty() as it may consume the first tuple
-	// in non-streaming mode. Empty results are handled naturally by the
-	// iteration loop below.
 
 	// Find column indices
 	cols := rel.Columns()
@@ -247,12 +307,22 @@ func (pe *PullExecutor) PullMany(entities []datalog.Identity, pattern *query.Pul
 // PullResolved executes a resolved pull pattern for a single entity
 // Uses pre-resolved cardinality info for proper handling of many-valued attributes
 func (pe *PullExecutor) PullResolved(entity datalog.Identity, pattern *query.ResolvedPullPattern) (map[string]interface{}, error) {
+	pe.ctx.PullBegin(entity, len(pattern.Specs), true)
+
 	visited := make(map[[20]byte]bool)
-	return pe.pullResolvedWithVisited(entity, pattern, visited)
+	result, err := pe.pullResolvedWithVisited(entity, pattern, visited, 0)
+
+	attrCount := 0
+	if result != nil {
+		attrCount = len(result)
+	}
+	pe.ctx.PullComplete(entity, attrCount, true, err)
+
+	return result, err
 }
 
 // pullResolvedWithVisited executes a resolved pull pattern with cycle detection
-func (pe *PullExecutor) pullResolvedWithVisited(entity datalog.Identity, pattern *query.ResolvedPullPattern, visited map[[20]byte]bool) (map[string]interface{}, error) {
+func (pe *PullExecutor) pullResolvedWithVisited(entity datalog.Identity, pattern *query.ResolvedPullPattern, visited map[[20]byte]bool, depth int) (map[string]interface{}, error) {
 	if pattern == nil {
 		return nil, nil
 	}
@@ -260,18 +330,23 @@ func (pe *PullExecutor) pullResolvedWithVisited(entity datalog.Identity, pattern
 	// Check for cycle using entity hash
 	entityHash := entity.Hash()
 	if visited[entityHash] {
+		pe.ctx.CycleDetected(entity, depth)
 		return nil, nil // Cycle detected, stop recursion
 	}
 	visited[entityHash] = true
 	defer delete(visited, entityHash) // Allow revisiting from different paths
 
+	pe.ctx.EntityBegin(entity, depth, len(pattern.Specs))
+
 	result := make(map[string]interface{})
 
 	for _, spec := range pattern.Specs {
-		if err := pe.processResolvedSpec(entity, spec, result, visited); err != nil {
+		if err := pe.processResolvedSpec(entity, spec, result, visited, depth); err != nil {
 			return nil, err
 		}
 	}
+
+	pe.ctx.EntityComplete(entity, depth, len(result))
 
 	if len(result) == 0 {
 		return nil, nil
@@ -280,7 +355,7 @@ func (pe *PullExecutor) pullResolvedWithVisited(entity datalog.Identity, pattern
 }
 
 // processResolvedSpec processes a single resolved pull spec
-func (pe *PullExecutor) processResolvedSpec(entity datalog.Identity, spec query.ResolvedPullAttrSpec, result map[string]interface{}, visited map[[20]byte]bool) error {
+func (pe *PullExecutor) processResolvedSpec(entity datalog.Identity, spec query.ResolvedPullAttrSpec, result map[string]interface{}, visited map[[20]byte]bool, depth int) error {
 	switch s := spec.(type) {
 	case *query.ResolvedPullAttribute:
 		if s.IsMany {
@@ -314,7 +389,16 @@ func (pe *PullExecutor) processResolvedSpec(entity datalog.Identity, spec query.
 				nestedResults := make([]interface{}, 0, len(refs))
 				for _, refVal := range refs {
 					if refEntity, ok := getIdentity(refVal); ok {
-						nested, err := pe.pullResolvedWithVisited(refEntity, s.Pattern, visited)
+						pe.ctx.NestedBegin(entity, s.Attr, refEntity, depth+1, true)
+
+						nested, err := pe.pullResolvedWithVisited(refEntity, s.Pattern, visited, depth+1)
+
+						attrCount := 0
+						if nested != nil {
+							attrCount = len(nested)
+						}
+						pe.ctx.NestedComplete(entity, s.Attr, refEntity, depth+1, attrCount, err)
+
 						if err != nil {
 							return fmt.Errorf("nested pull for %s failed: %w", s.Attr.String(), err)
 						}
@@ -331,7 +415,16 @@ func (pe *PullExecutor) processResolvedSpec(entity datalog.Identity, spec query.
 			// Cardinality-one reference: follow single ref
 			if refVal, ok := pe.lookupAttribute(entity, s.Attr); ok {
 				if refEntity, ok := getIdentity(refVal); ok {
-					nested, err := pe.pullResolvedWithVisited(refEntity, s.Pattern, visited)
+					pe.ctx.NestedBegin(entity, s.Attr, refEntity, depth+1, false)
+
+					nested, err := pe.pullResolvedWithVisited(refEntity, s.Pattern, visited, depth+1)
+
+					attrCount := 0
+					if nested != nil {
+						attrCount = len(nested)
+					}
+					pe.ctx.NestedComplete(entity, s.Attr, refEntity, depth+1, attrCount, err)
+
 					if err != nil {
 						return fmt.Errorf("nested pull for %s failed: %w", s.Attr.String(), err)
 					}
@@ -386,7 +479,18 @@ func (pe *PullExecutor) processResolvedSpec(entity datalog.Identity, spec query.
 
 // lookupAllValues retrieves all values for a cardinality-many attribute
 func (pe *PullExecutor) lookupAllValues(entity datalog.Identity, attr datalog.Keyword) []interface{} {
-	// Create pattern: [entity attr ?v] - gets all values for this attribute
+	var values []interface{}
+
+	pe.ctx.ManyValues(entity, attr, func() int {
+		values = pe.lookupAllValuesInternal(entity, attr)
+		return len(values)
+	})
+
+	return values
+}
+
+// lookupAllValuesInternal is the actual implementation
+func (pe *PullExecutor) lookupAllValuesInternal(entity datalog.Identity, attr datalog.Keyword) []interface{} {
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
 			query.Constant{Value: entity},

--- a/datalog/executor/pull_context.go
+++ b/datalog/executor/pull_context.go
@@ -1,0 +1,216 @@
+package executor
+
+import (
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+)
+
+// PullContext provides annotation points for Pull API operations.
+// Uses the same pattern as executor.Context - interface with no-op and annotated implementations.
+type PullContext interface {
+	// Top-level pull operations
+	PullBegin(entity datalog.Identity, specCount int, resolved bool)
+	PullComplete(entity datalog.Identity, attrCount int, resolved bool, err error)
+
+	// Entity-level operations (with depth tracking)
+	EntityBegin(entity datalog.Identity, depth, specCount int)
+	EntityComplete(entity datalog.Identity, depth, attrCount int)
+
+	// Cycle detection
+	CycleDetected(entity datalog.Identity, depth int)
+
+	// Attribute lookups
+	AttributeLookup(entity datalog.Identity, attr datalog.Keyword, found bool, via string, fn func())
+	AllAttributes(entity datalog.Identity, fn func() int) int
+	ManyValues(entity datalog.Identity, attr datalog.Keyword, fn func() int) int
+
+	// Nested ref traversal
+	NestedBegin(parentEntity datalog.Identity, attr datalog.Keyword, refEntity datalog.Identity, depth int, isMany bool)
+	NestedComplete(parentEntity datalog.Identity, attr datalog.Keyword, refEntity datalog.Identity, depth, attrCount int, err error)
+}
+
+// BasePullContext provides a no-op implementation with zero overhead.
+type BasePullContext struct{}
+
+func (c *BasePullContext) PullBegin(entity datalog.Identity, specCount int, resolved bool) {}
+func (c *BasePullContext) PullComplete(entity datalog.Identity, attrCount int, resolved bool, err error) {
+}
+func (c *BasePullContext) EntityBegin(entity datalog.Identity, depth, specCount int)  {}
+func (c *BasePullContext) EntityComplete(entity datalog.Identity, depth, attrCount int) {}
+func (c *BasePullContext) CycleDetected(entity datalog.Identity, depth int)            {}
+
+func (c *BasePullContext) AttributeLookup(entity datalog.Identity, attr datalog.Keyword, found bool, via string, fn func()) {
+	fn()
+}
+
+func (c *BasePullContext) AllAttributes(entity datalog.Identity, fn func() int) int {
+	return fn()
+}
+
+func (c *BasePullContext) ManyValues(entity datalog.Identity, attr datalog.Keyword, fn func() int) int {
+	return fn()
+}
+
+func (c *BasePullContext) NestedBegin(parentEntity datalog.Identity, attr datalog.Keyword, refEntity datalog.Identity, depth int, isMany bool) {
+}
+func (c *BasePullContext) NestedComplete(parentEntity datalog.Identity, attr datalog.Keyword, refEntity datalog.Identity, depth, attrCount int, err error) {
+}
+
+// AnnotatedPullContext wraps operations with timing and event emission.
+type AnnotatedPullContext struct {
+	handler   annotations.Handler
+	pullStart time.Time
+}
+
+// NewPullContext creates an appropriate context based on whether annotations are needed.
+func NewPullContext(handler annotations.Handler) PullContext {
+	if handler == nil {
+		return &BasePullContext{}
+	}
+	return &AnnotatedPullContext{handler: handler}
+}
+
+func (c *AnnotatedPullContext) PullBegin(entity datalog.Identity, specCount int, resolved bool) {
+	c.pullStart = time.Now()
+	c.handler(annotations.Event{
+		Name:  annotations.PullBegin,
+		Start: c.pullStart,
+		Data: map[string]interface{}{
+			"entity":     entity.String(),
+			"spec_count": specCount,
+			"resolved":   resolved,
+		},
+	})
+}
+
+func (c *AnnotatedPullContext) PullComplete(entity datalog.Identity, attrCount int, resolved bool, err error) {
+	end := time.Now()
+	c.handler(annotations.Event{
+		Name:    annotations.PullComplete,
+		Start:   c.pullStart,
+		End:     end,
+		Latency: end.Sub(c.pullStart),
+		Data: map[string]interface{}{
+			"entity":     entity.String(),
+			"attr_count": attrCount,
+			"resolved":   resolved,
+			"success":    err == nil,
+		},
+	})
+}
+
+func (c *AnnotatedPullContext) EntityBegin(entity datalog.Identity, depth, specCount int) {
+	c.handler(annotations.Event{
+		Name:  annotations.PullEntityBegin,
+		Start: time.Now(),
+		Data: map[string]interface{}{
+			"entity":     entity.String(),
+			"depth":      depth,
+			"spec_count": specCount,
+		},
+	})
+}
+
+func (c *AnnotatedPullContext) EntityComplete(entity datalog.Identity, depth, attrCount int) {
+	c.handler(annotations.Event{
+		Name: annotations.PullEntityComplete,
+		Data: map[string]interface{}{
+			"entity":     entity.String(),
+			"depth":      depth,
+			"attr_count": attrCount,
+		},
+	})
+}
+
+func (c *AnnotatedPullContext) CycleDetected(entity datalog.Identity, depth int) {
+	c.handler(annotations.Event{
+		Name: annotations.PullCycleDetected,
+		Data: map[string]interface{}{
+			"entity": entity.String(),
+			"depth":  depth,
+		},
+	})
+}
+
+func (c *AnnotatedPullContext) AttributeLookup(entity datalog.Identity, attr datalog.Keyword, found bool, via string, fn func()) {
+	start := time.Now()
+	fn()
+	end := time.Now()
+	c.handler(annotations.Event{
+		Name:    annotations.PullAttributeLookup,
+		Start:   start,
+		End:     end,
+		Latency: end.Sub(start),
+		Data: map[string]interface{}{
+			"entity": entity.String(),
+			"attr":   attr.String(),
+			"found":  found,
+			"via":    via,
+		},
+	})
+}
+
+func (c *AnnotatedPullContext) AllAttributes(entity datalog.Identity, fn func() int) int {
+	start := time.Now()
+	count := fn()
+	end := time.Now()
+	c.handler(annotations.Event{
+		Name:    annotations.PullAllAttributes,
+		Start:   start,
+		End:     end,
+		Latency: end.Sub(start),
+		Data: map[string]interface{}{
+			"entity":     entity.String(),
+			"attr_count": count,
+		},
+	})
+	return count
+}
+
+func (c *AnnotatedPullContext) ManyValues(entity datalog.Identity, attr datalog.Keyword, fn func() int) int {
+	start := time.Now()
+	count := fn()
+	end := time.Now()
+	c.handler(annotations.Event{
+		Name:    annotations.PullManyValues,
+		Start:   start,
+		End:     end,
+		Latency: end.Sub(start),
+		Data: map[string]interface{}{
+			"entity":      entity.String(),
+			"attr":        attr.String(),
+			"value_count": count,
+		},
+	})
+	return count
+}
+
+func (c *AnnotatedPullContext) NestedBegin(parentEntity datalog.Identity, attr datalog.Keyword, refEntity datalog.Identity, depth int, isMany bool) {
+	c.handler(annotations.Event{
+		Name:  annotations.PullNestedBegin,
+		Start: time.Now(),
+		Data: map[string]interface{}{
+			"parent_entity": parentEntity.String(),
+			"attr":          attr.String(),
+			"ref_entity":    refEntity.String(),
+			"depth":         depth,
+			"is_many":       isMany,
+		},
+	})
+}
+
+func (c *AnnotatedPullContext) NestedComplete(parentEntity datalog.Identity, attr datalog.Keyword, refEntity datalog.Identity, depth, attrCount int, err error) {
+	c.handler(annotations.Event{
+		Name: annotations.PullNestedComplete,
+		Data: map[string]interface{}{
+			"parent_entity": parentEntity.String(),
+			"attr":          attr.String(),
+			"ref_entity":    refEntity.String(),
+			"depth":         depth,
+			"attr_count":    attrCount,
+			"success":       err == nil,
+		},
+	})
+}

--- a/datalog/executor/pull_test.go
+++ b/datalog/executor/pull_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/parser"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
@@ -423,5 +424,217 @@ func TestKeyName(t *testing.T) {
 				t.Errorf("KeyName(%q) = %q, expected %q", tt.input, result, tt.expected)
 			}
 		})
+	}
+}
+
+// ============================================================================
+// Annotation tests for PullContext
+// ============================================================================
+
+func TestPullExecutor_AnnotationsEmitted(t *testing.T) {
+	// Create test data
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+	ageAttr := datalog.NewKeyword(":user/age")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+		{E: alice, A: ageAttr, V: int64(30), Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Capture events
+	var events []annotations.Event
+	handler := func(e annotations.Event) {
+		events = append(events, e)
+	}
+	puller.SetHandler(handler)
+
+	// Parse and execute pull
+	pattern, err := parser.ParsePullPattern(`[:user/name :user/age]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	result, err := puller.Pull(alice, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Verify events were emitted
+	if len(events) == 0 {
+		t.Fatal("expected annotation events to be emitted, got none")
+	}
+
+	// Check for pull/begin and pull/complete
+	var foundBegin, foundComplete bool
+	for _, e := range events {
+		if e.Name == annotations.PullBegin {
+			foundBegin = true
+			if e.Data["spec_count"] != 2 {
+				t.Errorf("expected spec_count=2, got %v", e.Data["spec_count"])
+			}
+		}
+		if e.Name == annotations.PullComplete {
+			foundComplete = true
+			if e.Data["success"] != true {
+				t.Errorf("expected success=true, got %v", e.Data["success"])
+			}
+		}
+	}
+
+	if !foundBegin {
+		t.Error("expected pull/begin event")
+	}
+	if !foundComplete {
+		t.Error("expected pull/complete event")
+	}
+}
+
+func TestPullExecutor_NoEventsWhenHandlerNil(t *testing.T) {
+	// Create test data
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+	// Don't set handler - should use BasePullContext (no-op)
+
+	pattern, err := parser.ParsePullPattern(`[:user/name]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	// This should work without panic and not emit any events
+	result, err := puller.Pull(alice, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	if result["user/name"] != "Alice" {
+		t.Errorf("expected name=Alice, got %v", result["user/name"])
+	}
+}
+
+func TestPullExecutor_CycleDetectedEvent(t *testing.T) {
+	// Create circular reference
+	entity1 := datalog.NewIdentity("entity:1")
+	entity2 := datalog.NewIdentity("entity:2")
+
+	nameAttr := datalog.NewKeyword(":entity/name")
+	nextAttr := datalog.NewKeyword(":entity/next")
+
+	datoms := []datalog.Datom{
+		{E: entity1, A: nameAttr, V: "Entity 1", Tx: 1},
+		{E: entity1, A: nextAttr, V: entity2, Tx: 1},
+		{E: entity2, A: nameAttr, V: "Entity 2", Tx: 1},
+		{E: entity2, A: nextAttr, V: entity1, Tx: 1}, // Circular reference
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Capture events
+	var events []annotations.Event
+	handler := func(e annotations.Event) {
+		events = append(events, e)
+	}
+	puller.SetHandler(handler)
+
+	// Pattern that would recurse infinitely without cycle detection
+	pattern, err := parser.ParsePullPattern(`[:entity/name {:entity/next [:entity/name {:entity/next [:entity/name]}]}]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	_, err = puller.Pull(entity1, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	// Check for cycle detected event
+	var foundCycle bool
+	for _, e := range events {
+		if e.Name == annotations.PullCycleDetected {
+			foundCycle = true
+			t.Logf("Cycle detected event: entity=%v depth=%v", e.Data["entity"], e.Data["depth"])
+		}
+	}
+
+	if !foundCycle {
+		t.Error("expected pull/cycle.detected event for circular reference")
+	}
+}
+
+func TestPullExecutor_NestedRefsEmitDepthEvents(t *testing.T) {
+	// Create 2-level nested reference
+	region := datalog.NewIdentity("region:us-west")
+	entity := datalog.NewIdentity("entity:apple")
+
+	regionNameAttr := datalog.NewKeyword(":region/name")
+	entityNameAttr := datalog.NewKeyword(":entity/name")
+	entityRegionAttr := datalog.NewKeyword(":entity/region")
+
+	datoms := []datalog.Datom{
+		{E: region, A: regionNameAttr, V: "US West", Tx: 1},
+		{E: entity, A: entityNameAttr, V: "Apple", Tx: 1},
+		{E: entity, A: entityRegionAttr, V: region, Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	puller := NewPullExecutor(matcher)
+
+	// Capture events
+	var events []annotations.Event
+	handler := func(e annotations.Event) {
+		events = append(events, e)
+	}
+	puller.SetHandler(handler)
+
+	// Nested pattern
+	pattern, err := parser.ParsePullPattern(`[:entity/name {:entity/region [:region/name]}]`)
+	if err != nil {
+		t.Fatalf("failed to parse pattern: %v", err)
+	}
+
+	result, err := puller.Pull(entity, pattern)
+	if err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+
+	// Verify result
+	nestedRegion := result["entity/region"].(map[string]interface{})
+	if nestedRegion["region/name"] != "US West" {
+		t.Errorf("expected region/name=US West, got %v", nestedRegion["region/name"])
+	}
+
+	// Check for nested begin/complete events
+	var nestedBeginCount, nestedCompleteCount int
+	for _, e := range events {
+		if e.Name == annotations.PullNestedBegin {
+			nestedBeginCount++
+			t.Logf("Nested begin: parent=%v attr=%v ref=%v depth=%v",
+				e.Data["parent_entity"], e.Data["attr"], e.Data["ref_entity"], e.Data["depth"])
+		}
+		if e.Name == annotations.PullNestedComplete {
+			nestedCompleteCount++
+		}
+	}
+
+	if nestedBeginCount == 0 {
+		t.Error("expected pull/nested.begin events for nested ref")
+	}
+	if nestedCompleteCount == 0 {
+		t.Error("expected pull/nested.complete events for nested ref")
 	}
 }

--- a/datalog/reflect/context.go
+++ b/datalog/reflect/context.go
@@ -1,0 +1,136 @@
+package reflect
+
+import (
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+)
+
+// ReflectContext provides annotation points for reflection operations.
+// Uses the same pattern as executor.Context - interface with no-op and annotated implementations.
+type ReflectContext interface {
+	// Read operations
+	ReadBegin(structName string, fieldCount, inputKeys int)
+	ReadComplete(structName string, err error)
+
+	// Write operations
+	WriteBegin(entity, structName string, fieldCount int)
+	WriteComplete(entity, structName string, fieldsWritten int, err error)
+
+	// Update operations
+	UpdateBegin(entity, structName string, fieldCount int, mode string)
+	UpdateComplete(entity, structName string, fieldsProcessed int, mode string, err error)
+}
+
+// BaseReflectContext provides a no-op implementation with zero overhead.
+type BaseReflectContext struct{}
+
+func (c *BaseReflectContext) ReadBegin(structName string, fieldCount, inputKeys int) {}
+func (c *BaseReflectContext) ReadComplete(structName string, err error)              {}
+
+func (c *BaseReflectContext) WriteBegin(entity, structName string, fieldCount int)                    {}
+func (c *BaseReflectContext) WriteComplete(entity, structName string, fieldsWritten int, err error)   {}
+
+func (c *BaseReflectContext) UpdateBegin(entity, structName string, fieldCount int, mode string)                    {}
+func (c *BaseReflectContext) UpdateComplete(entity, structName string, fieldsProcessed int, mode string, err error) {}
+
+// AnnotatedReflectContext wraps operations with timing and event emission.
+type AnnotatedReflectContext struct {
+	handler annotations.Handler
+	start   time.Time
+}
+
+// NewReflectContext creates an appropriate context based on whether annotations are needed.
+func NewReflectContext(handler annotations.Handler) ReflectContext {
+	if handler == nil {
+		return &BaseReflectContext{}
+	}
+	return &AnnotatedReflectContext{handler: handler}
+}
+
+func (c *AnnotatedReflectContext) ReadBegin(structName string, fieldCount, inputKeys int) {
+	c.start = time.Now()
+	c.handler(annotations.Event{
+		Name:  annotations.ReflectReadBegin,
+		Start: c.start,
+		Data: map[string]interface{}{
+			"struct_type": structName,
+			"field_count": fieldCount,
+			"input_keys":  inputKeys,
+		},
+	})
+}
+
+func (c *AnnotatedReflectContext) ReadComplete(structName string, err error) {
+	end := time.Now()
+	c.handler(annotations.Event{
+		Name:    annotations.ReflectReadComplete,
+		Start:   c.start,
+		End:     end,
+		Latency: end.Sub(c.start),
+		Data: map[string]interface{}{
+			"struct_type": structName,
+			"success":     err == nil,
+		},
+	})
+}
+
+func (c *AnnotatedReflectContext) WriteBegin(entity, structName string, fieldCount int) {
+	c.start = time.Now()
+	c.handler(annotations.Event{
+		Name:  annotations.ReflectWriteBegin,
+		Start: c.start,
+		Data: map[string]interface{}{
+			"entity":      entity,
+			"struct_type": structName,
+			"field_count": fieldCount,
+		},
+	})
+}
+
+func (c *AnnotatedReflectContext) WriteComplete(entity, structName string, fieldsWritten int, err error) {
+	end := time.Now()
+	c.handler(annotations.Event{
+		Name:    annotations.ReflectWriteComplete,
+		Start:   c.start,
+		End:     end,
+		Latency: end.Sub(c.start),
+		Data: map[string]interface{}{
+			"entity":         entity,
+			"struct_type":    structName,
+			"fields_written": fieldsWritten,
+			"success":        err == nil,
+		},
+	})
+}
+
+func (c *AnnotatedReflectContext) UpdateBegin(entity, structName string, fieldCount int, mode string) {
+	c.start = time.Now()
+	c.handler(annotations.Event{
+		Name:  annotations.ReflectUpdateBegin,
+		Start: c.start,
+		Data: map[string]interface{}{
+			"entity":      entity,
+			"struct_type": structName,
+			"field_count": fieldCount,
+			"mode":        mode,
+		},
+	})
+}
+
+func (c *AnnotatedReflectContext) UpdateComplete(entity, structName string, fieldsProcessed int, mode string, err error) {
+	end := time.Now()
+	c.handler(annotations.Event{
+		Name:    annotations.ReflectUpdateComplete,
+		Start:   c.start,
+		End:     end,
+		Latency: end.Sub(c.start),
+		Data: map[string]interface{}{
+			"entity":           entity,
+			"struct_type":      structName,
+			"fields_processed": fieldsProcessed,
+			"mode":             mode,
+			"success":          err == nil,
+		},
+	})
+}

--- a/datalog/reflect/integration_test.go
+++ b/datalog/reflect/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
 	dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 	"github.com/wbrown/janus-datalog/datalog/storage"
@@ -853,5 +854,216 @@ func TestLookupAttributeWithStructAPI(t *testing.T) {
 		t.Errorf("expected 1 query result, got %d", len(results))
 	} else {
 		t.Logf("Query result: name=%v age=%v", results[0][0], results[0][1])
+	}
+}
+
+// ============================================================================
+// Annotation tests for ReflectContext
+// ============================================================================
+
+// TestStructReader_AnnotationsEmitted verifies that StructReader emits annotation events.
+func TestStructReader_AnnotationsEmitted(t *testing.T) {
+	// Create test data to read
+	pullResult := map[string]interface{}{
+		"person/name": "Alice",
+		"person/age":  int64(30),
+	}
+
+	// Create struct reader with handler
+	var events []annotations.Event
+	handler := func(e annotations.Event) {
+		events = append(events, e)
+	}
+
+	reader, err := dlreflect.NewStructReaderWithHandler(&Person{}, nil, handler)
+	if err != nil {
+		t.Fatalf("failed to create reader: %v", err)
+	}
+
+	// Read into struct
+	var loaded Person
+	if err := reader.Read(pullResult, &loaded); err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	// Verify struct was loaded correctly
+	if loaded.Name != "Alice" {
+		t.Errorf("expected Name=Alice, got %s", loaded.Name)
+	}
+	if loaded.Age != 30 {
+		t.Errorf("expected Age=30, got %d", loaded.Age)
+	}
+
+	// Verify events were emitted
+	if len(events) == 0 {
+		t.Fatal("expected annotation events to be emitted, got none")
+	}
+
+	// Check for read begin/complete events
+	var foundBegin, foundComplete bool
+	for _, e := range events {
+		if e.Name == annotations.ReflectReadBegin {
+			foundBegin = true
+			if e.Data["struct_type"] != "Person" {
+				t.Errorf("expected struct_type=Person, got %v", e.Data["struct_type"])
+			}
+			if e.Data["input_keys"] != 2 {
+				t.Errorf("expected input_keys=2, got %v", e.Data["input_keys"])
+			}
+		}
+		if e.Name == annotations.ReflectReadComplete {
+			foundComplete = true
+			if e.Data["success"] != true {
+				t.Errorf("expected success=true, got %v", e.Data["success"])
+			}
+		}
+	}
+
+	if !foundBegin {
+		t.Error("expected reflect/read.begin event")
+	}
+	if !foundComplete {
+		t.Error("expected reflect/read.complete event")
+	}
+}
+
+// TestStructReader_NoEventsWhenHandlerNil verifies zero-overhead when no handler.
+func TestStructReader_NoEventsWhenHandlerNil(t *testing.T) {
+	pullResult := map[string]interface{}{
+		"person/name": "Alice",
+		"person/age":  int64(30),
+	}
+
+	// Create reader without handler
+	reader, err := dlreflect.NewStructReader(&Person{}, nil)
+	if err != nil {
+		t.Fatalf("failed to create reader: %v", err)
+	}
+
+	// Read into struct - should work without panic
+	var loaded Person
+	if err := reader.Read(pullResult, &loaded); err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	if loaded.Name != "Alice" {
+		t.Errorf("expected Name=Alice, got %s", loaded.Name)
+	}
+}
+
+// TestStructWriter_AnnotationsEmitted verifies that StructWriter emits annotation events.
+func TestStructWriter_AnnotationsEmitted(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "reflect-writer-annotation-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(Person{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create writer with handler
+	var events []annotations.Event
+	handler := func(e annotations.Event) {
+		events = append(events, e)
+	}
+
+	alice := Person{Name: "Alice", Age: 30}
+	writer, err := dlreflect.NewStructWriterWithHandler(&alice, schema, handler)
+	if err != nil {
+		t.Fatalf("failed to create writer: %v", err)
+	}
+
+	// Write struct
+	tx := db.NewTransaction()
+	entityID := datalog.NewIdentity("test:alice")
+	if err := writer.Write(tx, entityID, &alice); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	// Verify events were emitted
+	if len(events) == 0 {
+		t.Fatal("expected annotation events to be emitted, got none")
+	}
+
+	// Check for write begin/complete events
+	var foundBegin, foundComplete bool
+	for _, e := range events {
+		if e.Name == annotations.ReflectWriteBegin {
+			foundBegin = true
+			if e.Data["struct_type"] != "Person" {
+				t.Errorf("expected struct_type=Person, got %v", e.Data["struct_type"])
+			}
+		}
+		if e.Name == annotations.ReflectWriteComplete {
+			foundComplete = true
+			if e.Data["success"] != true {
+				t.Errorf("expected success=true, got %v", e.Data["success"])
+			}
+		}
+	}
+
+	if !foundBegin {
+		t.Error("expected reflect/write.begin event")
+	}
+	if !foundComplete {
+		t.Error("expected reflect/write.complete event")
+	}
+}
+
+// TestStructWriter_NoEventsWhenHandlerNil verifies zero-overhead when no handler.
+func TestStructWriter_NoEventsWhenHandlerNil(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "reflect-writer-no-annotation-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(Person{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create writer without handler
+	alice := Person{Name: "Alice", Age: 30}
+	writer, err := dlreflect.NewStructWriter(&alice, schema)
+	if err != nil {
+		t.Fatalf("failed to create writer: %v", err)
+	}
+
+	// Write struct - should work without panic
+	tx := db.NewTransaction()
+	entityID := datalog.NewIdentity("test:alice")
+	if err := writer.Write(tx, entityID, &alice); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	// Verify data was written
+	var loaded Person
+	if err := db.PullInto(entityID, &loaded); err != nil {
+		t.Fatalf("pull failed: %v", err)
+	}
+	if loaded.Name != "Alice" {
+		t.Errorf("expected Name=Alice, got %s", loaded.Name)
 	}
 }

--- a/datalog/reflect/reader.go
+++ b/datalog/reflect/reader.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -14,6 +15,7 @@ import (
 type StructReader struct {
 	info   *StructInfo
 	schema schema.SchemaProvider
+	ctx    ReflectContext
 }
 
 // NewStructReader creates a reader for a struct type
@@ -25,12 +27,37 @@ func NewStructReader(v interface{}, s schema.SchemaProvider) (*StructReader, err
 	return &StructReader{
 		info:   info,
 		schema: s,
+		ctx:    &BaseReflectContext{},
 	}, nil
+}
+
+// NewStructReaderWithHandler creates a reader with annotation support
+func NewStructReaderWithHandler(v interface{}, s schema.SchemaProvider, handler annotations.Handler) (*StructReader, error) {
+	info, err := GetStructInfoFromValue(v)
+	if err != nil {
+		return nil, err
+	}
+	return &StructReader{
+		info:   info,
+		schema: s,
+		ctx:    NewReflectContext(handler),
+	}, nil
+}
+
+// SetHandler configures the annotation handler
+func (sr *StructReader) SetHandler(handler annotations.Handler) {
+	sr.ctx = NewReflectContext(handler)
 }
 
 // Read populates struct from pull result map
 func (sr *StructReader) Read(result map[string]interface{}, v interface{}) error {
-	return sr.ReadWithDepth(result, v, 10) // Default max depth
+	sr.ctx.ReadBegin(sr.info.Name, len(sr.info.Fields), len(result))
+
+	err := sr.ReadWithDepth(result, v, 10) // Default max depth
+
+	sr.ctx.ReadComplete(sr.info.Name, err)
+
+	return err
 }
 
 // ReadWithDepth limits nested struct recursion
@@ -166,7 +193,7 @@ func (sr *StructReader) setSingleValue(fieldVal reflect.Value, fieldType reflect
 				return err
 			}
 			// Create temporary reader for nested struct
-			nestedReader := &StructReader{info: nestedInfo, schema: sr.schema}
+			nestedReader := &StructReader{info: nestedInfo, schema: sr.schema, ctx: sr.ctx}
 			return nestedReader.readIntoStruct(v, fieldVal, depth+1, maxDepth)
 
 		case datalog.Identity:
@@ -348,4 +375,12 @@ func (sr *StructReader) SetIDField(v interface{}, entityID datalog.Identity) err
 		idField.Set(reflect.ValueOf(entityID))
 	}
 	return nil
+}
+
+// ReadWithID reads a struct and sets the ID field
+func (sr *StructReader) ReadWithID(result map[string]interface{}, v interface{}, entityID datalog.Identity) error {
+	if err := sr.Read(result, v); err != nil {
+		return err
+	}
+	return sr.SetIDField(v, entityID)
 }

--- a/datalog/reflect/writer.go
+++ b/datalog/reflect/writer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -64,6 +65,7 @@ const (
 type StructWriter struct {
 	info   *StructInfo
 	schema schema.SchemaProvider
+	ctx    ReflectContext
 }
 
 // NewStructWriter creates a writer for a struct type
@@ -75,11 +77,32 @@ func NewStructWriter(v interface{}, s schema.SchemaProvider) (*StructWriter, err
 	return &StructWriter{
 		info:   info,
 		schema: s,
+		ctx:    &BaseReflectContext{},
 	}, nil
+}
+
+// NewStructWriterWithHandler creates a writer with annotation support
+func NewStructWriterWithHandler(v interface{}, s schema.SchemaProvider, handler annotations.Handler) (*StructWriter, error) {
+	info, err := GetStructInfoFromValue(v)
+	if err != nil {
+		return nil, err
+	}
+	return &StructWriter{
+		info:   info,
+		schema: s,
+		ctx:    NewReflectContext(handler),
+	}, nil
+}
+
+// SetHandler configures the annotation handler
+func (sw *StructWriter) SetHandler(handler annotations.Handler) {
+	sw.ctx = NewReflectContext(handler)
 }
 
 // Write adds all fields from struct to transaction
 func (sw *StructWriter) Write(tx TransactionAdder, entity datalog.Identity, v interface{}) error {
+	sw.ctx.WriteBegin(entity.String(), sw.info.Name, len(sw.info.Fields))
+
 	val := reflect.ValueOf(v)
 	if val.Kind() == reflect.Ptr {
 		if val.IsNil() {
@@ -92,6 +115,7 @@ func (sw *StructWriter) Write(tx TransactionAdder, entity datalog.Identity, v in
 		return fmt.Errorf("expected struct, got %s", val.Kind())
 	}
 
+	fieldsWritten := 0
 	for _, field := range sw.info.Fields {
 		fieldVal := val.Field(field.Index)
 
@@ -111,7 +135,10 @@ func (sw *StructWriter) Write(tx TransactionAdder, entity datalog.Identity, v in
 		if err := sw.writeField(tx, entity, kw, field, fieldVal); err != nil {
 			return fmt.Errorf("field %s: %w", field.FieldName, err)
 		}
+		fieldsWritten++
 	}
+
+	sw.ctx.WriteComplete(entity.String(), sw.info.Name, fieldsWritten, nil)
 
 	return nil
 }
@@ -123,6 +150,12 @@ func (sw *StructWriter) Write(tx TransactionAdder, entity datalog.Identity, v in
 // This requires both a TransactionUpdater (for retract capability) and an EntityLookup
 // (to find existing values to compare/retract).
 func (sw *StructWriter) Update(tx TransactionUpdater, lookup EntityLookup, entity datalog.Identity, v interface{}, mode UpdateMode) error {
+	modeStr := "add"
+	if mode == UpdateModeReplace {
+		modeStr = "replace"
+	}
+	sw.ctx.UpdateBegin(entity.String(), sw.info.Name, len(sw.info.Fields), modeStr)
+
 	val := reflect.ValueOf(v)
 	if val.Kind() == reflect.Ptr {
 		if val.IsNil() {
@@ -135,6 +168,7 @@ func (sw *StructWriter) Update(tx TransactionUpdater, lookup EntityLookup, entit
 		return fmt.Errorf("expected struct, got %s", val.Kind())
 	}
 
+	fieldsProcessed := 0
 	for _, field := range sw.info.Fields {
 		fieldVal := val.Field(field.Index)
 
@@ -155,7 +189,10 @@ func (sw *StructWriter) Update(tx TransactionUpdater, lookup EntityLookup, entit
 		if err := sw.updateField(tx, lookup, entity, kw, field, fieldVal, mode); err != nil {
 			return fmt.Errorf("field %s: %w", field.FieldName, err)
 		}
+		fieldsProcessed++
 	}
+
+	sw.ctx.UpdateComplete(entity.String(), sw.info.Name, fieldsProcessed, modeStr, nil)
 
 	return nil
 }


### PR DESCRIPTION
Instrument the Pull API and reflection-based struct operations to enable performance observability. Previously, these critical paths had zero annotation coverage despite the Pull API being 9x faster than queries.

## Architecture: Context Interface Pattern

Following the existing executor.Context pattern, instrumentation uses interface-based contexts with no-op and annotated implementations:

| Context | Pattern | Overhead When Disabled |
|---------|---------|------------------------|
| PullContext | Interface + factory | Single nil check at creation | | ReflectContext | Interface + factory | Single nil check at creation |

The factory functions select implementation once at creation time:
```go
func NewPullContext(handler annotations.Handler) PullContext {
    if handler == nil {
        return &BasePullContext{}      // No-op implementation
    }
    return &AnnotatedPullContext{...}  // Timing + events
}
```

## New Event Types

### Pull API Events (10 new)
| Event | Description |
|-------|-------------|
| `pull/begin` | Pull operation started |
| `pull/complete` | Pull operation finished |
| `pull/entity.begin` | Entity traversal started (with depth) | | `pull/entity.complete` | Entity traversal finished | | `pull/attr.lookup` | Single attribute lookup |
| `pull/attr.wildcard` | Wildcard (*) expansion |
| `pull/attr.many` | Cardinality-many value collection | | `pull/nested.begin` | Nested ref traversal started | | `pull/nested.complete` | Nested ref traversal finished | | `pull/cycle.detected` | Circular reference detected |

### Reflection Events (6 new)
| Event | Description |
|-------|-------------|
| `reflect/read.begin` | Struct read started |
| `reflect/read.complete` | Struct read finished | | `reflect/write.begin` | Struct write started |
| `reflect/write.complete` | Struct write finished | | `reflect/update.begin` | Struct update started | | `reflect/update.complete` | Struct update finished |

## Event Data Reference

| Event | Key Data Fields |
|-------|-----------------|
| `pull/begin` | entity, spec_count, resolved |
| `pull/complete` | entity, attr_count, resolved, success, latency | | `pull/entity.begin` | entity, depth, spec_count | | `pull/entity.complete` | entity, depth, attr_count | | `pull/cycle.detected` | entity, depth |
| `pull/nested.begin` | parent_entity, attr, ref_entity, depth, is_many | | `pull/nested.complete` | parent_entity, attr, ref_entity, depth, attr_count, success | | `reflect/read.begin` | struct_type, field_count, input_keys | | `reflect/read.complete` | struct_type, success, latency | | `reflect/write.begin` | entity, struct_type, field_count | | `reflect/write.complete` | entity, struct_type, fields_written, success, latency | | `reflect/update.begin` | entity, struct_type, field_count, mode | | `reflect/update.complete` | entity, struct_type, fields_processed, mode, success, latency |

## New Files
- `datalog/executor/pull_context.go` - PullContext interface and implementations
- `datalog/reflect/context.go` - ReflectContext interface and implementations

## Modified Files
- `datalog/annotations/types.go` - 16 new event type constants
- `datalog/executor/pull.go` - Instrumented with PullContext
- `datalog/reflect/reader.go` - Instrumented with ReflectContext
- `datalog/reflect/writer.go` - Instrumented with ReflectContext

## Tests Added
- `pull_test.go`: TestPullExecutor_AnnotationsEmitted
- `pull_test.go`: TestPullExecutor_NoEventsWhenHandlerNil
- `pull_test.go`: TestPullExecutor_CycleDetectedEvent
- `pull_test.go`: TestPullExecutor_NestedRefsEmitDepthEvents
- `integration_test.go`: TestStructReader_AnnotationsEmitted
- `integration_test.go`: TestStructReader_NoEventsWhenHandlerNil
- `integration_test.go`: TestStructWriter_AnnotationsEmitted
- `integration_test.go`: TestStructWriter_NoEventsWhenHandlerNil

## Usage

```go
// Enable Pull API annotations
handler := func(e annotations.Event) {
    log.Printf("Event: %s %v", e.Name, e.Data)
}
puller := executor.NewPullExecutor(matcher)
puller.SetHandler(handler)

// Enable reflection annotations
reader, _ := reflect.NewStructReaderWithHandler(&MyStruct{}, schema, handler)
writer, _ := reflect.NewStructWriterWithHandler(&MyStruct{}, schema, handler)
```