### PR TITLE
Implement QueryInto API for typed query results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,7 @@ The storage layer connects the query engine to BadgerDB:
 23. **Schema support** - Type validation, cardinality (one/many), uniqueness constraints; optional and additive
 24. **History mode** - Datomic-style retractions with `RetractHistory` mode; full audit trail via `ExecuteHistoryQuery`; 5-element patterns `[?e ?a ?v ?tx ?op]`
 25. **NOT/OR clauses** - Full support for `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with Datomic-compatible semantics
+26. **QueryInto API** - Typed query results via `QueryInto()` and `QueryOneInto()` with struct tag mapping for variables and aggregates
 
 ### 📋 TODO (Priority Order)
 
@@ -491,6 +492,8 @@ Note: While our planner is explicit and feature-complete, the **information flow
 
 ### Implementation Guides
 - **[docs/reference/SCHEMA.md](docs/reference/SCHEMA.md)** - Schema support: types, cardinality, uniqueness, Pull API integration
+- **[docs/reference/REFLECT.md](docs/reference/REFLECT.md)** - Struct reflection API: Go structs ↔ datoms
+- **[docs/reference/QUERY_INTO.md](docs/reference/QUERY_INTO.md)** - QueryInto API: typed query results into Go structs
 - **[docs/INPUT_PARAMETER_SEMANTICS.md](docs/INPUT_PARAMETER_SEMANTICS.md)** - Comprehensive guide to input parameter handling
 - **[docs/reference/PLANNER_OPTIONS.md](docs/reference/PLANNER_OPTIONS.md)** - Complete planner options reference with performance guidance
 

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -232,14 +232,14 @@ db.AsOf(timestamp)
 
 Every datom includes a transaction ID for temporal queries.
 
-### 8. Storage Model
+### 10. Storage Model
 
 - **EAVT model** with Entity-Attribute-Value-Transaction tuples
 - **Multiple indices**: EAVT, AEVT, AVET, VAET, TAEV
 - **BadgerDB backend** for persistence
 - **L85 encoding** for sortable, efficient keys
 
-### 9. Type System
+### 11. Type System
 
 **Supported types:**
 - Primitives: `string`, `int64`, `float64`, `bool`
@@ -248,7 +248,7 @@ Every datom includes a transaction ID for temporal queries.
 - Entity references via Identity type
 - Keywords as first-class values
 
-### 10. Pull API ✅
+### 12. Pull API ✅
 
 Declarative entity attribute retrieval with nested reference following:
 
@@ -291,7 +291,7 @@ results, err := db.PullMany(entityIDs, `[:user/name]`)
 - Wildcard `[*]` uses single EAVT prefix scan
 - Far more efficient than equivalent application-level N+1 queries
 
-### 11. Struct Reflection API ✅
+### 13. Struct Reflection API ✅
 
 **Go-specific feature** for ergonomic struct ↔ datom conversion:
 
@@ -351,6 +351,65 @@ db.PullInto(aliceID, &loaded)
 
 See [docs/reference/REFLECT.md](docs/reference/REFLECT.md) for complete documentation.
 
+### 14. QueryInto API ✅
+
+**Go-specific feature** for typed query results - eliminates manual tuple iteration:
+
+```go
+// Define result struct with datalog tags
+type TradeResult struct {
+    Symbol string    `datalog:"?symbol"`
+    Price  float64   `datalog:"?price"`
+    Date   time.Time `datalog:"?date"`
+}
+
+// Query directly into typed slice
+var results []TradeResult
+err := db.QueryInto(&results, `
+    [:find ?symbol ?price ?date
+     :where [?t :trade/symbol ?symbol]
+            [?t :trade/price ?price]
+            [?t :trade/date ?date]]
+`)
+
+// Use with aggregates - tag matches :find expression exactly
+type DeptStats struct {
+    Dept      string  `datalog:"?dept"`
+    TotalPay  float64 `datalog:"(sum ?salary)"`
+    HeadCount int64   `datalog:"(count ?emp)"`
+}
+
+var stats []DeptStats
+err := db.QueryInto(&stats, `
+    [:find ?dept (sum ?salary) (count ?emp)
+     :where [?e :employee/dept ?dept]
+            [?e :employee/salary ?salary]]
+`)
+
+// QueryOneInto for single-result queries
+var result TradeResult
+err := db.QueryOneInto(&result, `
+    [:find ?symbol ?price ?date
+     :where [?t :trade/id ?id]
+            [(= ?id 12345)]
+            [?t :trade/symbol ?symbol]
+            [?t :trade/price ?price]
+            [?t :trade/date ?date]]
+`)
+```
+
+**Tag mapping:**
+- Variables: `datalog:"?symbol"` matches `:find ?symbol`
+- Aggregates: `datalog:"(sum ?salary)"` matches `:find (sum ?salary)` exactly
+- Positional: Omit tags entirely to use field order = result column order
+
+**Error handling:**
+- `ErrNotFound` - QueryOneInto returns no results
+- `ErrMultipleResults` - QueryOneInto returns >1 result
+- `ErrSymbolNotFound` - Tag references symbol not in query
+
+See [docs/reference/QUERY_INTO.md](docs/reference/QUERY_INTO.md) for complete documentation.
+
 ## Missing Datomic Features
 
 ### 1. Rules ❌
@@ -366,21 +425,9 @@ No rule definitions or recursive queries:
   (ancestor ?p ?d)]]
 ```
 
-### 2. NOT and OR Clauses ❌
+### 2. Schema (Partial Support) ⚠️
 
-No logical negation or disjunction:
-
-```clojure
-; NOT SUPPORTED:
-(not [?e :archived true])
-(or [?e :status "active"] 
-    [?e :status "pending"])
-(or-join [?e] ...)
-```
-
-### 3. Schema ✅
-
-Schema support with Datomic-compatible attributes:
+Schema is supported but with limitations vs Datomic:
 
 **Supported schema features:**
 - `:db/valueType` - type constraints (string, long, double, boolean, instant, bytes, ref, keyword)
@@ -426,7 +473,7 @@ db, _ := storage.NewDatabaseWithSchema(path, schema)
 
 **Performance (writes only):** Type validation adds <1% overhead at `Add()` time; uniqueness checking adds ~6% at `Commit()` time. Reads are unaffected. See `PERFORMANCE_STATUS.md` for benchmarks.
 
-### 4. Transaction Features ❌
+### 3. Transaction Features ❌
 
 Limited transaction support:
 - **No transaction functions**
@@ -435,7 +482,7 @@ Limited transaction support:
 - **No transaction metadata** beyond timestamp
 - **No transaction entities**
 
-### 5. Entity API ❌
+### 4. Entity API ❌
 
 No entity navigation:
 
@@ -446,7 +493,7 @@ No entity navigation:
 (touch entity)
 ```
 
-### 6. Advanced Query Features (Partial) ⚠️
+### 5. Advanced Query Features (Partial) ⚠️
 
 **Implemented:**
 - `get-else` - default values for missing attributes ✅
@@ -458,7 +505,7 @@ No entity navigation:
 - `keys` - no map results
 - `with` - no duplicate control
 
-### 7. Time and History Features ⚠️
+### 6. Time and History Features ⚠️
 
 **Supported:**
 - As-of queries via `db.AsOf(txID)`
@@ -487,7 +534,7 @@ history, _ := db.ExecuteHistoryQuery(`[:find ?name ?tx ?op :where [?e :person/na
 - No `since` queries
 - No tx-range queries
 
-### 8. Database Features ❌
+### 7. Database Features ❌
 
 No advanced database operations:
 - No database branching/forking
@@ -495,7 +542,7 @@ No advanced database operations:
 - No database filters
 - No log API
 
-### 9. Other Missing Features ❌
+### 8. Other Missing Features ❌
 
 - **Nested expressions in predicates**: Cannot do `[(< (- ?t2 ?t1) 300)]`
 - **Distinct in aggregations**: No `(count-distinct ?x)`

--- a/README.md
+++ b/README.md
@@ -373,6 +373,59 @@ fmt.Println(loaded.Tags)  // ["dev", "lead"]
 
 See [docs/reference/REFLECT.md](docs/reference/REFLECT.md) for complete documentation.
 
+### QueryInto API
+
+Query directly into typed Go structs - no manual tuple iteration:
+
+```go
+// Define result struct with datalog tags
+type TradeResult struct {
+    Symbol string    `datalog:"?symbol"`
+    Price  float64   `datalog:"?price"`
+    Volume int64     `datalog:"?volume"`
+}
+
+// Query into typed slice
+var results []TradeResult
+err := db.QueryInto(&results, `
+    [:find ?symbol ?price ?volume
+     :where [?t :trade/symbol ?symbol]
+            [?t :trade/price ?price]
+            [?t :trade/volume ?volume]]
+`)
+
+for _, r := range results {
+    fmt.Printf("%s: $%.2f (%d shares)\n", r.Symbol, r.Price, r.Volume)
+}
+```
+
+**Works with aggregates too:**
+
+```go
+type DeptStats struct {
+    Dept      string  `datalog:"?dept"`
+    AvgSalary float64 `datalog:"(avg ?salary)"`  // Tag matches :find exactly
+    HeadCount int64   `datalog:"(count ?emp)"`
+}
+
+var stats []DeptStats
+db.QueryInto(&stats, `
+    [:find ?dept (avg ?salary) (count ?emp)
+     :where [?e :employee/dept ?dept]
+            [?e :employee/salary ?salary]]
+`)
+```
+
+**Single result queries:**
+
+```go
+var result TradeResult
+err := db.QueryOneInto(&result, `[:find ?symbol ?price ?volume :where ...]`)
+// Returns ErrNotFound if no results, ErrMultipleResults if >1
+```
+
+See [docs/reference/QUERY_INTO.md](docs/reference/QUERY_INTO.md) for complete documentation.
+
 ## What Makes Janus Different
 
 ### Pure Relational Algebra
@@ -726,6 +779,7 @@ Janus implements **~50-60% of Datomic's feature set**, focusing on the most comm
 - Schema: Type validation, cardinality, uniqueness constraints
 - Storage: Persistent BadgerDB backend
 - NOT/OR clauses: `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)`
+- Go-specific: Struct reflection API, QueryInto for typed results
 
 **Not implemented:**
 - Rules and recursive queries
@@ -743,6 +797,7 @@ See [DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md) for the complete compat
 - Core query engine complete and tested
 - Pull API with nested references and cycle detection
 - Schema support: type validation, cardinality, uniqueness
+- Struct reflection and QueryInto for Go-native ergonomics
 - Persistent storage with BadgerDB
 - Comprehensive test suite (1.28:1 test-to-code ratio)
 - Used in production for financial analysis

--- a/datalog/reflect/query_reader.go
+++ b/datalog/reflect/query_reader.go
@@ -1,0 +1,339 @@
+// Package reflect provides reflection-based utilities for converting
+// Go structs to/from datoms and query results.
+package reflect
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// Errors for query result mapping
+var (
+	ErrNotPointerToSlice  = errors.New("dest must be pointer to slice of structs")
+	ErrNotPointerToStruct = errors.New("dest must be pointer to struct")
+	ErrNotFound           = errors.New("query returned no results")
+	ErrMultipleResults    = errors.New("query returned multiple results, expected one")
+	ErrMixedTags          = errors.New("struct has mixed tagged and untagged query fields")
+	ErrSymbolNotFound     = errors.New("tagged symbol not found in query results")
+)
+
+// QueryFieldMapping maps a struct field to a query result column
+type QueryFieldMapping struct {
+	FieldIndex int          // Index in struct
+	FieldName  string       // Go field name
+	FieldType  reflect.Type // Go type
+	Tag        string       // The datalog tag value (e.g., "?name" or "(sum ?x)")
+	ColIndex   int          // Column index in result tuple (-1 if unmapped)
+}
+
+// QueryResultMapper handles query result -> struct conversion
+type QueryResultMapper struct {
+	elemType reflect.Type
+	mappings []QueryFieldMapping
+}
+
+// NewQueryResultMapper creates a mapper from struct type and :find column names.
+// The findColumns should be the string representations of FindElements
+// (e.g., "?name", "(sum ?salary)").
+func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryResultMapper, error) {
+	// Handle pointer to struct
+	if elemType.Kind() == reflect.Ptr {
+		elemType = elemType.Elem()
+	}
+
+	if elemType.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected struct type, got %s", elemType.Kind())
+	}
+
+	// Build column index map
+	colIndex := make(map[string]int)
+	for i, col := range findColumns {
+		colIndex[col] = i
+	}
+
+	// Parse struct fields
+	mappings := make([]QueryFieldMapping, 0)
+	hasTagged := false
+	hasUntagged := false
+
+	for i := 0; i < elemType.NumField(); i++ {
+		field := elemType.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		tag := field.Tag.Get("datalog")
+
+		// Skip fields marked with "-" or ID fields
+		if tag == "-" || strings.HasSuffix(tag, ",id") {
+			continue
+		}
+
+		mapping := QueryFieldMapping{
+			FieldIndex: i,
+			FieldName:  field.Name,
+			FieldType:  field.Type,
+			ColIndex:   -1,
+		}
+
+		// Check if this is a query symbol tag (starts with ? or ()
+		if isQueryTag(tag) {
+			mapping.Tag = tag
+			hasTagged = true
+
+			// Look up column index
+			idx, found := colIndex[tag]
+			if !found {
+				return nil, fmt.Errorf("%w: field %s tagged with %q not found in query results %v",
+					ErrSymbolNotFound, field.Name, tag, findColumns)
+			}
+			mapping.ColIndex = idx
+		} else if tag == "" {
+			// No tag - will use positional mapping
+			hasUntagged = true
+		} else {
+			// Has a tag but it's an attribute tag (e.g., "person/name"), not a query tag
+			// Skip this field for query mapping
+			continue
+		}
+
+		mappings = append(mappings, mapping)
+	}
+
+	// Check for mixed tags
+	if hasTagged && hasUntagged {
+		return nil, fmt.Errorf("%w: either all fields should have query tags (e.g., `datalog:\"?name\"`) or none",
+			ErrMixedTags)
+	}
+
+	// Apply positional mapping if no tags
+	if hasUntagged {
+		for i := range mappings {
+			if i < len(findColumns) {
+				mappings[i].ColIndex = i
+				mappings[i].Tag = findColumns[i] // For error messages
+			}
+		}
+	}
+
+	return &QueryResultMapper{
+		elemType: elemType,
+		mappings: mappings,
+	}, nil
+}
+
+// isQueryTag returns true if the tag looks like a query symbol or aggregate
+func isQueryTag(tag string) bool {
+	if tag == "" {
+		return false
+	}
+	// Query variables start with ?
+	if strings.HasPrefix(tag, "?") {
+		return true
+	}
+	// Aggregates are wrapped in parens: (sum ?x)
+	if strings.HasPrefix(tag, "(") && strings.HasSuffix(tag, ")") {
+		return true
+	}
+	return false
+}
+
+// MapTuple populates a struct from a single result tuple
+func (m *QueryResultMapper) MapTuple(tuple []interface{}, dest reflect.Value) error {
+	// Handle pointer to struct
+	if dest.Kind() == reflect.Ptr {
+		if dest.IsNil() {
+			dest.Set(reflect.New(dest.Type().Elem()))
+		}
+		dest = dest.Elem()
+	}
+
+	if dest.Kind() != reflect.Struct {
+		return fmt.Errorf("expected struct, got %s", dest.Kind())
+	}
+
+	for _, mapping := range m.mappings {
+		if mapping.ColIndex < 0 || mapping.ColIndex >= len(tuple) {
+			continue // Skip unmapped or out-of-range columns
+		}
+
+		value := tuple[mapping.ColIndex]
+		fieldVal := dest.Field(mapping.FieldIndex)
+
+		if err := setQueryValue(fieldVal, mapping.FieldType, value); err != nil {
+			return fmt.Errorf("field %s (tag %s): %w", mapping.FieldName, mapping.Tag, err)
+		}
+	}
+
+	return nil
+}
+
+// MapAll populates a slice of structs from multiple result tuples
+func (m *QueryResultMapper) MapAll(tuples [][]interface{}, destSlice reflect.Value) error {
+	if destSlice.Kind() != reflect.Slice {
+		return fmt.Errorf("expected slice, got %s", destSlice.Kind())
+	}
+
+	// Pre-allocate slice
+	newSlice := reflect.MakeSlice(destSlice.Type(), 0, len(tuples))
+
+	for i, tuple := range tuples {
+		elem := reflect.New(m.elemType).Elem()
+		if err := m.MapTuple(tuple, elem); err != nil {
+			return fmt.Errorf("row %d: %w", i, err)
+		}
+		newSlice = reflect.Append(newSlice, elem)
+	}
+
+	destSlice.Set(newSlice)
+	return nil
+}
+
+// setQueryValue sets a struct field from a query result value.
+// This handles type coercion similar to setSingleValue in reader.go.
+func setQueryValue(fieldVal reflect.Value, fieldType reflect.Type, value interface{}) error {
+	// Handle nil values
+	if value == nil {
+		if fieldType.Kind() == reflect.Ptr {
+			// Pointer field - leave as nil
+			return nil
+		}
+		// Non-pointer field with nil value - this is an error for required fields
+		// But we'll be lenient and leave as zero value
+		return nil
+	}
+
+	// Handle pointer fields
+	if fieldType.Kind() == reflect.Ptr {
+		// Create new value and set pointer
+		newVal := reflect.New(fieldType.Elem())
+		if err := setQueryValue(newVal.Elem(), fieldType.Elem(), value); err != nil {
+			return err
+		}
+		fieldVal.Set(newVal)
+		return nil
+	}
+
+	// Handle specific types
+	switch fieldType {
+	case timeType:
+		t, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("expected time.Time, got %T", value)
+		}
+		fieldVal.Set(reflect.ValueOf(t))
+		return nil
+
+	case identityType:
+		switch v := value.(type) {
+		case datalog.Identity:
+			fieldVal.Set(reflect.ValueOf(v))
+		case *datalog.Identity:
+			if v != nil {
+				fieldVal.Set(reflect.ValueOf(*v))
+			}
+		default:
+			return fmt.Errorf("expected Identity, got %T", value)
+		}
+		return nil
+
+	case keywordType:
+		kw, ok := value.(datalog.Keyword)
+		if !ok {
+			return fmt.Errorf("expected Keyword, got %T", value)
+		}
+		fieldVal.Set(reflect.ValueOf(kw))
+		return nil
+	}
+
+	// Handle basic types
+	switch fieldType.Kind() {
+	case reflect.String:
+		s, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("expected string, got %T", value)
+		}
+		fieldVal.SetString(s)
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		var i int64
+		switch v := value.(type) {
+		case int64:
+			i = v
+		case int:
+			i = int64(v)
+		case int32:
+			i = int64(v)
+		case float64:
+			i = int64(v)
+		case uint64:
+			i = int64(v)
+		default:
+			return fmt.Errorf("expected integer, got %T", value)
+		}
+		fieldVal.SetInt(i)
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		var u uint64
+		switch v := value.(type) {
+		case uint64:
+			u = v
+		case int64:
+			u = uint64(v)
+		case int:
+			u = uint64(v)
+		case float64:
+			u = uint64(v)
+		default:
+			return fmt.Errorf("expected unsigned integer, got %T", value)
+		}
+		fieldVal.SetUint(u)
+
+	case reflect.Float32, reflect.Float64:
+		var f float64
+		switch v := value.(type) {
+		case float64:
+			f = v
+		case float32:
+			f = float64(v)
+		case int64:
+			f = float64(v)
+		case int:
+			f = float64(v)
+		default:
+			return fmt.Errorf("expected float, got %T", value)
+		}
+		fieldVal.SetFloat(f)
+
+	case reflect.Bool:
+		b, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("expected bool, got %T", value)
+		}
+		fieldVal.SetBool(b)
+
+	case reflect.Slice:
+		// []byte
+		if fieldType.Elem().Kind() == reflect.Uint8 {
+			b, ok := value.([]byte)
+			if !ok {
+				return fmt.Errorf("expected []byte, got %T", value)
+			}
+			fieldVal.SetBytes(b)
+		} else {
+			return fmt.Errorf("unsupported slice type: %s", fieldType)
+		}
+
+	default:
+		return fmt.Errorf("unsupported type: %s", fieldType)
+	}
+
+	return nil
+}

--- a/datalog/reflect/query_reader_test.go
+++ b/datalog/reflect/query_reader_test.go
@@ -1,0 +1,546 @@
+package reflect
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// Test structs for various scenarios
+
+type SimpleTagged struct {
+	Name string `datalog:"?name"`
+	Age  int64  `datalog:"?age"`
+}
+
+type SimpleUntagged struct {
+	Name string
+	Age  int64
+}
+
+type WithAggregates struct {
+	Dept      string  `datalog:"?dept"`
+	TotalPay  float64 `datalog:"(sum ?salary)"`
+	HeadCount int64   `datalog:"(count ?emp)"`
+}
+
+type MixedTags struct {
+	Name string `datalog:"?name"`
+	Age  int64  // No tag - mixed!
+}
+
+type WithPointers struct {
+	Name  string  `datalog:"?name"`
+	Email *string `datalog:"?email"`
+}
+
+type AllTypes struct {
+	Str     string           `datalog:"?str"`
+	Int     int64            `datalog:"?int"`
+	Float   float64          `datalog:"?float"`
+	Bool    bool             `datalog:"?bool"`
+	Time    time.Time        `datalog:"?time"`
+	ID      datalog.Identity `datalog:"?id"`
+	Keyword datalog.Keyword  `datalog:"?kw"`
+}
+
+type TypeCoercion struct {
+	SmallInt   int     `datalog:"?small"`
+	SmallFloat float32 `datalog:"?float"`
+}
+
+type WithBytes struct {
+	Name string `datalog:"?name"`
+	Data []byte `datalog:"?data"`
+}
+
+type WithUint64 struct {
+	Name  string `datalog:"?name"`
+	Count uint64 `datalog:"?count"`
+}
+
+type WithIdentityPointer struct {
+	Name string            `datalog:"?name"`
+	Ref  *datalog.Identity `datalog:"?ref"`
+}
+
+type WithAttrTag struct {
+	ID   datalog.Identity `datalog:"-,id"`
+	Name string           `datalog:"person/name"` // Attribute tag, not query tag
+	Age  int64            `datalog:"?age"`
+}
+
+func TestNewQueryResultMapper_TaggedFields(t *testing.T) {
+	findColumns := []string{"?name", "?age"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(SimpleTagged{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mapper.mappings) != 2 {
+		t.Errorf("expected 2 mappings, got %d", len(mapper.mappings))
+	}
+
+	// Verify name mapping
+	if mapper.mappings[0].Tag != "?name" || mapper.mappings[0].ColIndex != 0 {
+		t.Errorf("name mapping incorrect: %+v", mapper.mappings[0])
+	}
+
+	// Verify age mapping
+	if mapper.mappings[1].Tag != "?age" || mapper.mappings[1].ColIndex != 1 {
+		t.Errorf("age mapping incorrect: %+v", mapper.mappings[1])
+	}
+}
+
+func TestNewQueryResultMapper_PositionalMapping(t *testing.T) {
+	findColumns := []string{"?name", "?age"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(SimpleUntagged{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mapper.mappings) != 2 {
+		t.Errorf("expected 2 mappings, got %d", len(mapper.mappings))
+	}
+
+	// Positional: first field -> column 0, second field -> column 1
+	if mapper.mappings[0].ColIndex != 0 {
+		t.Errorf("first field should map to column 0, got %d", mapper.mappings[0].ColIndex)
+	}
+	if mapper.mappings[1].ColIndex != 1 {
+		t.Errorf("second field should map to column 1, got %d", mapper.mappings[1].ColIndex)
+	}
+}
+
+func TestNewQueryResultMapper_Aggregates(t *testing.T) {
+	findColumns := []string{"?dept", "(sum ?salary)", "(count ?emp)"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(WithAggregates{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mapper.mappings) != 3 {
+		t.Errorf("expected 3 mappings, got %d", len(mapper.mappings))
+	}
+
+	// Verify aggregate mappings
+	for _, m := range mapper.mappings {
+		switch m.Tag {
+		case "?dept":
+			if m.ColIndex != 0 {
+				t.Errorf("?dept should map to column 0, got %d", m.ColIndex)
+			}
+		case "(sum ?salary)":
+			if m.ColIndex != 1 {
+				t.Errorf("(sum ?salary) should map to column 1, got %d", m.ColIndex)
+			}
+		case "(count ?emp)":
+			if m.ColIndex != 2 {
+				t.Errorf("(count ?emp) should map to column 2, got %d", m.ColIndex)
+			}
+		}
+	}
+}
+
+func TestNewQueryResultMapper_MixedTagsError(t *testing.T) {
+	findColumns := []string{"?name", "?age"}
+	_, err := NewQueryResultMapper(reflect.TypeOf(MixedTags{}), findColumns)
+	if err == nil {
+		t.Fatal("expected error for mixed tags")
+	}
+	if err.Error() == "" || !contains(err.Error(), "mixed") {
+		t.Errorf("error should mention mixed tags: %v", err)
+	}
+}
+
+func TestNewQueryResultMapper_SymbolNotFound(t *testing.T) {
+	findColumns := []string{"?name"} // Missing ?age
+	_, err := NewQueryResultMapper(reflect.TypeOf(SimpleTagged{}), findColumns)
+	if err == nil {
+		t.Fatal("expected error for missing symbol")
+	}
+	if err.Error() == "" || !contains(err.Error(), "?age") {
+		t.Errorf("error should mention missing symbol ?age: %v", err)
+	}
+}
+
+func TestNewQueryResultMapper_SkipsAttributeTags(t *testing.T) {
+	findColumns := []string{"?age"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(WithAttrTag{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should only have 1 mapping (the ?age field)
+	// The "person/name" field should be skipped (attribute tag, not query tag)
+	// The "-,id" field should be skipped
+	if len(mapper.mappings) != 1 {
+		t.Errorf("expected 1 mapping, got %d", len(mapper.mappings))
+	}
+	if mapper.mappings[0].Tag != "?age" {
+		t.Errorf("expected ?age mapping, got %s", mapper.mappings[0].Tag)
+	}
+}
+
+func TestMapTuple_BasicTypes(t *testing.T) {
+	findColumns := []string{"?name", "?age"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(SimpleTagged{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tuple := []interface{}{"Alice", int64(30)}
+	var result SimpleTagged
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.Name != "Alice" {
+		t.Errorf("expected Name='Alice', got %q", result.Name)
+	}
+	if result.Age != 30 {
+		t.Errorf("expected Age=30, got %d", result.Age)
+	}
+}
+
+func TestMapTuple_AllTypes(t *testing.T) {
+	findColumns := []string{"?str", "?int", "?float", "?bool", "?time", "?id", "?kw"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(AllTypes{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	now := time.Now()
+	id := datalog.NewIdentity("test-entity")
+	kw := datalog.NewKeyword(":status/active")
+
+	tuple := []interface{}{"hello", int64(42), float64(3.14), true, now, id, kw}
+	var result AllTypes
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.Str != "hello" {
+		t.Errorf("Str: expected 'hello', got %q", result.Str)
+	}
+	if result.Int != 42 {
+		t.Errorf("Int: expected 42, got %d", result.Int)
+	}
+	if result.Float != 3.14 {
+		t.Errorf("Float: expected 3.14, got %f", result.Float)
+	}
+	if result.Bool != true {
+		t.Errorf("Bool: expected true, got %v", result.Bool)
+	}
+	if !result.Time.Equal(now) {
+		t.Errorf("Time: expected %v, got %v", now, result.Time)
+	}
+	if result.ID != id {
+		t.Errorf("ID: expected %v, got %v", id, result.ID)
+	}
+	if result.Keyword != kw {
+		t.Errorf("Keyword: expected %v, got %v", kw, result.Keyword)
+	}
+}
+
+func TestMapTuple_TypeCoercion(t *testing.T) {
+	findColumns := []string{"?small", "?float"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(TypeCoercion{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Query returns int64 and float64, but struct wants int and float32
+	tuple := []interface{}{int64(100), float64(1.5)}
+	var result TypeCoercion
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.SmallInt != 100 {
+		t.Errorf("SmallInt: expected 100, got %d", result.SmallInt)
+	}
+	if result.SmallFloat != 1.5 {
+		t.Errorf("SmallFloat: expected 1.5, got %f", result.SmallFloat)
+	}
+}
+
+func TestMapTuple_PointerFields(t *testing.T) {
+	findColumns := []string{"?name", "?email"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(WithPointers{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Test with non-nil email
+	email := "alice@example.com"
+	tuple := []interface{}{"Alice", email}
+	var result WithPointers
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.Name != "Alice" {
+		t.Errorf("Name: expected 'Alice', got %q", result.Name)
+	}
+	if result.Email == nil || *result.Email != email {
+		t.Errorf("Email: expected %q, got %v", email, result.Email)
+	}
+
+	// Test with nil email
+	tuple2 := []interface{}{"Bob", nil}
+	var result2 WithPointers
+	if err := mapper.MapTuple(tuple2, reflect.ValueOf(&result2).Elem()); err != nil {
+		t.Fatalf("MapTuple with nil failed: %v", err)
+	}
+
+	if result2.Name != "Bob" {
+		t.Errorf("Name: expected 'Bob', got %q", result2.Name)
+	}
+	if result2.Email != nil {
+		t.Errorf("Email: expected nil, got %v", result2.Email)
+	}
+}
+
+func TestMapTuple_Aggregates(t *testing.T) {
+	findColumns := []string{"?dept", "(sum ?salary)", "(count ?emp)"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(WithAggregates{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tuple := []interface{}{"Engineering", float64(500000), int64(50)}
+	var result WithAggregates
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.Dept != "Engineering" {
+		t.Errorf("Dept: expected 'Engineering', got %q", result.Dept)
+	}
+	if result.TotalPay != 500000 {
+		t.Errorf("TotalPay: expected 500000, got %f", result.TotalPay)
+	}
+	if result.HeadCount != 50 {
+		t.Errorf("HeadCount: expected 50, got %d", result.HeadCount)
+	}
+}
+
+func TestMapTuple_ByteSlice(t *testing.T) {
+	findColumns := []string{"?name", "?data"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(WithBytes{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := []byte{0x01, 0x02, 0x03, 0xAB, 0xCD}
+	tuple := []interface{}{"test", data}
+	var result WithBytes
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.Name != "test" {
+		t.Errorf("Name: expected 'test', got %q", result.Name)
+	}
+	if len(result.Data) != 5 {
+		t.Errorf("Data length: expected 5, got %d", len(result.Data))
+	}
+	for i, b := range data {
+		if result.Data[i] != b {
+			t.Errorf("Data[%d]: expected %x, got %x", i, b, result.Data[i])
+		}
+	}
+}
+
+func TestMapTuple_Uint64(t *testing.T) {
+	findColumns := []string{"?name", "?count"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(WithUint64{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Test with uint64 value
+	tuple := []interface{}{"counter", uint64(18446744073709551615)} // Max uint64
+	var result WithUint64
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.Name != "counter" {
+		t.Errorf("Name: expected 'counter', got %q", result.Name)
+	}
+	if result.Count != 18446744073709551615 {
+		t.Errorf("Count: expected max uint64, got %d", result.Count)
+	}
+
+	// Test with int64 coercion to uint64
+	tuple2 := []interface{}{"small", int64(42)}
+	var result2 WithUint64
+	if err := mapper.MapTuple(tuple2, reflect.ValueOf(&result2).Elem()); err != nil {
+		t.Fatalf("MapTuple with int64 failed: %v", err)
+	}
+	if result2.Count != 42 {
+		t.Errorf("Count: expected 42, got %d", result2.Count)
+	}
+}
+
+func TestMapTuple_IdentityPointer(t *testing.T) {
+	findColumns := []string{"?name", "?ref"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(WithIdentityPointer{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Test with non-nil Identity
+	id := datalog.NewIdentity("entity:123")
+	tuple := []interface{}{"test", id}
+	var result WithIdentityPointer
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.Name != "test" {
+		t.Errorf("Name: expected 'test', got %q", result.Name)
+	}
+	if result.Ref == nil {
+		t.Fatal("Ref: expected non-nil, got nil")
+	}
+	if *result.Ref != id {
+		t.Errorf("Ref: expected %v, got %v", id, *result.Ref)
+	}
+
+	// Test with nil ref
+	tuple2 := []interface{}{"empty", nil}
+	var result2 WithIdentityPointer
+	if err := mapper.MapTuple(tuple2, reflect.ValueOf(&result2).Elem()); err != nil {
+		t.Fatalf("MapTuple with nil failed: %v", err)
+	}
+	if result2.Ref != nil {
+		t.Errorf("Ref: expected nil, got %v", result2.Ref)
+	}
+
+	// Test with *Identity value (pointer passed directly)
+	idPtr := &id
+	tuple3 := []interface{}{"ptr", idPtr}
+	var result3 WithIdentityPointer
+	if err := mapper.MapTuple(tuple3, reflect.ValueOf(&result3).Elem()); err != nil {
+		t.Fatalf("MapTuple with *Identity failed: %v", err)
+	}
+	if result3.Ref == nil || *result3.Ref != id {
+		t.Errorf("Ref: expected %v, got %v", id, result3.Ref)
+	}
+}
+
+func TestMapAll(t *testing.T) {
+	findColumns := []string{"?name", "?age"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(SimpleTagged{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tuples := [][]interface{}{
+		{"Alice", int64(30)},
+		{"Bob", int64(25)},
+		{"Charlie", int64(35)},
+	}
+
+	var results []SimpleTagged
+	sliceVal := reflect.ValueOf(&results).Elem()
+	if err := mapper.MapAll(tuples, sliceVal); err != nil {
+		t.Fatalf("MapAll failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	expected := []SimpleTagged{
+		{Name: "Alice", Age: 30},
+		{Name: "Bob", Age: 25},
+		{Name: "Charlie", Age: 35},
+	}
+
+	for i, exp := range expected {
+		if results[i].Name != exp.Name || results[i].Age != exp.Age {
+			t.Errorf("result[%d]: expected %+v, got %+v", i, exp, results[i])
+		}
+	}
+}
+
+func TestMapAll_EmptyResults(t *testing.T) {
+	findColumns := []string{"?name", "?age"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(SimpleTagged{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tuples := [][]interface{}{}
+	var results []SimpleTagged
+	sliceVal := reflect.ValueOf(&results).Elem()
+	if err := mapper.MapAll(tuples, sliceVal); err != nil {
+		t.Fatalf("MapAll failed: %v", err)
+	}
+
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestMapTuple_TypeMismatch(t *testing.T) {
+	findColumns := []string{"?name", "?age"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(SimpleTagged{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Pass wrong type: string instead of int64 for age
+	tuple := []interface{}{"Alice", "not a number"}
+	var result SimpleTagged
+	err = mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem())
+	if err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+}
+
+func TestIsQueryTag(t *testing.T) {
+	tests := []struct {
+		tag      string
+		expected bool
+	}{
+		{"?name", true},
+		{"?x", true},
+		{"(sum ?x)", true},
+		{"(count ?emp)", true},
+		{"(avg ?salary)", true},
+		{"person/name", false},
+		{":person/name", false},
+		{"", false},
+		{"-", false},
+		{"name", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			if got := isQueryTag(tt.tag); got != tt.expected {
+				t.Errorf("isQueryTag(%q) = %v, want %v", tt.tag, got, tt.expected)
+			}
+		})
+	}
+}
+
+// Helper function
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -413,6 +413,139 @@ func (d *Database) ExecuteQueryWithInputs(queryStr string, inputs ...interface{}
 	return relationToSlice(result), nil
 }
 
+// QueryInto executes a Datalog query and populates a slice of structs with the results.
+// Fields are mapped by `datalog` tags (e.g., `datalog:"?name"`) or by position if untagged.
+//
+// For aggregates, use the full expression as the tag (e.g., `datalog:"(sum ?salary)"`).
+//
+// Example:
+//
+//	type PersonResult struct {
+//	    Name string `datalog:"?name"`
+//	    Age  int64  `datalog:"?age"`
+//	}
+//
+//	var results []PersonResult
+//	err := db.QueryInto(&results, `[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
+//
+// Example with aggregates:
+//
+//	type DeptStats struct {
+//	    Dept     string  `datalog:"?dept"`
+//	    TotalPay float64 `datalog:"(sum ?salary)"`
+//	}
+//
+//	var stats []DeptStats
+//	err := db.QueryInto(&stats, `[:find ?dept (sum ?salary) :where [?e :employee/dept ?dept] [?e :employee/salary ?salary]]`)
+func (d *Database) QueryInto(dest interface{}, queryStr string, inputs ...interface{}) error {
+	// Validate dest is *[]T where T is struct
+	destVal := reflect.ValueOf(dest)
+	if destVal.Kind() != reflect.Ptr {
+		return dlreflect.ErrNotPointerToSlice
+	}
+	sliceVal := destVal.Elem()
+	if sliceVal.Kind() != reflect.Slice {
+		return dlreflect.ErrNotPointerToSlice
+	}
+	elemType := sliceVal.Type().Elem()
+	if elemType.Kind() == reflect.Ptr {
+		elemType = elemType.Elem()
+	}
+	if elemType.Kind() != reflect.Struct {
+		return dlreflect.ErrNotPointerToSlice
+	}
+
+	// Parse query to extract :find columns
+	q, err := parser.ParseQuery(queryStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	// Get column names from :find clause
+	findColumns := extractFindColumnStrings(q.Find)
+
+	// Create mapper
+	mapper, err := dlreflect.NewQueryResultMapper(elemType, findColumns)
+	if err != nil {
+		return err
+	}
+
+	// Execute query
+	results, err := d.ExecuteQueryWithInputs(queryStr, inputs...)
+	if err != nil {
+		return err
+	}
+
+	// Map results to slice
+	return mapper.MapAll(results, sliceVal)
+}
+
+// QueryOneInto executes a Datalog query expecting exactly one result and populates a struct.
+// Returns ErrNotFound if the query returns no results, or ErrMultipleResults if more than one.
+//
+// Example:
+//
+//	type PersonResult struct {
+//	    Name string `datalog:"?name"`
+//	    Age  int64  `datalog:"?age"`
+//	}
+//
+//	var result PersonResult
+//	err := db.QueryOneInto(&result, `[:find ?name ?age :in $ ?id :where [?id :person/name ?name] [?id :person/age ?age]]`, entityID)
+func (d *Database) QueryOneInto(dest interface{}, queryStr string, inputs ...interface{}) error {
+	// Validate dest is *T where T is struct
+	destVal := reflect.ValueOf(dest)
+	if destVal.Kind() != reflect.Ptr {
+		return dlreflect.ErrNotPointerToStruct
+	}
+	structVal := destVal.Elem()
+	if structVal.Kind() != reflect.Struct {
+		return dlreflect.ErrNotPointerToStruct
+	}
+
+	// Parse query to extract :find columns
+	q, err := parser.ParseQuery(queryStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	// Get column names from :find clause
+	findColumns := extractFindColumnStrings(q.Find)
+
+	// Create mapper
+	mapper, err := dlreflect.NewQueryResultMapper(structVal.Type(), findColumns)
+	if err != nil {
+		return err
+	}
+
+	// Execute query
+	results, err := d.ExecuteQueryWithInputs(queryStr, inputs...)
+	if err != nil {
+		return err
+	}
+
+	// Check result count
+	if len(results) == 0 {
+		return dlreflect.ErrNotFound
+	}
+	if len(results) > 1 {
+		return dlreflect.ErrMultipleResults
+	}
+
+	// Map single result to struct
+	return mapper.MapTuple(results[0], structVal)
+}
+
+// extractFindColumnStrings extracts column names from :find clause as strings.
+// For variables, returns "?name". For aggregates, returns "(sum ?x)".
+func extractFindColumnStrings(find []query.FindElement) []string {
+	columns := make([]string, len(find))
+	for i, elem := range find {
+		columns[i] = elem.String()
+	}
+	return columns
+}
+
 // ExecuteHistoryQuery executes a Datalog query against the history database
 // This requires the database to be created with RetractHistory mode
 //

--- a/datalog/storage/query_into_test.go
+++ b/datalog/storage/query_into_test.go
@@ -1,0 +1,472 @@
+package storage
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
+)
+
+// Test struct types
+
+type PersonResult struct {
+	Name string `datalog:"?name"`
+	Age  int64  `datalog:"?age"`
+}
+
+type TradeResult struct {
+	Symbol string    `datalog:"?symbol"`
+	Price  float64   `datalog:"?price"`
+	Time   time.Time `datalog:"?time"`
+}
+
+type DeptStats struct {
+	Dept      string  `datalog:"?dept"`
+	TotalPay  float64 `datalog:"(sum ?salary)"`
+	HeadCount int64   `datalog:"(count ?emp)"`
+}
+
+type PositionalResult struct {
+	Name string
+	Age  int64
+}
+
+type WithPointers struct {
+	Name  string  `datalog:"?name"`
+	Email *string `datalog:"?email"`
+}
+
+// Helper to create a test database with data
+func createTestDatabaseWithPeople(t *testing.T) (*Database, func()) {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "query-into-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	db, err := NewDatabase(tmpDir)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		t.Fatalf("failed to create database: %v", err)
+	}
+
+	// Add test data
+	alice := datalog.NewIdentity("person:alice")
+	bob := datalog.NewIdentity("person:bob")
+	charlie := datalog.NewIdentity("person:charlie")
+
+	tx := db.NewTransaction()
+	tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":person/age"), int64(30))
+	tx.Add(alice, datalog.NewKeyword(":person/email"), "alice@example.com")
+
+	tx.Add(bob, datalog.NewKeyword(":person/name"), "Bob")
+	tx.Add(bob, datalog.NewKeyword(":person/age"), int64(25))
+	// Bob has no email
+
+	tx.Add(charlie, datalog.NewKeyword(":person/name"), "Charlie")
+	tx.Add(charlie, datalog.NewKeyword(":person/age"), int64(35))
+	tx.Add(charlie, datalog.NewKeyword(":person/email"), "charlie@example.com")
+
+	if _, err := tx.Commit(); err != nil {
+		db.Close()
+		os.RemoveAll(tmpDir)
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	}
+
+	return db, cleanup
+}
+
+func createTestDatabaseWithEmployees(t *testing.T) (*Database, func()) {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "query-into-emp-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	db, err := NewDatabase(tmpDir)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		t.Fatalf("failed to create database: %v", err)
+	}
+
+	// Add employee data for aggregation tests
+	employees := []struct {
+		name   string
+		dept   string
+		salary float64
+	}{
+		{"Alice", "Engineering", 100000},
+		{"Bob", "Engineering", 120000},
+		{"Charlie", "Engineering", 110000},
+		{"Dave", "Sales", 80000},
+		{"Eve", "Sales", 90000},
+		{"Frank", "Marketing", 70000},
+	}
+
+	tx := db.NewTransaction()
+	for _, emp := range employees {
+		id := datalog.NewIdentity("emp:" + emp.name)
+		tx.Add(id, datalog.NewKeyword(":employee/name"), emp.name)
+		tx.Add(id, datalog.NewKeyword(":employee/dept"), emp.dept)
+		tx.Add(id, datalog.NewKeyword(":employee/salary"), emp.salary)
+	}
+
+	if _, err := tx.Commit(); err != nil {
+		db.Close()
+		os.RemoveAll(tmpDir)
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	}
+
+	return db, cleanup
+}
+
+func TestQueryInto_BasicQuery(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	var results []PersonResult
+	err := db.QueryInto(&results, `
+		[:find ?name ?age
+		 :where [?e :person/name ?name]
+		        [?e :person/age ?age]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	// Verify we got all people (order may vary)
+	names := make(map[string]int64)
+	for _, r := range results {
+		names[r.Name] = r.Age
+	}
+
+	if names["Alice"] != 30 {
+		t.Errorf("expected Alice age 30, got %d", names["Alice"])
+	}
+	if names["Bob"] != 25 {
+		t.Errorf("expected Bob age 25, got %d", names["Bob"])
+	}
+	if names["Charlie"] != 35 {
+		t.Errorf("expected Charlie age 35, got %d", names["Charlie"])
+	}
+}
+
+func TestQueryInto_WithInputs(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	// Test with a bound value directly in the pattern (this is how inputs typically work)
+	var results []PersonResult
+	err := db.QueryInto(&results, `
+		[:find ?name ?age
+		 :in $ ?search-name
+		 :where [?e :person/name ?search-name]
+		        [?e :person/name ?name]
+		        [?e :person/age ?age]]
+	`, "Alice")
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if results[0].Name != "Alice" {
+		t.Errorf("expected Name=Alice, got %q", results[0].Name)
+	}
+	if results[0].Age != 30 {
+		t.Errorf("expected Age=30, got %d", results[0].Age)
+	}
+}
+
+func TestQueryInto_WithAggregates(t *testing.T) {
+	db, cleanup := createTestDatabaseWithEmployees(t)
+	defer cleanup()
+
+	var results []DeptStats
+	err := db.QueryInto(&results, `
+		[:find ?dept (sum ?salary) (count ?emp)
+		 :where [?emp :employee/dept ?dept]
+		        [?emp :employee/salary ?salary]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 departments, got %d", len(results))
+	}
+
+	// Verify aggregates
+	deptStats := make(map[string]DeptStats)
+	for _, r := range results {
+		deptStats[r.Dept] = r
+	}
+
+	eng := deptStats["Engineering"]
+	if eng.TotalPay != 330000 {
+		t.Errorf("Engineering total: expected 330000, got %f", eng.TotalPay)
+	}
+	if eng.HeadCount != 3 {
+		t.Errorf("Engineering count: expected 3, got %d", eng.HeadCount)
+	}
+
+	sales := deptStats["Sales"]
+	if sales.TotalPay != 170000 {
+		t.Errorf("Sales total: expected 170000, got %f", sales.TotalPay)
+	}
+	if sales.HeadCount != 2 {
+		t.Errorf("Sales count: expected 2, got %d", sales.HeadCount)
+	}
+
+	mkt := deptStats["Marketing"]
+	if mkt.TotalPay != 70000 {
+		t.Errorf("Marketing total: expected 70000, got %f", mkt.TotalPay)
+	}
+	if mkt.HeadCount != 1 {
+		t.Errorf("Marketing count: expected 1, got %d", mkt.HeadCount)
+	}
+}
+
+func TestQueryInto_PositionalMapping(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	var results []PositionalResult
+	err := db.QueryInto(&results, `
+		[:find ?name ?age
+		 :where [?e :person/name ?name]
+		        [?e :person/age ?age]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	// Verify positional mapping worked
+	names := make(map[string]int64)
+	for _, r := range results {
+		names[r.Name] = r.Age
+	}
+
+	if names["Alice"] != 30 {
+		t.Errorf("expected Alice age 30, got %d", names["Alice"])
+	}
+}
+
+func TestQueryInto_EmptyResults(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	var results []PersonResult
+	err := db.QueryInto(&results, `
+		[:find ?name ?age
+		 :where [?e :person/name ?name]
+		        [?e :person/age ?age]
+		        [(> ?age 100)]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestQueryOneInto_SingleResult(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	var result PersonResult
+	err := db.QueryOneInto(&result, `
+		[:find ?name ?age
+		 :where [?e :person/name ?name]
+		        [?e :person/age ?age]
+		        [(= ?name "Alice")]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryOneInto failed: %v", err)
+	}
+
+	if result.Name != "Alice" {
+		t.Errorf("expected Name=Alice, got %q", result.Name)
+	}
+	if result.Age != 30 {
+		t.Errorf("expected Age=30, got %d", result.Age)
+	}
+}
+
+func TestQueryOneInto_NoResults(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	var result PersonResult
+	err := db.QueryOneInto(&result, `
+		[:find ?name ?age
+		 :where [?e :person/name ?name]
+		        [?e :person/age ?age]
+		        [(= ?name "NonExistent")]]
+	`)
+
+	if err == nil {
+		t.Fatal("expected error for no results")
+	}
+	if !errors.Is(err, dlreflect.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestQueryOneInto_MultipleResults(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	var result PersonResult
+	err := db.QueryOneInto(&result, `
+		[:find ?name ?age
+		 :where [?e :person/name ?name]
+		        [?e :person/age ?age]]
+	`)
+
+	if err == nil {
+		t.Fatal("expected error for multiple results")
+	}
+	if !errors.Is(err, dlreflect.ErrMultipleResults) {
+		t.Errorf("expected ErrMultipleResults, got %v", err)
+	}
+}
+
+func TestQueryInto_InvalidDest(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	// Test non-pointer
+	var results []PersonResult
+	err := db.QueryInto(results, `[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
+	if err == nil {
+		t.Error("expected error for non-pointer dest")
+	}
+
+	// Test pointer to non-slice
+	var single PersonResult
+	err = db.QueryInto(&single, `[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
+	if err == nil {
+		t.Error("expected error for pointer to non-slice")
+	}
+
+	// Test pointer to slice of non-structs
+	var ints []int
+	err = db.QueryInto(&ints, `[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
+	if err == nil {
+		t.Error("expected error for slice of non-structs")
+	}
+}
+
+func TestQueryOneInto_InvalidDest(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	// Test non-pointer
+	var result PersonResult
+	err := db.QueryOneInto(result, `[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age] [(= ?name "Alice")]]`)
+	if err == nil {
+		t.Error("expected error for non-pointer dest")
+	}
+
+	// Test pointer to non-struct
+	var str string
+	err = db.QueryOneInto(&str, `[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age] [(= ?name "Alice")]]`)
+	if err == nil {
+		t.Error("expected error for pointer to non-struct")
+	}
+}
+
+func TestQueryInto_SymbolNotFound(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	type BadStruct struct {
+		Name     string `datalog:"?name"`
+		NotThere string `datalog:"?notfound"` // This symbol doesn't exist in query
+	}
+
+	var results []BadStruct
+	err := db.QueryInto(&results, `
+		[:find ?name ?age
+		 :where [?e :person/name ?name]
+		        [?e :person/age ?age]]
+	`)
+
+	if err == nil {
+		t.Fatal("expected error for missing symbol")
+	}
+	if !errors.Is(err, dlreflect.ErrSymbolNotFound) {
+		t.Errorf("expected ErrSymbolNotFound, got %v", err)
+	}
+}
+
+func TestQueryInto_TypeCoercion(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	// Test int64 -> int coercion
+	type SmallResult struct {
+		Name string `datalog:"?name"`
+		Age  int    `datalog:"?age"` // int, not int64
+	}
+
+	var results []SmallResult
+	err := db.QueryInto(&results, `
+		[:find ?name ?age
+		 :where [?e :person/name ?name]
+		        [?e :person/age ?age]
+		        [(= ?name "Alice")]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if results[0].Age != 30 {
+		t.Errorf("expected Age=30, got %d", results[0].Age)
+	}
+}
+
+func TestQueryInto_ParseError(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	var results []PersonResult
+	err := db.QueryInto(&results, `[:find ?name :where [invalid syntax`)
+
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}

--- a/docs/archive/completed/QUERY_INTO_PROPOSAL.md
+++ b/docs/archive/completed/QUERY_INTO_PROPOSAL.md
@@ -1,0 +1,357 @@
+# Proposal: QueryInto[T] - Typed Query Results
+
+## Summary
+
+Add a `QueryInto` method that automatically populates typed Go structs from query results, eliminating the manual tuple iteration boilerplate that every downstream consumer currently writes.
+
+## Motivation
+
+### Current Pain Point
+
+Every query consumer writes the same boilerplate:
+
+```go
+results, err := db.Query(`
+    [:find ?symbol ?price ?volume ?date
+     :where [?t :trade/symbol ?symbol]
+            [?t :trade/price ?price]
+            [?t :trade/volume ?volume]
+            [?t :trade/date ?date]]
+`)
+if err != nil {
+    return err
+}
+
+// Every. Single. Consumer. Writes. This.
+trades := make([]Trade, 0, len(results))
+for _, row := range results {
+    trade := Trade{
+        Symbol: row[0].(string),
+        Price:  row[1].(float64),
+        Volume: row[2].(int64),
+        Date:   row[3].(time.Time),
+    }
+    trades = append(trades, trade)
+}
+```
+
+Problems with this approach:
+- **Duplicated code** - Same iteration logic at every call site
+- **Runtime panics** - Type assertions fail at runtime, not compile time
+- **Index errors** - Easy to get column order wrong (`row[2]` vs `row[3]`)
+- **Type mismatches** - Was it `int` or `int64`? `float32` or `float64`?
+- **No IDE support** - Magic indices, no autocomplete
+
+### Desired Experience
+
+```go
+var trades []Trade
+err := db.QueryInto(ctx, &trades, `
+    [:find ?symbol ?price ?volume ?date
+     :where [?t :trade/symbol ?symbol]
+            [?t :trade/price ?price]
+            [?t :trade/volume ?volume]
+            [?t :trade/date ?date]]
+`)
+```
+
+One line. Typed. Safe.
+
+## Design
+
+### API Surface
+
+```go
+// QueryInto executes a query and populates dest with typed results.
+// dest must be a pointer to a slice of structs.
+// Struct fields are matched to query results via `datalog` tags.
+func (db *Database) QueryInto(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+
+// QueryOneInto executes a query expecting exactly one result.
+// Returns ErrNotFound if no results, ErrMultipleResults if more than one.
+func (db *Database) QueryOneInto(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+```
+
+### Struct Tag Mapping
+
+Fields map to query variables via the `datalog` struct tag:
+
+```go
+type TradeResult struct {
+    Symbol string    `datalog:"?symbol"`
+    High   float64   `datalog:"?high"`
+    Date   time.Time `datalog:"?date"`
+}
+```
+
+The tag value matches the variable name in the `:find` clause.
+
+### Mapping Strategies
+
+#### Strategy 1: Positional (Simple)
+
+Match struct fields to `:find` clause by position:
+
+```go
+// Query: [:find ?symbol ?price ?date ...]
+type Result struct {
+    Symbol string    // position 0 -> ?symbol
+    Price  float64   // position 1 -> ?price
+    Date   time.Time // position 2 -> ?date
+}
+```
+
+**Pros:** No tags required for simple cases
+**Cons:** Fragile, order-dependent
+
+#### Strategy 2: Tag-Based (Recommended)
+
+Match struct fields to `:find` variables by tag:
+
+```go
+// Query: [:find ?symbol ?price ?date ...]
+type Result struct {
+    Date   time.Time `datalog:"?date"`   // matches ?date regardless of position
+    Symbol string    `datalog:"?symbol"` // matches ?symbol
+    Price  float64   `datalog:"?price"`  // matches ?price
+}
+```
+
+**Pros:** Order-independent, self-documenting, refactoring-safe
+**Cons:** Requires tags
+
+#### Strategy 3: Hybrid (Recommended Default)
+
+1. If struct has `datalog` tags, use tag-based mapping
+2. If no tags, fall back to positional mapping
+3. Mixed (some tagged, some not) returns an error
+
+### Type Coercion
+
+The implementation handles common type conversions:
+
+| Query Result | Struct Field | Conversion |
+|--------------|--------------|------------|
+| `int64` | `int` | Safe narrowing with overflow check |
+| `int64` | `int64` | Direct |
+| `float64` | `float32` | Narrowing |
+| `float64` | `float64` | Direct |
+| `string` | `string` | Direct |
+| `time.Time` | `time.Time` | Direct |
+| `time.Time` | `int64` | Unix timestamp |
+| `Identity` | `Identity` | Direct |
+| `Identity` | `string` | String representation |
+| `nil` | `*T` | nil pointer |
+| `nil` | `T` | Error (required field) |
+
+### Nullable Fields
+
+Use pointers for optional values:
+
+```go
+type Result struct {
+    Name  string   `datalog:"?name"`           // required
+    Email *string  `datalog:"?email,optional"` // nil if NULL/missing
+}
+```
+
+### Aggregation Results
+
+Works naturally with aggregations:
+
+```go
+type DeptStats struct {
+    Dept       string  `datalog:"?dept"`
+    TotalPay   float64 `datalog:"?total"`
+    HeadCount  int64   `datalog:"?count"`
+    AvgSalary  float64 `datalog:"?avg"`
+}
+
+var stats []DeptStats
+err := db.QueryInto(ctx, &stats, `
+    [:find ?dept (sum ?salary) (count ?emp) (avg ?salary)
+     :where [?emp :employee/dept ?dept]
+            [?emp :employee/salary ?salary]]
+`)
+```
+
+Note: Aggregation result variables use the pattern `(agg ?var)` -> `?var` for tag matching.
+
+## Implementation
+
+### Location
+
+`datalog/storage/database.go` - alongside existing `Query` method
+
+### Dependencies
+
+- Existing `Query` execution
+- Reflection machinery from `datalog/reflect/` package
+- Type conversion utilities
+
+### Implementation Sketch
+
+```go
+func (db *Database) QueryInto(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+    // 1. Validate dest is *[]T where T is a struct
+    destVal := reflect.ValueOf(dest)
+    if destVal.Kind() != reflect.Ptr || destVal.Elem().Kind() != reflect.Slice {
+        return fmt.Errorf("dest must be pointer to slice, got %T", dest)
+    }
+
+    sliceVal := destVal.Elem()
+    elemType := sliceVal.Type().Elem()
+    if elemType.Kind() != reflect.Struct {
+        return fmt.Errorf("slice element must be struct, got %v", elemType.Kind())
+    }
+
+    // 2. Execute query normally
+    results, err := db.Query(query, args...)
+    if err != nil {
+        return err
+    }
+
+    // 3. Parse :find clause to get variable names
+    findVars, err := parseQueryFindVars(query)
+    if err != nil {
+        return err
+    }
+
+    // 4. Build field mapping (tag -> field index)
+    fieldMap, err := buildFieldMapping(elemType, findVars)
+    if err != nil {
+        return err
+    }
+
+    // 5. Populate slice
+    newSlice := reflect.MakeSlice(sliceVal.Type(), 0, len(results))
+    for _, row := range results {
+        elem := reflect.New(elemType).Elem()
+        if err := populateStruct(elem, row, fieldMap); err != nil {
+            return fmt.Errorf("row %d: %w", i, err)
+        }
+        newSlice = reflect.Append(newSlice, elem)
+    }
+
+    sliceVal.Set(newSlice)
+    return nil
+}
+```
+
+### Error Handling
+
+```go
+var (
+    ErrNotFound        = errors.New("query returned no results")
+    ErrMultipleResults = errors.New("query returned multiple results")
+    ErrTypeMismatch    = errors.New("cannot convert query result to field type")
+    ErrMissingField    = errors.New("required field has no value")
+    ErrUnmappedColumn  = errors.New("query column has no matching struct field")
+)
+```
+
+## Examples
+
+### Basic Usage
+
+```go
+type Person struct {
+    Name string `datalog:"?name"`
+    Age  int64  `datalog:"?age"`
+}
+
+var people []Person
+err := db.QueryInto(ctx, &people, `
+    [:find ?name ?age
+     :where [?p :person/name ?name]
+            [?p :person/age ?age]
+            [(> ?age 21)]]
+`)
+```
+
+### With Input Parameters
+
+```go
+type Trade struct {
+    Price float64   `datalog:"?price"`
+    Time  time.Time `datalog:"?time"`
+}
+
+var trades []Trade
+err := db.QueryInto(ctx, &trades, `
+    [:find ?price ?time
+     :in $ ?symbol ?min-price
+     :where [?t :trade/symbol ?symbol]
+            [?t :trade/price ?price]
+            [?t :trade/time ?time]
+            [(> ?price ?min-price)]]
+`, "NVDA", 100.0)
+```
+
+### Single Result
+
+```go
+type MaxPrice struct {
+    Symbol string  `datalog:"?symbol"`
+    High   float64 `datalog:"?high"`
+}
+
+var result MaxPrice
+err := db.QueryOneInto(ctx, &result, `
+    [:find ?symbol (max ?price)
+     :in $ ?symbol
+     :where [?t :trade/symbol ?symbol]
+            [?t :trade/price ?price]]
+`, "NVDA")
+```
+
+### Anonymous Structs
+
+For one-off queries:
+
+```go
+var results []struct {
+    Symbol string  `datalog:"?symbol"`
+    Volume float64 `datalog:"?volume"`
+}
+err := db.QueryInto(ctx, &results, query)
+```
+
+## Testing Strategy
+
+1. **Unit tests** for type coercion (each type combination)
+2. **Unit tests** for mapping strategies (positional, tagged, hybrid)
+3. **Unit tests** for error cases (wrong types, missing fields, etc.)
+4. **Integration tests** with real queries against BadgerDB
+5. **Benchmark** vs manual iteration (should be comparable)
+
+## Migration Path
+
+- `Query` remains unchanged for power users and complex cases
+- `QueryInto` is additive, no breaking changes
+- Documentation recommends `QueryInto` for new code
+
+## Future Extensions
+
+1. **QueryBuilder integration** - `db.QueryInto(ctx, &results, queryBuilder)`
+2. **Streaming results** - `db.QueryIntoChannel(ctx, resultChan, query)`
+3. **Custom type handlers** - Register converters for custom types
+
+## Estimated Effort
+
+- **Core implementation**: 200-300 lines
+- **Tests**: 300-400 lines
+- **Documentation**: 100 lines
+
+**Timeline**: 1-2 days
+
+## Open Questions
+
+1. Should unmapped query columns be an error or silently ignored?
+   - Recommendation: Warning log, not error (allows SELECT * style flexibility)
+
+2. Should we support maps as dest (`[]map[string]interface{}`)?
+   - Recommendation: Not initially, structs only
+
+3. Should positional mapping require explicit opt-in?
+   - Recommendation: Yes, tag-based is safer default

--- a/docs/reference/QUERY_INTO.md
+++ b/docs/reference/QUERY_INTO.md
@@ -1,0 +1,319 @@
+# QueryInto API
+
+This document describes janus-datalog's QueryInto API for mapping Datalog query results directly into Go structs.
+
+## Overview
+
+The QueryInto API eliminates manual tuple iteration by populating typed Go structs from query results:
+
+- **`QueryInto()`** - Query into a slice of structs
+- **`QueryOneInto()`** - Query into a single struct (expects exactly one result)
+
+## Basic Usage
+
+### Define Result Struct
+
+Use the `datalog` tag to map struct fields to query columns:
+
+```go
+type PersonResult struct {
+    Name string `datalog:"?name"`
+    Age  int64  `datalog:"?age"`
+}
+```
+
+### Query Into Slice
+
+```go
+var results []PersonResult
+err := db.QueryInto(&results, `
+    [:find ?name ?age
+     :where [?e :person/name ?name]
+            [?e :person/age ?age]]
+`)
+
+for _, r := range results {
+    fmt.Printf("%s is %d years old\n", r.Name, r.Age)
+}
+```
+
+### Query Into Single Result
+
+```go
+var result PersonResult
+err := db.QueryOneInto(&result, `
+    [:find ?name ?age
+     :where [?e :person/name ?name]
+            [?e :person/age ?age]
+            [(= ?name "Alice")]]
+`)
+
+if errors.Is(err, dlreflect.ErrNotFound) {
+    fmt.Println("No matching person")
+} else if err != nil {
+    return err
+}
+```
+
+## Tag Mapping
+
+### Variable Tags
+
+Tags match the query's `:find` clause exactly:
+
+```go
+type Result struct {
+    Symbol string  `datalog:"?symbol"`  // matches :find ?symbol
+    Price  float64 `datalog:"?price"`   // matches :find ?price
+}
+
+// Query
+[:find ?symbol ?price :where ...]
+```
+
+### Aggregate Tags
+
+For aggregates, the tag must match the full aggregate expression:
+
+```go
+type DeptStats struct {
+    Dept      string  `datalog:"?dept"`          // matches :find ?dept
+    TotalPay  float64 `datalog:"(sum ?salary)"`  // matches :find (sum ?salary)
+    HeadCount int64   `datalog:"(count ?emp)"`   // matches :find (count ?emp)
+    MaxSalary float64 `datalog:"(max ?salary)"`  // matches :find (max ?salary)
+}
+
+// Query
+[:find ?dept (sum ?salary) (count ?emp) (max ?salary)
+ :where [?e :employee/dept ?dept]
+        [?e :employee/salary ?salary]]
+```
+
+### Positional Mapping
+
+If no fields have `datalog` tags, positional mapping is used:
+
+```go
+type PositionalResult struct {
+    Name string  // maps to column 0
+    Age  int64   // maps to column 1
+}
+
+// Query: [:find ?name ?age :where ...]
+// Column 0 (?name) -> Name, Column 1 (?age) -> Age
+```
+
+**Note:** Mixing tagged and untagged fields in the same struct is an error.
+
+## Query Inputs
+
+Use `:in` clause with additional arguments:
+
+```go
+var results []PersonResult
+err := db.QueryInto(&results, `
+    [:find ?name ?age
+     :in $ ?min-age
+     :where [?e :person/name ?name]
+            [?e :person/age ?age]
+            [(>= ?age ?min-age)]]
+`, int64(21))  // Bind ?min-age to 21
+```
+
+## Type Coercion
+
+QueryInto automatically converts between compatible types:
+
+| Query Result | Struct Field | Conversion |
+|--------------|--------------|------------|
+| `int64` | `int`, `int32`, `int64` | Numeric conversion |
+| `int64` | `uint64` | Numeric conversion |
+| `float64` | `float32`, `float64` | Numeric conversion |
+| `string` | `string` | Direct |
+| `bool` | `bool` | Direct |
+| `time.Time` | `time.Time` | Direct |
+| `[]byte` | `[]byte` | Direct |
+| `Identity` | `Identity` | Direct |
+| `Identity` | `*Identity` | Pointer set |
+| `Keyword` | `Keyword` | Direct |
+| `nil` | `*T` (pointer) | Leave nil |
+| `nil` | `T` (non-pointer) | Error |
+
+## Pointer Fields
+
+Use pointer fields for optional values:
+
+```go
+type WithOptional struct {
+    Name  string  `datalog:"?name"`
+    Email *string `datalog:"?email"`  // nil if not in query result
+}
+```
+
+## Error Types
+
+```go
+import dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
+
+// ErrNotFound - QueryOneInto returned no results
+if errors.Is(err, dlreflect.ErrNotFound) {
+    // Handle missing result
+}
+
+// ErrMultipleResults - QueryOneInto returned more than one result
+if errors.Is(err, dlreflect.ErrMultipleResults) {
+    // Handle unexpected multiple results
+}
+
+// ErrSymbolNotFound - Struct tag references symbol not in query
+if errors.Is(err, dlreflect.ErrSymbolNotFound) {
+    // Check struct tags match query :find clause
+}
+```
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "errors"
+    "fmt"
+    "os"
+
+    "github.com/wbrown/janus-datalog/datalog"
+    dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
+    "github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+type EmployeeStats struct {
+    Dept      string  `datalog:"?dept"`
+    AvgSalary float64 `datalog:"(avg ?salary)"`
+    Count     int64   `datalog:"(count ?emp)"`
+}
+
+func main() {
+    tmpDir, _ := os.MkdirTemp("", "example")
+    defer os.RemoveAll(tmpDir)
+
+    db, _ := storage.NewDatabase(tmpDir)
+    defer db.Close()
+
+    // Add test data
+    tx := db.NewTransaction()
+    for _, emp := range []struct {
+        name   string
+        dept   string
+        salary float64
+    }{
+        {"Alice", "Engineering", 100000},
+        {"Bob", "Engineering", 120000},
+        {"Charlie", "Sales", 80000},
+    } {
+        id := datalog.NewIdentity("emp:" + emp.name)
+        tx.Add(id, datalog.NewKeyword(":employee/name"), emp.name)
+        tx.Add(id, datalog.NewKeyword(":employee/dept"), emp.dept)
+        tx.Add(id, datalog.NewKeyword(":employee/salary"), emp.salary)
+    }
+    tx.Commit()
+
+    // Query with aggregates into typed slice
+    var stats []EmployeeStats
+    err := db.QueryInto(&stats, `
+        [:find ?dept (avg ?salary) (count ?emp)
+         :where [?emp :employee/dept ?dept]
+                [?emp :employee/salary ?salary]]
+    `)
+    if err != nil {
+        panic(err)
+    }
+
+    for _, s := range stats {
+        fmt.Printf("%s: %.0f avg salary, %d employees\n",
+            s.Dept, s.AvgSalary, s.Count)
+    }
+}
+```
+
+Output:
+```
+Engineering: 110000 avg salary, 2 employees
+Sales: 80000 avg salary, 1 employees
+```
+
+## Comparison with Manual Iteration
+
+**Before (manual):**
+```go
+results, err := db.ExecuteQuery(`[:find ?name ?age :where ...]`)
+if err != nil {
+    return err
+}
+
+type Person struct {
+    Name string
+    Age  int64
+}
+
+people := make([]Person, 0, len(results))
+for _, tuple := range results {
+    name, ok := tuple[0].(string)
+    if !ok {
+        return fmt.Errorf("expected string for name")
+    }
+    age, ok := tuple[1].(int64)
+    if !ok {
+        return fmt.Errorf("expected int64 for age")
+    }
+    people = append(people, Person{Name: name, Age: age})
+}
+```
+
+**After (QueryInto):**
+```go
+type Person struct {
+    Name string `datalog:"?name"`
+    Age  int64  `datalog:"?age"`
+}
+
+var people []Person
+err := db.QueryInto(&people, `[:find ?name ?age :where ...]`)
+```
+
+## Performance
+
+- **Reflection caching**: QueryResultMapper caches field mappings per struct type
+- **Single pass**: Results are mapped in a single iteration
+- **No intermediate allocation**: Results populate the destination slice directly
+- **Type coercion**: Handled at map time with minimal overhead
+
+## Relationship to Other APIs
+
+| API | Purpose | Use Case |
+|-----|---------|----------|
+| `QueryInto` | Query results → struct slice | Typed query results |
+| `QueryOneInto` | Query results → single struct | Single-row queries |
+| `PullInto` | Entity → struct | Load entity by ID |
+| `ExecuteQuery` | Query → `[][]interface{}` | Dynamic/untyped results |
+
+## Package Reference
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/storage"
+import dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
+
+// Database methods
+db.QueryInto(dest interface{}, queryStr string, inputs ...interface{}) error
+db.QueryOneInto(dest interface{}, queryStr string, inputs ...interface{}) error
+
+// Error types
+dlreflect.ErrNotFound
+dlreflect.ErrMultipleResults
+dlreflect.ErrSymbolNotFound
+dlreflect.ErrMixedTags
+
+// Low-level API (for advanced use)
+dlreflect.NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryResultMapper, error)
+mapper.MapTuple(tuple []interface{}, dest reflect.Value) error
+mapper.MapAll(tuples [][]interface{}, destSlice reflect.Value) error
+```


### PR DESCRIPTION
**TL;DR for Go developers:** Stop writing tuple iteration boilerplate. Define a struct with `datalog` tags, call `db.QueryInto(&results, query)`, and get typed results directly. Works with variables and aggregates.

Add QueryInto and QueryOneInto methods that populate Go structs directly from Datalog query results, eliminating manual tuple iteration and type assertions. This complements the existing PullInto (entity→struct) with query result mapping.

## Why This Matters

Before (manual iteration):
```go
results, _ := db.ExecuteQuery(`[:find ?name ?age :where ...]`)
people := make([]Person, 0, len(results))
for _, tuple := range results {
    name, _ := tuple[0].(string)
    age, _ := tuple[1].(int64)
    people = append(people, Person{Name: name, Age: age})
}
```

After (QueryInto):
```go
var people []Person
db.QueryInto(&people, `[:find ?name ?age :where ...]`)
```

## Features

### Basic Usage with Struct Tags
```go
type TradeResult struct {
    Symbol string    `datalog:"?symbol"`
    Price  float64   `datalog:"?price"`
    Time   time.Time `datalog:"?time"`
}

var results []TradeResult
db.QueryInto(&results, `
    [:find ?symbol ?price ?time
     :where [?t :trade/symbol ?symbol]
            [?t :trade/price ?price]
            [?t :trade/time ?time]]
`)
```

### Aggregate Queries
```go
type DeptStats struct {
    Dept      string  `datalog:"?dept"`
    TotalPay  float64 `datalog:"(sum ?salary)"`   // Full expression
    HeadCount int64   `datalog:"(count ?emp)"`
}

var stats []DeptStats
db.QueryInto(&stats, `
    [:find ?dept (sum ?salary) (count ?emp)
     :where [?e :employee/dept ?dept]
            [?e :employee/salary ?salary]]
`)
```

### Single Result Queries
```go
var result TradeResult
err := db.QueryOneInto(&result, query)
// Returns ErrNotFound if 0 results
// Returns ErrMultipleResults if >1 results
```

### Positional Mapping (No Tags)
```go
type Result struct {
    Name string  // Maps to column 0
    Age  int64   // Maps to column 1
}
// Fields map by position when no datalog tags present
```

## Tag Mapping Design

| Tag Format | Matches |
|------------|---------|
| `datalog:"?symbol"` | `:find ?symbol` |
| `datalog:"(sum ?x)"` | `:find (sum ?x)` |
| `datalog:"(count ?emp)"` | `:find (count ?emp)` |

Aggregate tags use the full expression to avoid ambiguity when both `?price` and `(max ?price)` appear in the same query.

## Type Coercion

| Query Result | Struct Field | Handling |
|--------------|--------------|----------|
| `int64` | `int`, `int32`, `uint64` | Numeric conversion | | `float64` | `float32`, `float64` | Numeric conversion | | `string` | `string` | Direct |
| `time.Time` | `time.Time` | Direct |
| `[]byte` | `[]byte` | Direct |
| `Identity` | `Identity`, `*Identity` | Direct/pointer | | `nil` | `*T` (pointer) | Leave nil |
| `nil` | `T` (non-pointer) | Error |

## Error Types

```go
import dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"

dlreflect.ErrNotFound         // QueryOneInto: no results
dlreflect.ErrMultipleResults  // QueryOneInto: >1 result
dlreflect.ErrSymbolNotFound   // Tag references missing symbol
dlreflect.ErrMixedTags        // Some fields tagged, some not
```

## Implementation

### New Files
- `datalog/reflect/query_reader.go` - QueryResultMapper for tuple→struct
- `datalog/reflect/query_reader_test.go` - 18 unit tests
- `datalog/storage/query_into_test.go` - 13 integration tests
- `docs/reference/QUERY_INTO.md` - Complete API reference

### Modified Files
- `datalog/storage/database.go` - QueryInto, QueryOneInto methods

### Test Coverage
- NewQueryResultMapper: 91.9%
- MapTuple: 64.3%
- setQueryValue: 69.6%

## Documentation Updates

- `README.md` - Added QueryInto API section in Tutorial
- `DATOMIC_COMPATIBILITY.md` - Added Section 14: QueryInto API
- `CLAUDE.md` - Added to Core Features Complete (#26)
- `docs/reference/QUERY_INTO.md` - Full reference documentation

Also fixed documentation inconsistencies:
- Removed duplicate NOT/OR section from Missing Features
- Fixed section numbering throughout DATOMIC_COMPATIBILITY.md
- Clarified Schema section as "Partial Support"