### PR TITLE
Add Explain and Analyze methods to Database API

### DIFF
--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -411,6 +412,217 @@ func (d *Database) ExecuteQueryWithInputs(queryStr string, inputs ...interface{}
 
 	// Convert result to [][]interface{}
 	return relationToSlice(result), nil
+}
+
+// Explain returns the query plan for a query without executing it.
+// This is useful for understanding index selection, phase structure, and
+// how input parameters affect symbol binding.
+//
+// Example:
+//
+//	plan, err := db.Explain(`[:find ?e :in $ ?scenario :where [?e :task/scenario ?scenario]]`, scenarioID)
+//	if err != nil { ... }
+//	fmt.Println(plan.String())  // Human-readable plan output
+//
+// The plan shows:
+//   - Index selection (EAVT, AEVT, AVET, VAET, TAEV)
+//   - Selectivity scores for patterns
+//   - Symbol availability and binding through phases
+//   - Predicate and expression assignment
+func (d *Database) Explain(queryStr string, inputs ...interface{}) (*planner.QueryPlan, error) {
+	// Parse the query
+	q, err := parser.ParseQuery(queryStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	// Validate inputs match :in clause (same validation as ExecuteQueryWithInputs)
+	_, err = d.convertInputsToRelations(q, inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create executor to get its planner (ensures same options as execution)
+	exec := d.NewExecutor()
+
+	// Get the query plan from the executor's planner
+	// Use GetUnderlyingPlanner() to get QueryPlan (not RealizedPlan)
+	queryPlanner := exec.GetPlanner()
+	if adapter, ok := queryPlanner.(*planner.PlannerAdapter); ok {
+		return adapter.GetUnderlyingPlanner().Plan(q)
+	}
+
+	// Fallback for other planner types
+	realizedPlan, err := queryPlanner.PlanQuery(q)
+	if err != nil {
+		return nil, fmt.Errorf("failed to plan query: %w", err)
+	}
+	// Return minimal QueryPlan from RealizedPlan
+	return &planner.QueryPlan{Query: realizedPlan.Query}, nil
+}
+
+// AnalyzeResult contains the query plan and execution statistics from Analyze().
+type AnalyzeResult struct {
+	Plan      *planner.QueryPlan   // The query plan
+	Result    executor.Relation    // Query result (not materialized)
+	Events    []annotations.Event  // All annotation events from execution
+	TotalTime time.Duration        // Total execution time
+}
+
+// String returns a formatted analysis report showing the query plan
+// and execution statistics.
+func (ar *AnalyzeResult) String() string {
+	var sb strings.Builder
+
+	// Plan section
+	sb.WriteString(ar.Plan.String())
+	sb.WriteString("\n")
+
+	// Execution summary
+	sb.WriteString("Execution:\n")
+	sb.WriteString(fmt.Sprintf("  Total time: %v\n", ar.TotalTime))
+	size := ar.Result.Size()
+	if size >= 0 {
+		sb.WriteString(fmt.Sprintf("  Result rows: %d\n", size))
+	} else {
+		sb.WriteString("  Result rows: (streaming - call Result.Size() to materialize)\n")
+	}
+
+	// Group events by type for summary
+	eventCounts := make(map[string]int)
+	eventTimes := make(map[string]time.Duration)
+	for _, e := range ar.Events {
+		eventCounts[e.Name]++
+		eventTimes[e.Name] += e.Latency
+	}
+
+	if len(eventCounts) > 0 {
+		sb.WriteString("\nEvent Summary:\n")
+
+		// Pattern matching events
+		if t, ok := eventTimes[annotations.PatternStorageScan]; ok {
+			sb.WriteString(fmt.Sprintf("  Storage scans: %d (%.2fms total)\n",
+				eventCounts[annotations.PatternStorageScan], float64(t.Microseconds())/1000))
+		}
+
+		// Join events
+		hashJoins := eventCounts[annotations.JoinHash]
+		nestedJoins := eventCounts[annotations.JoinNested]
+		mergeJoins := eventCounts[annotations.JoinMerge]
+		if hashJoins+nestedJoins+mergeJoins > 0 {
+			sb.WriteString(fmt.Sprintf("  Joins: hash=%d, nested=%d, merge=%d\n",
+				hashJoins, nestedJoins, mergeJoins))
+			if t := eventTimes[annotations.JoinHash]; t > 0 {
+				sb.WriteString(fmt.Sprintf("    Hash join time: %.2fms\n", float64(t.Microseconds())/1000))
+			}
+		}
+
+		// Phase events
+		if t, ok := eventTimes[annotations.PhaseComplete]; ok {
+			sb.WriteString(fmt.Sprintf("  Phases completed: %d (%.2fms total)\n",
+				eventCounts[annotations.PhaseComplete], float64(t.Microseconds())/1000))
+		}
+	}
+
+	// Detailed event trace
+	sb.WriteString("\nEvent Trace:\n")
+	for _, e := range ar.Events {
+		sb.WriteString(fmt.Sprintf("  [%6.2fms] %s", float64(e.Latency.Microseconds())/1000, e.Name))
+		// Add key metrics from Data
+		if e.Data != nil {
+			if tuples, ok := e.Data["tuples"]; ok {
+				sb.WriteString(fmt.Sprintf(" (tuples=%v)", tuples))
+			}
+			if inputSize, ok := e.Data["input_size"]; ok {
+				sb.WriteString(fmt.Sprintf(" (input=%v)", inputSize))
+			}
+			if outputSize, ok := e.Data["output_size"]; ok {
+				sb.WriteString(fmt.Sprintf(" (output=%v)", outputSize))
+			}
+			if index, ok := e.Data["index"]; ok {
+				sb.WriteString(fmt.Sprintf(" (index=%v)", index))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// Analyze executes a query and returns detailed execution statistics.
+// This is like EXPLAIN ANALYZE in PostgreSQL - it actually runs the query
+// and captures timing information at each step.
+//
+// Example:
+//
+//	result, err := db.Analyze(`[:find ?e :in $ ?scenario :where [?e :task/scenario ?scenario]]`, scenarioID)
+//	if err != nil { ... }
+//	fmt.Println(result.String())  // Shows plan + execution trace
+//
+// The result includes:
+//   - Query plan with index selection
+//   - Query result as a Relation (call .Size() or iterate to access)
+//   - Event trace with timing for each operation
+//   - Summary statistics
+func (d *Database) Analyze(queryStr string, inputs ...interface{}) (*AnalyzeResult, error) {
+	startTime := time.Now()
+
+	// Parse the query
+	q, err := parser.ParseQuery(queryStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	// Validate and convert inputs
+	inputRelations, err := d.convertInputsToRelations(q, inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create executor (this also creates the planner with proper options)
+	exec := d.NewExecutor()
+
+	// Get the query plan from the executor's planner
+	// Use GetUnderlyingPlanner() to get QueryPlan (not RealizedPlan)
+	queryPlanner := exec.GetPlanner()
+	var plan *planner.QueryPlan
+	if adapter, ok := queryPlanner.(*planner.PlannerAdapter); ok {
+		plan, err = adapter.GetUnderlyingPlanner().Plan(q)
+	} else {
+		// Fallback for other planner types - get RealizedPlan and note it in output
+		// This shouldn't happen with default options, but handles edge cases
+		realizedPlan, planErr := queryPlanner.PlanQuery(q)
+		if planErr != nil {
+			return nil, fmt.Errorf("failed to plan query: %w", planErr)
+		}
+		// Create a minimal QueryPlan from RealizedPlan for display
+		plan = &planner.QueryPlan{Query: realizedPlan.Query}
+		err = nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to plan query: %w", err)
+	}
+
+	// Create a collector to capture all events
+	var events []annotations.Event
+	collector := annotations.NewCollector(func(e annotations.Event) {
+		events = append(events, e)
+	})
+
+	// Execute with annotation collection
+	result, err := exec.ExecuteWithRelations(executor.NewContext(collector.Handler()), q, inputRelations)
+	if err != nil {
+		return nil, fmt.Errorf("query execution failed: %w", err)
+	}
+
+	totalTime := time.Since(startTime)
+
+	return &AnalyzeResult{
+		Plan:      plan,
+		Result:    result,
+		Events:    events,
+		TotalTime: totalTime,
+	}, nil
 }
 
 // QueryInto executes a Datalog query and populates a slice of structs with the results.

--- a/datalog/storage/explain_test.go
+++ b/datalog/storage/explain_test.go
@@ -1,0 +1,271 @@
+package storage
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+)
+
+// TestExplain tests the Explain method for query plan introspection
+func TestExplain(t *testing.T) {
+	// Create temporary database
+	dir, err := os.MkdirTemp("", "explain-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Add test data
+	tx := db.NewTransaction()
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	scenario1 := datalog.NewIdentity("scenario-1")
+
+	tx.Add(alice, datalog.NewKeyword(":task/name"), "Task A")
+	tx.Add(alice, datalog.NewKeyword(":task/scenario"), scenario1)
+	tx.Add(bob, datalog.NewKeyword(":task/name"), "Task B")
+	tx.Add(bob, datalog.NewKeyword(":task/scenario"), scenario1)
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	t.Run("simple pattern shows index selection", func(t *testing.T) {
+		plan, err := db.Explain(`[:find ?e :where [?e :task/name "Task A"]]`)
+		if err != nil {
+			t.Fatalf("Explain failed: %v", err)
+		}
+
+		planStr := plan.String()
+		t.Logf("Plan:\n%s", planStr)
+
+		// AVET index should be selected when attribute and value are bound
+		if !strings.Contains(planStr, "AVET index") {
+			t.Errorf("Expected AVET index for attribute+value bound pattern, got:\n%s", planStr)
+		}
+	})
+
+	t.Run("entity-only pattern uses EAVT", func(t *testing.T) {
+		plan, err := db.Explain(`[:find ?a ?v :in $ ?e :where [?e ?a ?v]]`, alice)
+		if err != nil {
+			t.Fatalf("Explain failed: %v", err)
+		}
+
+		planStr := plan.String()
+		t.Logf("Plan:\n%s", planStr)
+
+		// EAVT index should be selected when only entity is bound
+		if !strings.Contains(planStr, "EAVT index") {
+			t.Errorf("Expected EAVT index for entity-only bound pattern, got:\n%s", planStr)
+		}
+	})
+
+	t.Run("with input parameter shows available symbols", func(t *testing.T) {
+		plan, err := db.Explain(
+			`[:find ?e :in $ ?scenario :where [?e :task/scenario ?scenario]]`,
+			scenario1,
+		)
+		if err != nil {
+			t.Fatalf("Explain failed: %v", err)
+		}
+
+		planStr := plan.String()
+		t.Logf("Plan:\n%s", planStr)
+
+		// Input parameter should show as available
+		if !strings.Contains(planStr, "Available:") && !strings.Contains(planStr, "?scenario") {
+			t.Logf("Note: Input parameters may not be shown in Available (they're in :in clause)")
+		}
+
+		// AVET should be selected (attribute + value from input)
+		if !strings.Contains(planStr, "AVET index") {
+			t.Errorf("Expected AVET index for input-bound value pattern, got:\n%s", planStr)
+		}
+	})
+
+	t.Run("shows bound mask", func(t *testing.T) {
+		plan, err := db.Explain(`[:find ?e :where [?e :task/name "Task A"]]`)
+		if err != nil {
+			t.Fatalf("Explain failed: %v", err)
+		}
+
+		planStr := plan.String()
+		t.Logf("Plan:\n%s", planStr)
+
+		// Should show which components are bound
+		if !strings.Contains(planStr, "Bound:") {
+			t.Errorf("Expected bound mask in output, got:\n%s", planStr)
+		}
+		if !strings.Contains(planStr, "A=true") {
+			t.Errorf("Expected A=true for bound attribute, got:\n%s", planStr)
+		}
+		if !strings.Contains(planStr, "V=true") {
+			t.Errorf("Expected V=true for bound value, got:\n%s", planStr)
+		}
+	})
+
+	t.Run("invalid query returns error", func(t *testing.T) {
+		_, err := db.Explain(`[:find ?e :where]`) // missing pattern
+		if err == nil {
+			t.Error("Expected error for invalid query, got nil")
+		}
+	})
+
+	t.Run("wrong number of inputs returns error", func(t *testing.T) {
+		_, err := db.Explain(
+			`[:find ?e :in $ ?x ?y :where [?e :task/name ?x]]`,
+			"only-one-input", // missing second input
+		)
+		if err == nil {
+			t.Error("Expected error for wrong number of inputs, got nil")
+		}
+	})
+}
+
+// TestAnalyze tests the Analyze method for query execution tracing
+func TestAnalyze(t *testing.T) {
+	// Create temporary database
+	dir, err := os.MkdirTemp("", "analyze-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Add test data
+	tx := db.NewTransaction()
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	charlie := datalog.NewIdentity("charlie")
+	scenario1 := datalog.NewIdentity("scenario-1")
+
+	tx.Add(alice, datalog.NewKeyword(":task/name"), "Task A")
+	tx.Add(alice, datalog.NewKeyword(":task/scenario"), scenario1)
+	tx.Add(bob, datalog.NewKeyword(":task/name"), "Task B")
+	tx.Add(bob, datalog.NewKeyword(":task/scenario"), scenario1)
+	tx.Add(charlie, datalog.NewKeyword(":task/name"), "Task C")
+	tx.Add(charlie, datalog.NewKeyword(":task/scenario"), scenario1)
+
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	t.Run("returns plan and events", func(t *testing.T) {
+		result, err := db.Analyze(`[:find ?e :where [?e :task/name ?name]]`)
+		if err != nil {
+			t.Fatalf("Analyze failed: %v", err)
+		}
+
+		// Check we got a plan
+		if result.Plan == nil {
+			t.Error("Expected plan, got nil")
+		}
+
+		// Check we got events
+		if len(result.Events) == 0 {
+			t.Error("Expected events, got none")
+		}
+
+		// Check we have timing
+		if result.TotalTime == 0 {
+			t.Error("Expected non-zero total time")
+		}
+
+		t.Logf("Analyze result:\n%s", result.String())
+	})
+
+	t.Run("captures storage scan events", func(t *testing.T) {
+		result, err := db.Analyze(`[:find ?e :where [?e :task/name ?name]]`)
+		if err != nil {
+			t.Fatalf("Analyze failed: %v", err)
+		}
+
+		// Look for storage scan events
+		foundScan := false
+		for _, e := range result.Events {
+			if e.Name == annotations.PatternStorageScan {
+				foundScan = true
+				break
+			}
+		}
+
+		if !foundScan {
+			t.Log("Note: No storage scan events captured (may depend on executor path)")
+		}
+	})
+
+	t.Run("with input parameter", func(t *testing.T) {
+		result, err := db.Analyze(
+			`[:find ?e :in $ ?scenario :where [?e :task/scenario ?scenario]]`,
+			scenario1,
+		)
+		if err != nil {
+			t.Fatalf("Analyze failed: %v", err)
+		}
+
+		// Should have 3 results
+		if result.Result.Size() != 3 {
+			t.Errorf("Expected 3 results, got %d", result.Result.Size())
+		}
+
+		t.Logf("Analyze with input:\n%s", result.String())
+	})
+
+	t.Run("String output includes plan and execution", func(t *testing.T) {
+		result, err := db.Analyze(`[:find ?e :where [?e :task/name "Task A"]]`)
+		if err != nil {
+			t.Fatalf("Analyze failed: %v", err)
+		}
+
+		output := result.String()
+
+		// Check for plan section
+		if !strings.Contains(output, "Query Plan:") {
+			t.Error("Expected 'Query Plan:' in output")
+		}
+
+		// Check for execution section
+		if !strings.Contains(output, "Execution:") {
+			t.Error("Expected 'Execution:' in output")
+		}
+
+		// Check for event trace
+		if !strings.Contains(output, "Event Trace:") {
+			t.Error("Expected 'Event Trace:' in output")
+		}
+	})
+
+	t.Run("join query captures join events", func(t *testing.T) {
+		// Add some data that requires a join
+		tx := db.NewTransaction()
+		tx.Add(alice, datalog.NewKeyword(":task/priority"), int64(1))
+		tx.Add(bob, datalog.NewKeyword(":task/priority"), int64(2))
+		_, _ = tx.Commit()
+
+		result, err := db.Analyze(`[:find ?name ?priority
+			:where
+			[?e :task/name ?name]
+			[?e :task/priority ?priority]]`)
+		if err != nil {
+			t.Fatalf("Analyze failed: %v", err)
+		}
+
+		t.Logf("Join query analysis:\n%s", result.String())
+	})
+}


### PR DESCRIPTION
Introduce query introspection capabilities:

- `Explain(query, inputs...)` returns the query plan without executing, showing index selection, phase structure, and symbol binding

- `Analyze(query, inputs...)` executes with annotation collection, returning plan + execution trace with timing breakdown

These methods help diagnose query performance issues by revealing:
- Which indices are selected for each pattern
- How phases are structured and symbols flow between them
- Where time is spent during execution (joins, storage scans, etc.)

Example usage:
```golang
plan, _ := db.Explain(`[:find ?e :where [?e :task/name ?n]]`)
fmt.Println(plan.String())

result, _ := db.Analyze(`[:find ?e :in $ ?id  :where [?e :task/id ?id]]`,
                       id)
fmt.Println(result.String())  // Shows plan + execution trace
  ```