### PR TITLE
Consolidate key encoders with shared base implementation

### DIFF
--- a/datalog/storage/key_encoder_base.go
+++ b/datalog/storage/key_encoder_base.go
@@ -1,0 +1,253 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// ComponentEncoder handles encoding/decoding of individual key components.
+// This interface abstracts the difference between L85 and Binary encoding.
+type ComponentEncoder interface {
+	// Encoding
+	EncodeEntity(e [20]byte) []byte
+	EncodeAttr(a [32]byte) []byte
+	EncodeTx(tx [20]byte) []byte
+	EncodeValue(v datalog.Value) []byte
+
+	// Decoding
+	DecodeEntity(b []byte) ([20]byte, error)
+	DecodeAttr(b []byte) ([32]byte, error)
+	DecodeTx(b []byte) ([20]byte, error)
+	// DecodeValue decodes value bytes extracted from a key
+	// For L85, this detects and decodes L85-encoded RefValues
+	DecodeValue(b []byte) []byte
+
+	// Sizes (L85 expands bytes, Binary keeps them same size)
+	EntitySize() int // 25 for L85, 20 for Binary
+	AttrSize() int   // 40 for L85, 32 for Binary
+	TxSize() int     // 25 for L85, 20 for Binary
+
+	// Prefix encoding (L85 needs special handling)
+	EncodePrefixParts(index IndexType, parts [][]byte) []byte
+}
+
+// baseKeyEncoder implements KeyEncoder using a pluggable ComponentEncoder.
+// This consolidates the shared index ordering logic.
+type baseKeyEncoder struct {
+	comp ComponentEncoder
+}
+
+// EncodeKey creates an index key from a datom using the component encoder
+func (e *baseKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
+	sd := ToStorageDatom(*d)
+	prefix := []byte{byte(index)}
+
+	eEnc := e.comp.EncodeEntity(sd.E)
+	aEnc := e.comp.EncodeAttr(sd.A)
+	txEnc := e.comp.EncodeTx(sd.Tx)
+	vEnc := e.comp.EncodeValue(sd.V)
+
+	// Build key based on index type - this ordering is shared by all encoders
+	switch index {
+	case EAVT:
+		return concatBytes(prefix, eEnc, aEnc, vEnc, txEnc)
+	case AEVT:
+		return concatBytes(prefix, aEnc, eEnc, vEnc, txEnc)
+	case AVET:
+		return concatBytes(prefix, aEnc, vEnc, eEnc, txEnc)
+	case VAET:
+		return concatBytes(prefix, vEnc, aEnc, eEnc, txEnc)
+	case TAEV:
+		return concatBytes(prefix, txEnc, aEnc, eEnc, vEnc)
+	default:
+		panic(fmt.Sprintf("unknown index type: %v", index))
+	}
+}
+
+// DecodeKey extracts components from an index key
+func (e *baseKeyEncoder) DecodeKey(index IndexType, key []byte) (entity, attr, value, tx []byte, err error) {
+	if len(key) < 1 {
+		return nil, nil, nil, nil, fmt.Errorf("key too short")
+	}
+
+	// Skip the 1-byte prefix
+	key = key[1:]
+
+	eSize := e.comp.EntitySize()
+	aSize := e.comp.AttrSize()
+	txSize := e.comp.TxSize()
+
+	switch index {
+	case EAVT:
+		minSize := eSize + aSize + txSize
+		if len(key) < minSize {
+			return nil, nil, nil, nil, fmt.Errorf("EAVT key too short")
+		}
+		eArr, _ := e.comp.DecodeEntity(key[0:eSize])
+		entity = eArr[:]
+		aArr, _ := e.comp.DecodeAttr(key[eSize : eSize+aSize])
+		attr = aArr[:]
+		value = e.comp.DecodeValue(key[eSize+aSize : len(key)-txSize])
+		txArr, _ := e.comp.DecodeTx(key[len(key)-txSize:])
+		tx = txArr[:]
+
+	case AEVT:
+		minSize := aSize + eSize + txSize
+		if len(key) < minSize {
+			return nil, nil, nil, nil, fmt.Errorf("AEVT key too short")
+		}
+		aArr, _ := e.comp.DecodeAttr(key[0:aSize])
+		attr = aArr[:]
+		eArr, _ := e.comp.DecodeEntity(key[aSize : aSize+eSize])
+		entity = eArr[:]
+		value = e.comp.DecodeValue(key[aSize+eSize : len(key)-txSize])
+		txArr, _ := e.comp.DecodeTx(key[len(key)-txSize:])
+		tx = txArr[:]
+
+	case AVET:
+		minSize := aSize + eSize + txSize
+		if len(key) < minSize {
+			return nil, nil, nil, nil, fmt.Errorf("AVET key too short")
+		}
+		aArr, _ := e.comp.DecodeAttr(key[0:aSize])
+		attr = aArr[:]
+		txArr, _ := e.comp.DecodeTx(key[len(key)-txSize:])
+		tx = txArr[:]
+		eArr, _ := e.comp.DecodeEntity(key[len(key)-txSize-eSize : len(key)-txSize])
+		entity = eArr[:]
+		value = e.comp.DecodeValue(key[aSize : len(key)-txSize-eSize])
+
+	case VAET:
+		minSize := aSize + eSize + txSize
+		if len(key) < minSize {
+			return nil, nil, nil, nil, fmt.Errorf("VAET key too short")
+		}
+		txArr, _ := e.comp.DecodeTx(key[len(key)-txSize:])
+		tx = txArr[:]
+		eArr, _ := e.comp.DecodeEntity(key[len(key)-txSize-eSize : len(key)-txSize])
+		entity = eArr[:]
+		aArr, _ := e.comp.DecodeAttr(key[len(key)-txSize-eSize-aSize : len(key)-txSize-eSize])
+		attr = aArr[:]
+		value = e.comp.DecodeValue(key[0 : len(key)-txSize-eSize-aSize])
+
+	case TAEV:
+		minSize := txSize + aSize + eSize
+		if len(key) < minSize {
+			return nil, nil, nil, nil, fmt.Errorf("TAEV key too short")
+		}
+		txArr, _ := e.comp.DecodeTx(key[0:txSize])
+		tx = txArr[:]
+		aArr, _ := e.comp.DecodeAttr(key[txSize : txSize+aSize])
+		attr = aArr[:]
+		eArr, _ := e.comp.DecodeEntity(key[txSize+aSize : txSize+aSize+eSize])
+		entity = eArr[:]
+		value = e.comp.DecodeValue(key[txSize+aSize+eSize:])
+
+	default:
+		return nil, nil, nil, nil, fmt.Errorf("unknown index type: %v", index)
+	}
+
+	return entity, attr, value, tx, nil
+}
+
+// EncodePrefix creates a prefix key for range scans
+func (e *baseKeyEncoder) EncodePrefix(index IndexType, parts ...[]byte) []byte {
+	prefix := []byte{byte(index)}
+	encodedParts := e.comp.EncodePrefixParts(index, parts)
+	return concatBytes(prefix, encodedParts)
+}
+
+// EncodePrefixRange creates start and end keys for a prefix scan
+func (e *baseKeyEncoder) EncodePrefixRange(index IndexType, parts ...[]byte) (start, end []byte) {
+	start = e.EncodePrefix(index, parts...)
+
+	// End key is start with last byte incremented
+	end = make([]byte, len(start))
+	copy(end, start)
+
+	// Increment last byte, or append 0xFF if it would overflow
+	for i := len(end) - 1; i >= 0; i-- {
+		if end[i] < 0xFF {
+			end[i]++
+			break
+		}
+		if i == 0 {
+			// All bytes are 0xFF, append one more
+			end = append(end, 0x00)
+		}
+	}
+
+	return start, end
+}
+
+// historyIndexToBase maps history index types to their base current-state equivalents
+func historyIndexToBase(index IndexType) IndexType {
+	switch index {
+	case EAVT_HISTORY:
+		return EAVT
+	case AEVT_HISTORY:
+		return AEVT
+	case AVET_HISTORY:
+		return AVET
+	case VAET_HISTORY:
+		return VAET
+	case TAEV_HISTORY:
+		return TAEV
+	default:
+		return index
+	}
+}
+
+// EncodeHistoryKey creates an index key with Op appended for history indices
+func (e *baseKeyEncoder) EncodeHistoryKey(index IndexType, d *datalog.Datom, op Op) []byte {
+	sd := ToStorageDatom(*d)
+	prefix := []byte{byte(index)}
+
+	eEnc := e.comp.EncodeEntity(sd.E)
+	aEnc := e.comp.EncodeAttr(sd.A)
+	txEnc := e.comp.EncodeTx(sd.Tx)
+	vEnc := e.comp.EncodeValue(sd.V)
+
+	// Op encoding: 0x01 = assert (true), 0x00 = retract (false)
+	opByte := byte(0x00)
+	if op {
+		opByte = 0x01
+	}
+
+	// Build key based on base index type, then append Op
+	baseIndex := historyIndexToBase(index)
+	switch baseIndex {
+	case EAVT:
+		return concatBytes(prefix, eEnc, aEnc, vEnc, txEnc, []byte{opByte})
+	case AEVT:
+		return concatBytes(prefix, aEnc, eEnc, vEnc, txEnc, []byte{opByte})
+	case AVET:
+		return concatBytes(prefix, aEnc, vEnc, eEnc, txEnc, []byte{opByte})
+	case VAET:
+		return concatBytes(prefix, vEnc, aEnc, eEnc, txEnc, []byte{opByte})
+	case TAEV:
+		return concatBytes(prefix, txEnc, aEnc, eEnc, vEnc, []byte{opByte})
+	default:
+		panic(fmt.Sprintf("unknown history index type: %v", index))
+	}
+}
+
+// DecodeHistoryKey extracts components including Op from a history index key
+func (e *baseKeyEncoder) DecodeHistoryKey(index IndexType, key []byte) (entity, attr, value, tx []byte, op Op, err error) {
+	if len(key) < 2 { // At minimum: prefix + op
+		return nil, nil, nil, nil, false, fmt.Errorf("history key too short")
+	}
+
+	// Op is the last byte
+	opByte := key[len(key)-1]
+	op = opByte == 0x01
+
+	// Decode the rest as a normal key (without the Op byte)
+	keyWithoutOp := key[:len(key)-1]
+
+	// Use the base index type for decoding
+	baseIndex := historyIndexToBase(index)
+	entity, attr, value, tx, err = e.DecodeKey(baseIndex, keyWithoutOp)
+	return entity, attr, value, tx, op, err
+}

--- a/datalog/storage/key_encoder_binary.go
+++ b/datalog/storage/key_encoder_binary.go
@@ -1,229 +1,116 @@
 package storage
 
 import (
-	"fmt"
-
 	"github.com/wbrown/janus-datalog/datalog"
 )
 
+// binaryComponentEncoder implements ComponentEncoder using raw binary
+type binaryComponentEncoder struct{}
+
+func (c *binaryComponentEncoder) EncodeEntity(e [20]byte) []byte {
+	return e[:]
+}
+
+func (c *binaryComponentEncoder) EncodeAttr(a [32]byte) []byte {
+	return a[:]
+}
+
+func (c *binaryComponentEncoder) EncodeTx(tx [20]byte) []byte {
+	return tx[:]
+}
+
+func (c *binaryComponentEncoder) EncodeValue(v datalog.Value) []byte {
+	vType := byte(datalog.Type(v))
+	vData := datalog.ValueBytes(v)
+	return append([]byte{vType}, vData...)
+}
+
+func (c *binaryComponentEncoder) DecodeEntity(b []byte) ([20]byte, error) {
+	var arr [20]byte
+	copy(arr[:], b)
+	return arr, nil
+}
+
+func (c *binaryComponentEncoder) DecodeAttr(b []byte) ([32]byte, error) {
+	var arr [32]byte
+	copy(arr[:], b)
+	return arr, nil
+}
+
+func (c *binaryComponentEncoder) DecodeTx(b []byte) ([20]byte, error) {
+	var arr [20]byte
+	copy(arr[:], b)
+	return arr, nil
+}
+
+func (c *binaryComponentEncoder) DecodeValue(b []byte) []byte {
+	// Binary encoding doesn't transform values
+	return b
+}
+
+func (c *binaryComponentEncoder) EntitySize() int { return 20 }
+func (c *binaryComponentEncoder) AttrSize() int   { return 32 }
+func (c *binaryComponentEncoder) TxSize() int     { return 20 }
+
+func (c *binaryComponentEncoder) EncodePrefixParts(index IndexType, parts [][]byte) []byte {
+	// Binary encoding doesn't transform parts
+	return concatBytes(parts...)
+}
+
 // BinaryKeyEncoder implements KeyEncoder using raw binary for space efficiency
-type BinaryKeyEncoder struct{}
+type BinaryKeyEncoder struct {
+	baseKeyEncoder
+}
+
+// ensureInitialized lazily initializes the component encoder
+func (e *BinaryKeyEncoder) ensureInitialized() {
+	if e.comp == nil {
+		e.comp = &binaryComponentEncoder{}
+	}
+}
 
 // EncodeKey creates a binary index key from a datom
 func (e *BinaryKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
-	// Convert to storage datom first
-	sd := ToStorageDatom(*d)
-
-	// Each index has a 1-byte prefix to separate namespaces
-	prefix := []byte{byte(index)}
-
-	// Get value bytes with type prefix (1 byte type + variable length data)
-	vType := byte(datalog.Type(sd.V))
-	vData := datalog.ValueBytes(sd.V)
-	vBytes := append([]byte{vType}, vData...)
-
-	// Build key based on index type using raw bytes
-	switch index {
-	case EAVT:
-		// Entity + Attribute + Value + Tx
-		return concatBytes(prefix, sd.E[:], sd.A[:], vBytes, sd.Tx[:])
-
-	case AEVT:
-		// Attribute + Entity + Value + Tx
-		return concatBytes(prefix, sd.A[:], sd.E[:], vBytes, sd.Tx[:])
-
-	case AVET:
-		// Attribute + Value + Entity + Tx
-		return concatBytes(prefix, sd.A[:], vBytes, sd.E[:], sd.Tx[:])
-
-	case VAET:
-		// Value + Attribute + Entity + Tx
-		return concatBytes(prefix, vBytes, sd.A[:], sd.E[:], sd.Tx[:])
-
-	case TAEV:
-		// Tx + Attribute + Entity + Value
-		return concatBytes(prefix, sd.Tx[:], sd.A[:], sd.E[:], vBytes)
-
-	default:
-		panic(fmt.Sprintf("unknown index type: %v", index))
-	}
+	e.ensureInitialized()
+	return e.baseKeyEncoder.EncodeKey(index, d)
 }
 
 // DecodeKey extracts components from a binary index key
 func (e *BinaryKeyEncoder) DecodeKey(index IndexType, key []byte) (entity, attr, value, tx []byte, err error) {
-	if len(key) < 1 {
-		return nil, nil, nil, nil, fmt.Errorf("key too short")
-	}
-
-	// Skip the 1-byte prefix
-	key = key[1:]
-
-	// Component sizes: Entity=20, Attribute=32, Tx=20
-	const entitySize = 20
-	const attrSize = 32
-	const txSize = 20
-
-	// Decode based on index type
-	switch index {
-	case EAVT:
-		minSize := entitySize + attrSize + txSize
-		if len(key) < minSize {
-			return nil, nil, nil, nil, fmt.Errorf("EAVT key too short")
-		}
-		entity = key[0:entitySize]
-		attr = key[entitySize : entitySize+attrSize]
-		value = key[entitySize+attrSize : len(key)-txSize]
-		tx = key[len(key)-txSize:]
-
-	case AEVT:
-		minSize := attrSize + entitySize + txSize
-		if len(key) < minSize {
-			return nil, nil, nil, nil, fmt.Errorf("AEVT key too short")
-		}
-		attr = key[0:attrSize]
-		entity = key[attrSize : attrSize+entitySize]
-		value = key[attrSize+entitySize : len(key)-txSize]
-		tx = key[len(key)-txSize:]
-
-	case AVET:
-		// Value is variable length, so we work backwards
-		minSize := attrSize + entitySize + txSize
-		if len(key) < minSize {
-			return nil, nil, nil, nil, fmt.Errorf("AVET key too short")
-		}
-		attr = key[0:attrSize]
-		tx = key[len(key)-txSize:]
-		entity = key[len(key)-txSize-entitySize : len(key)-txSize]
-		value = key[attrSize : len(key)-txSize-entitySize]
-
-	case VAET:
-		// Value is at the beginning, variable length
-		minSize := attrSize + entitySize + txSize
-		if len(key) < minSize {
-			return nil, nil, nil, nil, fmt.Errorf("VAET key too short")
-		}
-		tx = key[len(key)-txSize:]
-		entity = key[len(key)-txSize-entitySize : len(key)-txSize]
-		attr = key[len(key)-txSize-entitySize-attrSize : len(key)-txSize-entitySize]
-		value = key[0 : len(key)-txSize-entitySize-attrSize]
-
-	case TAEV:
-		minSize := txSize + attrSize + entitySize
-		if len(key) < minSize {
-			return nil, nil, nil, nil, fmt.Errorf("TAEV key too short")
-		}
-		tx = key[0:txSize]
-		attr = key[txSize : txSize+attrSize]
-		entity = key[txSize+attrSize : txSize+attrSize+entitySize]
-		value = key[txSize+attrSize+entitySize:]
-
-	default:
-		return nil, nil, nil, nil, fmt.Errorf("unknown index type: %v", index)
-	}
-
-	return entity, attr, value, tx, nil
+	e.ensureInitialized()
+	return e.baseKeyEncoder.DecodeKey(index, key)
 }
 
 // EncodePrefix creates a binary prefix key for range scans
 func (e *BinaryKeyEncoder) EncodePrefix(index IndexType, parts ...[]byte) []byte {
-	prefix := []byte{byte(index)}
-	allParts := append([][]byte{prefix}, parts...)
-	return concatBytes(allParts...)
+	e.ensureInitialized()
+	return e.baseKeyEncoder.EncodePrefix(index, parts...)
 }
 
 // EncodePrefixRange creates start and end keys for a prefix scan
 func (e *BinaryKeyEncoder) EncodePrefixRange(index IndexType, parts ...[]byte) (start, end []byte) {
-	start = e.EncodePrefix(index, parts...)
-
-	// End key is start with last byte incremented
-	end = make([]byte, len(start))
-	copy(end, start)
-
-	// Increment last byte, or append 0xFF if it would overflow
-	for i := len(end) - 1; i >= 0; i-- {
-		if end[i] < 0xFF {
-			end[i]++
-			break
-		}
-		if i == 0 {
-			// All bytes are 0xFF, append one more
-			end = append(end, 0x00)
-		}
-	}
-
-	return start, end
-}
-
-// historyIndexToBase maps history index types to their base current-state equivalents
-func historyIndexToBase(index IndexType) IndexType {
-	switch index {
-	case EAVT_HISTORY:
-		return EAVT
-	case AEVT_HISTORY:
-		return AEVT
-	case AVET_HISTORY:
-		return AVET
-	case VAET_HISTORY:
-		return VAET
-	case TAEV_HISTORY:
-		return TAEV
-	default:
-		return index
-	}
+	e.ensureInitialized()
+	return e.baseKeyEncoder.EncodePrefixRange(index, parts...)
 }
 
 // EncodeHistoryKey creates a binary index key with Op appended for history indices
 func (e *BinaryKeyEncoder) EncodeHistoryKey(index IndexType, d *datalog.Datom, op Op) []byte {
-	// Convert to storage datom first
-	sd := ToStorageDatom(*d)
-
-	// Use the history index byte as prefix
-	prefix := []byte{byte(index)}
-
-	// Get value bytes with type prefix (1 byte type + variable length data)
-	vType := byte(datalog.Type(sd.V))
-	vData := datalog.ValueBytes(sd.V)
-	vBytes := append([]byte{vType}, vData...)
-
-	// Op encoding: 0x01 = assert (true), 0x00 = retract (false)
-	opByte := byte(0x00)
-	if op {
-		opByte = 0x01
-	}
-
-	// Build key based on base index type, then append Op
-	baseIndex := historyIndexToBase(index)
-	switch baseIndex {
-	case EAVT:
-		return concatBytes(prefix, sd.E[:], sd.A[:], vBytes, sd.Tx[:], []byte{opByte})
-	case AEVT:
-		return concatBytes(prefix, sd.A[:], sd.E[:], vBytes, sd.Tx[:], []byte{opByte})
-	case AVET:
-		return concatBytes(prefix, sd.A[:], vBytes, sd.E[:], sd.Tx[:], []byte{opByte})
-	case VAET:
-		return concatBytes(prefix, vBytes, sd.A[:], sd.E[:], sd.Tx[:], []byte{opByte})
-	case TAEV:
-		return concatBytes(prefix, sd.Tx[:], sd.A[:], sd.E[:], vBytes, []byte{opByte})
-	default:
-		panic(fmt.Sprintf("unknown history index type: %v", index))
-	}
+	e.ensureInitialized()
+	return e.baseKeyEncoder.EncodeHistoryKey(index, d, op)
 }
 
 // DecodeHistoryKey extracts components including Op from a binary history index key
 func (e *BinaryKeyEncoder) DecodeHistoryKey(index IndexType, key []byte) (entity, attr, value, tx []byte, op Op, err error) {
-	if len(key) < 2 { // At minimum: prefix + op
-		return nil, nil, nil, nil, false, fmt.Errorf("history key too short")
-	}
-
-	// Op is the last byte
-	opByte := key[len(key)-1]
-	op = opByte == 0x01
-
-	// Decode the rest as a normal key (without the Op byte)
-	keyWithoutOp := key[:len(key)-1]
-
-	// Use the base index type for decoding
-	baseIndex := historyIndexToBase(index)
-	entity, attr, value, tx, err = e.DecodeKey(baseIndex, keyWithoutOp)
-	return entity, attr, value, tx, op, err
+	e.ensureInitialized()
+	return e.baseKeyEncoder.DecodeHistoryKey(index, key)
 }
+
+// NewBinaryKeyEncoder creates a new binary key encoder
+func NewBinaryKeyEncoder() *BinaryKeyEncoder {
+	return &BinaryKeyEncoder{
+		baseKeyEncoder: baseKeyEncoder{comp: &binaryComponentEncoder{}},
+	}
+}
+
+// Ensure BinaryKeyEncoder satisfies KeyEncoder interface
+var _ KeyEncoder = (*BinaryKeyEncoder)(nil)

--- a/datalog/storage/key_encoder_interface.go
+++ b/datalog/storage/key_encoder_interface.go
@@ -43,11 +43,11 @@ const (
 func NewKeyEncoder(strategy KeyEncodingStrategy) KeyEncoder {
 	switch strategy {
 	case L85Strategy:
-		return &L85KeyEncoder{}
+		return NewL85KeyEncoder()
 	case BinaryStrategy:
-		return &BinaryKeyEncoder{}
+		return NewBinaryKeyEncoder()
 	default:
 		// Default to L85 for debugging
-		return &L85KeyEncoder{}
+		return NewL85KeyEncoder()
 	}
 }

--- a/datalog/storage/key_encoder_l85.go
+++ b/datalog/storage/key_encoder_l85.go
@@ -1,222 +1,80 @@
 package storage
 
 import (
-	"fmt"
-
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/codec"
 )
 
-// L85KeyEncoder implements KeyEncoder using L85 encoding for human-readable keys
-type L85KeyEncoder struct{}
+// l85ComponentEncoder implements ComponentEncoder using L85 encoding
+type l85ComponentEncoder struct{}
 
-// EncodeKey creates an L85-encoded index key from a datom
-func (e *L85KeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
-	// Convert to storage datom first
-	sd := ToStorageDatom(*d)
+func (c *l85ComponentEncoder) EncodeEntity(e [20]byte) []byte {
+	return []byte(codec.EncodeFixed20(e))
+}
 
-	// Each index has a 1-byte prefix to separate namespaces
-	prefix := []byte{byte(index)}
+func (c *l85ComponentEncoder) EncodeAttr(a [32]byte) []byte {
+	return []byte(codec.EncodeFixed32(a))
+}
 
-	// Encode the components to L85 (E and Tx are 20 bytes, A is 32 bytes)
-	eL85 := codec.EncodeFixed20(sd.E)
-	aL85 := codec.EncodeFixed32(sd.A)
-	txL85 := codec.EncodeFixed20(sd.Tx)
+func (c *l85ComponentEncoder) EncodeTx(tx [20]byte) []byte {
+	return []byte(codec.EncodeFixed20(tx))
+}
 
-	// Get value bytes with type prefix
+func (c *l85ComponentEncoder) EncodeValue(v datalog.Value) []byte {
+	vType := byte(datalog.Type(v))
 	// RefValues are 20-byte entity references and should be L85-encoded
-	vType := byte(datalog.Type(sd.V))
-	var vBytes []byte
-	if datalog.Type(sd.V) == datalog.TypeReference {
-		// RefValue is exactly 20 bytes, encode it
+	if datalog.Type(v) == datalog.TypeReference {
 		var vArr [20]byte
-		copy(vArr[:], datalog.ValueBytes(sd.V))
+		copy(vArr[:], datalog.ValueBytes(v))
+		return append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
+	}
+	// Other values: type prefix + raw bytes
+	vData := datalog.ValueBytes(v)
+	return append([]byte{vType}, vData...)
+}
+
+func (c *l85ComponentEncoder) DecodeEntity(b []byte) ([20]byte, error) {
+	return codec.DecodeFixed20(string(b))
+}
+
+func (c *l85ComponentEncoder) DecodeAttr(b []byte) ([32]byte, error) {
+	return codec.DecodeFixed32(string(b))
+}
+
+func (c *l85ComponentEncoder) DecodeTx(b []byte) ([20]byte, error) {
+	return codec.DecodeFixed20(string(b))
+}
+
+func (c *l85ComponentEncoder) DecodeValue(b []byte) []byte {
+	const l85Size = 25 // L85-encoded 20-byte value
+
+	// Check if this is a type-prefixed L85-encoded reference
+	// Format: [type_byte][25 L85 chars]
+	if len(b) == l85Size+1 && b[0] == byte(datalog.TypeReference) {
 		// Type prefix + L85-encoded reference
-		vBytes = append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
-	} else {
-		// Other values: type prefix + raw bytes
-		vData := datalog.ValueBytes(sd.V)
-		vBytes = append([]byte{vType}, vData...)
+		if decoded, err := codec.DecodeFixed20(string(b[1:])); err == nil {
+			return append([]byte{b[0]}, decoded[:]...)
+		}
 	}
 
-	// Build key based on index type
-	switch index {
-	case EAVT:
-		// Entity + Attribute + Value + Tx
-		return concatBytes(prefix, []byte(eL85), []byte(aL85), vBytes, []byte(txL85))
-
-	case AEVT:
-		// Attribute + Entity + Value + Tx
-		return concatBytes(prefix, []byte(aL85), []byte(eL85), vBytes, []byte(txL85))
-
-	case AVET:
-		// Attribute + Value + Entity + Tx
-		return concatBytes(prefix, []byte(aL85), vBytes, []byte(eL85), []byte(txL85))
-
-	case VAET:
-		// Value + Attribute + Entity + Tx
-		return concatBytes(prefix, vBytes, []byte(aL85), []byte(eL85), []byte(txL85))
-
-	case TAEV:
-		// Tx + Attribute + Entity + Value
-		return concatBytes(prefix, []byte(txL85), []byte(aL85), []byte(eL85), vBytes)
-
-	default:
-		panic(fmt.Sprintf("unknown index type: %v", index))
+	// For L85-only values (no type prefix, exactly 25 chars)
+	if len(b) == l85Size {
+		if decoded, err := codec.DecodeFixed20(string(b)); err == nil {
+			return decoded[:]
+		}
 	}
+
+	// Return as-is for other values
+	return b
 }
 
-// DecodeKey extracts components from an L85-encoded index key
-func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity, attr, value, tx []byte, err error) {
-	if len(key) < 1 {
-		return nil, nil, nil, nil, fmt.Errorf("key too short")
-	}
+func (c *l85ComponentEncoder) EntitySize() int { return 25 } // L85 expands 20 bytes to 25 chars
+func (c *l85ComponentEncoder) AttrSize() int   { return 40 } // L85 expands 32 bytes to 40 chars
+func (c *l85ComponentEncoder) TxSize() int     { return 25 } // L85 expands 20 bytes to 25 chars
 
-	// Skip the 1-byte prefix
-	key = key[1:]
+func (c *l85ComponentEncoder) EncodePrefixParts(index IndexType, parts [][]byte) []byte {
+	encoded := make([][]byte, len(parts))
 
-	// L85-encoded component sizes
-	const l85Size = 25     // For 20-byte components (Entity, Tx)
-	const l85SizeAttr = 40 // For 32-byte components (Attribute)
-
-	// Decode based on index type
-	switch index {
-	case EAVT:
-		minSize := l85Size + l85SizeAttr + l85Size // E + A + Tx
-		if len(key) < minSize {
-			return nil, nil, nil, nil, fmt.Errorf("EAVT key too short")
-		}
-		e, _ := codec.DecodeFixed20(string(key[0:l85Size]))
-		a, _ := codec.DecodeFixed32(string(key[l85Size : l85Size+l85SizeAttr]))
-		entity = e[:]
-		attr = a[:]
-		// Value is between A and Tx
-		valueBytes := key[l85Size+l85SizeAttr : len(key)-l85Size]
-		if len(valueBytes) == l85Size {
-			// Try to decode as L85 (likely a RefValue)
-			if decoded, err := codec.DecodeFixed20(string(valueBytes)); err == nil {
-				value = decoded[:]
-			} else {
-				value = valueBytes
-			}
-		} else {
-			value = valueBytes
-		}
-		t, _ := codec.DecodeFixed20(string(key[len(key)-l85Size:]))
-		tx = t[:]
-
-	case AEVT:
-		minSize := l85SizeAttr + l85Size + l85Size // A + E + Tx
-		if len(key) < minSize {
-			return nil, nil, nil, nil, fmt.Errorf("AEVT key too short")
-		}
-		a, _ := codec.DecodeFixed32(string(key[0:l85SizeAttr]))
-		e, _ := codec.DecodeFixed20(string(key[l85SizeAttr : l85SizeAttr+l85Size]))
-		attr = a[:]
-		entity = e[:]
-		// Value is between E and Tx
-		valueBytes := key[l85SizeAttr+l85Size : len(key)-l85Size]
-		if len(valueBytes) == l85Size {
-			// Try to decode as L85 (likely a RefValue)
-			if decoded, err := codec.DecodeFixed20(string(valueBytes)); err == nil {
-				value = decoded[:]
-			} else {
-				value = valueBytes
-			}
-		} else {
-			value = valueBytes
-		}
-		t, _ := codec.DecodeFixed20(string(key[len(key)-l85Size:]))
-		tx = t[:]
-
-	case AVET:
-		// Value is variable length, so we work backwards
-		if len(key) < 2*l85Size {
-			return nil, nil, nil, nil, fmt.Errorf("AVET key too short")
-		}
-		a, _ := codec.DecodeFixed32(string(key[0:l85SizeAttr]))
-		attr = a[:]
-		t, _ := codec.DecodeFixed20(string(key[len(key)-l85Size:]))
-		tx = t[:]
-		e, _ := codec.DecodeFixed20(string(key[len(key)-2*l85Size : len(key)-l85Size]))
-		entity = e[:]
-		// Value is between A and E+Tx
-		valueBytes := key[l85SizeAttr : len(key)-2*l85Size]
-		// Check if this is a type-prefixed L85-encoded reference
-		if len(valueBytes) == l85Size+1 && valueBytes[0] == byte(datalog.TypeReference) {
-			// Type prefix + L85-encoded reference
-			if decoded, err := codec.DecodeFixed20(string(valueBytes[1:])); err == nil {
-				value = append([]byte{valueBytes[0]}, decoded[:]...)
-			} else {
-				value = valueBytes
-			}
-		} else {
-			value = valueBytes
-		}
-
-	case VAET:
-		// Value is at the beginning, variable length
-		if len(key) < 3*l85Size {
-			return nil, nil, nil, nil, fmt.Errorf("VAET key too short")
-		}
-		t, _ := codec.DecodeFixed20(string(key[len(key)-l85Size:]))
-		tx = t[:]
-		e, _ := codec.DecodeFixed20(string(key[len(key)-2*l85Size : len(key)-l85Size]))
-		entity = e[:]
-		// Need to adjust for the larger attribute size
-		aStart := len(key) - 2*l85Size - l85SizeAttr
-		a, _ := codec.DecodeFixed32(string(key[aStart : aStart+l85SizeAttr]))
-		attr = a[:]
-		// Value is at the beginning
-		valueBytes := key[0:aStart]
-		if len(valueBytes) == l85Size {
-			// Try to decode as L85 (likely a RefValue)
-			if decoded, err := codec.DecodeFixed20(string(valueBytes)); err == nil {
-				value = decoded[:]
-			} else {
-				value = valueBytes
-			}
-		} else {
-			value = valueBytes
-		}
-
-	case TAEV:
-		if len(key) < 3*l85Size {
-			return nil, nil, nil, nil, fmt.Errorf("TAEV key too short")
-		}
-		t, _ := codec.DecodeFixed20(string(key[0:l85Size]))
-		tx = t[:]
-		a, _ := codec.DecodeFixed32(string(key[l85Size : l85Size+l85SizeAttr]))
-		attr = a[:]
-		e, _ := codec.DecodeFixed20(string(key[l85Size+l85SizeAttr : l85Size+l85SizeAttr+l85Size]))
-		entity = e[:]
-		// Value is at the end
-		valueBytes := key[l85Size+l85SizeAttr+l85Size:]
-		if len(valueBytes) == l85Size {
-			// Try to decode as L85 (likely a RefValue)
-			if decoded, err := codec.DecodeFixed20(string(valueBytes)); err == nil {
-				value = decoded[:]
-			} else {
-				value = valueBytes
-			}
-		} else {
-			value = valueBytes
-		}
-
-	default:
-		return nil, nil, nil, nil, fmt.Errorf("unknown index type: %v", index)
-	}
-
-	return entity, attr, value, tx, nil
-}
-
-// EncodePrefix creates an L85-encoded prefix key for range scans
-func (e *L85KeyEncoder) EncodePrefix(index IndexType, parts ...[]byte) []byte {
-	prefix := []byte{byte(index)}
-	encoded := make([][]byte, len(parts)+1)
-	encoded[0] = prefix
-
-	// Encode parts based on index type and position
 	for i, part := range parts {
 		shouldEncode := false
 		isValuePosition := false
@@ -249,132 +107,80 @@ func (e *L85KeyEncoder) EncodePrefix(index IndexType, parts ...[]byte) []byte {
 			// Entity or Tx (20-byte components)
 			var arr [20]byte
 			copy(arr[:], part)
-			encoded[i+1] = []byte(codec.EncodeFixed20(arr))
+			encoded[i] = []byte(codec.EncodeFixed20(arr))
 		} else if shouldEncode && len(part) == 32 {
 			// Attribute (32-byte component)
 			var arr [32]byte
 			copy(arr[:], part)
-			encoded[i+1] = []byte(codec.EncodeFixed32(arr))
+			encoded[i] = []byte(codec.EncodeFixed32(arr))
 		} else if isValuePosition && len(part) == 20 {
 			// This is a value position with exactly 20 bytes - likely a RefValue
-			// RefValues should be L85-encoded
 			var arr [20]byte
 			copy(arr[:], part)
-			encoded[i+1] = []byte(codec.EncodeFixed20(arr))
+			encoded[i] = []byte(codec.EncodeFixed20(arr))
 		} else {
 			// Variable-length values or other data
-			encoded[i+1] = part
+			encoded[i] = part
 		}
 	}
 
 	return concatBytes(encoded...)
 }
 
-// EncodePrefixRange creates start and end keys for a prefix scan
-func (e *L85KeyEncoder) EncodePrefixRange(index IndexType, parts ...[]byte) (start, end []byte) {
-	start = e.EncodePrefix(index, parts...)
-
-	// End key is start with last byte incremented
-	end = make([]byte, len(start))
-	copy(end, start)
-
-	// Increment last byte, or append 0xFF if it would overflow
-	for i := len(end) - 1; i >= 0; i-- {
-		if end[i] < 0xFF {
-			end[i]++
-			break
-		}
-		if i == 0 {
-			// All bytes are 0xFF, append one more
-			end = append(end, 0x00)
-		}
-	}
-
-	return start, end
+// L85KeyEncoder implements KeyEncoder using L85 encoding for human-readable keys
+type L85KeyEncoder struct {
+	baseKeyEncoder
 }
 
-// l85HistoryIndexToBase maps history index types to their base current-state equivalents
-func l85HistoryIndexToBase(index IndexType) IndexType {
-	switch index {
-	case EAVT_HISTORY:
-		return EAVT
-	case AEVT_HISTORY:
-		return AEVT
-	case AVET_HISTORY:
-		return AVET
-	case VAET_HISTORY:
-		return VAET
-	case TAEV_HISTORY:
-		return TAEV
-	default:
-		return index
+// ensureInitialized lazily initializes the component encoder
+func (e *L85KeyEncoder) ensureInitialized() {
+	if e.comp == nil {
+		e.comp = &l85ComponentEncoder{}
 	}
+}
+
+// EncodeKey creates an L85-encoded index key from a datom
+func (e *L85KeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
+	e.ensureInitialized()
+	return e.baseKeyEncoder.EncodeKey(index, d)
+}
+
+// DecodeKey extracts components from an L85-encoded index key
+func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity, attr, value, tx []byte, err error) {
+	e.ensureInitialized()
+	return e.baseKeyEncoder.DecodeKey(index, key)
+}
+
+// EncodePrefix creates an L85-encoded prefix key for range scans
+func (e *L85KeyEncoder) EncodePrefix(index IndexType, parts ...[]byte) []byte {
+	e.ensureInitialized()
+	return e.baseKeyEncoder.EncodePrefix(index, parts...)
+}
+
+// EncodePrefixRange creates start and end keys for a prefix scan
+func (e *L85KeyEncoder) EncodePrefixRange(index IndexType, parts ...[]byte) (start, end []byte) {
+	e.ensureInitialized()
+	return e.baseKeyEncoder.EncodePrefixRange(index, parts...)
 }
 
 // EncodeHistoryKey creates an L85-encoded index key with Op appended for history indices
 func (e *L85KeyEncoder) EncodeHistoryKey(index IndexType, d *datalog.Datom, op Op) []byte {
-	// Convert to storage datom first
-	sd := ToStorageDatom(*d)
-
-	// Use the history index byte as prefix
-	prefix := []byte{byte(index)}
-
-	// Encode the components to L85
-	eL85 := codec.EncodeFixed20(sd.E)
-	aL85 := codec.EncodeFixed32(sd.A)
-	txL85 := codec.EncodeFixed20(sd.Tx)
-
-	// Get value bytes with type prefix
-	vType := byte(datalog.Type(sd.V))
-	var vBytes []byte
-	if datalog.Type(sd.V) == datalog.TypeReference {
-		var vArr [20]byte
-		copy(vArr[:], datalog.ValueBytes(sd.V))
-		vBytes = append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
-	} else {
-		vData := datalog.ValueBytes(sd.V)
-		vBytes = append([]byte{vType}, vData...)
-	}
-
-	// Op encoding: 0x01 = assert (true), 0x00 = retract (false)
-	opByte := byte(0x00)
-	if op {
-		opByte = 0x01
-	}
-
-	// Build key based on base index type, then append Op
-	baseIndex := l85HistoryIndexToBase(index)
-	switch baseIndex {
-	case EAVT:
-		return concatBytes(prefix, []byte(eL85), []byte(aL85), vBytes, []byte(txL85), []byte{opByte})
-	case AEVT:
-		return concatBytes(prefix, []byte(aL85), []byte(eL85), vBytes, []byte(txL85), []byte{opByte})
-	case AVET:
-		return concatBytes(prefix, []byte(aL85), vBytes, []byte(eL85), []byte(txL85), []byte{opByte})
-	case VAET:
-		return concatBytes(prefix, vBytes, []byte(aL85), []byte(eL85), []byte(txL85), []byte{opByte})
-	case TAEV:
-		return concatBytes(prefix, []byte(txL85), []byte(aL85), []byte(eL85), vBytes, []byte{opByte})
-	default:
-		panic(fmt.Sprintf("unknown history index type: %v", index))
-	}
+	e.ensureInitialized()
+	return e.baseKeyEncoder.EncodeHistoryKey(index, d, op)
 }
 
 // DecodeHistoryKey extracts components including Op from an L85-encoded history index key
 func (e *L85KeyEncoder) DecodeHistoryKey(index IndexType, key []byte) (entity, attr, value, tx []byte, op Op, err error) {
-	if len(key) < 2 { // At minimum: prefix + op
-		return nil, nil, nil, nil, false, fmt.Errorf("history key too short")
-	}
-
-	// Op is the last byte
-	opByte := key[len(key)-1]
-	op = opByte == 0x01
-
-	// Decode the rest as a normal key (without the Op byte)
-	keyWithoutOp := key[:len(key)-1]
-
-	// Use the base index type for decoding
-	baseIndex := l85HistoryIndexToBase(index)
-	entity, attr, value, tx, err = e.DecodeKey(baseIndex, keyWithoutOp)
-	return entity, attr, value, tx, op, err
+	e.ensureInitialized()
+	return e.baseKeyEncoder.DecodeHistoryKey(index, key)
 }
+
+// NewL85KeyEncoder creates a new L85 key encoder
+func NewL85KeyEncoder() *L85KeyEncoder {
+	return &L85KeyEncoder{
+		baseKeyEncoder: baseKeyEncoder{comp: &l85ComponentEncoder{}},
+	}
+}
+
+// Ensure L85KeyEncoder satisfies KeyEncoder interface
+var _ KeyEncoder = (*L85KeyEncoder)(nil)


### PR DESCRIPTION
Extract common index ordering logic into baseKeyEncoder, reducing duplication between L85KeyEncoder and BinaryKeyEncoder.

Changes:
- Add key_encoder_base.go with ComponentEncoder interface and baseKeyEncoder implementing shared EncodeKey/DecodeKey logic
- Reduce L85KeyEncoder to l85ComponentEncoder + wrapper methods
- Reduce BinaryKeyEncoder to binaryComponentEncoder + wrapper methods
- Add lazy initialization to maintain backward compatibility with zero-value struct usage (e.g., &L85KeyEncoder{})

The shared logic consolidates:
- 5 identical switch cases for index types (EAVT, AEVT, AVET, VAET, TAEV)
- historyIndexToBase() function (was duplicated as l85HistoryIndexToBase)
- EncodePrefixRange() algorithm
- EncodeHistoryKey/DecodeHistoryKey structure

Net reduction: ~54 lines (-483/+429)