### PR TITLE
Fix StreamingRelation.Project() violating set semantics

### DIFF
--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -494,6 +494,22 @@ These are **ideas**, not commitments. Would require benchmarking before implemen
 2. BadgerDB time range integration - Push time constraints to storage layer
 3. Composite index support - For multi-attribute filters
 
+### Known Performance Regressions (Correctness Fixes)
+
+**Set Semantics Fix for StreamingRelation.Project() (2025-12-24)**
+
+`StreamingRelation.Project()` was not deduplicating results, violating set semantics. The fix wraps `ProjectIterator` with `DedupIterator`.
+
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| Time | 35,326 ns/op | 44,331 ns/op | +25% |
+| Memory | 2,520 B/op | 16,744 B/op | +6.6× |
+| Allocs | 111 allocs/op | 224 allocs/op | +2× |
+
+**Why this overhead is acceptable**: Without deduplication, projected relations can contain duplicates, violating Datalog semantics and causing incorrect query results. Correctness trumps performance.
+
+**Future optimization**: See `docs/proposals/TUPLEKEYMAP_OPTIMIZATION.md` for proposal to optimize `TupleKeyMap` for set membership (currently stores values we don't need for dedup).
+
 ### Rejected After Benchmarking ❌
 These were **tried and measured** - data showed they're not worth the complexity:
 

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -1040,8 +1040,12 @@ func (r *StreamingRelation) Project(columns []query.Symbol) (Relation, error) {
 	// When r.shouldCache=true, the first Iterator() call builds the cache, and both the
 	// original relation and the projection can iterate from cached data
 	projIter := NewProjectIterator(r, r.columns, columns)
+	// SET SEMANTICS: Wrap with DedupIterator to ensure projection maintains set semantics.
+	// Projection can produce duplicates when multiple distinct input tuples map to the same
+	// projected tuple (e.g., [(1,a), (2,a)] projected to column 2 yields [a, a]).
+	dedupIter := NewDedupIterator(projIter, 0)
 	// BUGFIX: Preserve options (especially EnableTrueStreaming) to prevent re-scanning
-	return NewStreamingRelationWithOptions(columns, projIter, r.options), nil
+	return NewStreamingRelationWithOptions(columns, dedupIter, r.options), nil
 }
 
 // Materialize converts this streaming relation to a materialized one

--- a/datalog/executor/set_semantics_test.go
+++ b/datalog/executor/set_semantics_test.go
@@ -1,0 +1,967 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// =============================================================================
+// Set Semantics Tests
+//
+// Relations in Datalog are SETS, not BAGS. This means:
+// - No duplicate tuples should ever appear in a relation
+// - Projection must deduplicate (projecting away columns can create duplicates)
+// - All relation operations must maintain set semantics
+//
+// These tests verify set semantics are maintained throughout the pipeline.
+// =============================================================================
+
+// Helper: check that a relation has no duplicate tuples
+// Uses datalog.ValuesEqual for comparison - same semantics as production code
+func assertNoDuplicates(t *testing.T, name string, rel Relation) {
+	t.Helper()
+	var seen []Tuple // Use slice + equality check instead of map with string keys
+	iter := rel.Iterator()
+	defer iter.Close()
+
+	idx := 0
+	for iter.Next() {
+		tuple := iter.Tuple()
+		if firstIdx := setTestFindDuplicate(seen, tuple); firstIdx >= 0 {
+			t.Errorf("%s: duplicate tuple at index %d (first seen at %d): %v", name, idx, firstIdx, tuple)
+		}
+		seen = append(seen, tuple)
+		idx++
+	}
+}
+
+// Helper: check if two tuples are equal using the same logic as production code
+func setTestTuplesEqual(a, b Tuple) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !datalog.ValuesEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Helper: find duplicate index using production equality semantics
+// Returns -1 if no duplicate found
+func setTestFindDuplicate(tuples []Tuple, newTuple Tuple) int {
+	for i, existing := range tuples {
+		if setTestTuplesEqual(existing, newTuple) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Helper: collect all tuples from a relation
+func setTestCollectTuples(rel Relation) []Tuple {
+	var tuples []Tuple
+	iter := rel.Iterator()
+	defer iter.Close()
+	for iter.Next() {
+		tuples = append(tuples, iter.Tuple())
+	}
+	return tuples
+}
+
+// =============================================================================
+// Test 1: MaterializedRelation Constructors
+// =============================================================================
+
+func TestSetSemantics_MaterializedRelation(t *testing.T) {
+	t.Run("NewMaterializedRelation deduplicates", func(t *testing.T) {
+		columns := []query.Symbol{"?x", "?y"}
+		tuples := []Tuple{
+			{1, "a"},
+			{2, "b"},
+			{1, "a"}, // duplicate
+			{3, "c"},
+			{2, "b"}, // duplicate
+		}
+
+		rel := NewMaterializedRelation(columns, tuples)
+
+		if rel.Size() != 3 {
+			t.Errorf("expected 3 unique tuples, got %d", rel.Size())
+		}
+		assertNoDuplicates(t, "NewMaterializedRelation", rel)
+	})
+
+	t.Run("NewMaterializedRelationWithOptions deduplicates", func(t *testing.T) {
+		columns := []query.Symbol{"?x"}
+		tuples := []Tuple{
+			{"foo"},
+			{"bar"},
+			{"foo"}, // duplicate
+			{"foo"}, // duplicate
+		}
+
+		rel := NewMaterializedRelationWithOptions(columns, tuples, ExecutorOptions{})
+
+		if rel.Size() != 2 {
+			t.Errorf("expected 2 unique tuples, got %d", rel.Size())
+		}
+		assertNoDuplicates(t, "NewMaterializedRelationWithOptions", rel)
+	})
+}
+
+// =============================================================================
+// Test 2: Projection Must Deduplicate
+// =============================================================================
+
+func TestSetSemantics_Projection(t *testing.T) {
+	t.Run("MaterializedRelation.Project deduplicates", func(t *testing.T) {
+		// Create relation with distinct full tuples that become duplicates after projection
+		columns := []query.Symbol{"?e", "?v"}
+		tuples := []Tuple{
+			{"entity1", "same_value"},
+			{"entity2", "same_value"}, // Different entity, same value
+			{"entity3", "different"},
+			{"entity4", "same_value"}, // Another with same value
+		}
+
+		rel := NewMaterializedRelation(columns, tuples)
+
+		// Project to just ?v - should deduplicate
+		projected, err := rel.Project([]query.Symbol{"?v"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		// Should have only 2 unique values: "same_value" and "different"
+		if projected.Size() != 2 {
+			t.Errorf("expected 2 unique values after projection, got %d", projected.Size())
+		}
+		assertNoDuplicates(t, "MaterializedRelation.Project", projected)
+	})
+
+	t.Run("StreamingRelation.Project deduplicates", func(t *testing.T) {
+		// Create streaming relation with tuples that become duplicates after projection
+		columns := []query.Symbol{"?e", "?v"}
+		tuples := []Tuple{
+			{"entity1", "value_a"},
+			{"entity2", "value_a"}, // Same value, different entity
+			{"entity3", "value_b"},
+			{"entity4", "value_a"}, // Same value again
+			{"entity5", "value_b"}, // Same value as entity3
+		}
+
+		// Create a streaming relation
+		iter := &sliceIterator{tuples: tuples, pos: -1}
+		rel := NewStreamingRelation(columns, iter)
+
+		// Project to just ?v - should deduplicate
+		projected, err := rel.Project([]query.Symbol{"?v"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		// Materialize to check results
+		materialized := projected.Materialize()
+		collected := setTestCollectTuples(materialized)
+
+		// Should have only 2 unique values: "value_a" and "value_b"
+		if len(collected) != 2 {
+			t.Errorf("expected 2 unique values after projection, got %d: %v", len(collected), collected)
+		}
+		assertNoDuplicates(t, "StreamingRelation.Project", materialized)
+	})
+
+	t.Run("Multiple column projection deduplicates", func(t *testing.T) {
+		// Project from 3 columns to 2 columns
+		columns := []query.Symbol{"?a", "?b", "?c"}
+		tuples := []Tuple{
+			{1, "x", 100},
+			{1, "x", 200}, // Same ?a, ?b - different ?c
+			{2, "y", 300},
+			{1, "x", 300}, // Same ?a, ?b again
+		}
+
+		rel := NewMaterializedRelation(columns, tuples)
+		projected, err := rel.Project([]query.Symbol{"?a", "?b"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		// Should have only 2 unique (?a, ?b) pairs
+		if projected.Size() != 2 {
+			t.Errorf("expected 2 unique tuples after projection, got %d", projected.Size())
+		}
+		assertNoDuplicates(t, "Multi-column projection", projected)
+	})
+}
+
+// =============================================================================
+// Test 3: Join Operations Must Maintain Set Semantics
+// =============================================================================
+
+func TestSetSemantics_Joins(t *testing.T) {
+	t.Run("HashJoin produces no duplicates", func(t *testing.T) {
+		// Create relations where join could produce duplicates
+		leftCols := []query.Symbol{"?x", "?y"}
+		leftTuples := []Tuple{
+			{1, "a"},
+			{1, "b"}, // Same ?x, different ?y
+			{2, "c"},
+		}
+		left := NewMaterializedRelation(leftCols, leftTuples)
+
+		rightCols := []query.Symbol{"?x", "?z"}
+		rightTuples := []Tuple{
+			{1, 100},
+			{1, 100}, // Duplicate in input (should be deduped by constructor)
+			{2, 200},
+		}
+		right := NewMaterializedRelation(rightCols, rightTuples)
+
+		joined := HashJoin(left, right, []query.Symbol{"?x"})
+		assertNoDuplicates(t, "HashJoin", joined)
+	})
+
+	t.Run("SemiJoin produces no duplicates", func(t *testing.T) {
+		leftCols := []query.Symbol{"?x", "?y"}
+		leftTuples := []Tuple{
+			{1, "a"},
+			{1, "b"},
+			{2, "c"},
+		}
+		left := NewMaterializedRelation(leftCols, leftTuples)
+
+		rightCols := []query.Symbol{"?x"}
+		rightTuples := []Tuple{
+			{1},
+			{1}, // Duplicate key
+		}
+		right := NewMaterializedRelation(rightCols, rightTuples)
+
+		joined := SemiJoin(left, right, []query.Symbol{"?x"})
+		assertNoDuplicates(t, "SemiJoin", joined)
+	})
+
+	t.Run("AntiJoin produces no duplicates", func(t *testing.T) {
+		leftCols := []query.Symbol{"?x", "?y"}
+		leftTuples := []Tuple{
+			{1, "a"},
+			{2, "b"},
+			{3, "c"},
+		}
+		left := NewMaterializedRelation(leftCols, leftTuples)
+
+		rightCols := []query.Symbol{"?x"}
+		rightTuples := []Tuple{
+			{1},
+		}
+		right := NewMaterializedRelation(rightCols, rightTuples)
+
+		joined := AntiJoin(left, right, []query.Symbol{"?x"})
+		assertNoDuplicates(t, "AntiJoin", joined)
+	})
+
+	t.Run("Natural Join (via Join method) produces no duplicates", func(t *testing.T) {
+		leftCols := []query.Symbol{"?x", "?y"}
+		leftTuples := []Tuple{
+			{1, "a"},
+			{2, "b"},
+		}
+		left := NewMaterializedRelation(leftCols, leftTuples)
+
+		rightCols := []query.Symbol{"?x", "?z"}
+		rightTuples := []Tuple{
+			{1, 100},
+			{2, 200},
+		}
+		right := NewMaterializedRelation(rightCols, rightTuples)
+
+		joined := left.Join(right)
+		assertNoDuplicates(t, "Natural Join", joined)
+	})
+}
+
+// =============================================================================
+// Test 4: Union Operations Must Deduplicate
+// =============================================================================
+
+func TestSetSemantics_Union(t *testing.T) {
+	t.Run("UnionRelation deduplicates across relations", func(t *testing.T) {
+		cols := []query.Symbol{"?x", "?y"}
+
+		// Create channel with relations that have overlapping tuples
+		ch := make(chan relationItem, 3)
+
+		rel1 := NewMaterializedRelation(cols, []Tuple{
+			{1, "a"},
+			{2, "b"},
+		})
+		rel2 := NewMaterializedRelation(cols, []Tuple{
+			{2, "b"}, // Duplicate from rel1
+			{3, "c"},
+		})
+		rel3 := NewMaterializedRelation(cols, []Tuple{
+			{1, "a"}, // Duplicate from rel1
+			{3, "c"}, // Duplicate from rel2
+			{4, "d"},
+		})
+
+		ch <- relationItem{relation: rel1}
+		ch <- relationItem{relation: rel2}
+		ch <- relationItem{relation: rel3}
+		close(ch)
+
+		union := NewUnionRelation(ch, cols, ExecutorOptions{})
+		materialized := union.Materialize()
+
+		// Should have 4 unique tuples
+		if materialized.Size() != 4 {
+			t.Errorf("expected 4 unique tuples, got %d", materialized.Size())
+		}
+		assertNoDuplicates(t, "UnionRelation", materialized)
+	})
+}
+
+// =============================================================================
+// Test 5: Filter Operations Preserve Set Semantics
+// =============================================================================
+
+func TestSetSemantics_Filter(t *testing.T) {
+	t.Run("Filter preserves set semantics", func(t *testing.T) {
+		columns := []query.Symbol{"?x", "?y"}
+		tuples := []Tuple{
+			{1, "a"},
+			{2, "b"},
+			{3, "c"},
+		}
+
+		rel := NewMaterializedRelation(columns, tuples)
+		filtered := rel.Select(func(t Tuple) bool {
+			return t[0].(int) > 1
+		})
+
+		assertNoDuplicates(t, "Filter", filtered)
+	})
+}
+
+// =============================================================================
+// Test 6: Iterator Wrappers Maintain Set Semantics
+// =============================================================================
+
+func TestSetSemantics_Iterators(t *testing.T) {
+	t.Run("DedupIterator removes duplicates", func(t *testing.T) {
+		tuples := []Tuple{
+			{1, "a"},
+			{2, "b"},
+			{1, "a"}, // duplicate
+			{3, "c"},
+			{2, "b"}, // duplicate
+		}
+
+		source := &sliceIterator{tuples: tuples, pos: -1}
+		dedupIter := NewDedupIterator(source, 10)
+
+		var results []Tuple
+		for dedupIter.Next() {
+			results = append(results, dedupIter.Tuple())
+		}
+		dedupIter.Close()
+
+		if len(results) != 3 {
+			t.Errorf("expected 3 unique tuples, got %d", len(results))
+		}
+
+		// Check no duplicates in results using production equality semantics
+		for i, tuple := range results {
+			if dupIdx := setTestFindDuplicate(results[:i], tuple); dupIdx >= 0 {
+				t.Errorf("DedupIterator produced duplicate at index %d (same as %d): %v", i, dupIdx, tuple)
+			}
+		}
+	})
+
+	t.Run("ProjectIterator should work with DedupIterator", func(t *testing.T) {
+		// This tests the fix: ProjectIterator output wrapped with DedupIterator
+		columns := []query.Symbol{"?e", "?v"}
+		tuples := []Tuple{
+			{"e1", "same"},
+			{"e2", "same"},
+			{"e3", "different"},
+		}
+
+		source := &sliceIterator{tuples: tuples, pos: -1}
+		rel := NewStreamingRelation(columns, source)
+
+		// Create project iterator
+		projIter := NewProjectIterator(rel, columns, []query.Symbol{"?v"})
+
+		// Wrap with dedup (this is what the fix should do)
+		dedupIter := NewDedupIterator(projIter, 10)
+
+		var results []Tuple
+		for dedupIter.Next() {
+			results = append(results, dedupIter.Tuple())
+		}
+		dedupIter.Close()
+
+		if len(results) != 2 {
+			t.Errorf("expected 2 unique values, got %d: %v", len(results), results)
+		}
+	})
+}
+
+// =============================================================================
+// Test 7: End-to-End Query Set Semantics
+// =============================================================================
+
+func TestSetSemantics_EndToEnd(t *testing.T) {
+	t.Run("Query projection deduplicates final result", func(t *testing.T) {
+		// Simulate the query: [:find ?v :where [_ :attr ?v]]
+		// Multiple entities with the same attribute value should produce one result
+
+		// This is what comes from storage: multiple datoms with same value
+		columns := []query.Symbol{"?e", "?a", "?v"}
+		tuples := []Tuple{
+			{"entity1", ":attr", "shared_value"},
+			{"entity2", ":attr", "shared_value"},
+			{"entity3", ":attr", "unique_value"},
+			{"entity4", ":attr", "shared_value"},
+		}
+
+		rel := NewMaterializedRelation(columns, tuples)
+
+		// Project to just ?v (like :find ?v)
+		projected, err := rel.Project([]query.Symbol{"?v"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		collected := setTestCollectTuples(projected)
+
+		// Should have only 2 unique values
+		if len(collected) != 2 {
+			t.Errorf("expected 2 unique values, got %d: %v", len(collected), collected)
+		}
+		assertNoDuplicates(t, "Query projection", projected)
+	})
+
+	t.Run("Streaming query projection deduplicates", func(t *testing.T) {
+		// Same test but with streaming relation
+		columns := []query.Symbol{"?e", "?v"}
+		tuples := []Tuple{
+			{"e1", "val1"},
+			{"e2", "val1"}, // duplicate value
+			{"e3", "val2"},
+			{"e4", "val1"}, // duplicate value
+			{"e5", "val2"}, // duplicate value
+		}
+
+		iter := &sliceIterator{tuples: tuples, pos: -1}
+		rel := NewStreamingRelation(columns, iter)
+
+		// Project and materialize
+		projected, err := rel.Project([]query.Symbol{"?v"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+		materialized := projected.Materialize()
+
+		collected := setTestCollectTuples(materialized)
+
+		// Should have only 2 unique values
+		if len(collected) != 2 {
+			t.Errorf("expected 2 unique values, got %d: %v", len(collected), collected)
+		}
+		assertNoDuplicates(t, "Streaming query projection", materialized)
+	})
+}
+
+// =============================================================================
+// Test 8: Aggregation Input Set Semantics
+// =============================================================================
+
+func TestSetSemantics_Aggregation(t *testing.T) {
+	t.Run("Aggregation receives deduplicated input", func(t *testing.T) {
+		// When aggregating, the input should be deduplicated
+		// This matters for COUNT - counting duplicates would be wrong
+		columns := []query.Symbol{"?group", "?value"}
+		tuples := []Tuple{
+			{"A", int64(10)},
+			{"A", int64(20)},
+			{"A", int64(10)}, // Duplicate - should not be counted twice
+			{"B", int64(30)},
+		}
+
+		rel := NewMaterializedRelation(columns, tuples)
+
+		// The relation should already be deduplicated
+		if rel.Size() != 3 {
+			t.Errorf("expected 3 unique tuples before aggregation, got %d", rel.Size())
+		}
+		assertNoDuplicates(t, "Aggregation input", rel)
+	})
+}
+
+// =============================================================================
+// Test 9: Relation Operations Chain
+// =============================================================================
+
+func TestSetSemantics_OperationChain(t *testing.T) {
+	t.Run("Filter then Project maintains set semantics", func(t *testing.T) {
+		columns := []query.Symbol{"?x", "?y", "?z"}
+		tuples := []Tuple{
+			{1, "a", 100},
+			{2, "a", 200}, // Same ?y as above
+			{3, "b", 300},
+			{4, "a", 400}, // Same ?y as first two
+		}
+
+		rel := NewMaterializedRelation(columns, tuples)
+
+		// Filter to x > 1
+		filtered := rel.Select(func(t Tuple) bool {
+			return t[0].(int) > 1
+		})
+
+		// Project to just ?y
+		projected, err := filtered.Project([]query.Symbol{"?y"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		// Should have 2 unique ?y values: "a" and "b"
+		if projected.Size() != 2 {
+			t.Errorf("expected 2 unique values, got %d", projected.Size())
+		}
+		assertNoDuplicates(t, "Filter+Project chain", projected)
+	})
+
+	t.Run("Join then Project maintains set semantics", func(t *testing.T) {
+		left := NewMaterializedRelation(
+			[]query.Symbol{"?x", "?y"},
+			[]Tuple{
+				{1, "a"},
+				{2, "a"}, // Same ?y
+			},
+		)
+
+		right := NewMaterializedRelation(
+			[]query.Symbol{"?x", "?z"},
+			[]Tuple{
+				{1, 100},
+				{2, 200},
+			},
+		)
+
+		joined := left.Join(right)
+
+		// Project to just ?y, ?z
+		projected, err := joined.Project([]query.Symbol{"?y", "?z"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		assertNoDuplicates(t, "Join+Project chain", projected)
+	})
+}
+
+// =============================================================================
+// Test 10: Edge Cases
+// =============================================================================
+
+func TestSetSemantics_EdgeCases(t *testing.T) {
+	t.Run("Empty relation has no duplicates", func(t *testing.T) {
+		rel := NewMaterializedRelation([]query.Symbol{"?x"}, []Tuple{})
+		assertNoDuplicates(t, "Empty relation", rel)
+	})
+
+	t.Run("Single tuple relation has no duplicates", func(t *testing.T) {
+		rel := NewMaterializedRelation([]query.Symbol{"?x"}, []Tuple{{1}})
+		assertNoDuplicates(t, "Single tuple", rel)
+	})
+
+	t.Run("All duplicate input produces single tuple", func(t *testing.T) {
+		tuples := []Tuple{
+			{"same"},
+			{"same"},
+			{"same"},
+			{"same"},
+		}
+		rel := NewMaterializedRelation([]query.Symbol{"?x"}, tuples)
+
+		if rel.Size() != 1 {
+			t.Errorf("expected 1 unique tuple, got %d", rel.Size())
+		}
+	})
+
+	t.Run("Nil values handled correctly", func(t *testing.T) {
+		tuples := []Tuple{
+			{nil, "a"},
+			{nil, "a"}, // duplicate with nil
+			{nil, "b"},
+		}
+		rel := NewMaterializedRelation([]query.Symbol{"?x", "?y"}, tuples)
+
+		if rel.Size() != 2 {
+			t.Errorf("expected 2 unique tuples, got %d", rel.Size())
+		}
+		assertNoDuplicates(t, "Nil values", rel)
+	})
+
+	t.Run("Different types with same string representation", func(t *testing.T) {
+		// "1" (string) vs 1 (int) should be different tuples
+		tuples := []Tuple{
+			{"1"},
+			{1},
+			{int64(1)},
+		}
+		rel := NewMaterializedRelation([]query.Symbol{"?x"}, tuples)
+
+		// These should all be considered different (type matters)
+		// Note: This depends on how TupleKey handles types
+		assertNoDuplicates(t, "Different types", rel)
+	})
+}
+
+// =============================================================================
+// Test 11: Semantic Contract Tests
+//
+// These tests document the SEMANTIC CONTRACT that Relations are sets.
+// They should pass regardless of implementation details (streaming vs materialized).
+// If future optimizations break these, the optimization is wrong.
+// =============================================================================
+
+func TestSetSemantics_Contract_ProjectionAlwaysDeduplicates(t *testing.T) {
+	// SEMANTIC CONTRACT: Projection MUST deduplicate, regardless of input relation type.
+	// This is not an implementation detail - it's fundamental to relational algebra.
+
+	columns := []query.Symbol{"?a", "?b", "?c"}
+	// Create tuples that are unique in full form but duplicate after projection
+	inputTuples := []Tuple{
+		{1, "x", 100},
+		{2, "x", 200}, // Same ?b
+		{3, "y", 300},
+		{4, "x", 400}, // Same ?b again
+		{5, "y", 500}, // Same ?b as row 3
+	}
+
+	testCases := []struct {
+		name       string
+		createRel  func() Relation
+		projectTo  []query.Symbol
+		expectSize int
+	}{
+		{
+			name: "MaterializedRelation project to single column",
+			createRel: func() Relation {
+				return NewMaterializedRelation(columns, inputTuples)
+			},
+			projectTo:  []query.Symbol{"?b"},
+			expectSize: 2, // "x" and "y"
+		},
+		{
+			name: "StreamingRelation project to single column",
+			createRel: func() Relation {
+				iter := &sliceIterator{tuples: inputTuples, pos: -1}
+				return NewStreamingRelation(columns, iter)
+			},
+			projectTo:  []query.Symbol{"?b"},
+			expectSize: 2, // "x" and "y"
+		},
+		{
+			name: "MaterializedRelation project to two columns",
+			createRel: func() Relation {
+				return NewMaterializedRelation(columns, inputTuples)
+			},
+			projectTo:  []query.Symbol{"?a", "?b"},
+			expectSize: 5, // All unique (a,b) pairs
+		},
+		{
+			name: "StreamingRelation project to two columns",
+			createRel: func() Relation {
+				iter := &sliceIterator{tuples: inputTuples, pos: -1}
+				return NewStreamingRelation(columns, iter)
+			},
+			projectTo:  []query.Symbol{"?a", "?b"},
+			expectSize: 5, // All unique (a,b) pairs
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rel := tc.createRel()
+			projected, err := rel.Project(tc.projectTo)
+			if err != nil {
+				t.Fatalf("projection failed: %v", err)
+			}
+
+			// Force materialization to get final result
+			materialized := projected.Materialize()
+			collected := setTestCollectTuples(materialized)
+
+			if len(collected) != tc.expectSize {
+				t.Errorf("expected %d unique tuples, got %d: %v", tc.expectSize, len(collected), collected)
+			}
+			assertNoDuplicates(t, tc.name, materialized)
+		})
+	}
+}
+
+func TestSetSemantics_Contract_JoinThenProjectDeduplicates(t *testing.T) {
+	// SEMANTIC CONTRACT: Join followed by projection must deduplicate.
+	// Even if join is optimized to be streaming in the future.
+
+	t.Run("Hash join then project creates duplicates that must be removed", func(t *testing.T) {
+		// Two people in same city - joining then projecting to city should dedupe
+		left := NewMaterializedRelation(
+			[]query.Symbol{"?person", "?city"},
+			[]Tuple{
+				{"alice", "NYC"},
+				{"bob", "NYC"},   // Same city
+				{"carol", "LA"},
+			},
+		)
+
+		right := NewMaterializedRelation(
+			[]query.Symbol{"?city", "?population"},
+			[]Tuple{
+				{"NYC", 8000000},
+				{"LA", 4000000},
+			},
+		)
+
+		// Join on ?city
+		joined := HashJoin(left, right, []query.Symbol{"?city"})
+
+		// Project to just ?city - should have 2 unique values
+		projected, err := joined.Project([]query.Symbol{"?city"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		collected := setTestCollectTuples(projected.Materialize())
+		if len(collected) != 2 {
+			t.Errorf("expected 2 unique cities, got %d: %v", len(collected), collected)
+		}
+		assertNoDuplicates(t, "Join then project", projected.Materialize())
+	})
+
+	t.Run("Natural join then project", func(t *testing.T) {
+		left := NewMaterializedRelation(
+			[]query.Symbol{"?x", "?y"},
+			[]Tuple{
+				{1, "a"},
+				{2, "a"}, // Same ?y
+				{3, "b"},
+			},
+		)
+
+		right := NewMaterializedRelation(
+			[]query.Symbol{"?x", "?z"},
+			[]Tuple{
+				{1, 100},
+				{2, 200},
+				{3, 300},
+			},
+		)
+
+		joined := left.Join(right)
+		projected, err := joined.Project([]query.Symbol{"?y"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		collected := setTestCollectTuples(projected.Materialize())
+		if len(collected) != 2 {
+			t.Errorf("expected 2 unique ?y values, got %d: %v", len(collected), collected)
+		}
+		assertNoDuplicates(t, "Natural join then project", projected.Materialize())
+	})
+}
+
+func TestSetSemantics_Contract_FilterPreservesSetSemantics(t *testing.T) {
+	// SEMANTIC CONTRACT: Filter cannot introduce duplicates.
+	// Input is a set, output must be a set.
+
+	columns := []query.Symbol{"?x", "?y"}
+	tuples := []Tuple{
+		{1, "a"},
+		{2, "b"},
+		{3, "a"}, // Same ?y as first
+		{4, "c"},
+	}
+
+	t.Run("Filter then project must deduplicate", func(t *testing.T) {
+		rel := NewMaterializedRelation(columns, tuples)
+
+		// Filter to x > 1
+		filtered := rel.Select(func(t Tuple) bool {
+			return t[0].(int) > 1
+		})
+
+		// Project to ?y - should dedupe "a" (from row 3) and "b", "c"
+		projected, err := filtered.Project([]query.Symbol{"?y"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		collected := setTestCollectTuples(projected.Materialize())
+		// Rows 2,3,4 pass filter -> ?y values are "b", "a", "c" -> 3 unique
+		if len(collected) != 3 {
+			t.Errorf("expected 3 unique values, got %d: %v", len(collected), collected)
+		}
+		assertNoDuplicates(t, "Filter then project", projected.Materialize())
+	})
+
+	t.Run("Streaming filter then project must deduplicate", func(t *testing.T) {
+		iter := &sliceIterator{tuples: tuples, pos: -1}
+		rel := NewStreamingRelation(columns, iter)
+
+		filtered := rel.Select(func(t Tuple) bool {
+			return t[0].(int) > 1
+		})
+
+		projected, err := filtered.Project([]query.Symbol{"?y"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		collected := setTestCollectTuples(projected.Materialize())
+		if len(collected) != 3 {
+			t.Errorf("expected 3 unique values, got %d: %v", len(collected), collected)
+		}
+		assertNoDuplicates(t, "Streaming filter then project", projected.Materialize())
+	})
+}
+
+func TestSetSemantics_Contract_ChainedOperationsPreserveSetSemantics(t *testing.T) {
+	// SEMANTIC CONTRACT: Any chain of relational operations must produce a set.
+	// Filter -> Join -> Project -> Filter -> Project must still be a set.
+
+	t.Run("Complex operation chain", func(t *testing.T) {
+		rel1 := NewMaterializedRelation(
+			[]query.Symbol{"?a", "?b"},
+			[]Tuple{
+				{1, "x"},
+				{2, "x"},
+				{3, "y"},
+				{4, "x"},
+			},
+		)
+
+		rel2 := NewMaterializedRelation(
+			[]query.Symbol{"?a", "?c"},
+			[]Tuple{
+				{1, 100},
+				{2, 200},
+				{3, 300},
+				{4, 400},
+			},
+		)
+
+		// Chain: filter -> join -> project
+		filtered := rel1.Select(func(t Tuple) bool {
+			return t[0].(int) > 1
+		})
+
+		joined := filtered.Join(rel2)
+
+		projected, err := joined.Project([]query.Symbol{"?b"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		collected := setTestCollectTuples(projected.Materialize())
+		// After filter: rows with a=2,3,4 -> b values "x", "y", "x"
+		// After project to ?b: should be 2 unique ("x", "y")
+		if len(collected) != 2 {
+			t.Errorf("expected 2 unique values, got %d: %v", len(collected), collected)
+		}
+		assertNoDuplicates(t, "Chained operations", projected.Materialize())
+	})
+}
+
+func TestSetSemantics_Contract_IteratorMultiplePassesSameResults(t *testing.T) {
+	// SEMANTIC CONTRACT: Multiple iterations over a relation must produce identical results.
+	// This ensures the relation behaves as a stable set, not a stream that changes.
+
+	columns := []query.Symbol{"?x"}
+	tuples := []Tuple{{1}, {2}, {3}, {2}, {1}} // With duplicates
+
+	t.Run("MaterializedRelation multiple iterations", func(t *testing.T) {
+		rel := NewMaterializedRelation(columns, tuples)
+
+		// First iteration
+		var first []Tuple
+		iter1 := rel.Iterator()
+		for iter1.Next() {
+			first = append(first, iter1.Tuple())
+		}
+		iter1.Close()
+
+		// Second iteration
+		var second []Tuple
+		iter2 := rel.Iterator()
+		for iter2.Next() {
+			second = append(second, iter2.Tuple())
+		}
+		iter2.Close()
+
+		if len(first) != len(second) {
+			t.Errorf("iterations produced different sizes: %d vs %d", len(first), len(second))
+		}
+
+		// Both should have 3 unique tuples (deduped)
+		if len(first) != 3 {
+			t.Errorf("expected 3 unique tuples, got %d", len(first))
+		}
+	})
+}
+
+// =============================================================================
+// Test 12: Storage Integration (requires mock or real storage)
+// =============================================================================
+
+func TestSetSemantics_StoragePattern(t *testing.T) {
+	t.Run("Pattern match with multiple entities same value", func(t *testing.T) {
+		// Simulate what comes from storage for pattern [_ :attr ?v]
+		// This is the core bug scenario
+
+		// Create datoms as they would come from storage
+		e1 := datalog.NewIdentity("entity:1")
+		e2 := datalog.NewIdentity("entity:2")
+		e3 := datalog.NewIdentity("entity:3")
+		attr := datalog.NewKeyword(":test/value")
+
+		datoms := []datalog.Datom{
+			{E: e1, A: attr, V: "shared", Tx: 1},
+			{E: e2, A: attr, V: "shared", Tx: 2}, // Same value
+			{E: e3, A: attr, V: "unique", Tx: 3},
+		}
+
+		// Convert to tuples as pattern matcher would
+		columns := []query.Symbol{"?e", "?v"}
+		tuples := make([]Tuple, len(datoms))
+		for i, d := range datoms {
+			tuples[i] = Tuple{d.E, d.V}
+		}
+
+		rel := NewMaterializedRelation(columns, tuples)
+
+		// Project to just ?v (the find clause)
+		projected, err := rel.Project([]query.Symbol{"?v"})
+		if err != nil {
+			t.Fatalf("projection failed: %v", err)
+		}
+
+		// Should have 2 unique values
+		if projected.Size() != 2 {
+			collected := setTestCollectTuples(projected)
+			t.Errorf("expected 2 unique values, got %d: %v", projected.Size(), collected)
+		}
+		assertNoDuplicates(t, "Storage pattern projection", projected)
+	})
+}

--- a/datalog/storage/set_semantics_storage_test.go
+++ b/datalog/storage/set_semantics_storage_test.go
@@ -1,0 +1,379 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// =============================================================================
+// Storage-Level Set Semantics Tests
+//
+// These tests verify that queries against real storage maintain set semantics.
+// The core scenario: multiple entities with the same attribute value should
+// produce only one result when projecting to just the value.
+// =============================================================================
+
+// Helper: check for duplicates in query results
+func assertResultNoDuplicates(t *testing.T, name string, results [][]interface{}) {
+	t.Helper()
+	seen := make(map[string]int)
+
+	for idx, row := range results {
+		key := fmt.Sprintf("%v", row)
+		if firstIdx, exists := seen[key]; exists {
+			t.Errorf("%s: duplicate row at index %d (first seen at %d): %v", name, idx, firstIdx, row)
+		}
+		seen[key] = idx
+	}
+}
+
+func TestSetSemantics_StorageQuery(t *testing.T) {
+	// Create temporary database
+	tmpDir, err := os.MkdirTemp("", "set_semantics_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create multiple entities with the SAME attribute value
+	// This is the core bug scenario
+	tx := db.NewTransaction()
+	attr := datalog.NewKeyword(":test/value")
+
+	e1 := datalog.NewIdentity("entity:1")
+	e2 := datalog.NewIdentity("entity:2")
+	e3 := datalog.NewIdentity("entity:3")
+	e4 := datalog.NewIdentity("entity:4")
+
+	// All have the same value "shared"
+	tx.Add(e1, attr, "shared")
+	tx.Add(e2, attr, "shared")
+	tx.Add(e3, attr, "unique")
+	tx.Add(e4, attr, "shared")
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	t.Run("Query projecting to value only - [:find ?v :where [_ :test/value ?v]]", func(t *testing.T) {
+		result, err := db.ExecuteQuery(`[:find ?v :where [_ :test/value ?v]]`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should have exactly 2 unique values: "shared" and "unique"
+		if len(result) != 2 {
+			t.Errorf("expected 2 unique values, got %d: %v", len(result), result)
+		}
+		assertResultNoDuplicates(t, "Value-only projection", result)
+	})
+
+	t.Run("Query projecting entity and value - [:find ?e ?v :where [?e :test/value ?v]]", func(t *testing.T) {
+		result, err := db.ExecuteQuery(`[:find ?e ?v :where [?e :test/value ?v]]`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should have 4 unique (entity, value) tuples
+		if len(result) != 4 {
+			t.Errorf("expected 4 tuples, got %d: %v", len(result), result)
+		}
+		assertResultNoDuplicates(t, "Entity+value projection", result)
+	})
+}
+
+func TestSetSemantics_StorageQuery_MultipleAttributes(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "set_semantics_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create data with overlapping values across different attributes
+	tx := db.NewTransaction()
+	name := datalog.NewKeyword(":person/name")
+	city := datalog.NewKeyword(":person/city")
+
+	e1 := datalog.NewIdentity("person:1")
+	e2 := datalog.NewIdentity("person:2")
+	e3 := datalog.NewIdentity("person:3")
+
+	tx.Add(e1, name, "Alice")
+	tx.Add(e1, city, "NYC")
+	tx.Add(e2, name, "Bob")
+	tx.Add(e2, city, "NYC") // Same city as e1
+	tx.Add(e3, name, "Alice") // Same name as e1
+	tx.Add(e3, city, "LA")
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	t.Run("Join then project to overlapping values", func(t *testing.T) {
+		// This query joins on entity, producing rows that might duplicate after projection
+		result, err := db.ExecuteQuery(`
+			[:find ?city
+			 :where [?e :person/name ?name]
+			        [?e :person/city ?city]]
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should have 2 unique cities: "NYC" and "LA"
+		if len(result) != 2 {
+			t.Errorf("expected 2 unique cities, got %d: %v", len(result), result)
+		}
+		assertResultNoDuplicates(t, "City projection after join", result)
+	})
+
+	t.Run("Multiple projection columns", func(t *testing.T) {
+		result, err := db.ExecuteQuery(`
+			[:find ?name ?city
+			 :where [?e :person/name ?name]
+			        [?e :person/city ?city]]
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should have 3 unique (name, city) pairs
+		if len(result) != 3 {
+			t.Errorf("expected 3 tuples, got %d: %v", len(result), result)
+		}
+		assertResultNoDuplicates(t, "Name+city projection", result)
+	})
+}
+
+func TestSetSemantics_StorageQuery_WithPredicates(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "set_semantics_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	age := datalog.NewKeyword(":person/age")
+
+	for i := 0; i < 10; i++ {
+		e := datalog.NewIdentity(fmt.Sprintf("person:%d", i))
+		// Ages cycle: 20, 25, 30, 20, 25, 30, ...
+		// This creates multiple entities with the same age
+		ageVal := int64(20 + (i%3)*5)
+		tx.Add(e, age, ageVal)
+	}
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	t.Run("Filter then project to repeated values", func(t *testing.T) {
+		result, err := db.ExecuteQuery(`
+			[:find ?age
+			 :where [?e :person/age ?age]
+			        [(>= ?age 25)]]
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should have 2 unique ages: 25 and 30
+		if len(result) != 2 {
+			t.Errorf("expected 2 unique ages (25, 30), got %d: %v", len(result), result)
+		}
+		assertResultNoDuplicates(t, "Age projection with filter", result)
+	})
+}
+
+func TestSetSemantics_StorageQuery_Aggregation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "set_semantics_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	dept := datalog.NewKeyword(":employee/dept")
+	salary := datalog.NewKeyword(":employee/salary")
+
+	// Create employees with duplicate (dept, salary) combinations
+	// If duplicates aren't removed, count will be wrong
+	e1 := datalog.NewIdentity("emp:1")
+	e2 := datalog.NewIdentity("emp:2")
+	e3 := datalog.NewIdentity("emp:3")
+	e4 := datalog.NewIdentity("emp:4")
+
+	tx.Add(e1, dept, "Engineering")
+	tx.Add(e1, salary, int64(100000))
+	tx.Add(e2, dept, "Engineering")
+	tx.Add(e2, salary, int64(100000)) // Same dept and salary as e1
+	tx.Add(e3, dept, "Engineering")
+	tx.Add(e3, salary, int64(120000))
+	tx.Add(e4, dept, "Sales")
+	tx.Add(e4, salary, int64(80000))
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	t.Run("Count with potential duplicates", func(t *testing.T) {
+		// Count employees per department
+		result, err := db.ExecuteQuery(`
+			[:find ?dept (count ?e)
+			 :where [?e :employee/dept ?dept]
+			        [?e :employee/salary ?salary]]
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should have 2 groups (Engineering, Sales)
+		// Engineering should count 3 employees
+		// Sales should count 1 employee
+		if len(result) != 2 {
+			t.Errorf("expected 2 department groups, got %d: %v", len(result), result)
+		}
+		assertResultNoDuplicates(t, "Aggregation result", result)
+	})
+}
+
+func TestSetSemantics_StorageQuery_NotClause(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "set_semantics_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	status := datalog.NewKeyword(":user/status")
+	role := datalog.NewKeyword(":user/role")
+
+	e1 := datalog.NewIdentity("user:1")
+	e2 := datalog.NewIdentity("user:2")
+	e3 := datalog.NewIdentity("user:3")
+
+	tx.Add(e1, status, "active")
+	tx.Add(e1, role, "admin")
+	tx.Add(e2, status, "active")
+	tx.Add(e2, role, "user")
+	tx.Add(e3, status, "inactive")
+	tx.Add(e3, role, "admin")
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	t.Run("NOT clause with projection", func(t *testing.T) {
+		result, err := db.ExecuteQuery(`
+			[:find ?role
+			 :where [?e :user/role ?role]
+			        (not [?e :user/status "inactive"])]
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Active users have roles: "admin" and "user"
+		// Should be 2 unique roles
+		if len(result) != 2 {
+			t.Errorf("expected 2 unique roles, got %d: %v", len(result), result)
+		}
+		assertResultNoDuplicates(t, "NOT clause projection", result)
+	})
+}
+
+func TestSetSemantics_StorageQuery_OrClause(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "set_semantics_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	status := datalog.NewKeyword(":item/status")
+	priority := datalog.NewKeyword(":item/priority")
+
+	e1 := datalog.NewIdentity("item:1")
+	e2 := datalog.NewIdentity("item:2")
+	e3 := datalog.NewIdentity("item:3")
+	e4 := datalog.NewIdentity("item:4")
+
+	tx.Add(e1, status, "pending")
+	tx.Add(e1, priority, "high")
+	tx.Add(e2, status, "pending")
+	tx.Add(e2, priority, "low")
+	tx.Add(e3, status, "done")
+	tx.Add(e3, priority, "high") // high priority but done
+	tx.Add(e4, status, "pending")
+	tx.Add(e4, priority, "high") // Same as e1
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	t.Run("OR clause with overlapping results", func(t *testing.T) {
+		// Items that are either pending OR high priority
+		// e1, e2, e3, e4 match - but projecting to priority should dedupe
+		result, err := db.ExecuteQuery(`
+			[:find ?priority
+			 :where [?e :item/priority ?priority]
+			        (or [?e :item/status "pending"]
+			            [?e :item/priority "high"])]
+		`)
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should have 2 unique priorities: "high" and "low"
+		if len(result) != 2 {
+			t.Errorf("expected 2 unique priorities, got %d: %v", len(result), result)
+		}
+		assertResultNoDuplicates(t, "OR clause projection", result)
+	})
+}

--- a/docs/proposals/TUPLEKEYMAP_OPTIMIZATION.md
+++ b/docs/proposals/TUPLEKEYMAP_OPTIMIZATION.md
@@ -1,0 +1,150 @@
+# TupleKeyMap Optimization for Set Membership
+
+**Status**: Proposal
+**Created**: 2025-12-24
+**Context**: Performance regression from set semantics fix
+
+## Problem Statement
+
+The set semantics fix for `StreamingRelation.Project()` added `DedupIterator` which uses `TupleKeyMap` for deduplication. This caused:
+
+| Metric | Before | After | Regression |
+|--------|--------|-------|------------|
+| Time | 35,326 ns/op | 44,331 ns/op | +25% |
+| Memory | 2,520 B/op | 16,744 B/op | +6.6× |
+| Allocs | 111 allocs/op | 224 allocs/op | +2× |
+
+The overhead comes from `TupleKeyMap` being designed for **key-value storage** when deduplication only needs **set membership**.
+
+## Current Implementation
+
+```go
+// TupleKeyMap stores key-value pairs
+type TupleKeyMap struct {
+    m map[uint64][]mapEntry
+}
+
+type mapEntry struct {
+    values []interface{}  // For collision detection
+    value  interface{}    // The stored value - NOT NEEDED FOR DEDUP
+}
+
+// DedupIterator uses it as a set
+it.seen.Put(key, true)      // Stores `true` but never retrieves it
+it.seen.Exists(key)         // Only checks membership
+```
+
+For every tuple:
+1. Compute FNV-1a hash over all values
+2. Look up hash in map
+3. If collision bucket exists, compare values using `datalog.ValuesEqual()`
+4. Store `mapEntry{values, true}` - wastes space on the `value` field
+
+## Proposed Optimizations
+
+### Option 1: TupleSet (Minimal Change)
+
+Create a specialized `TupleSet` that doesn't store values:
+
+```go
+type TupleSet struct {
+    m map[uint64][]Tuple  // Just tuples, no mapEntry wrapper
+}
+
+func (s *TupleSet) Add(tuple Tuple) bool {
+    hash := hashValues(tuple)
+    for _, existing := range s.m[hash] {
+        if tuplesEqual(tuple, existing) {
+            return false  // Already exists
+        }
+    }
+    s.m[hash] = append(s.m[hash], tuple)
+    return true  // Was added
+}
+
+func (s *TupleSet) Contains(tuple Tuple) bool {
+    hash := hashValues(tuple)
+    for _, existing := range s.m[hash] {
+        if tuplesEqual(tuple, existing) {
+            return true
+        }
+    }
+    return false
+}
+```
+
+**Expected savings**: Eliminates `mapEntry` wrapper and `value` field per unique tuple.
+
+### Option 2: Interned Value Fast Path
+
+For single-column projections on interned types (`*Identity`, `*Keyword`), use pointer comparison:
+
+```go
+type SingleColumnSet struct {
+    m map[interface{}]struct{}
+}
+
+func (s *SingleColumnSet) Add(val interface{}) bool {
+    if _, exists := s.m[val]; exists {
+        return false
+    }
+    s.m[val] = struct{}{}
+    return true
+}
+```
+
+**When applicable**: Projection to single column of interned type.
+**Expected speedup**: Significant - avoids hashing entirely, uses Go's native map.
+
+### Option 3: Adaptive Strategy
+
+Choose strategy based on projection characteristics:
+
+```go
+func NewDedupIterator(source Iterator, columns []Symbol) Iterator {
+    if len(columns) == 1 && isInternedType(columns[0]) {
+        return &SingleColumnDedupIterator{...}
+    }
+    if expectedCardinality < 100 {
+        return &LinearScanDedupIterator{...}  // O(n²) but cache-friendly
+    }
+    return &HashDedupIterator{...}  // Current approach with TupleSet
+}
+```
+
+### Option 4: Probabilistic (Not Recommended)
+
+Use Bloom filter for approximate membership. **Rejected** because false positives would drop valid tuples, violating correctness.
+
+## Implementation Plan
+
+1. **Phase 1**: Create `TupleSet` (Option 1)
+   - Simple change, no behavior difference
+   - Measure improvement
+
+2. **Phase 2**: Add single-column fast path (Option 2)
+   - Requires detecting projection column types
+   - Only if Phase 1 shows insufficient improvement
+
+3. **Phase 3**: Adaptive strategy (Option 3)
+   - Only if real-world profiling shows benefit
+
+## Acceptance Criteria
+
+- Memory overhead reduced by at least 50%
+- Time overhead reduced by at least 15%
+- No correctness regressions (set semantics tests pass)
+- No additional allocations per tuple
+
+## Related Files
+
+- `datalog/executor/tuple_key.go` - Current `TupleKeyMap` implementation
+- `datalog/executor/iterator_composition.go` - `DedupIterator` implementation
+- `datalog/executor/relation.go` - `StreamingRelation.Project()` fix
+- `datalog/executor/set_semantics_test.go` - Correctness tests
+
+## Notes
+
+The 6.6× memory increase is significant but the fix is necessary for correctness. Datalog relations are **sets**, not **bags**. Without deduplication, queries can return incorrect results.
+
+The optimization should be measured against the fixed implementation, not the broken one. The goal is to reduce the correctness tax, not eliminate it entirely.


### PR DESCRIPTION
`StreamingRelation.Project()` was returning duplicate tuples, violating the fundamental Datalog invariant that relations are sets, not bags.

Reproduction:
- Query: `[:find ?v :where [_ :attribute ?v]]`
- Data: entity1 and entity2 both have `:attribute "shared"`, entity3 has `"unique"`
- Expected: 2 rows (`"shared"`, `"unique"`)
- Actual: 3 rows (`"shared"`, `"shared"`, `"unique"`)

Root cause: When projecting to fewer columns, previously-distinct tuples can become duplicates. `MaterializedRelation.Project()` correctly deduplicated, but `StreamingRelation.Project()` only wrapped with `ProjectIterator` without dedup.

Fix: Wrap `ProjectIterator` output with `DedupIterator`.

Why this matters:
- Set semantics are fundamental to Datalog correctness
- The bug is silent (extra rows, no errors) and easy to miss
- With streaming enabled by default, this affected the common path
- Aggregations (`COUNT`, `SUM`, `AVG`) over duplicates produce wrong values

Performance impact (BenchmarkStreamingVsMaterialized/Streaming):
- Time: 35,326 ns/op -> 44,331 ns/op (+25%)
- Memory: 2,520 B/op -> 16,744 B/op (+6.6x)
- Allocs: 111 -> 224 (+2x)

This overhead is acceptable for correctness. Future optimization proposal in `docs/proposals/TUPLEKEYMAP_OPTIMIZATION.md` to reduce the dedup cost.

Tests added:
- `datalog/executor/set_semantics_test.go` (20+ unit tests)
- `datalog/storage/set_semantics_storage_test.go` (integration tests)

Tests use `datalog.ValuesEqual` for duplicate detection, ensuring test/production parity for type-sensitive equality (e.g., `int` vs `int64`).