### PR TITLE
Add Go-native query builder (qb) package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Built for real-world financial analysis with sentiment, options, and OHLC data w
 go get github.com/wbrown/janus-datalog
 ```
 
+**Define your schema attributes as constants:**
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/qb"
+
+var (
+    UserName = qb.Kw(":user/name")
+    UserAge  = qb.Kw(":user/age")
+)
+```
+
 **Write data:**
 
 ```go
@@ -45,35 +56,95 @@ db, _ := storage.NewDatabase("my.db")
 tx := db.NewTransaction()
 
 alice := datalog.NewIdentity("user:alice")
-tx.Add(alice, datalog.NewKeyword(":user/name"), "Alice")
-tx.Add(alice, datalog.NewKeyword(":user/age"), int64(30))
+tx.Add(alice, UserName.Keyword(), "Alice")
+tx.Add(alice, UserAge.Keyword(), int64(30))
 tx.Commit()
 ```
 
-**Query it:**
+**Query it (Go-native):**
 
 ```go
-query, _ := parser.ParseQuery(`
-    [:find ?name ?age
-     :where [?user :user/name ?name]
-            [?user :user/age ?age]
-            [(> ?age 21)]]
-`)
+e := qb.NewVar()
+name := qb.NewVar()
+age := qb.NewVar()
 
-exec := executor.NewExecutor(db.Matcher())
-results, _ := exec.Execute(query)
-fmt.Println(results.Table())  // Markdown table output
+q := qb.Query().
+    Find(name, age).
+    Where(
+        qb.Pat(e, UserName, name),
+        qb.Pat(e, UserAge, age),
+        qb.Gt(age, 21),
+    ).
+    MustBuild()
+
+results, _ := db.ExecuteQuery(q)
 ```
 
 **Output:**
 
 ```
-| ?name | ?age |
-|-------|------|
-| Alice |   30 |
+[["Alice" 30]]
 ```
 
-That's it. No schema required. No connection pools. No query tuning.
+That's it. No schema required. No connection pools. No query tuning. Typos caught at compile time.
+
+## Query Builder vs EDN Strings
+
+Janus supports two ways to write queries:
+
+### Query Builder (Recommended)
+
+The `qb` package provides compile-time safety and IDE support:
+
+```go
+var (
+    PersonName = qb.Kw(":person/name")
+    PersonAge  = qb.Kw(":person/age")
+)
+
+e := qb.NewVar()
+name := qb.NewVar()
+age := qb.NewVar()
+
+q := qb.Query().
+    Find(name, age).
+    Where(
+        qb.Pat(e, PersonName, name),
+        qb.Pat(e, PersonAge, age),
+        qb.Gte(age, 21),
+    ).
+    MustBuild()
+
+results, _ := db.ExecuteQuery(q)
+```
+
+**Why use it:**
+- Typos in `":person/naem"` silently return empty results; `PersonName` catches typos at compile time
+- IDE autocomplete shows available attributes
+- Refactoring is safe with find-replace
+- Same `*Var` in multiple patterns = join (no string matching)
+
+### EDN Strings (Fallback)
+
+For REPL exploration, porting Datomic queries, or when you prefer Datalog syntax:
+
+```go
+results, _ := db.ExecuteQuery(`
+    [:find ?name ?age
+     :where [?e :person/name ?name]
+            [?e :person/age ?age]
+            [(>= ?age 21)]]
+`)
+```
+
+**When to use:**
+- Quick ad-hoc queries during development
+- Porting existing Clojure/Datomic code
+- Documentation showing Datalog equivalents
+
+Both produce identical results. All database methods accept either form.
+
+See [docs/reference/QUERY_BUILDER.md](docs/reference/QUERY_BUILDER.md) for complete query builder documentation.
 
 ## Running Examples
 
@@ -689,6 +760,7 @@ See [docs/papers/README.md](docs/papers/README.md) for complete details.
 
 ### Getting Started
 
+- **[docs/reference/QUERY_BUILDER.md](docs/reference/QUERY_BUILDER.md)** - Go-native query builder (recommended)
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - System architecture and design decisions
 - **[DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md)** - Feature comparison (~70% compatibility)
 - **[DOCUMENTATION_INDEX.md](DOCUMENTATION_INDEX.md)** - Complete documentation guide

--- a/datalog/qb/README.md
+++ b/datalog/qb/README.md
@@ -1,0 +1,124 @@
+# qb - Go-Native Query Builder
+
+The `qb` package is the **recommended way** to write Datalog queries in Go. It provides compile-time safety, IDE support, and eliminates string manipulation errors.
+
+## Why Use the Query Builder?
+
+| | Query Builder | EDN Strings |
+|---|---|---|
+| **Typos** | Compile-time error | Silent empty results |
+| **Refactoring** | Safe find-replace | Manual text search |
+| **IDE Support** | Full autocomplete | None |
+| **Type Safety** | Go compiler checks | Runtime parse errors |
+| **Joins** | Variable identity | String matching |
+
+**EDN strings are still supported** for REPL exploration, porting existing queries, or when you prefer the Datalog syntax directly.
+
+## Quick Start
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/qb"
+
+// 1. Define your schema attributes as constants
+var (
+    PersonName = qb.Kw(":person/name")
+    PersonAge  = qb.Kw(":person/age")
+    PersonCity = qb.Kw(":person/city")
+)
+
+// 2. Build queries with Go variables
+func FindAdultsInCity(db *storage.Database, city string) ([][]interface{}, error) {
+    e := qb.NewVar()
+    name := qb.NewVar()
+    age := qb.NewVar()
+    inputCity := qb.NewVar()
+
+    q := qb.Query().
+        Find(name, age).
+        In(qb.DB, qb.Scalar(inputCity)).
+        Where(
+            qb.Pat(e, PersonName, name),
+            qb.Pat(e, PersonAge, age),
+            qb.Pat(e, PersonCity, inputCity),
+            qb.Gte(age, 18),
+        ).
+        MustBuild()
+
+    return db.ExecuteQueryWithInputs(q, city)
+}
+```
+
+## The Key Insight
+
+**Go variable identity IS the join condition.**
+
+```go
+e := qb.NewVar()    // This pointer...
+name := qb.NewVar()
+age := qb.NewVar()
+
+qb.Pat(e, PersonName, name)  // ...used here
+qb.Pat(e, PersonAge, age)    // ...and here = JOIN
+```
+
+Same `*Var` pointer in multiple patterns = join on that variable. No string matching, no typos possible.
+
+## Comparison
+
+### Query Builder (Recommended)
+
+```go
+var (
+    PersonName = qb.Kw(":person/name")
+    PersonAge  = qb.Kw(":person/age")
+)
+
+e := qb.NewVar()
+name := qb.NewVar()
+age := qb.NewVar()
+
+q := qb.Query().
+    Find(name, age).
+    Where(
+        qb.Pat(e, PersonName, name),
+        qb.Pat(e, PersonAge, age),
+        qb.Gt(age, 21),
+    ).
+    MustBuild()
+
+results, err := db.ExecuteQuery(q)
+```
+
+### EDN String (Fallback)
+
+```go
+results, err := db.ExecuteQuery(`
+    [:find ?name ?age
+     :where
+     [?e :person/name ?name]
+     [?e :person/age ?age]
+     [(> ?age 21)]]
+`)
+```
+
+Both produce identical results. The query builder version catches errors at compile time.
+
+## When to Use EDN Strings
+
+- **REPL/exploration**: Quick ad-hoc queries during development
+- **Migration**: Porting queries from Clojure/Datomic codebases
+- **Dynamic queries**: Building query strings from user input (with proper escaping)
+- **Documentation**: Showing equivalent Datalog syntax
+
+## Full Documentation
+
+See [docs/reference/QUERY_BUILDER.md](../../docs/reference/QUERY_BUILDER.md) for complete API documentation including:
+
+- Patterns (any arity)
+- Predicates and comparisons
+- Aggregations
+- Expressions (arithmetic, string, time)
+- Input parameters (scalar, collection, tuple, relation)
+- Logical clauses (NOT, OR)
+- Subqueries
+- Ordering

--- a/datalog/qb/agg.go
+++ b/datalog/qb/agg.go
@@ -1,0 +1,75 @@
+package qb
+
+import (
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Agg represents an aggregation function result.
+// Used in Find() to aggregate over grouped results.
+type Agg struct {
+	fn  string
+	arg *Var
+}
+
+// Sum creates a sum aggregation over a variable.
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(dept, qb.Sum(salary)).
+//	    Where(...)
+func Sum(v *Var) Agg {
+	return Agg{fn: "sum", arg: v}
+}
+
+// Count creates a count aggregation over a variable.
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(dept, qb.Count(employee)).
+//	    Where(...)
+func Count(v *Var) Agg {
+	return Agg{fn: "count", arg: v}
+}
+
+// Avg creates an average aggregation over a variable.
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(dept, qb.Avg(salary)).
+//	    Where(...)
+func Avg(v *Var) Agg {
+	return Agg{fn: "avg", arg: v}
+}
+
+// Min creates a minimum aggregation over a variable.
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(symbol, qb.Min(price)).
+//	    Where(...)
+func Min(v *Var) Agg {
+	return Agg{fn: "min", arg: v}
+}
+
+// Max creates a maximum aggregation over a variable.
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(symbol, qb.Max(price)).
+//	    Where(...)
+func Max(v *Var) Agg {
+	return Agg{fn: "max", arg: v}
+}
+
+// toFindElement converts Agg to a query.FindElement
+func (a Agg) toFindElement() query.FindElement {
+	return query.FindAggregate{
+		Function: a.fn,
+		Arg:      a.arg.Symbol(),
+	}
+}

--- a/datalog/qb/attr.go
+++ b/datalog/qb/attr.go
@@ -1,0 +1,98 @@
+package qb
+
+import (
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Attr represents a keyword attribute. Define once per attribute
+// and reuse throughout your queries.
+//
+// Example:
+//
+//	var (
+//	    PersonName = qb.Kw(":person/name")
+//	    PersonAge  = qb.Kw(":person/age")
+//	)
+type Attr struct {
+	kw datalog.Keyword
+}
+
+// Kw creates an attribute keyword. This should be called once per attribute
+// in your schema definitions, then reused in queries.
+//
+// Accepts keywords with or without the leading colon:
+//
+//	PersonName := qb.Kw(":person/name")  // with colon
+//	PersonAge := qb.Kw("person/age")     // without colon (added automatically)
+func Kw(s string) Attr {
+	return Attr{kw: datalog.NewKeyword(s)}
+}
+
+// Keyword returns the underlying datalog.Keyword for internal use.
+func (a Attr) Keyword() datalog.Keyword {
+	return a.kw
+}
+
+// String returns the keyword string representation.
+func (a Attr) String() string {
+	return a.kw.String()
+}
+
+// toPatternElement converts Attr to a query.PatternElement (constant)
+func (a Attr) toPatternElement() query.PatternElement {
+	return query.Constant{Value: a.kw}
+}
+
+// Val wraps a constant value for use in patterns.
+// This disambiguates between variables and literal values in the API.
+//
+// Example:
+//
+//	qb.Pat(e, PersonCity, qb.V("NYC"))  // literal string value
+//	qb.Pat(e, PersonActive, qb.V(true)) // literal boolean
+type Val struct {
+	value interface{}
+}
+
+// V creates a constant value wrapper for use in patterns.
+// Use this when you want a literal value, not a variable.
+//
+// Example:
+//
+//	qb.Pat(e, PersonCity, qb.V("NYC"))
+//	qb.Pat(e, PersonAge, qb.V(int64(30)))
+func V(value interface{}) Val {
+	return Val{value: value}
+}
+
+// Value returns the underlying value.
+func (v Val) Value() interface{} {
+	return v.value
+}
+
+// toPatternElement converts Val to a query.PatternElement
+func (v Val) toPatternElement() query.PatternElement {
+	return query.Constant{Value: v.value}
+}
+
+// toTerm converts Val to a query.Term for use in predicates
+func (v Val) toTerm() query.Term {
+	return query.ConstantTerm{Value: v.value}
+}
+
+// Blank returns a blank/wildcard pattern element.
+// Use this when you don't care about a position in a pattern.
+//
+// Example:
+//
+//	qb.Pat(e, qb.Blank(), name)  // match any attribute
+func Blank() blankElement {
+	return blankElement{}
+}
+
+type blankElement struct{}
+
+func (b blankElement) toPatternElement() query.PatternElement {
+	return query.Blank{}
+}

--- a/datalog/qb/builder.go
+++ b/datalog/qb/builder.go
@@ -1,0 +1,265 @@
+package qb
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// QueryBuilder constructs a *query.Query using fluent methods.
+// The built query can be passed directly to Database.QueryInto,
+// Database.ExecuteQuery, etc.
+type QueryBuilder struct {
+	find    []query.FindElement
+	in      []query.InputSpec
+	where   []query.Clause
+	orderBy []query.OrderByClause
+	errors  []error
+}
+
+// Query starts building a new query.
+//
+// Example:
+//
+//	e, name, age := qb.NewVar(), qb.NewVar(), qb.NewVar()
+//	q := qb.Query().
+//	    Find(name, age).
+//	    Where(
+//	        qb.Pat(e, PersonName, name),
+//	        qb.Pat(e, PersonAge, age),
+//	        qb.Gt(age, 21),
+//	    ).MustBuild()
+func Query() *QueryBuilder {
+	return &QueryBuilder{}
+}
+
+// Find specifies what to return from the query.
+//
+// Accepts:
+//   - *Var: returns the variable's value
+//   - Agg: returns an aggregation result (Sum, Count, etc.)
+//
+// Example:
+//
+//	qb.Query().Find(name, age)              // return two variables
+//	qb.Query().Find(dept, qb.Sum(salary))   // return variable and aggregation
+func (b *QueryBuilder) Find(elements ...interface{}) *QueryBuilder {
+	for _, elem := range elements {
+		findElem, err := toFindElement(elem)
+		if err != nil {
+			b.errors = append(b.errors, err)
+			continue
+		}
+		b.find = append(b.find, findElem)
+	}
+	return b
+}
+
+// In specifies input parameters for the query.
+// The first input is typically DB (the database), followed by parameter specs.
+//
+// Example:
+//
+//	minAge := qb.NewVar()
+//	qb.Query().
+//	    Find(name).
+//	    In(qb.DB, qb.Scalar(minAge)).
+//	    Where(...)
+func (b *QueryBuilder) In(specs ...interface{}) *QueryBuilder {
+	for _, spec := range specs {
+		inputSpec, err := toInputSpec(spec)
+		if err != nil {
+			b.errors = append(b.errors, err)
+			continue
+		}
+		b.in = append(b.in, inputSpec)
+	}
+	return b
+}
+
+// Where adds clauses to the query.
+//
+// Accepts:
+//   - *Pattern: data patterns from Pat(e, a, v), Pat(e, a, v, tx), Pat(e, a, v, tx, op)
+//   - *Comparison: comparisons from Lt(), Gt(), Eq(), etc.
+//   - *ChainedComparison: from Chained(), Range()
+//   - *Expression: from Add().As(), Str().As(), etc.
+//   - *NotClause: from Not()
+//   - *NotJoinClause: from NotJoin()
+//   - *OrClause: from Or()
+//   - *OrJoinClause: from OrJoin()
+//   - *SubqueryBuilder: from Subquery()
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(name, age).
+//	    Where(
+//	        qb.Pat(e, PersonName, name),
+//	        qb.Pat(e, PersonAge, age),
+//	        qb.Gt(age, 21),
+//	    )
+func (b *QueryBuilder) Where(clauses ...interface{}) *QueryBuilder {
+	for i, clause := range clauses {
+		c, err := toClause(clause)
+		if err != nil {
+			b.errors = append(b.errors, err)
+			continue
+		}
+		if c == nil {
+			panic(fmt.Sprintf("Where: clause %d converted to nil", i))
+		}
+		b.where = append(b.where, c)
+	}
+	return b
+}
+
+// OrderBy adds ordering to the query results.
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(name, age).
+//	    Where(...).
+//	    OrderBy(qb.Asc(name), qb.Desc(age))
+func (b *QueryBuilder) OrderBy(specs ...interface{}) *QueryBuilder {
+	for _, spec := range specs {
+		orderSpec, err := toOrderByClause(spec)
+		if err != nil {
+			b.errors = append(b.errors, err)
+			continue
+		}
+		b.orderBy = append(b.orderBy, orderSpec)
+	}
+	return b
+}
+
+// Build finalizes and validates the query, returning the built *query.Query.
+// Returns an error if the query is invalid or if any errors occurred during construction.
+func (b *QueryBuilder) Build() (*query.Query, error) {
+	if len(b.errors) > 0 {
+		return nil, fmt.Errorf("query builder errors: %v", b.errors)
+	}
+	if len(b.find) == 0 {
+		return nil, fmt.Errorf("query must have at least one find element")
+	}
+	if len(b.where) == 0 {
+		return nil, fmt.Errorf("query must have at least one where clause")
+	}
+
+	return &query.Query{
+		Find:    b.find,
+		In:      b.in,
+		Where:   b.where,
+		OrderBy: b.orderBy,
+	}, nil
+}
+
+// MustBuild is like Build but panics on error.
+// Useful for static query definitions where errors indicate programming bugs.
+//
+// Example:
+//
+//	var FindAdults = qb.Query().
+//	    Find(name, age).
+//	    Where(...).
+//	    MustBuild()
+func (b *QueryBuilder) MustBuild() *query.Query {
+	q, err := b.Build()
+	if err != nil {
+		panic(err)
+	}
+	return q
+}
+
+// OrderSpec represents an ordering specification.
+type OrderSpec struct {
+	v         *Var
+	direction query.OrderDirection
+}
+
+// Asc creates an ascending order specification.
+func Asc(v *Var) OrderSpec {
+	return OrderSpec{v: v, direction: query.OrderAsc}
+}
+
+// Desc creates a descending order specification.
+func Desc(v *Var) OrderSpec {
+	return OrderSpec{v: v, direction: query.OrderDesc}
+}
+
+// findElementer is implemented by types that can convert to FindElement
+type findElementer interface {
+	toFindElement() query.FindElement
+}
+
+// toFindElement converts various types to query.FindElement
+func toFindElement(elem interface{}) (query.FindElement, error) {
+	switch x := elem.(type) {
+	case *Var:
+		return x.toFindElement(), nil
+	case Agg:
+		return x.toFindElement(), nil
+	case findElementer:
+		return x.toFindElement(), nil
+	default:
+		return nil, fmt.Errorf("cannot convert %T to FindElement", elem)
+	}
+}
+
+// toInputSpec converts various types to query.InputSpec
+func toInputSpec(spec interface{}) (query.InputSpec, error) {
+	switch x := spec.(type) {
+	case InputSpec:
+		return x.toInputSpec(), nil
+	default:
+		return nil, fmt.Errorf("cannot convert %T to InputSpec", spec)
+	}
+}
+
+// toClause converts various types to query.Clause
+func toClause(c interface{}) (query.Clause, error) {
+	switch x := c.(type) {
+	case Clause:
+		return x.toClause(), nil
+	case *Pattern:
+		return x.toClause(), nil
+	case *Comparison:
+		return x.toClause(), nil
+	case *ChainedComparison:
+		return x.toClause(), nil
+	case *Expression:
+		return x.toClause(), nil
+	case *NotClause:
+		return x.toClause(), nil
+	case *NotJoinClause:
+		return x.toClause(), nil
+	case *OrClause:
+		return x.toClause(), nil
+	case *OrJoinClause:
+		return x.toClause(), nil
+	case *SubqueryBuilder:
+		return x.toClause(), nil
+	default:
+		return nil, fmt.Errorf("cannot convert %T to Clause", c)
+	}
+}
+
+// toOrderByClause converts various types to query.OrderByClause
+func toOrderByClause(spec interface{}) (query.OrderByClause, error) {
+	switch x := spec.(type) {
+	case OrderSpec:
+		return query.OrderByClause{
+			Variable:  x.v.Symbol(),
+			Direction: x.direction,
+		}, nil
+	case *Var:
+		// Default to ascending
+		return query.OrderByClause{
+			Variable:  x.Symbol(),
+			Direction: query.OrderAsc,
+		}, nil
+	default:
+		return query.OrderByClause{}, fmt.Errorf("cannot convert %T to OrderByClause", spec)
+	}
+}

--- a/datalog/qb/clause.go
+++ b/datalog/qb/clause.go
@@ -1,0 +1,160 @@
+package qb
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// NotClause represents a NOT (negation) clause.
+type NotClause struct {
+	clauses []interface{}
+}
+
+// Not creates a negation clause (anti-join).
+// Matches entities that do NOT match the inner patterns.
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(name).
+//	    Where(
+//	        qb.Pat(e, PersonName, name),
+//	        qb.Not(
+//	            qb.Pat(e, PersonCity, qb.V("NYC")),
+//	        ),
+//	    )
+func Not(clauses ...interface{}) *NotClause {
+	return &NotClause{clauses: clauses}
+}
+
+func (n *NotClause) toClause() query.Clause {
+	qclauses := make([]query.Clause, len(n.clauses))
+	for i, c := range n.clauses {
+		clause, ok := c.(Clause)
+		if !ok {
+			panic(fmt.Sprintf("Not: argument %d is not a Clause (got %T)", i, c))
+		}
+		qclauses[i] = clause.toClause()
+	}
+	return &query.NotClause{Clauses: qclauses}
+}
+
+// NotJoinClause represents a NOT-JOIN clause with explicit join variables.
+type NotJoinClause struct {
+	joinVars []*Var
+	clauses  []interface{}
+}
+
+// NotJoin creates a negation clause with explicit join variables.
+// Only the specified variables are used for joining with the outer query.
+//
+// Example:
+//
+//	qb.NotJoin([]*qb.Var{e},
+//	    qb.Pat(e, PersonStatus, qb.V("banned")),
+//	)
+func NotJoin(joinVars []*Var, clauses ...interface{}) *NotJoinClause {
+	return &NotJoinClause{joinVars: joinVars, clauses: clauses}
+}
+
+func (n *NotJoinClause) toClause() query.Clause {
+	joinSyms := make([]query.Symbol, len(n.joinVars))
+	for i, v := range n.joinVars {
+		joinSyms[i] = v.Symbol()
+	}
+
+	qclauses := make([]query.Clause, len(n.clauses))
+	for i, c := range n.clauses {
+		clause, ok := c.(Clause)
+		if !ok {
+			panic(fmt.Sprintf("NotJoin: argument %d is not a Clause (got %T)", i, c))
+		}
+		qclauses[i] = clause.toClause()
+	}
+
+	return &query.NotJoinClause{
+		JoinVars: joinSyms,
+		Clauses:  qclauses,
+	}
+}
+
+// OrClause represents an OR (disjunction) clause.
+type OrClause struct {
+	branches [][]interface{}
+}
+
+// Or creates a disjunction clause (union).
+// Each branch is a slice of clauses; a match in any branch satisfies the OR.
+//
+// Example:
+//
+//	qb.Or(
+//	    []interface{}{qb.Eq(status, qb.V("active"))},
+//	    []interface{}{qb.Eq(status, qb.V("pending"))},
+//	)
+func Or(branches ...[]interface{}) *OrClause {
+	return &OrClause{branches: branches}
+}
+
+func (o *OrClause) toClause() query.Clause {
+	qbranches := make([][]query.Clause, len(o.branches))
+	for i, branch := range o.branches {
+		qbranches[i] = make([]query.Clause, len(branch))
+		for j, c := range branch {
+			clause, ok := c.(Clause)
+			if !ok {
+				panic(fmt.Sprintf("Or: branch %d argument %d is not a Clause (got %T)", i, j, c))
+			}
+			qbranches[i][j] = clause.toClause()
+		}
+	}
+	return &query.OrClause{Branches: qbranches}
+}
+
+// OrJoinClause represents an OR-JOIN clause with explicit join variables.
+type OrJoinClause struct {
+	joinVars []*Var
+	branches [][]interface{}
+}
+
+// OrJoin creates a disjunction clause with explicit join variables.
+// Only the specified variables are exposed from the union.
+//
+// Example:
+//
+//	qb.OrJoin([]*qb.Var{name},
+//	    []interface{}{
+//	        qb.Pat(e, PersonNickname, name),
+//	    },
+//	    []interface{}{
+//	        qb.Pat(e, PersonName, name),
+//	    },
+//	)
+func OrJoin(joinVars []*Var, branches ...[]interface{}) *OrJoinClause {
+	return &OrJoinClause{joinVars: joinVars, branches: branches}
+}
+
+func (o *OrJoinClause) toClause() query.Clause {
+	joinSyms := make([]query.Symbol, len(o.joinVars))
+	for i, v := range o.joinVars {
+		joinSyms[i] = v.Symbol()
+	}
+
+	qbranches := make([][]query.Clause, len(o.branches))
+	for i, branch := range o.branches {
+		qbranches[i] = make([]query.Clause, len(branch))
+		for j, c := range branch {
+			clause, ok := c.(Clause)
+			if !ok {
+				panic(fmt.Sprintf("OrJoin: branch %d argument %d is not a Clause (got %T)", i, j, c))
+			}
+			qbranches[i][j] = clause.toClause()
+		}
+	}
+
+	return &query.OrJoinClause{
+		JoinVars: joinSyms,
+		Branches: qbranches,
+	}
+}

--- a/datalog/qb/doc.go
+++ b/datalog/qb/doc.go
@@ -1,0 +1,96 @@
+// Package qb provides an idiomatic Go query builder for Datalog queries.
+//
+// The key insight: Go variable identity IS the join condition. Using the same
+// *Var pointer in multiple patterns creates a join between those patterns.
+//
+// # Define Attributes as Constants
+//
+// Define schema attributes as package-level constants to prevent typos and
+// enable IDE completion:
+//
+//	var (
+//	    PersonName = qb.Kw(":person/name")
+//	    PersonAge  = qb.Kw(":person/age")
+//	    PersonCity = qb.Kw(":person/city")
+//	)
+//
+// # Basic Usage
+//
+//	e := qb.NewVar()
+//	name := qb.NewVar()
+//	age := qb.NewVar()
+//
+//	q := qb.Query().
+//	    Find(name, age).
+//	    Where(
+//	        qb.Pat(e, PersonName, name),
+//	        qb.Pat(e, PersonAge, age),  // same e = join
+//	        qb.Gt(age, 21),
+//	    ).
+//	    MustBuild()
+//
+//	results, err := db.ExecuteQuery(q)
+//
+// # Variables
+//
+// Variables represent unknowns in queries. Same pointer = same logical variable:
+//
+//	e := qb.NewVar()
+//	name := qb.NewVar()
+//	// Using same variable in multiple patterns creates a join
+//
+// # Patterns
+//
+// Pat creates patterns of any arity:
+//
+//	qb.Pat(e, a, v)           // [e a v] database pattern
+//	qb.Pat(e, a, v, tx)       // [e a v tx] with transaction
+//	qb.Pat(e, a, v, tx, op)   // [e a v tx op] history
+//	qb.Pat(name, age)         // 2-tuple input relation
+//
+// # Input Parameters
+//
+//	qb.DB                     // database source
+//	qb.Scalar(v)              // single value
+//	qb.Collection(v)          // iterate values [?v ...]
+//	qb.Tuple(a, b)            // single tuple [[?a ?b]]
+//	qb.Relation(a, b)         // multiple tuples [[?a ?b] ...]
+//
+// # Predicates
+//
+//	qb.Lt(a, b)               // a < b
+//	qb.Lte(a, b)              // a <= b
+//	qb.Gt(a, b)               // a > b
+//	qb.Gte(a, b)              // a >= b
+//	qb.Eq(a, b)               // a = b
+//	qb.Ne(a, b)               // a != b
+//	qb.Range(min, v, max)          // min < v < max
+//	qb.RangeInclusive(min, v, max) // min <= v <= max
+//
+// # Aggregations
+//
+//	qb.Sum(v)
+//	qb.Count(v)
+//	qb.Avg(v)
+//	qb.Min(v)
+//	qb.Max(v)
+//
+// # Expressions
+//
+//	qb.Add(a, b).As(result)
+//	qb.Sub(a, b).As(result)
+//	qb.Mul(a, b).As(result)
+//	qb.Div(a, b).As(result)
+//	qb.Str(parts...).As(result)
+//	qb.Ground(value).As(result)
+//	qb.Year(time).As(result)
+//
+// # Logical Clauses
+//
+//	qb.Not(clauses...)
+//	qb.NotJoin(joinVars, clauses...)
+//	qb.Or(branch1, branch2, ...)
+//	qb.OrJoin(joinVars, branch1, branch2, ...)
+//
+// See docs/reference/QUERY_BUILDER.md for complete documentation.
+package qb

--- a/datalog/qb/expression.go
+++ b/datalog/qb/expression.go
@@ -1,0 +1,191 @@
+package qb
+
+import (
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Expression represents an expression clause that binds a computed result.
+type Expression struct {
+	fn      query.Function
+	binding *Var
+}
+
+// toClause converts Expression to a query.Clause
+func (e *Expression) toClause() query.Clause {
+	return &query.Expression{
+		Function: e.fn,
+		Binding:  e.binding.Symbol(),
+	}
+}
+
+// ArithBuilder builds an arithmetic expression.
+type ArithBuilder struct {
+	op    query.ArithmeticOp
+	left  interface{}
+	right interface{}
+}
+
+// Add creates an addition expression.
+// Call .As(resultVar) to bind the result.
+//
+// Example:
+//
+//	total := qb.NewVar()
+//	qb.Add(price, tax).As(total)  // [(+ ?price ?tax) ?total]
+func Add(left, right interface{}) *ArithBuilder {
+	return &ArithBuilder{op: query.OpAdd, left: left, right: right}
+}
+
+// Sub creates a subtraction expression.
+// Call .As(resultVar) to bind the result.
+func Sub(left, right interface{}) *ArithBuilder {
+	return &ArithBuilder{op: query.OpSubtract, left: left, right: right}
+}
+
+// Mul creates a multiplication expression.
+// Call .As(resultVar) to bind the result.
+func Mul(left, right interface{}) *ArithBuilder {
+	return &ArithBuilder{op: query.OpMultiply, left: left, right: right}
+}
+
+// Div creates a division expression.
+// Call .As(resultVar) to bind the result.
+func Div(left, right interface{}) *ArithBuilder {
+	return &ArithBuilder{op: query.OpDivide, left: left, right: right}
+}
+
+// As binds the arithmetic result to a variable, completing the expression.
+func (a *ArithBuilder) As(result *Var) *Expression {
+	return &Expression{
+		fn: query.ArithmeticFunction{
+			Op:    a.op,
+			Left:  toTerm(a.left),
+			Right: toTerm(a.right),
+		},
+		binding: result,
+	}
+}
+
+// StrBuilder builds a string concatenation expression.
+type StrBuilder struct {
+	parts []interface{}
+}
+
+// Str creates a string concatenation expression.
+// Call .As(resultVar) to bind the result.
+//
+// Example:
+//
+//	fullName := qb.NewVar()
+//	qb.Str(firstName, " ", lastName).As(fullName)
+func Str(parts ...interface{}) *StrBuilder {
+	return &StrBuilder{parts: parts}
+}
+
+// As binds the string concatenation result to a variable.
+func (s *StrBuilder) As(result *Var) *Expression {
+	terms := make([]query.Term, len(s.parts))
+	for i, p := range s.parts {
+		terms[i] = toTerm(p)
+	}
+	return &Expression{
+		fn:      query.StringConcatFunction{Terms: terms},
+		binding: result,
+	}
+}
+
+// GroundBuilder builds a ground expression (constant binding).
+type GroundBuilder struct {
+	value interface{}
+}
+
+// Ground creates a ground expression that binds a constant value.
+// Call .As(resultVar) to bind the result.
+//
+// Example:
+//
+//	taxRate := qb.NewVar()
+//	qb.Ground(0.08).As(taxRate)  // [(ground 0.08) ?taxRate]
+func Ground(value interface{}) *GroundBuilder {
+	return &GroundBuilder{value: value}
+}
+
+// As binds the ground value to a variable.
+func (g *GroundBuilder) As(result *Var) *Expression {
+	return &Expression{
+		fn:      query.GroundFunction{Value: g.value},
+		binding: result,
+	}
+}
+
+// IdentityBuilder builds an identity expression (pass-through binding).
+type IdentityBuilder struct {
+	arg interface{}
+}
+
+// Identity creates an identity expression that passes a value through.
+// Useful for binding an existing variable to a new name.
+func Identity(arg interface{}) *IdentityBuilder {
+	return &IdentityBuilder{arg: arg}
+}
+
+// As binds the identity result to a variable.
+func (i *IdentityBuilder) As(result *Var) *Expression {
+	return &Expression{
+		fn:      query.IdentityFunction{Arg: toTerm(i.arg)},
+		binding: result,
+	}
+}
+
+// TimeBuilder builds a time extraction expression.
+type TimeBuilder struct {
+	field   string
+	timeVar *Var
+}
+
+// Year extracts the year from a time variable.
+// Call .As(resultVar) to bind the result.
+//
+// Example:
+//
+//	year := qb.NewVar()
+//	qb.Year(createdAt).As(year)
+func Year(timeVar *Var) *TimeBuilder {
+	return &TimeBuilder{field: "year", timeVar: timeVar}
+}
+
+// Month extracts the month from a time variable.
+func Month(timeVar *Var) *TimeBuilder {
+	return &TimeBuilder{field: "month", timeVar: timeVar}
+}
+
+// Day extracts the day from a time variable.
+func Day(timeVar *Var) *TimeBuilder {
+	return &TimeBuilder{field: "day", timeVar: timeVar}
+}
+
+// Hour extracts the hour from a time variable.
+func Hour(timeVar *Var) *TimeBuilder {
+	return &TimeBuilder{field: "hour", timeVar: timeVar}
+}
+
+// Minute extracts the minute from a time variable.
+func Minute(timeVar *Var) *TimeBuilder {
+	return &TimeBuilder{field: "minute", timeVar: timeVar}
+}
+
+// Second extracts the second from a time variable.
+func Second(timeVar *Var) *TimeBuilder {
+	return &TimeBuilder{field: "second", timeVar: timeVar}
+}
+
+// As binds the time extraction result to a variable.
+func (t *TimeBuilder) As(result *Var) *Expression {
+	return &Expression{
+		fn: query.TimeExtractionFunction{
+			Field:    t.field,
+			TimeTerm: query.VariableTerm{Symbol: t.timeVar.Symbol()},
+		},
+		binding: result,
+	}
+}

--- a/datalog/qb/input.go
+++ b/datalog/qb/input.go
@@ -1,0 +1,144 @@
+package qb
+
+import (
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// InputSpec represents an input specification in the :in clause.
+type InputSpec interface {
+	toInputSpec() query.InputSpec
+}
+
+// dbInput represents the database input ($).
+type dbInput struct{}
+
+// DB represents the database input parameter ($) in the :in clause.
+// This is typically the first input and is implicit if omitted.
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(name).
+//	    In(qb.DB, qb.Scalar(minAge)).
+//	    Where(...)
+var DB InputSpec = dbInput{}
+
+func (d dbInput) toInputSpec() query.InputSpec {
+	return query.DatabaseInput{}
+}
+
+// scalarInput represents a scalar input parameter (?x).
+type scalarInput struct {
+	v *Var
+}
+
+// Scalar creates a scalar input parameter specification.
+// The corresponding input value should be a single value.
+//
+// Example:
+//
+//	minAge := qb.NewVar()
+//	q := qb.Query().
+//	    Find(name, age).
+//	    In(qb.DB, qb.Scalar(minAge)).
+//	    Where(
+//	        qb.Pat(e, PersonName, name),
+//	        qb.Pat(e, PersonAge, age),
+//	        qb.Gte(age, minAge),
+//	    ).MustBuild()
+//
+//	db.ExecuteQueryWithInputs(q, 21)  // 21 is bound to minAge
+func Scalar(v *Var) InputSpec {
+	return scalarInput{v: v}
+}
+
+func (s scalarInput) toInputSpec() query.InputSpec {
+	return query.ScalarInput{Symbol: s.v.Symbol()}
+}
+
+// collectionInput represents a collection input [?x ...].
+type collectionInput struct {
+	v *Var
+}
+
+// Collection creates a collection input parameter specification.
+// The corresponding input should be a slice of values.
+// Each value is bound to the variable in turn.
+//
+// Example:
+//
+//	id := qb.NewVar()
+//	q := qb.Query().
+//	    Find(name).
+//	    In(qb.DB, qb.Collection(id)).
+//	    Where(qb.Pat(e, PersonID, id), qb.Pat(e, PersonName, name)).
+//	    MustBuild()
+//
+//	db.ExecuteQueryWithInputs(q, []string{"id1", "id2", "id3"})
+func Collection(v *Var) InputSpec {
+	return collectionInput{v: v}
+}
+
+func (c collectionInput) toInputSpec() query.InputSpec {
+	return query.CollectionInput{Symbol: c.v.Symbol()}
+}
+
+// tupleInput represents a tuple input [[?x ?y]].
+type tupleInput struct {
+	vars []*Var
+}
+
+// Tuple creates a tuple input parameter specification.
+// The corresponding input should be a slice with one value per variable.
+//
+// Example:
+//
+//	x, y := qb.NewVar(), qb.NewVar()
+//	q := qb.Query().
+//	    Find(name).
+//	    In(qb.DB, qb.Tuple(x, y)).
+//	    Where(...).
+//	    MustBuild()
+//
+//	db.ExecuteQueryWithInputs(q, []interface{}{10, 20})
+func Tuple(vars ...*Var) InputSpec {
+	return tupleInput{vars: vars}
+}
+
+func (t tupleInput) toInputSpec() query.InputSpec {
+	syms := make([]query.Symbol, len(t.vars))
+	for i, v := range t.vars {
+		syms[i] = v.Symbol()
+	}
+	return query.TupleInput{Symbols: syms}
+}
+
+// relationInput represents a relation input [[?x ?y] ...].
+type relationInput struct {
+	vars []*Var
+}
+
+// Relation creates a relation input parameter specification.
+// The corresponding input should be a slice of slices (rows).
+//
+// Example:
+//
+//	x, y := qb.NewVar(), qb.NewVar()
+//	q := qb.Query().
+//	    Find(name).
+//	    In(qb.DB, qb.Relation(x, y)).
+//	    Where(...).
+//	    MustBuild()
+//
+//	db.ExecuteQueryWithInputs(q, [][]interface{}{{1, 2}, {3, 4}})
+func Relation(vars ...*Var) InputSpec {
+	return relationInput{vars: vars}
+}
+
+func (r relationInput) toInputSpec() query.InputSpec {
+	syms := make([]query.Symbol, len(r.vars))
+	for i, v := range r.vars {
+		syms[i] = v.Symbol()
+	}
+	return query.RelationInput{Symbols: syms}
+}

--- a/datalog/qb/integration_test.go
+++ b/datalog/qb/integration_test.go
@@ -1,0 +1,1183 @@
+package qb_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/qb"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// Test attributes - defined once, reused throughout tests
+var (
+	PersonName   = qb.Kw(":person/name")
+	PersonAge    = qb.Kw(":person/age")
+	PersonCity   = qb.Kw(":person/city")
+	PersonSalary = qb.Kw(":person/salary")
+	PersonDept   = qb.Kw(":person/dept")
+	PersonActive = qb.Kw(":person/active")
+)
+
+// setupTestDB creates a test database with sample data
+func setupTestDB(t *testing.T) (*storage.Database, func()) {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "qb-integration-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		t.Fatalf("Failed to create database: %v", err)
+	}
+
+	// Insert test data
+	tx := db.NewTransaction()
+
+	// People with various attributes
+	people := []struct {
+		id     string
+		name   string
+		age    int64
+		city   string
+		salary float64
+		dept   string
+		active bool
+	}{
+		{"alice", "Alice", 30, "NYC", 75000, "Engineering", true},
+		{"bob", "Bob", 25, "LA", 65000, "Engineering", true},
+		{"charlie", "Charlie", 35, "NYC", 85000, "Sales", true},
+		{"diana", "Diana", 28, "Chicago", 70000, "Engineering", false},
+		{"eve", "Eve", 32, "LA", 90000, "Sales", true},
+	}
+
+	for _, p := range people {
+		e := datalog.NewIdentity(p.id)
+		tx.Add(e, PersonName.Keyword(), p.name)
+		tx.Add(e, PersonAge.Keyword(), p.age)
+		tx.Add(e, PersonCity.Keyword(), p.city)
+		tx.Add(e, PersonSalary.Keyword(), p.salary)
+		tx.Add(e, PersonDept.Keyword(), p.dept)
+		tx.Add(e, PersonActive.Keyword(), p.active)
+	}
+
+	if _, err := tx.Commit(); err != nil {
+		db.Close()
+		os.RemoveAll(tmpDir)
+		t.Fatalf("Failed to commit transaction: %v", err)
+	}
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	}
+
+	return db, cleanup
+}
+
+// TestIntegration_BasicQuery tests basic query execution
+func TestIntegration_BasicQuery(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+
+	q := qb.Query().
+		Find(name).
+		Where(qb.Pat(e, PersonName, name)).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 5 {
+		t.Errorf("Expected 5 results, got %d", len(results))
+	}
+
+	// Verify all names are present
+	names := make(map[string]bool)
+	for _, row := range results {
+		if name, ok := row[0].(string); ok {
+			names[name] = true
+		}
+	}
+
+	expected := []string{"Alice", "Bob", "Charlie", "Diana", "Eve"}
+	for _, exp := range expected {
+		if !names[exp] {
+			t.Errorf("Missing expected name: %s", exp)
+		}
+	}
+}
+
+// TestIntegration_JoinQuery tests that same variable creates join
+func TestIntegration_JoinQuery(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Same `e` variable in both patterns = join on entity
+	e := qb.NewVar()
+	name := qb.NewVar()
+	age := qb.NewVar()
+
+	q := qb.Query().
+		Find(name, age).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonAge, age),
+		).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 5 {
+		t.Errorf("Expected 5 results, got %d", len(results))
+	}
+
+	// Verify Alice is 30
+	for _, row := range results {
+		if row[0] == "Alice" {
+			if age, ok := row[1].(int64); ok {
+				if age != 30 {
+					t.Errorf("Expected Alice age 30, got %d", age)
+				}
+			}
+		}
+	}
+}
+
+// TestIntegration_PredicateQuery tests queries with predicates
+func TestIntegration_PredicateQuery(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+	age := qb.NewVar()
+
+	// Find people over 30
+	q := qb.Query().
+		Find(name).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonAge, age),
+			qb.Gt(age, qb.V(int64(30))),
+		).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	// Should be Charlie (35) and Eve (32)
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+
+	names := make(map[string]bool)
+	for _, row := range results {
+		if name, ok := row[0].(string); ok {
+			names[name] = true
+		}
+	}
+
+	if !names["Charlie"] {
+		t.Error("Expected Charlie in results")
+	}
+	if !names["Eve"] {
+		t.Error("Expected Eve in results")
+	}
+}
+
+// TestIntegration_MultiplePredicates tests queries with multiple predicates
+func TestIntegration_MultiplePredicates(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+	age := qb.NewVar()
+	city := qb.NewVar()
+
+	// Find people in NYC who are over 25
+	q := qb.Query().
+		Find(name, age).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonAge, age),
+			qb.Pat(e, PersonCity, city),
+			qb.Eq(city, qb.V("NYC")),
+			qb.Gt(age, qb.V(int64(25))),
+		).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	// Should be Alice (30, NYC) and Charlie (35, NYC)
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+}
+
+// TestIntegration_AggregationQuery tests queries with aggregation
+func TestIntegration_AggregationQuery(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	dept := qb.NewVar()
+	salary := qb.NewVar()
+
+	// Sum salary by department
+	q := qb.Query().
+		Find(dept, qb.Sum(salary)).
+		Where(
+			qb.Pat(e, PersonDept, dept),
+			qb.Pat(e, PersonSalary, salary),
+		).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	// Should have 2 departments
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+
+	// Verify totals
+	totals := make(map[string]float64)
+	for _, row := range results {
+		if d, ok := row[0].(string); ok {
+			if s, ok := row[1].(float64); ok {
+				totals[d] = s
+			}
+		}
+	}
+
+	// Engineering: Alice (75000) + Bob (65000) + Diana (70000) = 210000
+	if totals["Engineering"] != 210000 {
+		t.Errorf("Expected Engineering total 210000, got %v", totals["Engineering"])
+	}
+
+	// Sales: Charlie (85000) + Eve (90000) = 175000
+	if totals["Sales"] != 175000 {
+		t.Errorf("Expected Sales total 175000, got %v", totals["Sales"])
+	}
+}
+
+// TestIntegration_CountAggregation tests count aggregation
+func TestIntegration_CountAggregation(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	dept := qb.NewVar()
+	name := qb.NewVar()
+
+	// Count people by department
+	q := qb.Query().
+		Find(dept, qb.Count(name)).
+		Where(
+			qb.Pat(e, PersonDept, dept),
+			qb.Pat(e, PersonName, name),
+		).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	counts := make(map[string]int64)
+	for _, row := range results {
+		if d, ok := row[0].(string); ok {
+			if c, ok := row[1].(int64); ok {
+				counts[d] = c
+			}
+		}
+	}
+
+	if counts["Engineering"] != 3 {
+		t.Errorf("Expected Engineering count 3, got %v", counts["Engineering"])
+	}
+	if counts["Sales"] != 2 {
+		t.Errorf("Expected Sales count 2, got %v", counts["Sales"])
+	}
+}
+
+// TestIntegration_InputParameters tests queries with input parameters
+func TestIntegration_InputParameters(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	inputName := qb.NewVar()
+	age := qb.NewVar()
+
+	// Scalar input used directly in pattern - this is idiomatic Datalog
+	// The input variable is bound to the input value, then used to match patterns
+	q := qb.Query().
+		Find(inputName, age).
+		In(qb.DB, qb.Scalar(inputName)).
+		Where(
+			qb.Pat(e, PersonName, inputName), // inputName bound to "Alice" from input
+			qb.Pat(e, PersonAge, age),
+		).
+		MustBuild()
+
+	// Find person named "Alice" and return their age
+	results, err := db.ExecuteQueryWithInputs(q, "Alice")
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(results))
+	}
+
+	if len(results) > 0 {
+		if results[0][0] != "Alice" {
+			t.Errorf("Expected name Alice, got %v", results[0][0])
+		}
+		if results[0][1] != int64(30) {
+			t.Errorf("Expected age 30, got %v", results[0][1])
+		}
+	}
+}
+
+// TestIntegration_CollectionInput tests queries with collection input
+func TestIntegration_CollectionInput(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	inputName := qb.NewVar()
+	age := qb.NewVar()
+
+	// Collection input - each value is iterated and used to match patterns
+	// [?inputName ...] means: for each value in the collection, bind ?inputName
+	q := qb.Query().
+		Find(inputName, age).
+		In(qb.DB, qb.Collection(inputName)).
+		Where(
+			qb.Pat(e, PersonName, inputName), // inputName bound from collection
+			qb.Pat(e, PersonAge, age),
+		).
+		MustBuild()
+
+	// Find people named Alice or Bob and their ages
+	results, err := db.ExecuteQueryWithInputs(q, []string{"Alice", "Bob"})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	// Should be Alice and Bob
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+
+	names := make(map[string]bool)
+	for _, row := range results {
+		if n, ok := row[0].(string); ok {
+			names[n] = true
+		}
+	}
+	if !names["Alice"] || !names["Bob"] {
+		t.Errorf("Expected Alice and Bob, got %v", names)
+	}
+}
+
+// TestIntegration_OrderBy tests queries with ordering
+func TestIntegration_OrderBy(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+	age := qb.NewVar()
+
+	q := qb.Query().
+		Find(name, age).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonAge, age),
+		).
+		OrderBy(qb.Desc(age)).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 5 {
+		t.Fatalf("Expected 5 results, got %d", len(results))
+	}
+
+	// First result should be Charlie (35)
+	if results[0][0] != "Charlie" {
+		t.Errorf("Expected first result to be Charlie, got %v", results[0][0])
+	}
+
+	// Last result should be Bob (25)
+	if results[4][0] != "Bob" {
+		t.Errorf("Expected last result to be Bob, got %v", results[4][0])
+	}
+}
+
+// TestIntegration_QueryInto tests QueryInto with struct mapping
+// Uses positional mapping - no datalog tags needed, fields map by order
+func TestIntegration_QueryInto(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// No datalog tags - fields map positionally to Find() order
+	type PersonResult struct {
+		Name string
+		Age  int64
+	}
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+	age := qb.NewVar()
+
+	q := qb.Query().
+		Find(name, age). // Position 0: Name, Position 1: Age
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonAge, age),
+			qb.Gt(age, qb.V(int64(30))),
+		).
+		OrderBy(qb.Desc(age)).
+		MustBuild()
+
+	var results []PersonResult
+	err := db.QueryInto(&results, q)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+
+	// First should be Charlie (35)
+	if results[0].Name != "Charlie" || results[0].Age != 35 {
+		t.Errorf("Expected Charlie/35, got %s/%d", results[0].Name, results[0].Age)
+	}
+}
+
+// TestIntegration_QueryOneInto tests QueryOneInto for single result
+// Uses positional mapping - no datalog tags needed
+func TestIntegration_QueryOneInto(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// No datalog tags - fields map positionally
+	type PersonResult struct {
+		Name string
+		Age  int64
+	}
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+	age := qb.NewVar()
+
+	// Query for Alice specifically
+	q := qb.Query().
+		Find(name, age).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonAge, age),
+			qb.Eq(name, qb.V("Alice")),
+		).
+		MustBuild()
+
+	var result PersonResult
+	found, err := db.QueryOneInto(&result, q)
+	if err != nil {
+		t.Fatalf("QueryOneInto failed: %v", err)
+	}
+
+	if !found {
+		t.Error("Expected to find Alice")
+	}
+
+	if result.Name != "Alice" || result.Age != 30 {
+		t.Errorf("Expected Alice/30, got %s/%d", result.Name, result.Age)
+	}
+}
+
+// TestIntegration_QueryIntoWithAggregation tests QueryInto with aggregation functions
+// Uses positional mapping - no datalog tags needed
+func TestIntegration_QueryIntoWithAggregation(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// No datalog tags - fields map positionally to Find() order
+	type DeptStats struct {
+		Dept  string  // Position 0: dept
+		Avg   float64 // Position 1: (avg salary)
+		Count int64   // Position 2: (count e)
+	}
+
+	e := qb.NewVar()
+	dept := qb.NewVar()
+	salary := qb.NewVar()
+
+	q := qb.Query().
+		Find(dept, qb.Avg(salary), qb.Count(e)).
+		Where(
+			qb.Pat(e, PersonDept, dept),
+			qb.Pat(e, PersonSalary, salary),
+		).
+		OrderBy(qb.Asc(dept)).
+		MustBuild()
+
+	var results []DeptStats
+	err := db.QueryInto(&results, q)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("Expected 2 departments, got %d", len(results))
+	}
+
+	// Check Engineering: 3 people (Alice 75000, Bob 65000, Diana 70000) avg = 70000
+	// Check Sales: 2 people (Charlie 85000, Eve 90000) avg = 87500
+	deptMap := make(map[string]DeptStats)
+	for _, r := range results {
+		deptMap[r.Dept] = r
+	}
+
+	if eng, ok := deptMap["Engineering"]; ok {
+		if eng.Count != 3 {
+			t.Errorf("Expected Engineering count 3, got %d", eng.Count)
+		}
+		if eng.Avg != 70000 {
+			t.Errorf("Expected Engineering avg 70000, got %f", eng.Avg)
+		}
+	} else {
+		t.Error("Missing Engineering department")
+	}
+
+	if sales, ok := deptMap["Sales"]; ok {
+		if sales.Count != 2 {
+			t.Errorf("Expected Sales count 2, got %d", sales.Count)
+		}
+		if sales.Avg != 87500 {
+			t.Errorf("Expected Sales avg 87500, got %f", sales.Avg)
+		}
+	} else {
+		t.Error("Missing Sales department")
+	}
+}
+
+// TestIntegration_CompareWithEDN verifies built query produces same results as EDN string
+func TestIntegration_CompareWithEDN(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// EDN query
+	ednQuery := `[:find ?name ?age
+                  :where
+                  [?e :person/name ?name]
+                  [?e :person/age ?age]
+                  [(> ?age 30)]]`
+
+	// Built query
+	e := qb.NewVar()
+	name := qb.NewVar()
+	age := qb.NewVar()
+
+	builtQuery := qb.Query().
+		Find(name, age).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonAge, age),
+			qb.Gt(age, qb.V(int64(30))),
+		).
+		MustBuild()
+
+	// Execute both
+	ednResults, err := db.ExecuteQuery(ednQuery)
+	if err != nil {
+		t.Fatalf("EDN query failed: %v", err)
+	}
+
+	builtResults, err := db.ExecuteQuery(builtQuery)
+	if err != nil {
+		t.Fatalf("Built query failed: %v", err)
+	}
+
+	// Compare results
+	if len(ednResults) != len(builtResults) {
+		t.Errorf("Result count mismatch: EDN=%d, built=%d", len(ednResults), len(builtResults))
+	}
+
+	// Both should have Charlie and Eve
+	ednNames := make(map[string]bool)
+	builtNames := make(map[string]bool)
+
+	for _, row := range ednResults {
+		if n, ok := row[0].(string); ok {
+			ednNames[n] = true
+		}
+	}
+	for _, row := range builtResults {
+		if n, ok := row[0].(string); ok {
+			builtNames[n] = true
+		}
+	}
+
+	if !ednNames["Charlie"] || !ednNames["Eve"] {
+		t.Error("EDN query missing expected results")
+	}
+	if !builtNames["Charlie"] || !builtNames["Eve"] {
+		t.Error("Built query missing expected results")
+	}
+}
+
+// TestIntegration_ConstantValue tests pattern with constant value
+func TestIntegration_ConstantValue(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+
+	// Find people in NYC (constant value in pattern)
+	q := qb.Query().
+		Find(name).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonCity, qb.V("NYC")),
+		).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	// Should be Alice and Charlie
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+}
+
+// TestIntegration_BooleanPredicate tests boolean comparison
+func TestIntegration_BooleanPredicate(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+	active := qb.NewVar()
+
+	// Find active people
+	q := qb.Query().
+		Find(name).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonActive, active),
+			qb.Eq(active, qb.V(true)),
+		).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	// Should be Alice, Bob, Charlie, Eve (Diana is inactive)
+	if len(results) != 4 {
+		t.Errorf("Expected 4 active people, got %d", len(results))
+	}
+}
+
+// TestIntegration_AvgAggregation tests average aggregation
+func TestIntegration_AvgAggregation(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	age := qb.NewVar()
+
+	// Average age of all people
+	q := qb.Query().
+		Find(qb.Avg(age)).
+		Where(
+			qb.Pat(e, PersonAge, age),
+		).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(results))
+	}
+
+	// Average of 30, 25, 35, 28, 32 = 150/5 = 30
+	if avg, ok := results[0][0].(float64); ok {
+		if avg != 30 {
+			t.Errorf("Expected average 30, got %v", avg)
+		}
+	} else {
+		t.Errorf("Expected float64, got %T", results[0][0])
+	}
+}
+
+// TestIntegration_MinMaxAggregation tests min/max aggregation
+func TestIntegration_MinMaxAggregation(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	salary := qb.NewVar()
+
+	// Min and max salary (separate queries since we can't have two aggregates without grouping)
+	minQ := qb.Query().
+		Find(qb.Min(salary)).
+		Where(qb.Pat(e, PersonSalary, salary)).
+		MustBuild()
+
+	maxQ := qb.Query().
+		Find(qb.Max(salary)).
+		Where(qb.Pat(e, PersonSalary, salary)).
+		MustBuild()
+
+	minResults, err := db.ExecuteQuery(minQ)
+	if err != nil {
+		t.Fatalf("Min query failed: %v", err)
+	}
+
+	maxResults, err := db.ExecuteQuery(maxQ)
+	if err != nil {
+		t.Fatalf("Max query failed: %v", err)
+	}
+
+	// Min should be Bob's 65000
+	if min, ok := minResults[0][0].(float64); ok {
+		if min != 65000 {
+			t.Errorf("Expected min 65000, got %v", min)
+		}
+	}
+
+	// Max should be Eve's 90000
+	if max, ok := maxResults[0][0].(float64); ok {
+		if max != 90000 {
+			t.Errorf("Expected max 90000, got %v", max)
+		}
+	}
+}
+
+// TestIntegration_ThreeWayJoin tests joining three patterns
+func TestIntegration_ThreeWayJoin(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+	age := qb.NewVar()
+	city := qb.NewVar()
+
+	q := qb.Query().
+		Find(name, age, city).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonAge, age),
+			qb.Pat(e, PersonCity, city),
+		).
+		MustBuild()
+
+	results, err := db.ExecuteQuery(q)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 5 {
+		t.Errorf("Expected 5 results, got %d", len(results))
+	}
+
+	// Verify Alice's data
+	for _, row := range results {
+		if row[0] == "Alice" {
+			if row[1] != int64(30) {
+				t.Errorf("Expected Alice age 30, got %v", row[1])
+			}
+			if row[2] != "NYC" {
+				t.Errorf("Expected Alice city NYC, got %v", row[2])
+			}
+		}
+	}
+}
+
+// TestIntegration_Explain tests the Explain function with built query
+func TestIntegration_Explain(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	name := qb.NewVar()
+	age := qb.NewVar()
+
+	q := qb.Query().
+		Find(name, age).
+		Where(
+			qb.Pat(e, PersonName, name),
+			qb.Pat(e, PersonAge, age),
+		).
+		MustBuild()
+
+	plan, err := db.Explain(q)
+	if err != nil {
+		t.Fatalf("Explain failed: %v", err)
+	}
+
+	// Verify plan exists and has content
+	planStr := plan.String()
+	if len(planStr) == 0 {
+		t.Error("Expected non-empty plan string")
+	}
+
+	// Plan should mention the attributes
+	if !containsAny(planStr, ":person/name", "person/name") {
+		t.Error("Plan should mention :person/name")
+	}
+}
+
+func containsAny(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if len(s) > 0 && len(sub) > 0 {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// TestIntegration_TupleInput tests queries with tuple input [[?x ?y]]
+func TestIntegration_TupleInput(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	inputName := qb.NewVar()
+	inputAge := qb.NewVar()
+	city := qb.NewVar()
+
+	// Tuple input - binds a single tuple of values
+	// [[?inputName ?inputAge]] means: bind these two variables from a single input tuple
+	q := qb.Query().
+		Find(inputName, inputAge, city).
+		In(qb.DB, qb.Tuple(inputName, inputAge)).
+		Where(
+			qb.Pat(e, PersonName, inputName),
+			qb.Pat(e, PersonAge, inputAge),
+			qb.Pat(e, PersonCity, city),
+		).
+		MustBuild()
+
+	// Find person with name "Alice" and age 30
+	results, err := db.ExecuteQueryWithInputs(q, []interface{}{"Alice", int64(30)})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(results))
+	}
+
+	if len(results) > 0 {
+		if results[0][0] != "Alice" {
+			t.Errorf("Expected name Alice, got %v", results[0][0])
+		}
+		if results[0][1] != int64(30) {
+			t.Errorf("Expected age 30, got %v", results[0][1])
+		}
+		if results[0][2] != "NYC" {
+			t.Errorf("Expected city NYC, got %v", results[0][2])
+		}
+	}
+}
+
+// TestIntegration_RelationInput tests queries with relation input [[?x ?y] ...]
+func TestIntegration_RelationInput(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	inputName := qb.NewVar()
+	inputCity := qb.NewVar()
+	age := qb.NewVar()
+
+	// Relation input - binds multiple tuples, iterating over each
+	// [[?inputName ?inputCity] ...] means: for each tuple in the relation, bind both variables
+	q := qb.Query().
+		Find(inputName, inputCity, age).
+		In(qb.DB, qb.Relation(inputName, inputCity)).
+		Where(
+			qb.Pat(e, PersonName, inputName),
+			qb.Pat(e, PersonCity, inputCity),
+			qb.Pat(e, PersonAge, age),
+		).
+		MustBuild()
+
+	// Find people matching (name, city) pairs
+	results, err := db.ExecuteQueryWithInputs(q, [][]interface{}{
+		{"Alice", "NYC"},
+		{"Eve", "LA"},
+	})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(results))
+	}
+
+	// Verify we got Alice and Eve
+	names := make(map[string]bool)
+	for _, row := range results {
+		if n, ok := row[0].(string); ok {
+			names[n] = true
+		}
+	}
+	if !names["Alice"] || !names["Eve"] {
+		t.Errorf("Expected Alice and Eve, got %v", names)
+	}
+}
+
+// TestIntegration_RelationInputNoMatch tests relation input with no matching data
+func TestIntegration_RelationInputNoMatch(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	inputName := qb.NewVar()
+	inputCity := qb.NewVar()
+	age := qb.NewVar()
+
+	q := qb.Query().
+		Find(inputName, inputCity, age).
+		In(qb.DB, qb.Relation(inputName, inputCity)).
+		Where(
+			qb.Pat(e, PersonName, inputName),
+			qb.Pat(e, PersonCity, inputCity),
+			qb.Pat(e, PersonAge, age),
+		).
+		MustBuild()
+
+	// Alice is in NYC, not LA - should not match
+	results, err := db.ExecuteQueryWithInputs(q, [][]interface{}{
+		{"Alice", "LA"},
+		{"Bob", "NYC"},
+	})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	// Neither should match
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results, got %d: %v", len(results), results)
+	}
+}
+
+// TestIntegration_MultipleScalarInputs tests queries with multiple scalar inputs
+func TestIntegration_MultipleScalarInputs(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	e := qb.NewVar()
+	inputName := qb.NewVar()
+	inputCity := qb.NewVar()
+	age := qb.NewVar()
+
+	// Two scalar inputs
+	q := qb.Query().
+		Find(inputName, age).
+		In(qb.DB, qb.Scalar(inputName), qb.Scalar(inputCity)).
+		Where(
+			qb.Pat(e, PersonName, inputName),
+			qb.Pat(e, PersonCity, inputCity),
+			qb.Pat(e, PersonAge, age),
+		).
+		MustBuild()
+
+	// Find Alice in NYC
+	results, err := db.ExecuteQueryWithInputs(q, "Alice", "NYC")
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(results))
+	}
+
+	if len(results) > 0 && results[0][0] != "Alice" {
+		t.Errorf("Expected Alice, got %v", results[0][0])
+	}
+}
+
+// TestIntegration_CompareInputBindingsWithEDN verifies input bindings match EDN behavior
+func TestIntegration_CompareInputBindingsWithEDN(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	t.Run("ScalarInput", func(t *testing.T) {
+		// EDN query with scalar input
+		ednQuery := `[:find ?name ?age
+		              :in $ ?name
+		              :where
+		              [?e :person/name ?name]
+		              [?e :person/age ?age]]`
+
+		// Built query
+		e := qb.NewVar()
+		inputName := qb.NewVar()
+		age := qb.NewVar()
+
+		builtQuery := qb.Query().
+			Find(inputName, age).
+			In(qb.DB, qb.Scalar(inputName)).
+			Where(
+				qb.Pat(e, PersonName, inputName),
+				qb.Pat(e, PersonAge, age),
+			).
+			MustBuild()
+
+		ednResults, err := db.ExecuteQueryWithInputs(ednQuery, "Bob")
+		if err != nil {
+			t.Fatalf("EDN query failed: %v", err)
+		}
+
+		builtResults, err := db.ExecuteQueryWithInputs(builtQuery, "Bob")
+		if err != nil {
+			t.Fatalf("Built query failed: %v", err)
+		}
+
+		if len(ednResults) != len(builtResults) {
+			t.Errorf("Result count mismatch: EDN=%d, built=%d", len(ednResults), len(builtResults))
+		}
+
+		if len(builtResults) > 0 && builtResults[0][0] != "Bob" {
+			t.Errorf("Expected Bob, got %v", builtResults[0][0])
+		}
+	})
+
+	t.Run("CollectionInput", func(t *testing.T) {
+		// EDN query with collection input
+		ednQuery := `[:find ?name ?age
+		              :in $ [?name ...]
+		              :where
+		              [?e :person/name ?name]
+		              [?e :person/age ?age]]`
+
+		// Built query
+		e := qb.NewVar()
+		inputName := qb.NewVar()
+		age := qb.NewVar()
+
+		builtQuery := qb.Query().
+			Find(inputName, age).
+			In(qb.DB, qb.Collection(inputName)).
+			Where(
+				qb.Pat(e, PersonName, inputName),
+				qb.Pat(e, PersonAge, age),
+			).
+			MustBuild()
+
+		ednResults, err := db.ExecuteQueryWithInputs(ednQuery, []string{"Alice", "Charlie"})
+		if err != nil {
+			t.Fatalf("EDN query failed: %v", err)
+		}
+
+		builtResults, err := db.ExecuteQueryWithInputs(builtQuery, []string{"Alice", "Charlie"})
+		if err != nil {
+			t.Fatalf("Built query failed: %v", err)
+		}
+
+		if len(ednResults) != len(builtResults) {
+			t.Errorf("Result count mismatch: EDN=%d, built=%d", len(ednResults), len(builtResults))
+		}
+
+		if len(ednResults) != 2 {
+			t.Errorf("Expected 2 results, got %d", len(ednResults))
+		}
+	})
+
+	t.Run("RelationInput", func(t *testing.T) {
+		// EDN query with relation input
+		ednQuery := `[:find ?name ?city ?age
+		              :in $ [[?name ?city] ...]
+		              :where
+		              [?e :person/name ?name]
+		              [?e :person/city ?city]
+		              [?e :person/age ?age]]`
+
+		// Built query
+		e := qb.NewVar()
+		inputName := qb.NewVar()
+		inputCity := qb.NewVar()
+		age := qb.NewVar()
+
+		builtQuery := qb.Query().
+			Find(inputName, inputCity, age).
+			In(qb.DB, qb.Relation(inputName, inputCity)).
+			Where(
+				qb.Pat(e, PersonName, inputName),
+				qb.Pat(e, PersonCity, inputCity),
+				qb.Pat(e, PersonAge, age),
+			).
+			MustBuild()
+
+		input := [][]interface{}{
+			{"Alice", "NYC"},
+			{"Bob", "LA"},
+		}
+
+		ednResults, err := db.ExecuteQueryWithInputs(ednQuery, input)
+		if err != nil {
+			t.Fatalf("EDN query failed: %v", err)
+		}
+
+		builtResults, err := db.ExecuteQueryWithInputs(builtQuery, input)
+		if err != nil {
+			t.Fatalf("Built query failed: %v", err)
+		}
+
+		if len(ednResults) != len(builtResults) {
+			t.Errorf("Result count mismatch: EDN=%d, built=%d", len(ednResults), len(builtResults))
+		}
+
+		if len(ednResults) != 2 {
+			t.Errorf("Expected 2 results, got %d", len(ednResults))
+		}
+	})
+}

--- a/datalog/qb/pattern.go
+++ b/datalog/qb/pattern.go
@@ -1,0 +1,120 @@
+package qb
+
+import (
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Clause is the interface for anything that can appear in a Where clause.
+// This includes patterns, predicates, expressions, and logical combinators.
+type Clause interface {
+	toClause() query.Clause
+}
+
+// Pattern represents a data pattern clause being constructed.
+type Pattern struct {
+	elements []query.PatternElement
+}
+
+// Pat creates a data pattern of any arity.
+//
+// Common database patterns:
+//   - Pat(e, a, v)           - standard [e a v] pattern
+//   - Pat(e, a, v, tx)       - transaction-aware [e a v tx] pattern
+//   - Pat(e, a, v, tx, op)   - history [e a v tx op] pattern
+//
+// Patterns can also match input relations of any arity:
+//   - Pat(name, age)         - matches [[?name ?age] ...] input
+//   - Pat(a, b, c, d, e, f)  - matches 6-tuple input relation
+//
+// Arguments can be:
+//   - *Var: a query variable
+//   - Attr: a keyword attribute
+//   - Val: a constant value wrapper
+//   - blankElement: wildcard (from Blank())
+//   - Raw values (string, int64, etc.): converted to constants
+//
+// Example:
+//
+//	qb.Pat(e, PersonName, name)              // [e a v] database pattern
+//	qb.Pat(e, PersonCity, qb.V("NYC"))       // with constant
+//	qb.Pat(e, PersonName, name, tx)          // [e a v tx]
+//	qb.Pat(e, PersonName, name, tx, op)      // [e a v tx op] for history
+//	qb.Pat(name, age)                        // 2-tuple input relation
+func Pat(args ...interface{}) *Pattern {
+	if len(args) == 0 {
+		panic("Pat requires at least one argument")
+	}
+	elements := make([]query.PatternElement, len(args))
+	for i, arg := range args {
+		elements[i] = toPatternElement(arg)
+	}
+	return &Pattern{elements: elements}
+}
+
+// toClause converts Pattern to a query.Clause
+func (p *Pattern) toClause() query.Clause {
+	return &query.DataPattern{Elements: p.elements}
+}
+
+// patternElementer is implemented by types that can convert to PatternElement
+type patternElementer interface {
+	toPatternElement() query.PatternElement
+}
+
+// toPatternElement converts various types to query.PatternElement
+func toPatternElement(v interface{}) query.PatternElement {
+	// Check if it implements the interface directly
+	if pe, ok := v.(patternElementer); ok {
+		return pe.toPatternElement()
+	}
+
+	// Handle specific types
+	switch x := v.(type) {
+	case *Var:
+		return x.toPatternElement()
+	case Attr:
+		return x.toPatternElement()
+	case Val:
+		return x.toPatternElement()
+	case blankElement:
+		return x.toPatternElement()
+	case query.Blank:
+		return x
+	case query.Variable:
+		return x
+	case query.Constant:
+		return x
+	case datalog.Keyword:
+		return query.Constant{Value: x}
+	case datalog.Identity:
+		return query.Constant{Value: x}
+	default:
+		// Raw values become constants
+		return query.Constant{Value: v}
+	}
+}
+
+// termer is implemented by types that can convert to Term
+type termer interface {
+	toTerm() query.Term
+}
+
+// toTerm converts various types to query.Term for use in predicates
+func toTerm(v interface{}) query.Term {
+	// Check if it implements the interface directly
+	if t, ok := v.(termer); ok {
+		return t.toTerm()
+	}
+
+	// Handle specific types
+	switch x := v.(type) {
+	case *Var:
+		return x.toTerm()
+	case Val:
+		return x.toTerm()
+	default:
+		// Raw values become constants
+		return query.ConstantTerm{Value: v}
+	}
+}

--- a/datalog/qb/predicate.go
+++ b/datalog/qb/predicate.go
@@ -1,0 +1,113 @@
+package qb
+
+import (
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Comparison represents a binary comparison predicate.
+type Comparison struct {
+	op    query.CompareOp
+	left  interface{}
+	right interface{}
+}
+
+// Lt creates a less-than comparison: left < right
+//
+// Example:
+//
+//	qb.Lt(age, 30)       // ?age < 30
+//	qb.Lt(price, limit)  // ?price < ?limit
+func Lt(left, right interface{}) *Comparison {
+	return &Comparison{op: query.OpLT, left: left, right: right}
+}
+
+// Lte creates a less-than-or-equal comparison: left <= right
+func Lte(left, right interface{}) *Comparison {
+	return &Comparison{op: query.OpLTE, left: left, right: right}
+}
+
+// Gt creates a greater-than comparison: left > right
+//
+// Example:
+//
+//	qb.Gt(age, 21)  // ?age > 21
+func Gt(left, right interface{}) *Comparison {
+	return &Comparison{op: query.OpGT, left: left, right: right}
+}
+
+// Gte creates a greater-than-or-equal comparison: left >= right
+func Gte(left, right interface{}) *Comparison {
+	return &Comparison{op: query.OpGTE, left: left, right: right}
+}
+
+// Eq creates an equality comparison: left = right
+//
+// Example:
+//
+//	qb.Eq(status, qb.V("active"))  // ?status = "active"
+func Eq(left, right interface{}) *Comparison {
+	return &Comparison{op: query.OpEQ, left: left, right: right}
+}
+
+// Ne creates a not-equal comparison: left != right
+func Ne(left, right interface{}) *Comparison {
+	return &Comparison{op: query.OpNE, left: left, right: right}
+}
+
+// toClause converts Comparison to a query.Clause
+func (c *Comparison) toClause() query.Clause {
+	return &query.Comparison{
+		Op:    c.op,
+		Left:  toTerm(c.left),
+		Right: toTerm(c.right),
+	}
+}
+
+// ChainedComparison represents a chained comparison like (< 0 ?x 100).
+// This is evaluated as (0 < ?x) AND (?x < 100).
+type ChainedComparison struct {
+	op    query.CompareOp
+	terms []interface{}
+}
+
+// Chained creates a chained comparison with 3 or more terms.
+// All adjacent pairs are compared with the same operator.
+//
+// Example:
+//
+//	qb.Chained(query.OpLT, 0, x, 100)  // 0 < ?x < 100
+//	qb.Chained(query.OpLTE, a, b, c)   // ?a <= ?b <= ?c
+func Chained(op query.CompareOp, terms ...interface{}) *ChainedComparison {
+	return &ChainedComparison{op: op, terms: terms}
+}
+
+// Range creates a range check: min < v < max
+// This is a convenience wrapper for Chained with OpLT.
+//
+// Example:
+//
+//	qb.Range(0, price, 100)  // 0 < ?price < 100
+func Range(min interface{}, v *Var, max interface{}) *ChainedComparison {
+	return Chained(query.OpLT, min, v, max)
+}
+
+// RangeInclusive creates an inclusive range check: min <= v <= max
+//
+// Example:
+//
+//	qb.RangeInclusive(1, rating, 5)  // 1 <= ?rating <= 5
+func RangeInclusive(min interface{}, v *Var, max interface{}) *ChainedComparison {
+	return Chained(query.OpLTE, min, v, max)
+}
+
+// toClause converts ChainedComparison to a query.Clause
+func (c *ChainedComparison) toClause() query.Clause {
+	terms := make([]query.Term, len(c.terms))
+	for i, t := range c.terms {
+		terms[i] = toTerm(t)
+	}
+	return &query.ChainedComparison{
+		Op:    c.op,
+		Terms: terms,
+	}
+}

--- a/datalog/qb/qb_test.go
+++ b/datalog/qb/qb_test.go
@@ -1,0 +1,861 @@
+package qb
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestNewVar tests that variables get unique IDs
+func TestNewVar(t *testing.T) {
+	v1 := NewVar()
+	v2 := NewVar()
+	v3 := NewVar()
+
+	if v1.id == v2.id {
+		t.Error("v1 and v2 should have different IDs")
+	}
+	if v2.id == v3.id {
+		t.Error("v2 and v3 should have different IDs")
+	}
+
+	// Symbol should start with ?v
+	sym1 := v1.Symbol()
+	if sym1[0] != '?' {
+		t.Errorf("Symbol should start with ?, got %s", sym1)
+	}
+}
+
+// TestKw tests keyword creation
+func TestKw(t *testing.T) {
+	attr := Kw(":person/name")
+
+	// Should create a proper keyword
+	if attr.kw == nil {
+		t.Error("Keyword should not be nil")
+	}
+
+	// Test Keyword method
+	kw := attr.Keyword()
+	if kw.String() != ":person/name" {
+		t.Errorf("Expected :person/name, got %s", kw.String())
+	}
+}
+
+// TestVal tests value wrapping
+func TestVal(t *testing.T) {
+	// String value
+	strVal := V("hello")
+	if strVal.value != "hello" {
+		t.Errorf("Expected hello, got %v", strVal.value)
+	}
+
+	// Int value
+	intVal := V(42)
+	if intVal.value != 42 {
+		t.Errorf("Expected 42, got %v", intVal.value)
+	}
+
+	// Float value
+	floatVal := V(3.14)
+	if floatVal.value != 3.14 {
+		t.Errorf("Expected 3.14, got %v", floatVal.value)
+	}
+}
+
+// TestBlank tests blank/wildcard
+func TestBlank(t *testing.T) {
+	b := Blank()
+
+	// Convert to pattern element and check type
+	elem := b.toPatternElement()
+	if _, ok := elem.(query.Blank); !ok {
+		t.Error("Blank should convert to query.Blank")
+	}
+}
+
+// TestPat tests 3-element pattern creation
+func TestPat(t *testing.T) {
+	e := NewVar()
+	name := NewVar()
+	PersonName := Kw(":person/name")
+
+	pat := Pat(e, PersonName, name)
+
+	// Should have 3 elements
+	clause := pat.toClause()
+	dp, ok := clause.(*query.DataPattern)
+	if !ok {
+		t.Fatalf("Expected *query.DataPattern, got %T", clause)
+	}
+	if len(dp.Elements) != 3 {
+		t.Errorf("Expected 3 elements, got %d", len(dp.Elements))
+	}
+}
+
+// TestPat4 tests 4-element pattern creation (with tx)
+func TestPat4(t *testing.T) {
+	e := NewVar()
+	name := NewVar()
+	tx := NewVar()
+	PersonName := Kw(":person/name")
+
+	pat := Pat(e, PersonName, name, tx)
+
+	clause := pat.toClause()
+	dp, ok := clause.(*query.DataPattern)
+	if !ok {
+		t.Fatalf("Expected *query.DataPattern, got %T", clause)
+	}
+	if len(dp.Elements) != 4 {
+		t.Errorf("Expected 4 elements, got %d", len(dp.Elements))
+	}
+}
+
+// TestPat5 tests 5-element pattern creation (history with op)
+func TestPat5(t *testing.T) {
+	e := NewVar()
+	name := NewVar()
+	tx := NewVar()
+	op := NewVar()
+	PersonName := Kw(":person/name")
+
+	pat := Pat(e, PersonName, name, tx, op)
+
+	clause := pat.toClause()
+	dp, ok := clause.(*query.DataPattern)
+	if !ok {
+		t.Fatalf("Expected *query.DataPattern, got %T", clause)
+	}
+	if len(dp.Elements) != 5 {
+		t.Errorf("Expected 5 elements, got %d", len(dp.Elements))
+	}
+}
+
+// TestPatternWithValues tests pattern with constant values
+func TestPatternWithValues(t *testing.T) {
+	e := NewVar()
+	PersonName := Kw(":person/name")
+
+	pat := Pat(e, PersonName, V("Alice"))
+
+	clause := pat.toClause()
+	dp := clause.(*query.DataPattern)
+
+	// Third element should be a constant
+	if _, ok := dp.Elements[2].(query.Constant); !ok {
+		t.Errorf("Expected constant, got %T", dp.Elements[2])
+	}
+}
+
+// TestPatInvalidArity tests that Pat panics with zero arguments
+func TestPatInvalidArity(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Pat() should panic with zero arguments")
+		}
+	}()
+	Pat() // Should panic
+}
+
+// TestPat2 tests 2-element pattern (for input relations)
+func TestPat2(t *testing.T) {
+	name := NewVar()
+	age := NewVar()
+
+	pat := Pat(name, age)
+
+	clause := pat.toClause()
+	dp, ok := clause.(*query.DataPattern)
+	if !ok {
+		t.Fatalf("Expected *query.DataPattern, got %T", clause)
+	}
+	if len(dp.Elements) != 2 {
+		t.Errorf("Expected 2 elements, got %d", len(dp.Elements))
+	}
+}
+
+// TestPredicates tests comparison predicates
+func TestPredicates(t *testing.T) {
+	age := NewVar()
+
+	tests := []struct {
+		name string
+		pred *Comparison
+		op   query.CompareOp
+	}{
+		{"Lt", Lt(age, V(30)), query.OpLT},
+		{"Lte", Lte(age, V(30)), query.OpLTE},
+		{"Gt", Gt(age, V(30)), query.OpGT},
+		{"Gte", Gte(age, V(30)), query.OpGTE},
+		{"Eq", Eq(age, V(30)), query.OpEQ},
+		{"Ne", Ne(age, V(30)), query.OpNE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clause := tt.pred.toClause()
+			comp, ok := clause.(*query.Comparison)
+			if !ok {
+				t.Fatalf("Expected *query.Comparison, got %T", clause)
+			}
+			if comp.Op != tt.op {
+				t.Errorf("Expected %v, got %v", tt.op, comp.Op)
+			}
+		})
+	}
+}
+
+// TestChainedComparison tests range predicates
+func TestChainedComparison(t *testing.T) {
+	x := NewVar()
+
+	// Range: 0 < x < 100
+	chain := Chained(query.OpLT, V(0), x, V(100))
+
+	clause := chain.toClause()
+	cpc, ok := clause.(*query.ChainedComparison)
+	if !ok {
+		t.Fatalf("Expected *query.ChainedComparison, got %T", clause)
+	}
+	if len(cpc.Terms) != 3 {
+		t.Errorf("Expected 3 terms, got %d", len(cpc.Terms))
+	}
+	if cpc.Op != query.OpLT {
+		t.Errorf("Expected OpLT, got %v", cpc.Op)
+	}
+}
+
+// TestRange tests convenience range function
+func TestRange(t *testing.T) {
+	x := NewVar()
+
+	// Range: 10 < x < 20
+	chain := Range(V(10), x, V(20))
+
+	clause := chain.toClause()
+	cpc := clause.(*query.ChainedComparison)
+	if len(cpc.Terms) != 3 {
+		t.Errorf("Expected 3 terms, got %d", len(cpc.Terms))
+	}
+}
+
+// TestAggregations tests aggregation functions
+func TestAggregations(t *testing.T) {
+	salary := NewVar()
+
+	tests := []struct {
+		name string
+		agg  Agg
+		fn   string
+	}{
+		{"Sum", Sum(salary), "sum"},
+		{"Count", Count(salary), "count"},
+		{"Avg", Avg(salary), "avg"},
+		{"Min", Min(salary), "min"},
+		{"Max", Max(salary), "max"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elem := tt.agg.toFindElement()
+			aggElem, ok := elem.(query.FindAggregate)
+			if !ok {
+				t.Fatalf("Expected query.FindAggregate, got %T", elem)
+			}
+			if aggElem.Function != tt.fn {
+				t.Errorf("Expected %s, got %s", tt.fn, aggElem.Function)
+			}
+		})
+	}
+}
+
+// TestArithmeticExpressions tests arithmetic expression builders
+func TestArithmeticExpressions(t *testing.T) {
+	a := NewVar()
+	b := NewVar()
+	result := NewVar()
+
+	tests := []struct {
+		name string
+		expr *Expression
+		op   query.ArithmeticOp
+	}{
+		{"Add", Add(a, b).As(result), query.OpAdd},
+		{"Sub", Sub(a, b).As(result), query.OpSubtract},
+		{"Mul", Mul(a, b).As(result), query.OpMultiply},
+		{"Div", Div(a, b).As(result), query.OpDivide},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clause := tt.expr.toClause()
+			expr, ok := clause.(*query.Expression)
+			if !ok {
+				t.Fatalf("Expected *query.Expression, got %T", clause)
+			}
+			arith, ok := expr.Function.(query.ArithmeticFunction)
+			if !ok {
+				t.Fatalf("Expected ArithmeticFunction, got %T", expr.Function)
+			}
+			if arith.Op != tt.op {
+				t.Errorf("Expected %v, got %v", tt.op, arith.Op)
+			}
+		})
+	}
+}
+
+// TestStrConcat tests string concatenation expression
+func TestStrConcat(t *testing.T) {
+	firstName := NewVar()
+	lastName := NewVar()
+	fullName := NewVar()
+
+	expr := Str(firstName, V(" "), lastName).As(fullName)
+
+	clause := expr.toClause()
+	e := clause.(*query.Expression)
+	_, ok := e.Function.(query.StringConcatFunction)
+	if !ok {
+		t.Errorf("Expected StringConcatFunction, got %T", e.Function)
+	}
+}
+
+// TestGround tests ground expression
+func TestGround(t *testing.T) {
+	taxRate := NewVar()
+
+	expr := Ground(0.08).As(taxRate)
+
+	clause := expr.toClause()
+	e := clause.(*query.Expression)
+	gf, ok := e.Function.(query.GroundFunction)
+	if !ok {
+		t.Fatalf("Expected GroundFunction, got %T", e.Function)
+	}
+	if gf.Value != 0.08 {
+		t.Errorf("Expected 0.08, got %v", gf.Value)
+	}
+}
+
+// TestIdentity tests identity expression
+func TestIdentity(t *testing.T) {
+	original := NewVar()
+	alias := NewVar()
+
+	expr := Identity(original).As(alias)
+
+	clause := expr.toClause()
+	e := clause.(*query.Expression)
+	_, ok := e.Function.(query.IdentityFunction)
+	if !ok {
+		t.Errorf("Expected IdentityFunction, got %T", e.Function)
+	}
+}
+
+// TestTimeExtraction tests time extraction functions
+func TestTimeExtraction(t *testing.T) {
+	createdAt := NewVar()
+	y := NewVar()
+
+	tests := []struct {
+		name  string
+		expr  *Expression
+		field string
+	}{
+		{"Year", Year(createdAt).As(y), "year"},
+		{"Month", Month(createdAt).As(y), "month"},
+		{"Day", Day(createdAt).As(y), "day"},
+		{"Hour", Hour(createdAt).As(y), "hour"},
+		{"Minute", Minute(createdAt).As(y), "minute"},
+		{"Second", Second(createdAt).As(y), "second"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clause := tt.expr.toClause()
+			e := clause.(*query.Expression)
+			te, ok := e.Function.(query.TimeExtractionFunction)
+			if !ok {
+				t.Fatalf("Expected TimeExtractionFunction, got %T", e.Function)
+			}
+			if te.Field != tt.field {
+				t.Errorf("Expected field %s, got %s", tt.field, te.Field)
+			}
+		})
+	}
+}
+
+// TestInputSpecs tests input parameter specifications
+func TestInputSpecs(t *testing.T) {
+	// Test DB input
+	dbSpec := DB.toInputSpec()
+	if _, ok := dbSpec.(query.DatabaseInput); !ok {
+		t.Errorf("DB should produce DatabaseInput, got %T", dbSpec)
+	}
+
+	// Test Scalar input
+	minAge := NewVar()
+	scalarSpec := Scalar(minAge).toInputSpec()
+	if _, ok := scalarSpec.(query.ScalarInput); !ok {
+		t.Errorf("Scalar should produce ScalarInput, got %T", scalarSpec)
+	}
+
+	// Test Collection input
+	id := NewVar()
+	collSpec := Collection(id).toInputSpec()
+	if _, ok := collSpec.(query.CollectionInput); !ok {
+		t.Errorf("Collection should produce CollectionInput, got %T", collSpec)
+	}
+
+	// Test Tuple input
+	x, y := NewVar(), NewVar()
+	tupleSpec := Tuple(x, y).toInputSpec()
+	if _, ok := tupleSpec.(query.TupleInput); !ok {
+		t.Errorf("Tuple should produce TupleInput, got %T", tupleSpec)
+	}
+
+	// Test Relation input
+	relSpec := Relation(x, y).toInputSpec()
+	if _, ok := relSpec.(query.RelationInput); !ok {
+		t.Errorf("Relation should produce RelationInput, got %T", relSpec)
+	}
+}
+
+// TestNotClause tests NOT clause
+func TestNotClause(t *testing.T) {
+	e := NewVar()
+	PersonCity := Kw(":person/city")
+
+	notClause := Not(Pat(e, PersonCity, V("NYC")))
+
+	clause := notClause.toClause()
+	nc, ok := clause.(*query.NotClause)
+	if !ok {
+		t.Fatalf("Expected *query.NotClause, got %T", clause)
+	}
+	if len(nc.Clauses) != 1 {
+		t.Errorf("Expected 1 clause, got %d", len(nc.Clauses))
+	}
+}
+
+// TestNotJoinClause tests NOT-JOIN clause
+func TestNotJoinClause(t *testing.T) {
+	e := NewVar()
+	PersonStatus := Kw(":person/status")
+
+	notJoin := NotJoin([]*Var{e}, Pat(e, PersonStatus, V("banned")))
+
+	clause := notJoin.toClause()
+	njc, ok := clause.(*query.NotJoinClause)
+	if !ok {
+		t.Fatalf("Expected *query.NotJoinClause, got %T", clause)
+	}
+	if len(njc.JoinVars) != 1 {
+		t.Errorf("Expected 1 join var, got %d", len(njc.JoinVars))
+	}
+}
+
+// TestOrClause tests OR clause
+func TestOrClause(t *testing.T) {
+	status := NewVar()
+
+	orClause := Or(
+		[]interface{}{Eq(status, V("active"))},
+		[]interface{}{Eq(status, V("pending"))},
+	)
+
+	clause := orClause.toClause()
+	oc, ok := clause.(*query.OrClause)
+	if !ok {
+		t.Fatalf("Expected *query.OrClause, got %T", clause)
+	}
+	if len(oc.Branches) != 2 {
+		t.Errorf("Expected 2 branches, got %d", len(oc.Branches))
+	}
+}
+
+// TestOrJoinClause tests OR-JOIN clause
+func TestOrJoinClause(t *testing.T) {
+	e := NewVar()
+	name := NewVar()
+	PersonNickname := Kw(":person/nickname")
+	PersonName := Kw(":person/name")
+
+	orJoin := OrJoin([]*Var{name},
+		[]interface{}{Pat(e, PersonNickname, name)},
+		[]interface{}{Pat(e, PersonName, name)},
+	)
+
+	clause := orJoin.toClause()
+	ojc, ok := clause.(*query.OrJoinClause)
+	if !ok {
+		t.Fatalf("Expected *query.OrJoinClause, got %T", clause)
+	}
+	if len(ojc.JoinVars) != 1 {
+		t.Errorf("Expected 1 join var, got %d", len(ojc.JoinVars))
+	}
+	if len(ojc.Branches) != 2 {
+		t.Errorf("Expected 2 branches, got %d", len(ojc.Branches))
+	}
+}
+
+// TestOrderSpecs tests ordering specifications
+func TestOrderSpecs(t *testing.T) {
+	name := NewVar()
+
+	// Test Asc
+	ascSpec := Asc(name)
+	if ascSpec.direction != query.OrderAsc {
+		t.Errorf("Expected OrderAsc, got %v", ascSpec.direction)
+	}
+
+	// Test Desc
+	descSpec := Desc(name)
+	if descSpec.direction != query.OrderDesc {
+		t.Errorf("Expected OrderDesc, got %v", descSpec.direction)
+	}
+}
+
+// TestQueryBuilder tests the main query builder
+func TestQueryBuilder(t *testing.T) {
+	e := NewVar()
+	name := NewVar()
+	age := NewVar()
+	PersonName := Kw(":person/name")
+	PersonAge := Kw(":person/age")
+
+	q, err := Query().
+		Find(name, age).
+		Where(
+			Pat(e, PersonName, name),
+			Pat(e, PersonAge, age),
+			Gt(age, V(21)),
+		).
+		OrderBy(Asc(name)).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Check find elements
+	if len(q.Find) != 2 {
+		t.Errorf("Expected 2 find elements, got %d", len(q.Find))
+	}
+
+	// Check where clauses
+	if len(q.Where) != 3 {
+		t.Errorf("Expected 3 where clauses, got %d", len(q.Where))
+	}
+
+	// Check order by
+	if len(q.OrderBy) != 1 {
+		t.Errorf("Expected 1 order by clause, got %d", len(q.OrderBy))
+	}
+}
+
+// TestQueryBuilderWithInputs tests query builder with input parameters
+func TestQueryBuilderWithInputs(t *testing.T) {
+	e := NewVar()
+	name := NewVar()
+	age := NewVar()
+	minAge := NewVar()
+	PersonName := Kw(":person/name")
+	PersonAge := Kw(":person/age")
+
+	q, err := Query().
+		Find(name, age).
+		In(DB, Scalar(minAge)).
+		Where(
+			Pat(e, PersonName, name),
+			Pat(e, PersonAge, age),
+			Gte(age, minAge),
+		).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Check inputs
+	if len(q.In) != 2 {
+		t.Errorf("Expected 2 input specs, got %d", len(q.In))
+	}
+}
+
+// TestQueryBuilderWithAggregation tests query builder with aggregation
+func TestQueryBuilderWithAggregation(t *testing.T) {
+	e := NewVar()
+	dept := NewVar()
+	salary := NewVar()
+	EmpDept := Kw(":employee/dept")
+	EmpSalary := Kw(":employee/salary")
+
+	q, err := Query().
+		Find(dept, Sum(salary)).
+		Where(
+			Pat(e, EmpDept, dept),
+			Pat(e, EmpSalary, salary),
+		).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Check find elements include aggregation
+	if len(q.Find) != 2 {
+		t.Errorf("Expected 2 find elements, got %d", len(q.Find))
+	}
+
+	// Second element should be an aggregate
+	if _, ok := q.Find[1].(query.FindAggregate); !ok {
+		t.Errorf("Expected AggregateElement, got %T", q.Find[1])
+	}
+}
+
+// TestQueryBuilderMustBuild tests MustBuild panics on error
+func TestQueryBuilderMustBuild(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("MustBuild should panic on invalid query")
+		}
+	}()
+
+	// Query without Find or Where should fail
+	Query().MustBuild()
+}
+
+// TestQueryBuilderValidation tests build validation
+func TestQueryBuilderValidation(t *testing.T) {
+	// No find elements
+	_, err := Query().Where(Eq(NewVar(), V(1))).Build()
+	if err == nil {
+		t.Error("Expected error for query without find elements")
+	}
+
+	// No where clauses
+	_, err = Query().Find(NewVar()).Build()
+	if err == nil {
+		t.Error("Expected error for query without where clauses")
+	}
+}
+
+// TestSubquery tests subquery builder
+func TestSubquery(t *testing.T) {
+	// Inner query: find max salary for a department
+	dept := NewVar()
+	maxSalary := NewVar()
+	innerSalary := NewVar()
+	innerE := NewVar()
+	EmpDept := Kw(":employee/dept")
+	EmpSalary := Kw(":employee/salary")
+
+	innerQ := Query().
+		Find(Max(innerSalary)).
+		In(DB, Scalar(dept)).
+		Where(
+			Pat(innerE, EmpDept, dept),
+			Pat(innerE, EmpSalary, innerSalary),
+		)
+
+	// Create subquery with binding
+	sub := Subquery(innerQ, dept).BindTuple(maxSalary)
+
+	clause := sub.toClause()
+	sqp, ok := clause.(*query.SubqueryPattern)
+	if !ok {
+		t.Fatalf("Expected *query.SubqueryPattern, got %T", clause)
+	}
+
+	// Should have 1 input
+	if len(sqp.Inputs) != 1 {
+		t.Errorf("Expected 1 input, got %d", len(sqp.Inputs))
+	}
+
+	// Should have tuple binding
+	if _, ok := sqp.Binding.(query.TupleBinding); !ok {
+		t.Errorf("Expected TupleBinding, got %T", sqp.Binding)
+	}
+}
+
+// TestSubqueryRelationBinding tests subquery with relation binding
+func TestSubqueryRelationBinding(t *testing.T) {
+	dept := NewVar()
+	empName := NewVar()
+	innerE := NewVar()
+	EmpDept := Kw(":employee/dept")
+	EmpName := Kw(":employee/name")
+
+	innerQ := Query().
+		Find(empName).
+		In(DB, Scalar(dept)).
+		Where(
+			Pat(innerE, EmpDept, dept),
+			Pat(innerE, EmpName, empName),
+		)
+
+	sub := Subquery(innerQ, dept).BindRelation(empName)
+
+	clause := sub.toClause()
+	sqp := clause.(*query.SubqueryPattern)
+
+	if _, ok := sqp.Binding.(query.RelationBinding); !ok {
+		t.Errorf("Expected RelationBinding, got %T", sqp.Binding)
+	}
+}
+
+// TestSubqueryCollectionBinding tests subquery with collection binding
+func TestSubqueryCollectionBinding(t *testing.T) {
+	dept := NewVar()
+	empName := NewVar()
+	innerE := NewVar()
+	EmpDept := Kw(":employee/dept")
+	EmpName := Kw(":employee/name")
+
+	innerQ := Query().
+		Find(empName).
+		In(DB, Scalar(dept)).
+		Where(
+			Pat(innerE, EmpDept, dept),
+			Pat(innerE, EmpName, empName),
+		)
+
+	names := NewVar()
+	sub := Subquery(innerQ, dept).BindCollection(names)
+
+	clause := sub.toClause()
+	sqp := clause.(*query.SubqueryPattern)
+
+	if _, ok := sqp.Binding.(query.CollectionBinding); !ok {
+		t.Errorf("Expected CollectionBinding, got %T", sqp.Binding)
+	}
+}
+
+// TestVariableIdentityIsJoin tests that same variable creates join
+func TestVariableIdentityIsJoin(t *testing.T) {
+	// This is the key insight: using the same Go variable in multiple patterns
+	// creates a join condition
+	e := NewVar() // <-- This single variable
+	name := NewVar()
+	age := NewVar()
+	PersonName := Kw(":person/name")
+	PersonAge := Kw(":person/age")
+
+	q, err := Query().
+		Find(name, age).
+		Where(
+			Pat(e, PersonName, name), // e is used here
+			Pat(e, PersonAge, age),   // and here - same variable = join!
+		).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Both patterns should reference the same symbol
+	dp1 := q.Where[0].(*query.DataPattern)
+	dp2 := q.Where[1].(*query.DataPattern)
+
+	// Get the entity variable from each pattern
+	var1 := dp1.Elements[0].(query.Variable)
+	var2 := dp2.Elements[0].(query.Variable)
+
+	// They should have the same symbol name (the join condition)
+	if var1.Name != var2.Name {
+		t.Errorf("Variables should have same symbol for join: %s != %s", var1.Name, var2.Name)
+	}
+}
+
+// TestPatternWithDatalogKeyword tests pattern with datalog.Keyword directly
+func TestPatternWithDatalogKeyword(t *testing.T) {
+	e := NewVar()
+	name := NewVar()
+
+	// Can use datalog.Keyword directly
+	directKw := datalog.NewKeyword(":person/name")
+	pat := Pat(e, directKw, name)
+
+	clause := pat.toClause()
+	dp := clause.(*query.DataPattern)
+
+	// Should still work
+	if len(dp.Elements) != 3 {
+		t.Errorf("Expected 3 elements, got %d", len(dp.Elements))
+	}
+}
+
+// TestPatternWithDatalogIdentity tests pattern with datalog.Identity directly
+func TestPatternWithDatalogIdentity(t *testing.T) {
+	name := NewVar()
+	PersonName := Kw(":person/name")
+
+	// Can use datalog.Identity directly for entity
+	entityID := datalog.NewIdentity("person-123")
+	pat := Pat(entityID, PersonName, name)
+
+	clause := pat.toClause()
+	dp := clause.(*query.DataPattern)
+
+	// First element should be a constant with the identity
+	if _, ok := dp.Elements[0].(query.Constant); !ok {
+		t.Errorf("Expected Constant, got %T", dp.Elements[0])
+	}
+}
+
+// TestComplexQuery tests a realistic complex query
+func TestComplexQuery(t *testing.T) {
+	// Find employees who earn more than the average in their department
+	e := NewVar()
+	dept := NewVar()
+	salary := NewVar()
+	name := NewVar()
+	avgSalary := NewVar()
+
+	EmpName := Kw(":employee/name")
+	EmpDept := Kw(":employee/dept")
+	EmpSalary := Kw(":employee/salary")
+
+	// Inner query to compute average salary per department
+	innerE := NewVar()
+	innerSalary := NewVar()
+	innerDept := NewVar()
+
+	innerQ := Query().
+		Find(Avg(innerSalary)).
+		In(DB, Scalar(innerDept)).
+		Where(
+			Pat(innerE, EmpDept, innerDept),
+			Pat(innerE, EmpSalary, innerSalary),
+		)
+
+	// Main query
+	q, err := Query().
+		Find(name, dept, salary).
+		Where(
+			Pat(e, EmpName, name),
+			Pat(e, EmpDept, dept),
+			Pat(e, EmpSalary, salary),
+			Subquery(innerQ, dept).BindTuple(avgSalary),
+			Gt(salary, avgSalary),
+		).
+		OrderBy(Desc(salary)).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Should have 5 where clauses (3 patterns + 1 subquery + 1 predicate)
+	if len(q.Where) != 5 {
+		t.Errorf("Expected 5 where clauses, got %d", len(q.Where))
+	}
+
+	// Should have 3 find elements
+	if len(q.Find) != 3 {
+		t.Errorf("Expected 3 find elements, got %d", len(q.Find))
+	}
+}

--- a/datalog/qb/subquery.go
+++ b/datalog/qb/subquery.go
@@ -1,0 +1,133 @@
+package qb
+
+import (
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// SubqueryBuilder builds a subquery clause.
+type SubqueryBuilder struct {
+	innerQuery *QueryBuilder
+	inputs     []*Var
+	binding    bindingForm
+}
+
+// bindingForm interface for subquery result bindings
+type bindingForm interface {
+	toBindingForm() query.BindingForm
+}
+
+// tupleBind binds results as a single tuple [[?a ?b]]
+type tupleBind struct {
+	vars []*Var
+}
+
+func (t tupleBind) toBindingForm() query.BindingForm {
+	syms := make([]query.Symbol, len(t.vars))
+	for i, v := range t.vars {
+		syms[i] = v.Symbol()
+	}
+	return query.TupleBinding{Variables: syms}
+}
+
+// relationBind binds results as a relation [[?a ?b] ...]
+type relationBind struct {
+	vars []*Var
+}
+
+func (r relationBind) toBindingForm() query.BindingForm {
+	syms := make([]query.Symbol, len(r.vars))
+	for i, v := range r.vars {
+		syms[i] = v.Symbol()
+	}
+	return query.RelationBinding{Variables: syms}
+}
+
+// collectionBind binds results to a collection variable
+type collectionBind struct {
+	v *Var
+}
+
+func (c collectionBind) toBindingForm() query.BindingForm {
+	return query.CollectionBinding{Variable: c.v.Symbol()}
+}
+
+// Subquery creates a nested query pattern.
+// The inner query is executed with the given input variables from the outer scope.
+//
+// Example:
+//
+//	// Inner query: find max salary for a department
+//	dept := qb.NewVar()
+//	maxSalary := qb.NewVar()
+//	innerSalary := qb.NewVar()
+//
+//	innerQ := qb.Query().
+//	    Find(qb.Max(innerSalary)).
+//	    In(qb.DB, qb.Scalar(dept)).
+//	    Where(
+//	        qb.Pat(e, EmployeeDept, dept),
+//	        qb.Pat(e, EmployeeSalary, innerSalary),
+//	    )
+//
+//	// Outer query uses the subquery
+//	qb.Query().
+//	    Find(name, maxSalary).
+//	    Where(
+//	        qb.Pat(p, PersonName, name),
+//	        qb.Pat(p, PersonDept, dept),
+//	        qb.Subquery(innerQ, dept).BindTuple(maxSalary),
+//	    )
+func Subquery(innerQuery *QueryBuilder, inputs ...*Var) *SubqueryBuilder {
+	return &SubqueryBuilder{
+		innerQuery: innerQuery,
+		inputs:     inputs,
+	}
+}
+
+// BindTuple binds subquery results as a single tuple [[?a ?b]].
+// Use when the subquery returns exactly one row.
+func (s *SubqueryBuilder) BindTuple(vars ...*Var) *SubqueryBuilder {
+	s.binding = tupleBind{vars: vars}
+	return s
+}
+
+// BindRelation binds subquery results as a relation [[?a ?b] ...].
+// Use when the subquery may return multiple rows.
+func (s *SubqueryBuilder) BindRelation(vars ...*Var) *SubqueryBuilder {
+	s.binding = relationBind{vars: vars}
+	return s
+}
+
+// BindCollection binds subquery results to a collection variable.
+// Use when the subquery returns a single column of values.
+func (s *SubqueryBuilder) BindCollection(v *Var) *SubqueryBuilder {
+	s.binding = collectionBind{v: v}
+	return s
+}
+
+// toClause converts SubqueryBuilder to a query.Clause
+func (s *SubqueryBuilder) toClause() query.Clause {
+	// Build the inner query - panic on error since we're in a fluent chain
+	innerQ, err := s.innerQuery.Build()
+	if err != nil {
+		panic("subquery build failed: " + err.Error())
+	}
+
+	// Convert input variables to pattern elements
+	inputs := make([]query.PatternElement, len(s.inputs))
+	for i, v := range s.inputs {
+		inputs[i] = query.Variable{Name: v.Symbol()}
+	}
+
+	// Convert binding form
+	var binding query.BindingForm
+	if s.binding != nil {
+		binding = s.binding.toBindingForm()
+	}
+
+	return &query.SubqueryPattern{
+		Query:   innerQ,
+		Inputs:  inputs,
+		Binding: binding,
+	}
+}

--- a/datalog/qb/var.go
+++ b/datalog/qb/var.go
@@ -1,0 +1,74 @@
+// Package qb provides a fluent query builder for constructing Datalog queries
+// without string-based variable names. Go variable identity IS the join condition.
+//
+// Example:
+//
+//	e, name, age := qb.NewVar(), qb.NewVar(), qb.NewVar()
+//	q := qb.Query().
+//	    Find(name, age).
+//	    Where(
+//	        qb.Pat(e, PersonName, name),
+//	        qb.Pat(e, PersonAge, age),
+//	        qb.Gt(age, 21),
+//	    ).MustBuild()
+package qb
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// varCounter generates unique variable IDs
+var varCounter atomic.Uint64
+
+// Var represents a query variable. Using the same Var instance
+// in multiple patterns creates a join on that variable.
+//
+// Variables are created with NewVar() and reused across patterns:
+//
+//	e := qb.NewVar()
+//	qb.Pat(e, PersonName, name)  // e bound here
+//	qb.Pat(e, PersonAge, age)    // same e = implicit join
+type Var struct {
+	id   uint64
+	name query.Symbol
+}
+
+// NewVar creates a new query variable with a unique identity.
+// The variable name is auto-generated (e.g., ?v1, ?v2).
+// Join semantics come from using the same *Var instance in multiple places.
+func NewVar() *Var {
+	id := varCounter.Add(1)
+	return &Var{
+		id:   id,
+		name: query.Symbol(fmt.Sprintf("?v%d", id)),
+	}
+}
+
+// Symbol returns the query.Symbol for this variable.
+// Used internally when building query structures.
+func (v *Var) Symbol() query.Symbol {
+	return v.name
+}
+
+// String returns the variable name for debugging.
+func (v *Var) String() string {
+	return string(v.name)
+}
+
+// toPatternElement converts Var to a query.PatternElement
+func (v *Var) toPatternElement() query.PatternElement {
+	return query.Variable{Name: v.name}
+}
+
+// toTerm converts Var to a query.Term for use in predicates
+func (v *Var) toTerm() query.Term {
+	return query.VariableTerm{Symbol: v.name}
+}
+
+// toFindElement converts Var to a query.FindElement
+func (v *Var) toFindElement() query.FindElement {
+	return query.FindVariable{Symbol: v.name}
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -18,6 +18,19 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
+// resolveQuery converts a query input (string or *query.Query) to *query.Query.
+// This enables the query builder to work seamlessly with database methods.
+func resolveQuery(q interface{}) (*query.Query, error) {
+	switch v := q.(type) {
+	case string:
+		return parser.ParseQuery(v)
+	case *query.Query:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("query must be string or *query.Query, got %T", q)
+	}
+}
+
 // Database provides the main API for reading and writing datoms
 type Database struct {
 	store             *BadgerStore
@@ -350,18 +363,25 @@ func (d *Database) ClearPlanCache() {
 	}
 }
 
-// ExecuteQuery executes a Datalog query string and returns results as a slice of tuples
-// This is a convenience method that handles parsing and execution
+// ExecuteQuery executes a Datalog query and returns results as a slice of tuples.
+// The query can be either an EDN string or a *query.Query from the query builder.
 //
-// Example:
+// Example with string:
 //
 //	results, err := db.ExecuteQuery(`[:find ?name :where [?e :person/name ?name]]`)
-func (d *Database) ExecuteQuery(queryStr string) ([][]interface{}, error) {
-	return d.ExecuteQueryWithInputs(queryStr)
+//
+// Example with query builder:
+//
+//	e, name := qb.NewVar(), qb.NewVar()
+//	q := qb.Query().Find(name).Where(qb.Pat(e, PersonName, name)).MustBuild()
+//	results, err := db.ExecuteQuery(q)
+func (d *Database) ExecuteQuery(q interface{}) ([][]interface{}, error) {
+	return d.ExecuteQueryWithInputs(q)
 }
 
-// ExecuteQueryWithInputs executes a parameterized Datalog query with input parameters
-// This provides type-safe query execution without string formatting
+// ExecuteQueryWithInputs executes a parameterized Datalog query with input parameters.
+// The query can be either an EDN string or a *query.Query from the query builder.
+// This provides type-safe query execution without string formatting.
 //
 // Input parameters are matched with the :in clause in order (after the $ database parameter):
 //   - Scalar inputs: ?name
@@ -371,28 +391,27 @@ func (d *Database) ExecuteQuery(queryStr string) ([][]interface{}, error) {
 //
 // Examples:
 //
-//	// Scalar input
+//	// Scalar input with string query
 //	results, err := db.ExecuteQueryWithInputs(
 //	    `[:find ?e :in $ ?name :where [?e :person/name ?name]]`,
 //	    "Alice",
 //	)
 //
-//	// Multiple scalar inputs
-//	results, err := db.ExecuteQueryWithInputs(
-//	    `[:find ?e :in $ ?name ?min-age :where [?e :person/name ?name] [?e :person/age ?age] [(>= ?age ?min-age)]]`,
-//	    "Alice", 25,
-//	)
+//	// Scalar input with query builder
+//	e, name, minAge := qb.NewVar(), qb.NewVar(), qb.NewVar()
+//	q := qb.Query().Find(e).In(qb.DB, qb.Scalar(minAge)).Where(...).MustBuild()
+//	results, err := db.ExecuteQueryWithInputs(q, 25)
 //
 //	// Collection input
 //	results, err := db.ExecuteQueryWithInputs(
 //	    `[:find ?e ?food :in $ [?food ...] :where [?e :person/likes ?food]]`,
 //	    []string{"pizza", "pasta"},
 //	)
-func (d *Database) ExecuteQueryWithInputs(queryStr string, inputs ...interface{}) ([][]interface{}, error) {
-	// Parse the query
-	q, err := parser.ParseQuery(queryStr)
+func (d *Database) ExecuteQueryWithInputs(queryInput interface{}, inputs ...interface{}) ([][]interface{}, error) {
+	// Resolve the query (string or *query.Query)
+	q, err := resolveQuery(queryInput)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse query: %w", err)
+		return nil, fmt.Errorf("failed to resolve query: %w", err)
 	}
 
 	// Convert inputs to Relations based on :in clause
@@ -413,6 +432,7 @@ func (d *Database) ExecuteQueryWithInputs(queryStr string, inputs ...interface{}
 }
 
 // Explain returns the query plan for a query without executing it.
+// The query can be either an EDN string or a *query.Query from the query builder.
 // This is useful for understanding index selection, phase structure, and
 // how input parameters affect symbol binding.
 //
@@ -427,11 +447,11 @@ func (d *Database) ExecuteQueryWithInputs(queryStr string, inputs ...interface{}
 //   - Selectivity scores for patterns
 //   - Symbol availability and binding through phases
 //   - Predicate and expression assignment
-func (d *Database) Explain(queryStr string, inputs ...interface{}) (*planner.QueryPlan, error) {
-	// Parse the query
-	q, err := parser.ParseQuery(queryStr)
+func (d *Database) Explain(queryInput interface{}, inputs ...interface{}) (*planner.QueryPlan, error) {
+	// Resolve the query (string or *query.Query)
+	q, err := resolveQuery(queryInput)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse query: %w", err)
+		return nil, fmt.Errorf("failed to resolve query: %w", err)
 	}
 
 	// Validate inputs match :in clause (same validation as ExecuteQueryWithInputs)
@@ -548,6 +568,7 @@ func (ar *AnalyzeResult) String() string {
 }
 
 // Analyze executes a query and returns detailed execution statistics.
+// The query can be either an EDN string or a *query.Query from the query builder.
 // This is like EXPLAIN ANALYZE in PostgreSQL - it actually runs the query
 // and captures timing information at each step.
 //
@@ -562,13 +583,13 @@ func (ar *AnalyzeResult) String() string {
 //   - Query result as a Relation (call .Size() or iterate to access)
 //   - Event trace with timing for each operation
 //   - Summary statistics
-func (d *Database) Analyze(queryStr string, inputs ...interface{}) (*AnalyzeResult, error) {
+func (d *Database) Analyze(queryInput interface{}, inputs ...interface{}) (*AnalyzeResult, error) {
 	startTime := time.Now()
 
-	// Parse the query
-	q, err := parser.ParseQuery(queryStr)
+	// Resolve the query (string or *query.Query)
+	q, err := resolveQuery(queryInput)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse query: %w", err)
+		return nil, fmt.Errorf("failed to resolve query: %w", err)
 	}
 
 	// Validate and convert inputs
@@ -624,6 +645,7 @@ func (d *Database) Analyze(queryStr string, inputs ...interface{}) (*AnalyzeResu
 }
 
 // QueryInto executes a Datalog query and populates a slice of structs with the results.
+// The query can be either an EDN string or a *query.Query from the query builder.
 // Fields are mapped by `datalog` tags (e.g., `datalog:"?name"`) or by position if untagged.
 //
 // For aggregates, use the full expression as the tag (e.g., `datalog:"(sum ?salary)"`).
@@ -638,6 +660,12 @@ func (d *Database) Analyze(queryStr string, inputs ...interface{}) (*AnalyzeResu
 //	var results []PersonResult
 //	err := db.QueryInto(&results, `[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
 //
+// Example with query builder:
+//
+//	e, name, age := qb.NewVar(), qb.NewVar(), qb.NewVar()
+//	q := qb.Query().Find(name, age).Where(qb.Pat(e, PersonName, name), qb.Pat(e, PersonAge, age)).MustBuild()
+//	err := db.QueryInto(&results, q)
+//
 // Example with aggregates:
 //
 //	type DeptStats struct {
@@ -647,7 +675,7 @@ func (d *Database) Analyze(queryStr string, inputs ...interface{}) (*AnalyzeResu
 //
 //	var stats []DeptStats
 //	err := db.QueryInto(&stats, `[:find ?dept (sum ?salary) :where [?e :employee/dept ?dept] [?e :employee/salary ?salary]]`)
-func (d *Database) QueryInto(dest interface{}, queryStr string, inputs ...interface{}) error {
+func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ...interface{}) error {
 	// Validate dest is *[]T
 	destVal := reflect.ValueOf(dest)
 	if destVal.Kind() != reflect.Ptr {
@@ -665,10 +693,10 @@ func (d *Database) QueryInto(dest interface{}, queryStr string, inputs ...interf
 		elemType = elemType.Elem()
 	}
 
-	// Parse query to extract :find columns
-	q, err := parser.ParseQuery(queryStr)
+	// Resolve the query (string or *query.Query)
+	q, err := resolveQuery(queryInput)
 	if err != nil {
-		return fmt.Errorf("failed to parse query: %w", err)
+		return fmt.Errorf("failed to resolve query: %w", err)
 	}
 
 	// Check if element type is a struct or scalar
@@ -682,7 +710,7 @@ func (d *Database) QueryInto(dest interface{}, queryStr string, inputs ...interf
 			return err
 		}
 
-		results, err := d.ExecuteQueryWithInputs(queryStr, inputs...)
+		results, err := d.ExecuteQueryWithInputs(q, inputs...)
 		if err != nil {
 			return err
 		}
@@ -695,7 +723,7 @@ func (d *Database) QueryInto(dest interface{}, queryStr string, inputs ...interf
 		return fmt.Errorf("scalar QueryInto requires exactly 1 find element, got %d", len(q.Find))
 	}
 
-	results, err := d.ExecuteQueryWithInputs(queryStr, inputs...)
+	results, err := d.ExecuteQueryWithInputs(q, inputs...)
 	if err != nil {
 		return err
 	}
@@ -705,6 +733,7 @@ func (d *Database) QueryInto(dest interface{}, queryStr string, inputs ...interf
 }
 
 // QueryOneInto executes a Datalog query expecting at most one result and populates a value.
+// The query can be either an EDN string or a *query.Query from the query builder.
 // Supports both struct destinations (multi-column) and scalar destinations (single-column).
 // Returns (true, nil) if a result was found and mapped successfully.
 // Returns (false, nil) if the query returns no results (empty result is valid, not an error).
@@ -720,7 +749,7 @@ func (d *Database) QueryInto(dest interface{}, queryStr string, inputs ...interf
 //
 //	var name string
 //	found, err := db.QueryOneInto(&name, `[:find ?name :where [?e :person/name ?name] [(= ?e eid)]]`)
-func (d *Database) QueryOneInto(dest interface{}, queryStr string, inputs ...interface{}) (found bool, err error) {
+func (d *Database) QueryOneInto(dest interface{}, queryInput interface{}, inputs ...interface{}) (found bool, err error) {
 	destVal := reflect.ValueOf(dest)
 	if destVal.Kind() != reflect.Ptr {
 		return false, fmt.Errorf("QueryOneInto requires pointer destination")
@@ -728,10 +757,10 @@ func (d *Database) QueryOneInto(dest interface{}, queryStr string, inputs ...int
 	elemVal := destVal.Elem()
 	elemType := elemVal.Type()
 
-	// Parse query to extract :find columns
-	q, err := parser.ParseQuery(queryStr)
+	// Resolve the query (string or *query.Query)
+	q, err := resolveQuery(queryInput)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse query: %w", err)
+		return false, fmt.Errorf("failed to resolve query: %w", err)
 	}
 
 	// Check if destination is a struct (but not time.Time, Identity, Keyword which are scalars)
@@ -745,7 +774,7 @@ func (d *Database) QueryOneInto(dest interface{}, queryStr string, inputs ...int
 			return false, err
 		}
 
-		results, err := d.ExecuteQueryWithInputs(queryStr, inputs...)
+		results, err := d.ExecuteQueryWithInputs(q, inputs...)
 		if err != nil {
 			return false, err
 		}
@@ -768,7 +797,7 @@ func (d *Database) QueryOneInto(dest interface{}, queryStr string, inputs ...int
 		return false, fmt.Errorf("scalar QueryOneInto requires exactly 1 find element, got %d", len(q.Find))
 	}
 
-	results, err := d.ExecuteQueryWithInputs(queryStr, inputs...)
+	results, err := d.ExecuteQueryWithInputs(q, inputs...)
 	if err != nil {
 		return false, err
 	}
@@ -960,8 +989,9 @@ func setScalarValue(dest reflect.Value, val interface{}) error {
 	return fmt.Errorf("cannot convert %T to %s", val, destType)
 }
 
-// ExecuteHistoryQuery executes a Datalog query against the history database
-// This requires the database to be created with RetractHistory mode
+// ExecuteHistoryQuery executes a Datalog query against the history database.
+// The query can be either an EDN string or a *query.Query from the query builder.
+// This requires the database to be created with RetractHistory mode.
 //
 // History queries support 5-element patterns: [?e ?a ?v ?tx ?op]
 // where ?op is true for assertions and false for retractions
@@ -969,22 +999,23 @@ func setScalarValue(dest reflect.Value, val interface{}) error {
 // Example:
 //
 //	results, err := db.ExecuteHistoryQuery(`[:find ?v ?tx ?op :where [?e :person/name ?v ?tx ?op]]`)
-func (d *Database) ExecuteHistoryQuery(queryStr string) ([][]interface{}, error) {
-	return d.ExecuteHistoryQueryWithInputs(queryStr)
+func (d *Database) ExecuteHistoryQuery(q interface{}) ([][]interface{}, error) {
+	return d.ExecuteHistoryQueryWithInputs(q)
 }
 
-// ExecuteHistoryQueryWithInputs executes a parameterized query against the history database
-// This is the history equivalent of ExecuteQueryWithInputs
-func (d *Database) ExecuteHistoryQueryWithInputs(queryStr string, inputs ...interface{}) ([][]interface{}, error) {
+// ExecuteHistoryQueryWithInputs executes a parameterized query against the history database.
+// The query can be either an EDN string or a *query.Query from the query builder.
+// This is the history equivalent of ExecuteQueryWithInputs.
+func (d *Database) ExecuteHistoryQueryWithInputs(queryInput interface{}, inputs ...interface{}) ([][]interface{}, error) {
 	historyMatcher := d.History()
 	if historyMatcher == nil {
 		return nil, fmt.Errorf("history queries require RetractHistory mode (database was created with RetractDelete mode)")
 	}
 
-	// Parse the query
-	q, err := parser.ParseQuery(queryStr)
+	// Resolve the query (string or *query.Query)
+	q, err := resolveQuery(queryInput)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse query: %w", err)
+		return nil, fmt.Errorf("failed to resolve query: %w", err)
 	}
 
 	// Convert inputs to Relations based on :in clause

--- a/docs/reference/QUERY_BUILDER.md
+++ b/docs/reference/QUERY_BUILDER.md
@@ -1,0 +1,558 @@
+# Query Builder (qb)
+
+The `qb` package provides an idiomatic Go API for building Datalog queries without string manipulation. The key insight: **Go variable identity IS the join condition** - using the same `*Var` in multiple patterns creates a join.
+
+## Overview
+
+```go
+import "github.com/wbrown/janus-datalog/datalog/qb"
+
+// Define attributes as package-level constants - this is the recommended pattern
+var (
+    PersonName = qb.Kw(":person/name")
+    PersonAge  = qb.Kw(":person/age")
+    PersonCity = qb.Kw(":person/city")
+)
+
+func FindAdults(db *storage.Database) ([][]interface{}, error) {
+    // Variables are created per-query - same pointer = same logical variable
+    e := qb.NewVar()
+    name := qb.NewVar()
+    age := qb.NewVar()
+
+    q := qb.Query().
+        Find(name, age).
+        Where(
+            qb.Pat(e, PersonName, name),
+            qb.Pat(e, PersonAge, age),  // same `e` = join!
+            qb.Gt(age, 21),
+        ).
+        MustBuild()
+
+    return db.ExecuteQuery(q)
+}
+```
+
+## Attributes
+
+**Define attributes as package-level constants.** This prevents typos, enables IDE completion, and makes refactoring safe.
+
+```go
+// schema.go - define your schema's attributes once
+package myapp
+
+import "github.com/wbrown/janus-datalog/datalog/qb"
+
+// Person attributes
+var (
+    PersonName   = qb.Kw(":person/name")
+    PersonAge    = qb.Kw(":person/age")
+    PersonEmail  = qb.Kw(":person/email")
+    PersonCity   = qb.Kw(":person/city")
+    PersonActive = qb.Kw(":person/active")
+)
+
+// Order attributes
+var (
+    OrderCustomer = qb.Kw(":order/customer")
+    OrderTotal    = qb.Kw(":order/total")
+    OrderDate     = qb.Kw(":order/date")
+    OrderStatus   = qb.Kw(":order/status")
+)
+```
+
+Then use them throughout your code:
+
+```go
+// queries.go
+q := qb.Query().
+    Find(name, total).
+    Where(
+        qb.Pat(p, PersonName, name),
+        qb.Pat(o, OrderCustomer, p),
+        qb.Pat(o, OrderTotal, total),
+    ).
+    MustBuild()
+```
+
+**Why this matters:**
+- Typo in `":person/naem"` silently returns no results
+- Constant `PersonName` catches typos at compile time
+- Refactoring attribute names is safe with find-and-replace
+- IDE autocompletion shows available attributes
+
+## Variables
+
+Variables represent unknowns in your query. The same `*Var` pointer used in multiple places creates a join condition.
+
+```go
+e := qb.NewVar()
+name := qb.NewVar()
+age := qb.NewVar()
+
+// Same variable in multiple patterns = join
+qb.Pat(e, PersonName, name)
+qb.Pat(e, PersonAge, age)  // joins on e
+```
+
+## Patterns
+
+`Pat` creates data patterns of any arity. Patterns can match against:
+- The database (EAVT storage)
+- Input relations of any arity
+
+```go
+// Database patterns
+qb.Pat(e, a, v)              // [e a v] - standard pattern
+qb.Pat(e, a, v, tx)          // [e a v tx] - with transaction
+qb.Pat(e, a, v, tx, op)      // [e a v tx op] - history pattern
+
+// Input relation patterns (any arity)
+qb.Pat(name, age)            // 2-tuple
+qb.Pat(a, b, c, d, e, f)     // 6-tuple
+
+// Wildcards
+qb.Pat(e, qb.Blank(), name)  // ignore attribute
+```
+
+### Pattern Arguments
+
+Patterns accept:
+- `*Var` - query variables
+- `qb.Kw(":attr/name")` - keyword attributes
+- `qb.V(value)` - constant values
+- `qb.Blank()` - wildcard (ignore position)
+- Raw Go values - converted to constants
+
+```go
+// Using Kw for attributes
+PersonName := qb.Kw(":person/name")
+qb.Pat(e, PersonName, name)
+
+// Using V for constants
+qb.Pat(e, PersonName, qb.V("Alice"))
+
+// Raw values work too
+qb.Pat(e, PersonName, "Alice")
+```
+
+## Predicates
+
+Comparison predicates filter results:
+
+```go
+qb.Lt(age, 30)       // age < 30
+qb.Lte(age, 30)      // age <= 30
+qb.Gt(age, 18)       // age > 18
+qb.Gte(age, 18)      // age >= 18
+qb.Eq(city, "NYC")   // city = "NYC"
+qb.Ne(status, "X")   // status != "X"
+```
+
+### Chained Comparisons
+
+```go
+// Exclusive range: 18 < age < 65
+qb.Range(18, age, 65)
+
+// Inclusive range: 1 <= rating <= 5
+qb.RangeInclusive(1, rating, 5)
+```
+
+## Aggregations
+
+```go
+qb.Query().
+    Find(dept, qb.Sum(salary)).
+    Where(
+        qb.Pat(e, PersonDept, dept),
+        qb.Pat(e, PersonSalary, salary),
+    ).
+    MustBuild()
+```
+
+Available aggregations:
+- `qb.Sum(v)` - sum of values
+- `qb.Count(v)` - count of values
+- `qb.Avg(v)` - average of values
+- `qb.Min(v)` - minimum value
+- `qb.Max(v)` - maximum value
+
+## Expressions
+
+Expressions compute values and bind them to variables:
+
+### Arithmetic
+
+```go
+total := qb.NewVar()
+qb.Add(price, tax).As(total)
+qb.Sub(gross, deductions).As(net)
+qb.Mul(quantity, unitPrice).As(lineTotal)
+qb.Div(total, count).As(average)
+```
+
+### String Concatenation
+
+```go
+fullName := qb.NewVar()
+qb.Str(firstName, " ", lastName).As(fullName)
+```
+
+### Ground Values
+
+```go
+constant := qb.NewVar()
+qb.Ground(42).As(constant)
+```
+
+### Time Extraction
+
+```go
+y := qb.NewVar()
+qb.Year(timestamp).As(y)
+qb.Month(timestamp).As(m)
+qb.Day(timestamp).As(d)
+qb.Hour(timestamp).As(h)
+qb.Minute(timestamp).As(min)
+qb.Second(timestamp).As(sec)
+```
+
+## Input Parameters
+
+Input parameters allow parameterized queries:
+
+```go
+// Database source (always first)
+qb.DB
+
+// Scalar input - single value
+qb.Scalar(nameVar)
+
+// Collection input - iterate over values
+qb.Collection(nameVar)
+
+// Tuple input - single row of values
+qb.Tuple(nameVar, ageVar)
+
+// Relation input - multiple rows
+qb.Relation(nameVar, ageVar)
+```
+
+### Scalar Input Example
+
+```go
+inputName := qb.NewVar()
+age := qb.NewVar()
+
+q := qb.Query().
+    Find(inputName, age).
+    In(qb.DB, qb.Scalar(inputName)).
+    Where(
+        qb.Pat(e, PersonName, inputName),
+        qb.Pat(e, PersonAge, age),
+    ).
+    MustBuild()
+
+// Execute with input value
+results, err := db.ExecuteQueryWithInputs(q, "Alice")
+```
+
+### Collection Input Example
+
+```go
+inputName := qb.NewVar()
+age := qb.NewVar()
+
+q := qb.Query().
+    Find(inputName, age).
+    In(qb.DB, qb.Collection(inputName)).
+    Where(
+        qb.Pat(e, PersonName, inputName),
+        qb.Pat(e, PersonAge, age),
+    ).
+    MustBuild()
+
+// Execute with multiple values - returns results for each
+results, err := db.ExecuteQueryWithInputs(q, []string{"Alice", "Bob", "Charlie"})
+```
+
+### Relation Input Example
+
+```go
+inputName := qb.NewVar()
+inputCity := qb.NewVar()
+age := qb.NewVar()
+
+q := qb.Query().
+    Find(inputName, inputCity, age).
+    In(qb.DB, qb.Relation(inputName, inputCity)).
+    Where(
+        qb.Pat(e, PersonName, inputName),
+        qb.Pat(e, PersonCity, inputCity),
+        qb.Pat(e, PersonAge, age),
+    ).
+    MustBuild()
+
+// Execute with relation - finds matching (name, city) pairs
+results, err := db.ExecuteQueryWithInputs(q, [][]interface{}{
+    {"Alice", "NYC"},
+    {"Bob", "LA"},
+})
+```
+
+## Logical Clauses
+
+### NOT
+
+Exclude results matching patterns:
+
+```go
+// Exclude inactive people
+qb.Not(
+    qb.Pat(e, PersonActive, false),
+)
+
+// NOT with join variable
+qb.NotJoin([]*qb.Var{e},
+    qb.Pat(e, PersonStatus, qb.V("banned")),
+)
+```
+
+### OR
+
+Match any of several alternatives:
+
+```go
+// Match NYC or LA
+qb.Or(
+    []interface{}{qb.Pat(e, PersonCity, qb.V("NYC"))},
+    []interface{}{qb.Pat(e, PersonCity, qb.V("LA"))},
+)
+
+// OR with join variables
+qb.OrJoin([]*qb.Var{e, city},
+    []interface{}{qb.Pat(e, PersonCity, city), qb.Eq(city, "NYC")},
+    []interface{}{qb.Pat(e, PersonCity, city), qb.Eq(city, "LA")},
+)
+```
+
+## Ordering
+
+```go
+qb.Query().
+    Find(name, age).
+    Where(...).
+    OrderBy(qb.Desc(age), qb.Asc(name)).
+    MustBuild()
+```
+
+## Subqueries
+
+```go
+// Inner query finds max salary per department
+innerQ := qb.Query().
+    Find(qb.Max(innerSalary)).
+    In(qb.DB, qb.Scalar(dept)).
+    Where(
+        qb.Pat(emp, EmpDept, dept),
+        qb.Pat(emp, EmpSalary, innerSalary),
+    )
+
+// Outer query uses subquery
+maxSalary := qb.NewVar()
+q := qb.Query().
+    Find(name, maxSalary).
+    Where(
+        qb.Pat(p, PersonName, name),
+        qb.Pat(p, PersonDept, dept),
+        qb.Subquery(innerQ, dept).BindTuple(maxSalary),
+    ).
+    MustBuild()
+```
+
+Binding forms:
+- `BindTuple(vars...)` - single row result `[[?a ?b]]`
+- `BindRelation(vars...)` - multiple rows `[[?a ?b] ...]`
+- `BindCollection(v)` - single column `[?a ...]`
+
+## Building Queries
+
+```go
+// Build returns (*query.Query, error)
+q, err := qb.Query().
+    Find(name).
+    Where(qb.Pat(e, PersonName, name)).
+    Build()
+if err != nil {
+    return err
+}
+
+// MustBuild panics on error - useful for static queries
+var FindAllPeople = qb.Query().
+    Find(name).
+    Where(qb.Pat(e, PersonName, name)).
+    MustBuild()
+```
+
+## Database Integration
+
+All database query methods accept both `*query.Query` and EDN strings:
+
+```go
+// Basic execution
+results, err := db.ExecuteQuery(q)
+results, err := db.ExecuteQueryWithInputs(q, inputs...)
+
+// Explain query plan
+plan, err := db.Explain(q)
+```
+
+### QueryInto - Typed Results
+
+Query directly into Go structs. With the query builder, **fields map positionally** to your `Find()` elements - no tags needed:
+
+```go
+// Define attributes
+var (
+    PersonName = qb.Kw(":person/name")
+    PersonAge  = qb.Kw(":person/age")
+)
+
+// Result struct - fields map positionally to Find() order
+type PersonResult struct {
+    Name string  // maps to first Find() element
+    Age  int64   // maps to second Find() element
+}
+
+func FindAdults(db *storage.Database) ([]PersonResult, error) {
+    e := qb.NewVar()
+    name := qb.NewVar()
+    age := qb.NewVar()
+
+    q := qb.Query().
+        Find(name, age).
+        Where(
+            qb.Pat(e, PersonName, name),
+            qb.Pat(e, PersonAge, age),
+            qb.Gte(age, 18),
+        ).
+        MustBuild()
+
+    var results []PersonResult
+    err := db.QueryInto(&results, q)
+    return results, err
+}
+```
+
+### QueryOneInto - Single Result
+
+For queries that return exactly one result:
+
+```go
+func FindPerson(db *storage.Database, personName string) (*PersonResult, error) {
+    e := qb.NewVar()
+    name := qb.NewVar()
+    age := qb.NewVar()
+
+    q := qb.Query().
+        Find(name, age).
+        In(qb.DB, qb.Scalar(name)).
+        Where(
+            qb.Pat(e, PersonName, name),
+            qb.Pat(e, PersonAge, age),
+        ).
+        MustBuild()
+
+    var result PersonResult
+    found, err := db.QueryOneInto(&result, q, personName)
+    if err != nil {
+        return nil, err
+    }
+    if !found {
+        return nil, nil // Not found
+    }
+    return &result, nil
+}
+```
+
+### Aggregations with QueryInto
+
+Positional mapping works with aggregations too - fields map by position:
+
+```go
+type DeptStats struct {
+    Dept      string   // maps to first Find() element (dept)
+    AvgSalary float64  // maps to second Find() element (avg salary)
+    Count     int64    // maps to third Find() element (count emp)
+}
+
+func GetDeptStats(db *storage.Database) ([]DeptStats, error) {
+    emp := qb.NewVar()
+    dept := qb.NewVar()
+    salary := qb.NewVar()
+
+    q := qb.Query().
+        Find(dept, qb.Avg(salary), qb.Count(emp)).
+        Where(
+            qb.Pat(emp, EmpDept, dept),
+            qb.Pat(emp, EmpSalary, salary),
+        ).
+        MustBuild()
+
+    var stats []DeptStats
+    err := db.QueryInto(&stats, q)
+    return stats, err
+}
+```
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/wbrown/janus-datalog/datalog/qb"
+    "github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// Define attributes once
+var (
+    PersonName = qb.Kw(":person/name")
+    PersonAge  = qb.Kw(":person/age")
+    PersonCity = qb.Kw(":person/city")
+)
+
+func main() {
+    db, _ := storage.NewDatabase("example.db")
+    defer db.Close()
+
+    // Find adults in specific cities
+    e := qb.NewVar()
+    name := qb.NewVar()
+    age := qb.NewVar()
+    city := qb.NewVar()
+
+    q := qb.Query().
+        Find(name, age, city).
+        In(qb.DB, qb.Collection(city)).
+        Where(
+            qb.Pat(e, PersonName, name),
+            qb.Pat(e, PersonAge, age),
+            qb.Pat(e, PersonCity, city),
+            qb.Gte(age, 18),
+        ).
+        OrderBy(qb.Desc(age)).
+        MustBuild()
+
+    results, err := db.ExecuteQueryWithInputs(q, []string{"NYC", "LA"})
+    if err != nil {
+        panic(err)
+    }
+
+    for _, row := range results {
+        fmt.Printf("%s (%d) - %s\n", row[0], row[1], row[2])
+    }
+}
+```

--- a/docs/wip/GO_FUNCTIONS_AND_RULES.md
+++ b/docs/wip/GO_FUNCTIONS_AND_RULES.md
@@ -1,0 +1,504 @@
+# Go Functions and Rules
+
+Design document for extending the query builder with Go function integration and forward-chaining rules.
+
+## Goals
+
+1. Allow Go functions in queries for filtering and value computation
+2. Support forward-chaining rules that transform data
+3. Keep the API additive - no changes to existing `qb` functions
+4. Let developers choose their tradeoffs (closures vs pure functions)
+
+## Part 1: Go Functions in Queries
+
+### API
+
+```go
+// Filter - predicate function, must return bool
+qb.Filter(fn, args...)
+
+// Eval - expression function, returns value, bind with .As()
+qb.Eval(fn, args...).As(result)
+```
+
+### Usage
+
+**With closures** (simple, captures state):
+
+```go
+// Rebuild query when captured values change
+q := qb.Query().
+    Find(e).
+    Where(
+        qb.Pat(e, Position, pos),
+        qb.Filter(func(p Vec3) bool {
+            return p.DistanceTo(playerPos) < attackRange
+        }, pos),
+    ).
+    MustBuild()
+```
+
+**With pure functions** (reusable query):
+
+```go
+func InRange(a, b Vec3, r float64) bool {
+    return a.DistanceTo(b) < r
+}
+
+playerPos := qb.NewVar()
+rangeVar := qb.NewVar()
+
+q := qb.Query().
+    Find(e).
+    In(qb.DB, qb.Scalar(playerPos), qb.Scalar(rangeVar)).
+    Where(
+        qb.Pat(e, Position, pos),
+        qb.Filter(InRange, pos, playerPos, rangeVar),
+    ).
+    MustBuild()
+
+// Reuse query with different values each frame
+results := db.ExecuteQueryWithInputs(q, player.Pos, player.Range)
+```
+
+**Computing values**:
+
+```go
+func CalculateDamage(base, armor int64, multiplier float64) int64 {
+    return int64(float64(base-armor) * multiplier)
+}
+
+finalDamage := qb.NewVar()
+
+q := qb.Query().
+    Find(target, finalDamage).
+    Where(
+        qb.Pat(attack, AttackTarget, target),
+        qb.Pat(attack, BaseDamage, baseDmg),
+        qb.Pat(target, Armor, armor),
+        qb.Pat(attack, DamageMultiplier, mult),
+        qb.Eval(CalculateDamage, baseDmg, armor, mult).As(finalDamage),
+    ).
+    MustBuild()
+```
+
+### Implementation
+
+```go
+// GoFilter represents a Go function used as a predicate
+type GoFilter struct {
+    fn   reflect.Value
+    args []*Var
+}
+
+func Filter(fn interface{}, args ...*Var) *GoFilter {
+    rv := reflect.ValueOf(fn)
+    if rv.Kind() != reflect.Func {
+        panic("Filter: first argument must be a function")
+    }
+    // Validate returns bool
+    if rv.Type().NumOut() != 1 || rv.Type().Out(0).Kind() != reflect.Bool {
+        panic("Filter: function must return bool")
+    }
+    // Validate arg count
+    if rv.Type().NumIn() != len(args) {
+        panic(fmt.Sprintf("Filter: function takes %d args, got %d",
+            rv.Type().NumIn(), len(args)))
+    }
+    return &GoFilter{fn: rv, args: args}
+}
+
+func (g *GoFilter) toClause() query.Clause {
+    syms := make([]query.Symbol, len(g.args))
+    for i, v := range g.args {
+        syms[i] = v.Symbol()
+    }
+    return &query.GoFilterClause{
+        Fn:   g.fn,
+        Args: syms,
+    }
+}
+```
+
+The executor calls `fn.Call()` with bound values for each candidate tuple.
+
+### Type Checking
+
+- Argument count validated at Build() time
+- Argument types validated at execution time (first invocation)
+- Type mismatches panic with clear error message
+
+---
+
+## Part 2: Forward-Chaining Rules
+
+### API
+
+```go
+qb.Rule().
+    When(clauses...).
+    Then(effects...).
+    MustBuild()
+```
+
+**When clause** - uses same clause types as `Query().Where()`:
+- `qb.Pat()` - patterns
+- `qb.Filter()` - Go predicates
+- `qb.Eval().As()` - computed values
+- `qb.Lt()`, `qb.Gt()`, etc. - comparisons
+- `qb.Not()`, `qb.Or()` - logical operators
+
+**Then clause** - effects to apply:
+- `qb.Assert(e, a, v)` - add datom
+- `qb.Retract(e, a, v)` - retract specific datom
+- `qb.RetractEntity(e)` - retract all datoms for entity
+
+### Usage
+
+**Damage application rule**:
+
+```go
+var (
+    AttackTarget = qb.Kw(":attack/target")
+    AttackDamage = qb.Kw(":attack/damage")
+    Health       = qb.Kw(":entity/health")
+)
+
+func ApplyDamage(current, damage int64) int64 {
+    if damage > current {
+        return 0
+    }
+    return current - damage
+}
+
+attack := qb.NewVar()
+target := qb.NewVar()
+damage := qb.NewVar()
+currentHealth := qb.NewVar()
+newHealth := qb.NewVar()
+
+damageRule := qb.Rule().
+    When(
+        qb.Pat(attack, AttackTarget, target),
+        qb.Pat(attack, AttackDamage, damage),
+        qb.Pat(target, Health, currentHealth),
+        qb.Eval(ApplyDamage, currentHealth, damage).As(newHealth),
+    ).
+    Then(
+        qb.Assert(target, Health, newHealth),
+        qb.RetractEntity(attack),  // consume the event
+    ).
+    MustBuild()
+```
+
+**Death detection rule**:
+
+```go
+entity := qb.NewVar()
+health := qb.NewVar()
+
+deathRule := qb.Rule().
+    When(
+        qb.Pat(entity, Health, health),
+        qb.Lte(health, 0),
+        qb.Not(qb.Pat(entity, Dead, qb.V(true))),
+    ).
+    Then(
+        qb.Assert(entity, Dead, qb.V(true)),
+        qb.Assert(entity, DeathTime, qb.V(time.Now())),
+    ).
+    MustBuild()
+```
+
+### Firing Rules
+
+**Single rule, manual control**:
+
+```go
+// Fire returns transaction for inspection
+tx := damageRule.Fire(db)
+fmt.Printf("Rule matched %d times\n", tx.DatomCount())
+tx.Commit()
+
+// Or direct commit
+damageRule.FireAndCommit(db)
+```
+
+**Multiple rules, batch execution**:
+
+```go
+// Register rules
+db.RegisterRule("damage", damageRule)
+db.RegisterRule("death", deathRule)
+db.RegisterRule("cleanup", cleanupRule)
+
+// Fire all rules once
+db.FireRulesOnce()
+
+// Fire until fixpoint (no rule matches)
+db.FireRulesToFixpoint()
+
+// Fire with iteration limit
+db.FireRules(MaxIterations(100))
+```
+
+**Event-driven game loop**:
+
+```go
+// Each frame
+func (g *Game) Update() {
+    // Process input -> create attack events
+    g.processInput()
+
+    // Fire combat rules
+    g.db.FireRulesToFixpoint()
+
+    // Query for rendering
+    g.render()
+}
+```
+
+### Implementation
+
+```go
+// RuleBuilder constructs a forward-chaining rule
+type RuleBuilder struct {
+    when   []interface{}  // same as Where clauses
+    then   []Effect
+    errors []error
+}
+
+func Rule() *RuleBuilder {
+    return &RuleBuilder{}
+}
+
+func (r *RuleBuilder) When(clauses ...interface{}) *RuleBuilder {
+    r.when = append(r.when, clauses...)
+    return r
+}
+
+func (r *RuleBuilder) Then(effects ...Effect) *RuleBuilder {
+    r.then = append(r.then, effects...)
+    return r
+}
+
+func (r *RuleBuilder) Build() (*CompiledRule, error) {
+    // Build internal query from When clauses
+    // Compile Then effects with variable references
+}
+
+func (r *RuleBuilder) MustBuild() *CompiledRule {
+    rule, err := r.Build()
+    if err != nil {
+        panic(err)
+    }
+    return rule
+}
+```
+
+**Effect types**:
+
+```go
+// Effect is something that happens when a rule fires
+type Effect interface {
+    toEffect() ruleEffect
+}
+
+// AssertEffect adds a datom
+type AssertEffect struct {
+    e, a, v interface{}  // can be *Var or constant
+}
+
+func Assert(e, a, v interface{}) *AssertEffect {
+    return &AssertEffect{e: e, a: a, v: v}
+}
+
+// RetractEffect removes a datom
+type RetractEffect struct {
+    e, a, v interface{}
+}
+
+func Retract(e, a, v interface{}) *RetractEffect {
+    return &RetractEffect{e: e, a: a, v: v}
+}
+
+// RetractEntityEffect removes all datoms for an entity
+type RetractEntityEffect struct {
+    e interface{}
+}
+
+func RetractEntity(e interface{}) *RetractEntityEffect {
+    return &RetractEntityEffect{e: e}
+}
+```
+
+### CompiledRule Execution
+
+```go
+type CompiledRule struct {
+    query   *query.Query      // built from When clauses
+    effects []compiledEffect  // built from Then clause
+}
+
+func (r *CompiledRule) Fire(db *Database) *Transaction {
+    // Execute query
+    results, _ := db.ExecuteQuery(r.query)
+
+    // Create transaction
+    tx := db.NewTransaction()
+
+    // For each result row, apply effects with bound values
+    for _, row := range results {
+        for _, effect := range r.effects {
+            effect.apply(tx, row)
+        }
+    }
+
+    return tx
+}
+```
+
+---
+
+## API Compatibility
+
+### Existing API (unchanged)
+
+```go
+// Variables and constants
+qb.NewVar()
+qb.Kw(":attr/name")
+qb.V(value)
+qb.Blank()
+
+// Query builder
+qb.Query().Find(...).In(...).Where(...).OrderBy(...).Build()
+
+// Patterns
+qb.Pat(e, a, v)
+
+// Predicates
+qb.Lt(), qb.Lte(), qb.Gt(), qb.Gte(), qb.Eq(), qb.Ne()
+qb.Range(), qb.RangeInclusive()
+
+// Expressions
+qb.Add(), qb.Sub(), qb.Mul(), qb.Div()
+qb.Str(), qb.Ground(), qb.Identity()
+qb.Year(), qb.Month(), qb.Day(), qb.Hour(), qb.Minute(), qb.Second()
+
+// Aggregations
+qb.Sum(), qb.Count(), qb.Avg(), qb.Min(), qb.Max()
+
+// Logical
+qb.Not(), qb.NotJoin(), qb.Or(), qb.OrJoin()
+
+// Subqueries
+qb.Subquery().BindTuple(), .BindRelation(), .BindCollection()
+
+// Ordering
+qb.Asc(), qb.Desc()
+```
+
+### New API (additive)
+
+```go
+// Go functions (Part 1)
+qb.Filter(fn, args...)        // predicate
+qb.Eval(fn, args...).As(v)    // expression
+
+// Rules (Part 2)
+qb.Rule().When(...).Then(...).Build()
+
+// Effects (for Then clause)
+qb.Assert(e, a, v)
+qb.Retract(e, a, v)
+qb.RetractEntity(e)
+
+// Database rule registration
+db.RegisterRule(name, rule)
+db.FireRulesOnce()
+db.FireRulesToFixpoint()
+db.FireRules(opts...)
+```
+
+### Clause Reuse
+
+The key design insight: `When()` accepts the same clause types as `Where()`.
+
+This means `Filter` and `Eval` work in both contexts:
+
+```go
+// In a query
+qb.Query().
+    Where(
+        qb.Pat(e, Health, hp),
+        qb.Filter(IsAlive, hp),
+    )
+
+// In a rule
+qb.Rule().
+    When(
+        qb.Pat(e, Health, hp),
+        qb.Filter(IsAlive, hp),
+    ).
+    Then(...)
+```
+
+No API changes needed. The `Clause` interface already supports this.
+
+---
+
+## Future Considerations
+
+### Rule Priorities
+
+```go
+qb.Rule().
+    Priority(10).  // higher = fires first
+    When(...).
+    Then(...)
+```
+
+### Conditional Effects
+
+```go
+qb.Rule().
+    When(...).
+    Then(
+        qb.If(condition,
+            qb.Assert(...),
+        ).Else(
+            qb.Assert(...),
+        ),
+    )
+```
+
+### New Entity Creation
+
+```go
+newEntity := qb.NewVar()
+
+qb.Rule().
+    When(...).
+    Then(
+        qb.Create(newEntity),  // generates new entity ID
+        qb.Assert(newEntity, Type, qb.V("explosion")),
+        qb.Assert(newEntity, Position, pos),
+    )
+```
+
+### Aggregating Rules
+
+```go
+// Rule that fires once with aggregated data
+qb.Rule().
+    When(
+        qb.Pat(e, Faction, faction),
+        qb.Pat(e, Score, score),
+    ).
+    GroupBy(faction).
+    Aggregate(qb.Sum(score).As(totalScore)).
+    Then(
+        qb.Assert(faction, TotalScore, totalScore),
+    )
+```


### PR DESCRIPTION
Introduces a new query builder package that provides compile-time safety and IDE support for constructing Datalog queries. The key insight: Go variable identity IS the join condition - using the same *Var pointer in multiple patterns creates a join.

## Core Design

The query builder uses Go's type system to catch errors at compile time:
- Attributes defined as package constants (qb.Kw) catch typos
- Variables created with qb.NewVar() ensure join semantics via pointer identity
- Fluent builder API mirrors the structure of Datalog queries

Example:
```go
var PersonName = qb.Kw(":person/name")
var PersonAge = qb.Kw(":person/age")

e := qb.NewVar()
name := qb.NewVar()
age := qb.NewVar()

q := qb.Query().
    Find(name, age).
    Where(
        qb.Pat(e, PersonName, name),
        qb.Pat(e, PersonAge, age),  // same e = join!
        qb.Gt(age, 21),
    ).
    MustBuild()
```

## Package Structure (datalog/qb/)

- var.go: Var type with atomic counter for unique IDs
- attr.go: Kw() for keywords, V() for constants, Blank() for wildcards
- pattern.go: Pat() for patterns of any arity (2-5 elements)
- predicate.go: Lt, Gt, Eq, Ne, Lte, Gte, Range, RangeInclusive
- expression.go: Add, Sub, Mul, Div, Str, Ground, Identity, Year/Month/Day/etc
- agg.go: Sum, Count, Avg, Min, Max
- clause.go: Not, NotJoin, Or, OrJoin with explicit panic on invalid types
- input.go: DB, Scalar, Collection, Tuple, Relation input specs
- subquery.go: Subquery with BindTuple, BindRelation, BindCollection
- builder.go: QueryBuilder with Find, In, Where, OrderBy, Build, MustBuild

## Database Integration

Modified datalog/storage/database.go to accept both *query.Query and EDN strings in all query methods via a new resolveQuery() helper:
- ExecuteQuery / ExecuteQueryWithInputs
- QueryInto / QueryOneInto
- Explain / Analyze
- ExecuteHistoryQuery / ExecuteHistoryQueryWithInputs

This is fully backward compatible - existing EDN string queries work unchanged.

## Test Coverage

- qb_test.go (861 lines): Unit tests for all builder functions
- integration_test.go (1183 lines): End-to-end tests against real database
  - Basic queries, joins, predicates, aggregations
  - Input parameters (scalar, collection, tuple, relation)
  - QueryInto with positional struct mapping
  - Comparison tests verifying identical results from qb vs EDN

## Documentation

- docs/reference/QUERY_BUILDER.md: Complete API reference with examples
- docs/wip/GO_FUNCTIONS_AND_RULES.md: Design doc for future Go function integration (qb.Filter, qb.Eval) and forward-chaining rules (qb.Rule)
- README.md: Updated with query builder examples as primary interface

## Key Features

1. **Compile-time safety**: Typo in ":person/naem" silently returns empty; constant PersonName catches it at compile time

2. **Variable identity joins**: Same *Var in multiple patterns = join

3. **Positional QueryInto mapping**: Struct fields map by position to Find() elements - no datalog tags needed for simple cases

4. **Full Datalog support**: Patterns, predicates, expressions, aggregations, input parameters, NOT/OR clauses, subqueries, ordering

5. **Interoperability**: Built queries work with all database methods alongside EDN strings - choose the right tool for each use case

6. **Explicit error handling**: All clause conversions panic on invalid types rather than silently failing; subquery build errors panic with message