### PR TITLE
Add OR clause fallback semantics for expression branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ The storage layer connects the query engine to BadgerDB:
 22. **Pull API** - Declarative entity attribute retrieval with nested refs, cycle detection, wildcards (9× faster than queries)
 23. **Schema support** - Type validation, cardinality (one/many), uniqueness constraints; optional and additive
 24. **History mode** - Datomic-style retractions with `RetractHistory` mode; full audit trail via `ExecuteHistoryQuery`; 5-element patterns `[?e ?a ?v ?tx ?op]`
-25. **NOT/OR clauses** - Full support for `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with Datomic-compatible semantics
+25. **NOT/OR clauses** - Full support for `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with Datomic-compatible semantics; OR supports fallback expressions for default values
 26. **QueryInto API** - Typed query results via `QueryInto()` and `QueryOneInto()` with struct tag mapping for variables and aggregates
 
 ### 📋 TODO (Priority Order)

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -232,7 +232,25 @@ Logical negation and disjunction for complex query patterns:
                  [?e :admin/status "enabled"])]
 ```
 
-**Note:** Nested NOT/OR clauses support data patterns. Predicates and expressions inside NOT/OR are not yet supported.
+**OR with fallback expressions:**
+
+When an OR clause contains expression branches (e.g., `ground`, arithmetic), janus-datalog uses **fallback semantics**: branches are tried in order, returning the first non-empty result. This enables default values:
+
+```clojure
+;; Return "Unknown" if no name exists
+[:find ?name
+ :where (or [?e :person/name ?name]
+            [(ground "Unknown") ?name])]
+
+;; Count with zero default
+[:find ?count
+ :where (or [(q [:find (count ?t) :where [?t :task/done true]] $) [[?count]]]
+            [(ground 0) ?count])]
+```
+
+This differs from Datomic, where OR always uses union semantics. See [OR_FALLBACK_SEMANTICS.md](docs/reference/OR_FALLBACK_SEMANTICS.md) for details.
+
+**Note:** NOT clauses support data patterns. Predicates and expressions inside NOT are not yet supported.
 
 ### 9. Time-Based Queries
 

--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ Janus implements **~70% of Datomic's feature set** (weighted by typical usage), 
 - Pull API: Nested references, cycle detection, wildcards
 - Schema: Type validation, cardinality, uniqueness constraints
 - Storage: Persistent BadgerDB backend
-- NOT/OR clauses: `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)`
+- NOT/OR clauses: `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with fallback expressions
 - Go-specific: Struct reflection API, QueryInto for typed results
 
 **Not implemented:**

--- a/datalog/executor/expressions_and_predicates.go
+++ b/datalog/executor/expressions_and_predicates.go
@@ -13,10 +13,12 @@ import (
 // add new symbols that might connect them.
 func (e *Executor) applyExpressionsAndPredicates(ctx Context, phase *planner.Phase, relations Relations) (Relation, error) {
 
-	// If we have no relations, return empty
+	// If we have no relations AND no OR clauses, return empty
 	// CRITICAL: Don't call IsEmpty() - it consumes streaming iterators!
 	// Empty detection happens naturally through subsequent operations
-	if len(relations) == 0 {
+	// NOTE: We must NOT return early if there are OR clauses or OR-JOIN clauses,
+	// as they can provide symbols even with no input relations (e.g., fallback semantics).
+	if len(relations) == 0 && len(phase.OrClauses) == 0 && len(phase.OrJoinClauses) == 0 {
 		return NewMaterializedRelationWithOptions(phase.Provides, []Tuple{}, e.options), nil
 	}
 

--- a/datalog/executor/indexed_memory_matcher.go
+++ b/datalog/executor/indexed_memory_matcher.go
@@ -24,8 +24,9 @@ type IndexedMemoryMatcher struct {
 	collectorMutex sync.RWMutex
 	collector      *annotations.Collector
 
-	// ExecutorOptions for configuring relation behavior
-	options ExecutorOptions
+	// ExecutorOptions for configuring relation behavior (protected by optionsMutex)
+	optionsMutex sync.RWMutex
+	options      ExecutorOptions
 }
 
 // boundDatomIterator lazily matches bound patterns during iteration
@@ -141,7 +142,9 @@ func (m *IndexedMemoryMatcher) WithCollector(collector *annotations.Collector) C
 
 // WithOptions sets the executor options and returns self for chaining
 func (m *IndexedMemoryMatcher) WithOptions(opts ExecutorOptions) *IndexedMemoryMatcher {
+	m.optionsMutex.Lock()
 	m.options = opts
+	m.optionsMutex.Unlock()
 	return m
 }
 
@@ -163,7 +166,9 @@ func (m *IndexedMemoryMatcher) MatchWithConstraints(
 	columns := pattern.ExtractColumns()
 
 	// Extract options: prefer bindings, fall back to matcher's options
+	m.optionsMutex.RLock()
 	opts := m.options
+	m.optionsMutex.RUnlock()
 	if bindings != nil && len(bindings) > 0 {
 		opts = bindings[0].Options()
 	}

--- a/datalog/executor/not_or.go
+++ b/datalog/executor/not_or.go
@@ -172,12 +172,55 @@ func (e *Executor) executeNotJoinClause(ctx Context, clause *query.NotJoinClause
 	return NewMaterializedRelationWithOptions(inputCols, filtered, e.options), nil
 }
 
-// executeOrClause performs union of branches
+// executeOrClause performs union of branches, or fallback semantics for expression branches
 func (e *Executor) executeOrClause(ctx Context, clause *query.OrClause, available Relations) (Relation, error) {
 	if len(clause.Branches) == 0 {
 		return NewMaterializedRelationWithOptions(nil, nil, e.options), nil
 	}
 
+	// Check if any branch has expressions - use fallback semantics if so
+	if query.OrHasExpressions(clause.Branches) {
+		return e.executeOrClauseFallback(ctx, clause, available)
+	}
+
+	// Standard union semantics for pattern-only OR
+	return e.executeOrClauseUnion(ctx, clause, available)
+}
+
+// executeOrClauseFallback implements Clojure-style fallback semantics:
+// Try each branch in order, return first non-empty result
+func (e *Executor) executeOrClauseFallback(ctx Context, clause *query.OrClause, available Relations) (Relation, error) {
+	for i, branch := range clause.Branches {
+		// Execute branch with available bindings
+		branchResult, err := e.executeInnerClauses(ctx, branch, nil)
+		if err != nil {
+			return nil, fmt.Errorf("OR branch %d execution failed: %w", i+1, err)
+		}
+
+		// Check if result is non-empty by collecting tuples
+		// We materialize here because fallback semantics require knowing if a branch
+		// produced results before trying the next branch
+		if branchResult != nil {
+			var tuples []Tuple
+			iter := branchResult.Iterator()
+			for iter.Next() {
+				tuples = append(tuples, iter.Tuple())
+			}
+			iter.Close()
+
+			if len(tuples) > 0 {
+				return NewMaterializedRelationWithOptions(branchResult.Columns(), tuples, e.options), nil
+			}
+		}
+	}
+
+	// All branches empty
+	return NewMaterializedRelationWithOptions(nil, nil, e.options), nil
+}
+
+// executeOrClauseUnion implements standard Datalog union semantics:
+// Execute all branches and merge results
+func (e *Executor) executeOrClauseUnion(ctx Context, clause *query.OrClause, available Relations) (Relation, error) {
 	// Execute each branch and collect results
 	var branchResults []Relation
 	var commonCols []query.Symbol
@@ -222,7 +265,7 @@ func (e *Executor) executeOrClause(ctx Context, clause *query.OrClause, availabl
 	return unionRelations(branchResults, commonCols, e.options), nil
 }
 
-// executeOrJoinClause performs union with explicit join variables
+// executeOrJoinClause performs union with explicit join variables, or fallback for expressions
 func (e *Executor) executeOrJoinClause(ctx Context, clause *query.OrJoinClause, available Relations) (Relation, error) {
 	if len(clause.Branches) == 0 {
 		return NewMaterializedRelationWithOptions(nil, nil, e.options), nil
@@ -231,6 +274,11 @@ func (e *Executor) executeOrJoinClause(ctx Context, clause *query.OrJoinClause, 
 	joinVars := clause.JoinVars
 	if len(joinVars) == 0 {
 		return nil, fmt.Errorf("OR-JOIN clause has no join variables")
+	}
+
+	// Check if any branch has expressions - use fallback semantics if so
+	if query.OrHasExpressions(clause.Branches) {
+		return e.executeOrJoinClauseFallback(ctx, clause, available)
 	}
 
 	var branchResults []Relation
@@ -252,6 +300,63 @@ func (e *Executor) executeOrJoinClause(ctx Context, clause *query.OrJoinClause, 
 
 	// Union all branch results, projecting to join vars
 	return unionRelations(branchResults, joinVars, e.options), nil
+}
+
+// executeOrJoinClauseFallback implements fallback semantics for or-join with expressions
+func (e *Executor) executeOrJoinClauseFallback(ctx Context, clause *query.OrJoinClause, available Relations) (Relation, error) {
+	joinVars := clause.JoinVars
+
+	for i, branch := range clause.Branches {
+		branchResult, err := e.executeInnerClauses(ctx, branch, nil)
+		if err != nil {
+			return nil, fmt.Errorf("OR-JOIN branch %d execution failed: %w", i+1, err)
+		}
+
+		// Return first non-empty result, projected to join vars
+		if branchResult != nil && branchResult.Size() > 0 {
+			// Project to join vars only
+			return projectToColumns(branchResult, joinVars, e.options), nil
+		}
+	}
+
+	// All branches empty
+	return NewMaterializedRelationWithOptions(joinVars, nil, e.options), nil
+}
+
+// projectToColumns projects a relation to specified columns
+func projectToColumns(rel Relation, cols []query.Symbol, opts ExecutorOptions) Relation {
+	relCols := rel.Columns()
+
+	// Build column index mapping
+	colIndices := make([]int, len(cols))
+	for i, col := range cols {
+		found := false
+		for j, relCol := range relCols {
+			if relCol == col {
+				colIndices[i] = j
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Column not found - return empty relation
+			return NewMaterializedRelationWithOptions(cols, nil, opts)
+		}
+	}
+
+	var projected []Tuple
+	iter := rel.Iterator()
+	for iter.Next() {
+		tuple := iter.Tuple()
+		newTuple := make(Tuple, len(cols))
+		for i, idx := range colIndices {
+			newTuple[i] = tuple[idx]
+		}
+		projected = append(projected, newTuple)
+	}
+	iter.Close()
+
+	return NewMaterializedRelationWithOptions(cols, projected, opts)
 }
 
 // executeInnerClauses executes a list of clauses and returns the result
@@ -314,8 +419,26 @@ func (e *Executor) executeInnerClauses(ctx Context, clauses []query.Clause, bind
 				result = Relations{orResult}
 			}
 
-		// Note: Predicates and expressions inside NOT/OR are not yet supported
-		// They would need similar handling to the main executor
+		case *query.Expression:
+			// Expression evaluation - supports ground, arithmetic, etc.
+			exprResult, err := e.executeInnerExpression(ctx, c, result)
+			if err != nil {
+				return nil, fmt.Errorf("expression evaluation failed: %w", err)
+			}
+			result = Relations{exprResult}
+
+		case query.Predicate:
+			// Predicate filtering
+			if len(result) == 0 {
+				return nil, fmt.Errorf("predicate requires prior bindings")
+			}
+			collapsed := result.Collapse(ctx)
+			if len(collapsed) != 1 {
+				return nil, fmt.Errorf("predicate requires single relation")
+			}
+			predResult := filterWithPredicate(collapsed[0], c)
+			result = Relations{predResult}
+
 		default:
 			return nil, fmt.Errorf("unsupported clause type in NOT/OR: %T", clause)
 		}
@@ -332,6 +455,31 @@ func (e *Executor) executeInnerClauses(ctx Context, clauses []query.Clause, bind
 	}
 
 	return collapsed[0], nil
+}
+
+// executeInnerExpression evaluates an expression within an OR/NOT branch
+func (e *Executor) executeInnerExpression(ctx Context, expr *query.Expression, groups Relations) (Relation, error) {
+	// If no input relations, create a single empty tuple to evaluate against
+	// This is needed for ground expressions like [(ground 0) ?x]
+	if len(groups) == 0 {
+		// Create a single-tuple relation with just the binding
+		result, err := expr.Function.Eval(make(map[query.Symbol]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		columns := []query.Symbol{expr.Binding}
+		tuples := []Tuple{{result}}
+		return NewMaterializedRelationWithOptions(columns, tuples, e.options), nil
+	}
+
+	// Collapse groups to single relation for expression evaluation
+	collapsed := groups.Collapse(ctx)
+	if len(collapsed) != 1 {
+		return nil, fmt.Errorf("expression requires single relation, got %d disjoint groups", len(collapsed))
+	}
+
+	// Evaluate expression over the relation
+	return evaluateExpressionWithLookup(collapsed[0], expr, nil), nil
 }
 
 // collectInnerVars collects all variables from inner clauses

--- a/datalog/executor/not_or_test.go
+++ b/datalog/executor/not_or_test.go
@@ -434,3 +434,420 @@ func TestOrJoinClause(t *testing.T) {
 		t.Error("Charlie should not be in results")
 	}
 }
+
+// =============================================================================
+// OR Fallback Semantics Tests
+// =============================================================================
+
+func TestOrFallbackWithGroundExpressionDirectQueryExecutor(t *testing.T) {
+	// Directly test the query executor to isolate the issue
+	matcher := NewMemoryPatternMatcher(nil)
+	queryExecutor := NewQueryExecutor(matcher, ExecutorOptions{})
+	ctx := NewContext(nil)
+
+	// Build the OR clause query directly
+	orClause := &query.OrClause{
+		Branches: [][]query.Clause{
+			{
+				&query.DataPattern{
+					Elements: []query.PatternElement{
+						query.Variable{Name: "?e"},
+						query.Constant{Value: datalog.NewKeyword(":nonexistent/attr")},
+						query.Variable{Name: "?x"},
+					},
+				},
+			},
+			{
+				&query.Expression{
+					Function: &query.GroundFunction{Value: int64(0)},
+					Binding:  "?x",
+				},
+			},
+		},
+	}
+
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: "?x"},
+		},
+		Where: []query.Clause{orClause},
+	}
+
+	result, err := queryExecutor.Execute(ctx, q, nil)
+	if err != nil {
+		t.Fatalf("query executor failed: %v", err)
+	}
+
+	t.Logf("Results: %d", len(result))
+	for i, r := range result {
+		t.Logf("Result %d: columns=%v, size=%d", i, r.Columns(), r.Size())
+	}
+
+	// Collapse to single relation
+	collapsed := Relations(result).Collapse(ctx)
+	if len(collapsed) != 1 {
+		t.Fatalf("Expected 1 collapsed relation, got %d", len(collapsed))
+	}
+
+	finalRel := collapsed[0]
+	t.Logf("Final: columns=%v, size=%d", finalRel.Columns(), finalRel.Size())
+
+	if finalRel.Size() != 1 {
+		t.Errorf("Expected 1 result, got %d", finalRel.Size())
+	}
+}
+
+func TestOrFallbackWithGroundExpression(t *testing.T) {
+	// Test OR with ground expression as fallback
+	// When pattern matches nothing, ground should provide default value
+	matcher := NewMemoryPatternMatcher(nil) // Empty database
+	executor := NewExecutor(matcher)
+
+	// Query: (or [?e :nonexistent ?x] [(ground 0) ?x])
+	// Since no data exists, should fall back to ground(0)
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: "?x"},
+		},
+		Where: []query.Clause{
+			&query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: datalog.NewKeyword(":nonexistent/attr")},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+					{
+						&query.Expression{
+							Function: &query.GroundFunction{Value: int64(0)},
+							Binding:  "?x",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(q)
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	// Should have 1 result with value 0
+	if result.Size() != 1 {
+		t.Errorf("expected 1 result, got %d", result.Size())
+	}
+
+	if result.Size() > 0 {
+		val := result.Get(0)[0]
+		if val != int64(0) {
+			t.Errorf("expected 0, got %v (type %T)", val, val)
+		}
+	}
+}
+
+func TestOrFallbackFirstBranchMatches(t *testing.T) {
+	// Test that when first branch matches, second is not evaluated
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	executor := NewExecutor(matcher)
+
+	// Query: (or [?e :user/name ?x] [(ground "fallback") ?x])
+	// First branch should match, so we should get "Alice", not "fallback"
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: "?x"},
+		},
+		Where: []query.Clause{
+			&query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: nameAttr},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+					{
+						&query.Expression{
+							Function: &query.GroundFunction{Value: "fallback"},
+							Binding:  "?x",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(q)
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	// Should have 1 result with value "Alice"
+	if result.Size() != 1 {
+		t.Errorf("expected 1 result, got %d", result.Size())
+	}
+
+	if result.Size() > 0 {
+		val := result.Get(0)[0]
+		if val != "Alice" {
+			t.Errorf("expected 'Alice', got %v", val)
+		}
+	}
+}
+
+func TestOrFallbackMultipleBranches(t *testing.T) {
+	// Test OR with multiple fallback branches
+	// (or [nonexistent1] [nonexistent2] [(ground "default")])
+	matcher := NewMemoryPatternMatcher(nil) // Empty database
+	executor := NewExecutor(matcher)
+
+	nonexistent1 := datalog.NewKeyword(":nonexistent1")
+	nonexistent2 := datalog.NewKeyword(":nonexistent2")
+
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: "?x"},
+		},
+		Where: []query.Clause{
+			&query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: nonexistent1},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: nonexistent2},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+					{
+						&query.Expression{
+							Function: &query.GroundFunction{Value: "default"},
+							Binding:  "?x",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(q)
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	// Should fall through to third branch with "default"
+	if result.Size() != 1 {
+		t.Errorf("expected 1 result, got %d", result.Size())
+	}
+
+	if result.Size() > 0 {
+		val := result.Get(0)[0]
+		if val != "default" {
+			t.Errorf("expected 'default', got %v", val)
+		}
+	}
+}
+
+func TestOrFallbackWithArithmeticExpression(t *testing.T) {
+	// Test OR with arithmetic expression as fallback
+	alice := datalog.NewIdentity("user:alice")
+	ageAttr := datalog.NewKeyword(":user/age")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: ageAttr, V: int64(30), Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	executor := NewExecutor(matcher)
+
+	// Query: (or [?e :nonexistent ?x] [(+ 1 1) ?x])
+	// Pattern won't match, so should get 2 from arithmetic
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: "?x"},
+		},
+		Where: []query.Clause{
+			&query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: datalog.NewKeyword(":nonexistent/attr")},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+					{
+						&query.Expression{
+							Function: &query.ArithmeticFunction{
+								Op:    query.OpAdd,
+								Left:  query.ConstantTerm{Value: int64(1)},
+								Right: query.ConstantTerm{Value: int64(1)},
+							},
+							Binding: "?x",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(q)
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	if result.Size() != 1 {
+		t.Errorf("expected 1 result, got %d", result.Size())
+	}
+
+	if result.Size() > 0 {
+		val := result.Get(0)[0]
+		// Arithmetic on integers returns int64
+		expected := int64(2)
+		if val != expected {
+			t.Errorf("expected %v, got %v (type %T)", expected, val, val)
+		}
+	}
+}
+
+func TestOrFallbackPatternOnlyUnionSemantics(t *testing.T) {
+	// Verify pattern-only OR still uses union semantics (regression test)
+	alice := datalog.NewIdentity("user:alice")
+	bob := datalog.NewIdentity("user:bob")
+	nameAttr := datalog.NewKeyword(":user/name")
+	activeAttr := datalog.NewKeyword(":user/active")
+	premiumAttr := datalog.NewKeyword(":user/premium")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+		{E: bob, A: nameAttr, V: "Bob", Tx: 1},
+		{E: alice, A: activeAttr, V: true, Tx: 1}, // Alice is active
+		{E: bob, A: premiumAttr, V: true, Tx: 1},  // Bob is premium
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	executor := NewExecutor(matcher)
+
+	// Pattern-only OR should return BOTH Alice and Bob (union semantics)
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: "?e"},
+		},
+		Where: []query.Clause{
+			&query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: activeAttr},
+								query.Constant{Value: true},
+							},
+						},
+					},
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: premiumAttr},
+								query.Constant{Value: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(q)
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	// Should have both Alice and Bob (union of both branches)
+	if result.Size() != 2 {
+		t.Errorf("expected 2 results (union semantics), got %d", result.Size())
+	}
+}
+
+func TestOrFallbackPatternWithStreamingRelation(t *testing.T) {
+	// Test that pattern matching works correctly in OR fallback path
+	// even when the pattern returns a streaming relation
+	nameAttr := datalog.NewKeyword(":user/name")
+	alice := datalog.NewIdentity("user:alice")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: 1},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	executor := NewExecutor(matcher)
+
+	// Query: (or [?e :user/name ?x] [(ground "fallback") ?x])
+	// Pattern should match, returning "Alice"
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: "?x"},
+		},
+		Where: []query.Clause{
+			&query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: nameAttr},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+					{
+						&query.Expression{
+							Function: &query.GroundFunction{Value: "fallback"},
+							Binding:  "?x",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(q)
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	if result.Size() != 1 {
+		t.Errorf("expected 1 result, got %d", result.Size())
+	}
+
+	if result.Size() > 0 && result.Get(0)[0] != "Alice" {
+		t.Errorf("expected 'Alice', got %v", result.Get(0)[0])
+	}
+}

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -333,6 +333,19 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 	var otherRels []Relation
 
 	requiredSyms := expr.Function.RequiredSymbols()
+
+	// Special case: if groups is empty and expression has no required symbols
+	// (e.g., ground expression), evaluate once and create a single-tuple result
+	if len(groups) == 0 && len(requiredSyms) == 0 {
+		result, err := expr.Function.Eval(make(map[query.Symbol]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		columns := []query.Symbol{expr.Binding}
+		tuples := []Tuple{{result}}
+		return []Relation{NewMaterializedRelationWithOptions(columns, tuples, e.options)}, nil
+	}
+
 	for _, rel := range groups {
 		hasAny := false
 		relCols := rel.Columns()
@@ -902,12 +915,42 @@ func (e *DefaultQueryExecutor) executePulls(rel Relation, find []query.FindEleme
 	}, nil
 }
 
-// executeOrClause performs union of OR branches and returns a new relation
+// executeOrClause performs union of OR branches, or fallback semantics for expression branches
 func (e *DefaultQueryExecutor) executeOrClause(ctx Context, clause *query.OrClause, groups Relations) (Relation, error) {
 	if len(clause.Branches) == 0 {
 		return NewMaterializedRelationWithOptions(nil, nil, e.options), nil
 	}
 
+	// Check if any branch has expressions - use fallback semantics if so
+	if query.OrHasExpressions(clause.Branches) {
+		return e.executeOrClauseFallback(ctx, clause, groups)
+	}
+
+	// Standard union semantics for pattern-only OR
+	return e.executeOrClauseUnion(ctx, clause, groups)
+}
+
+// executeOrClauseFallback implements Clojure-style fallback semantics:
+// Try each branch in order, return first non-empty result
+func (e *DefaultQueryExecutor) executeOrClauseFallback(ctx Context, clause *query.OrClause, groups Relations) (Relation, error) {
+	for i, branch := range clause.Branches {
+		branchResult, err := e.executeInnerClauses(ctx, branch, nil)
+		if err != nil {
+			return nil, fmt.Errorf("OR branch %d execution failed: %w", i+1, err)
+		}
+
+		// Return first non-empty result (fallback semantics)
+		if branchResult != nil && branchResult.Size() > 0 {
+			return branchResult, nil
+		}
+	}
+
+	// All branches empty
+	return NewMaterializedRelationWithOptions(nil, nil, e.options), nil
+}
+
+// executeOrClauseUnion implements standard Datalog union semantics
+func (e *DefaultQueryExecutor) executeOrClauseUnion(ctx Context, clause *query.OrClause, groups Relations) (Relation, error) {
 	// Execute each branch and collect results
 	var branchResults []Relation
 	var commonCols []query.Symbol
@@ -952,7 +995,7 @@ func (e *DefaultQueryExecutor) executeOrClause(ctx Context, clause *query.OrClau
 	return unionRelations(branchResults, commonCols, e.options), nil
 }
 
-// executeOrJoinClause performs union with explicit join variables
+// executeOrJoinClause performs union with explicit join variables, or fallback for expressions
 func (e *DefaultQueryExecutor) executeOrJoinClause(ctx Context, clause *query.OrJoinClause, groups Relations) (Relation, error) {
 	if len(clause.Branches) == 0 {
 		return NewMaterializedRelationWithOptions(nil, nil, e.options), nil
@@ -961,6 +1004,11 @@ func (e *DefaultQueryExecutor) executeOrJoinClause(ctx Context, clause *query.Or
 	joinVars := clause.JoinVars
 	if len(joinVars) == 0 {
 		return nil, fmt.Errorf("OR-JOIN clause has no join variables")
+	}
+
+	// Check if any branch has expressions - use fallback semantics if so
+	if query.OrHasExpressions(clause.Branches) {
+		return e.executeOrJoinClauseFallback(ctx, clause, groups)
 	}
 
 	var branchResults []Relation
@@ -982,6 +1030,26 @@ func (e *DefaultQueryExecutor) executeOrJoinClause(ctx Context, clause *query.Or
 
 	// Union all branch results, projecting to join vars
 	return unionRelations(branchResults, joinVars, e.options), nil
+}
+
+// executeOrJoinClauseFallback implements fallback semantics for or-join with expressions
+func (e *DefaultQueryExecutor) executeOrJoinClauseFallback(ctx Context, clause *query.OrJoinClause, groups Relations) (Relation, error) {
+	joinVars := clause.JoinVars
+
+	for i, branch := range clause.Branches {
+		branchResult, err := e.executeInnerClauses(ctx, branch, nil)
+		if err != nil {
+			return nil, fmt.Errorf("OR-JOIN branch %d execution failed: %w", i+1, err)
+		}
+
+		// Return first non-empty result, projected to join vars
+		if branchResult != nil && branchResult.Size() > 0 {
+			return projectToColumns(branchResult, joinVars, e.options), nil
+		}
+	}
+
+	// All branches empty
+	return NewMaterializedRelationWithOptions(joinVars, nil, e.options), nil
 }
 
 // executeNotClause performs anti-join filtering on groups

--- a/datalog/planner/clause_utils_test.go
+++ b/datalog/planner/clause_utils_test.go
@@ -1,0 +1,256 @@
+package planner
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+func TestExtractOrClauseSymbols(t *testing.T) {
+	tests := []struct {
+		name            string
+		orClause        *query.OrClause
+		expectedProvides []query.Symbol
+	}{
+		{
+			name: "Pattern and expression both provide same variable",
+			orClause: &query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: datalog.NewKeyword(":test/attr")},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+					{
+						&query.Expression{
+							Function: &query.GroundFunction{Value: int64(0)},
+							Binding:  "?x",
+						},
+					},
+				},
+			},
+			expectedProvides: []query.Symbol{"?x"},
+		},
+		{
+			name: "Two patterns providing same variables",
+			orClause: &query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: datalog.NewKeyword(":attr1")},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: datalog.NewKeyword(":attr2")},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+				},
+			},
+			expectedProvides: []query.Symbol{"?e", "?x"},
+		},
+		{
+			name: "Expression-only branches",
+			orClause: &query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.Expression{
+							Function: &query.GroundFunction{Value: "first"},
+							Binding:  "?x",
+						},
+					},
+					{
+						&query.Expression{
+							Function: &query.GroundFunction{Value: "second"},
+							Binding:  "?x",
+						},
+					},
+				},
+			},
+			expectedProvides: []query.Symbol{"?x"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			syms := extractOrClauseSymbols(tt.orClause)
+
+			// Check that all expected symbols are provided
+			providedSet := make(map[query.Symbol]bool)
+			for _, sym := range syms.Provides {
+				providedSet[sym] = true
+			}
+
+			for _, expected := range tt.expectedProvides {
+				if !providedSet[expected] {
+					t.Errorf("Expected symbol %s to be provided, but it wasn't. Got: %v", expected, syms.Provides)
+				}
+			}
+
+			// Check we don't have extra unexpected symbols (for single-symbol cases)
+			if len(tt.expectedProvides) == 1 && len(syms.Provides) != 1 {
+				// For multi-symbol cases, just check all expected are present
+				if len(tt.expectedProvides) != len(syms.Provides) {
+					t.Logf("Note: Expected %d symbols, got %d: %v", len(tt.expectedProvides), len(syms.Provides), syms.Provides)
+				}
+			}
+		})
+	}
+}
+
+func TestOrOnlyQueryPlanning(t *testing.T) {
+	// Test that an OR-only query creates phases correctly
+	planner := NewPlanner(nil, PlannerOptions{})
+
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: "?x"},
+		},
+		Where: []query.Clause{
+			&query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: "?e"},
+								query.Constant{Value: datalog.NewKeyword(":test/attr")},
+								query.Variable{Name: "?x"},
+							},
+						},
+					},
+					{
+						&query.Expression{
+							Function: &query.GroundFunction{Value: int64(0)},
+							Binding:  "?x",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	plan, err := planner.Plan(q)
+	if err != nil {
+		t.Fatalf("Planning failed: %v", err)
+	}
+
+	if len(plan.Phases) == 0 {
+		t.Fatal("Expected at least 1 phase, got 0")
+	}
+
+	t.Logf("Phases: %d", len(plan.Phases))
+	for i, phase := range plan.Phases {
+		t.Logf("Phase %d: Available=%v, Provides=%v, Keep=%v, OrClauses=%d",
+			i, phase.Available, phase.Provides, phase.Keep, len(phase.OrClauses))
+	}
+
+	// Check that the OR clause is assigned to a phase
+	hasOrClause := false
+	for _, phase := range plan.Phases {
+		if len(phase.OrClauses) > 0 {
+			hasOrClause = true
+		}
+	}
+	if !hasOrClause {
+		t.Error("Expected OR clause to be assigned to a phase")
+	}
+
+	// Check that ?x is in Provides
+	foundX := false
+	for _, phase := range plan.Phases {
+		for _, sym := range phase.Provides {
+			if sym == "?x" {
+				foundX = true
+			}
+		}
+	}
+	if !foundX {
+		t.Error("Expected ?x to be in Provides")
+	}
+
+	// Test the realized plan
+	realized := plan.Realize()
+	t.Logf("Realized phases: %d", len(realized.Phases))
+	for i, rp := range realized.Phases {
+		t.Logf("Realized Phase %d:", i)
+		t.Logf("  Query: %s", rp.Query.String())
+		t.Logf("  Query.Where: %d clauses", len(rp.Query.Where))
+		for j, clause := range rp.Query.Where {
+			t.Logf("    Clause %d: %T - %s", j, clause, clause.String())
+		}
+		t.Logf("  Provides: %v", rp.Provides)
+		t.Logf("  Keep: %v", rp.Keep)
+	}
+}
+
+func TestExtractExpressionSymbols(t *testing.T) {
+	tests := []struct {
+		name            string
+		expression      *query.Expression
+		expectedProvides []query.Symbol
+		expectedRequires []query.Symbol
+	}{
+		{
+			name: "Ground function provides binding",
+			expression: &query.Expression{
+				Function: &query.GroundFunction{Value: int64(0)},
+				Binding:  "?x",
+			},
+			expectedProvides: []query.Symbol{"?x"},
+			expectedRequires: []query.Symbol{},
+		},
+		{
+			name: "Arithmetic requires inputs, provides binding",
+			expression: &query.Expression{
+				Function: &query.ArithmeticFunction{
+					Op:    query.OpAdd,
+					Left:  query.VariableTerm{Symbol: "?a"},
+					Right: query.VariableTerm{Symbol: "?b"},
+				},
+				Binding: "?sum",
+			},
+			expectedProvides: []query.Symbol{"?sum"},
+			expectedRequires: []query.Symbol{"?a", "?b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			syms := extractExpressionSymbols(tt.expression)
+
+			// Check provides
+			if len(syms.Provides) != len(tt.expectedProvides) {
+				t.Errorf("Expected %d provides, got %d: %v", len(tt.expectedProvides), len(syms.Provides), syms.Provides)
+			}
+			for i, expected := range tt.expectedProvides {
+				if i < len(syms.Provides) && syms.Provides[i] != expected {
+					t.Errorf("Expected provides[%d] = %s, got %s", i, expected, syms.Provides[i])
+				}
+			}
+
+			// Check requires
+			requiresSet := make(map[query.Symbol]bool)
+			for _, sym := range syms.Requires {
+				requiresSet[sym] = true
+			}
+			for _, expected := range tt.expectedRequires {
+				if !requiresSet[expected] {
+					t.Errorf("Expected symbol %s to be required, but it wasn't. Got: %v", expected, syms.Requires)
+				}
+			}
+		})
+	}
+}

--- a/datalog/planner/planner_phases.go
+++ b/datalog/planner/planner_phases.go
@@ -108,9 +108,9 @@ func (p *Planner) createPhases(dataPatterns []*query.DataPattern, predicates []q
 		}
 	}
 
-	// If we have no phases but have predicates/expressions/subqueries, create at least one phase
-	if len(phases) == 0 && (len(predicates) > 0 || len(expressions) > 0 || len(subqueries) > 0) {
-		// Create a phase that can execute predicates/expressions with input symbols
+	// If we have no phases but have predicates/expressions/subqueries/OR clauses, create at least one phase
+	if len(phases) == 0 && (len(predicates) > 0 || len(expressions) > 0 || len(subqueries) > 0 || len(orClauses) > 0 || len(orJoinClauses) > 0) {
+		// Create a phase that can execute predicates/expressions/OR clauses with input symbols
 		phase := Phase{
 			Available: p.getResolvedSymbols(availableSymbols),
 			Provides:  []query.Symbol{},
@@ -411,9 +411,9 @@ func (p *Planner) createFineGrainedPhases(dataPatterns []*query.DataPattern, pre
 		}
 	}
 
-	// If we have no phases but have predicates/expressions/subqueries, create at least one phase
-	if len(phases) == 0 && (len(predicates) > 0 || len(expressions) > 0 || len(subqueries) > 0) {
-		// Create a phase that can execute predicates/expressions with input symbols
+	// If we have no phases but have predicates/expressions/subqueries/OR clauses, create at least one phase
+	if len(phases) == 0 && (len(predicates) > 0 || len(expressions) > 0 || len(subqueries) > 0 || len(orClauses) > 0 || len(orJoinClauses) > 0) {
+		// Create a phase that can execute predicates/expressions/OR clauses with input symbols
 		phase := Phase{
 			Available: p.getResolvedSymbols(availableSymbols),
 			Provides:  []query.Symbol{},
@@ -666,14 +666,38 @@ func (p *Planner) assignOrClausesToPhases(phases []Phase, orClauses []*query.OrC
 		return
 	}
 
+	// Track symbols provided by OR clauses
+	orProvides := make(map[query.Symbol]bool)
+
 	// OR clauses don't require prior bindings - they are data sources
 	// Assign them to the first phase
 	for _, orClause := range orClauses {
 		phases[0].OrClauses = append(phases[0].OrClauses, orClause)
+		// Track what this OR clause provides
+		syms := extractOrClauseSymbols(orClause)
+		for _, sym := range syms.Provides {
+			orProvides[sym] = true
+		}
 	}
 
 	for _, orJoinClause := range orJoinClauses {
 		phases[0].OrJoinClauses = append(phases[0].OrJoinClauses, orJoinClause)
+		// OR-JOIN provides exactly its join vars
+		for _, sym := range orJoinClause.JoinVars {
+			orProvides[sym] = true
+		}
+	}
+
+	// Add OR clause symbols to the phase's Provides list
+	// (they weren't already there because Provides is normally from patterns)
+	existingProvides := make(map[query.Symbol]bool)
+	for _, sym := range phases[0].Provides {
+		existingProvides[sym] = true
+	}
+	for sym := range orProvides {
+		if !existingProvides[sym] {
+			phases[0].Provides = append(phases[0].Provides, sym)
+		}
 	}
 }
 

--- a/datalog/planner/planner_utils.go
+++ b/datalog/planner/planner_utils.go
@@ -152,6 +152,21 @@ func (p *Planner) validatePlan(phases []Phase, expressions []*query.Expression, 
 				resolved[pred.Variable] = true
 			}
 		}
+
+		// Track symbols provided by OR clauses
+		for _, orClause := range phase.OrClauses {
+			syms := extractOrClauseSymbols(orClause)
+			for _, sym := range syms.Provides {
+				resolved[sym] = true
+			}
+		}
+
+		// Track symbols provided by OR-JOIN clauses
+		for _, orJoinClause := range phase.OrJoinClauses {
+			for _, sym := range orJoinClause.JoinVars {
+				resolved[sym] = true
+			}
+		}
 	}
 
 	// Track what symbols are resolved by expressions

--- a/datalog/query/clause.go
+++ b/datalog/query/clause.go
@@ -111,6 +111,31 @@ type OrJoinClause struct {
 	Branches [][]Clause // Each branch is a list of clauses
 }
 
+// BranchHasExpressions checks if any clause in a branch is an expression type.
+// This is used to determine whether an OR clause should use fallback semantics
+// (Clojure-style first-non-empty-wins) vs union semantics (Datalog-style).
+func BranchHasExpressions(branch []Clause) bool {
+	for _, c := range branch {
+		switch c.(type) {
+		case *Expression, *Subquery:
+			return true
+		case *GroundPredicate:
+			return true
+		}
+	}
+	return false
+}
+
+// OrHasExpressions checks if any branch in an OR clause contains expressions.
+func OrHasExpressions(branches [][]Clause) bool {
+	for _, branch := range branches {
+		if BranchHasExpressions(branch) {
+			return true
+		}
+	}
+	return false
+}
+
 func (o *OrJoinClause) String() string {
 	result := "(or-join ["
 	for i, v := range o.JoinVars {

--- a/docs/reference/OR_FALLBACK_SEMANTICS.md
+++ b/docs/reference/OR_FALLBACK_SEMANTICS.md
@@ -1,0 +1,156 @@
+# OR Clause Fallback Semantics
+
+This document describes the extended OR clause semantics that allow expressions (including `ground` and arithmetic) to be used as fallback values when pattern branches return no results.
+
+## Overview
+
+Standard Datalog OR clauses use **union semantics**: all branches are executed and results are merged. This works well for pattern matching but doesn't support providing default values when queries return empty.
+
+When an OR clause contains expression branches (e.g., `ground`, arithmetic), janus-datalog switches to **fallback semantics**: branches are tried in order, and the first non-empty result is returned.
+
+## Motivation
+
+Consider a scenario where you want to count tasks but return 0 when none exist:
+
+```clojure
+;; Standard subquery - returns empty when no tasks match
+[(q [:find (count ?t)
+     :in $ ?scenario
+     :where [?t :task/scenario ?scenario]
+            [?t :task/status :status/complete]]
+   $ ?scenario) [[?count]]]
+```
+
+When no matching tasks exist, this subquery returns empty (no rows), causing the outer query row to be excluded entirely.
+
+With OR fallback semantics, you can provide a default:
+
+```clojure
+(or [(q [:find (count ?t) ...] $ ?scenario) [[?count]]]
+    [(ground 0) ?count])
+```
+
+Now when the subquery returns empty, the ground expression provides `0` as the fallback.
+
+## Semantics
+
+### Pattern-Only OR (Union Semantics)
+
+When all branches contain only patterns, standard Datalog union semantics apply:
+
+```clojure
+;; Union: returns ALL users who are either active OR premium
+(or [?e :user/active true]
+    [?e :user/premium true])
+```
+
+Both branches execute, and results are merged (deduplicated on common columns).
+
+### OR with Expressions (Fallback Semantics)
+
+When any branch contains an expression, fallback semantics apply:
+
+```clojure
+;; Fallback: returns first non-empty result
+(or [?e :user/name ?name]           ;; Try pattern first
+    [(ground "Unknown") ?name])      ;; Fallback if no match
+```
+
+Branches are tried in order:
+1. If branch 1 returns results, return immediately
+2. If branch 1 is empty, try branch 2
+3. Continue until a non-empty result or all branches exhausted
+
+## Supported Expression Types
+
+The following expressions can be used in OR branches:
+
+### Ground Expressions
+
+Bind a constant value to a variable:
+
+```clojure
+(or [?e :config/value ?v]
+    [(ground "default") ?v])
+```
+
+### Arithmetic Expressions
+
+Compute values when patterns don't match:
+
+```clojure
+(or [?e :item/discount ?discount]
+    [(* ?price 0) ?discount])  ;; 0 discount if none specified
+```
+
+### Subquery Expressions
+
+Use subqueries as branches with fallbacks:
+
+```clojure
+(or [(q [:find (sum ?amount) :where ...] $) [[?total]]]
+    [(ground 0) ?total])
+```
+
+## Examples
+
+### Default Value for Missing Attribute
+
+```clojure
+[:find ?name ?status
+ :where [?e :user/name ?name]
+        (or [?e :user/status ?status]
+            [(ground :status/unknown) ?status])]
+```
+
+### Count with Zero Default
+
+```clojure
+[:find ?category ?count
+ :where [?c :category/name ?category]
+        (or [(q [:find (count ?p)
+                 :in $ ?c
+                 :where [?p :product/category ?c]]
+               $ ?c) [[?count]]]
+            [(ground 0) ?count])]
+```
+
+### Multiple Fallback Levels
+
+```clojure
+;; Try multiple sources in priority order
+(or [?e :user/nickname ?display]
+    [?e :user/fullname ?display]
+    [?e :user/email ?display]
+    [(ground "Anonymous") ?display])
+```
+
+## OR-JOIN with Fallback
+
+The same semantics apply to `or-join` when expressions are present:
+
+```clojure
+(or-join [?x]
+  [?e :source1/value ?x]
+  [?e :source2/value ?x]
+  [(ground 0) ?x])
+```
+
+## Implementation Notes
+
+- Fallback semantics require materializing branch results to check for emptiness
+- Pattern-only OR continues to use efficient union/streaming semantics
+- Detection is automatic based on branch contents - no explicit syntax needed
+- Predicates are also supported within expression branches
+
+## Comparison with Datomic
+
+Datomic's OR clauses use pure union semantics and do not support this fallback pattern directly. The workaround in Datomic is typically application-level code:
+
+```clojure
+;; Datomic workaround
+(or (seq (d/q [:find ...] db))
+    [[0]])  ;; application-level default
+```
+
+janus-datalog's fallback semantics provide this capability within the query itself, enabling more declarative queries.

--- a/docs/wip/KEYWORD_POINTER_OPTIMIZATION.md
+++ b/docs/wip/KEYWORD_POINTER_OPTIMIZATION.md
@@ -1,0 +1,34 @@
+# Keyword Pointer Optimization TODO
+
+## Background
+
+With the migration to `*Keyword` (interned pointers), several places in the codebase still use string conversion for comparison/hashing when pointer equality would be more efficient.
+
+## Files to Refactor
+
+### `datalog/storage/batch_iterator.go`
+
+The `valueToString()` function converts values to strings for use as map keys:
+
+```go
+bindingValues := make(map[string]executor.Tuple)
+// ...
+key := valueToString(tuple[it.position])
+```
+
+**Optimization**: Change to `map[interface{}]executor.Tuple` and use native Go comparison:
+- `*Keyword` → pointer equality (interned keywords are unique pointers)
+- `Identity` → struct equality
+- Primitives → value equality
+
+This eliminates `fmt.Sprintf("%p", val)` overhead.
+
+### Other potential locations
+
+- `datalog/storage/simple_batch_scanner.go`
+- `datalog/storage/hash_join_matcher.go`
+- `datalog/storage/key_mask_iterator.go`
+
+## Invariant
+
+All `Keyword` values MUST be `*Keyword` (interned pointers). Non-pointer `datalog.Keyword` in type switches should panic with assertion failure.

--- a/docs/wip/OR_CLAUSE_EXECUTION_ANALYSIS.md
+++ b/docs/wip/OR_CLAUSE_EXECUTION_ANALYSIS.md
@@ -1,0 +1,308 @@
+# OR Clause Execution Analysis
+
+This document describes the execution lifecycle of OR clauses in the Datalog engine, based on analysis of the bug reported in `datalog/storage/or_clause_bug_test.go`.
+
+## The Bug
+
+**Query without OR** (works correctly):
+```clojure
+[:find ?t ?type
+ :where
+ [?t :task/status :status/complete]
+ [?t :task/type ?type]
+ [?t :task/type :type/a]]
+```
+Returns 1 result: `[task-1 :type/a]`
+
+**Query with OR** (returns incorrect results):
+```clojure
+[:find ?t ?type
+ :where
+ [?t :task/status :status/complete]
+ [?t :task/type ?type]
+ (or [?t :task/type :type/a]
+     [?t :task/type :type/b])]
+```
+Returns 3 results (should return 2): `[task-1 :type/a]`, `[task-2 :type/b]`, `[task-3 :type/c]`
+
+## Execution Lifecycle
+
+### 1. Query Parsing (`datalog/parser/parser.go`)
+
+The parser transforms EDN into query structures:
+- Patterns like `[?t :task/type :type/a]` become `*query.DataPattern`
+- OR clauses become `*query.OrClause` with branches containing patterns
+- Keywords like `:type/a` are parsed via `datalog.NewKeyword()` which interns them
+
+### 2. Query Planning (`datalog/planner/`)
+
+The planner organizes clauses into phases:
+
+```go
+// planner_phases.go:664-677
+func (p *Planner) assignOrClausesToPhases(phases []Phase, orClauses []*query.OrClause, ...) {
+    // OR clauses don't require prior bindings - they are data sources
+    // Assign them to the first phase
+    for _, orClause := range orClauses {
+        phases[0].OrClauses = append(phases[0].OrClauses, orClause)
+    }
+}
+```
+
+**Key insight**: OR clauses are treated as "data sources" and placed in phase[0] alongside patterns.
+
+### 3. Phase Execution (`datalog/executor/executor_sequential.go`)
+
+Each phase executes in `executePhaseSequentialV2`:
+
+1. **Pattern matching loop** (lines 35-143):
+   - Each pattern is matched against storage with available bindings
+   - Results are progressively collapsed (joined)
+   - After all patterns: `independentGroups` contains collapsed pattern results
+
+2. **Apply expressions and predicates** (line 167):
+   ```go
+   return e.applyExpressionsAndPredicates(ctx, phase, collapsed)
+   ```
+
+### 4. OR Clause Execution (`datalog/executor/expressions_and_predicates.go`)
+
+In `applyExpressionsAndPredicates`, OR clauses execute first:
+
+```go
+// lines 32-40
+groups := relations  // Pattern results: 3 tuples with columns [?t, ?type]
+
+for _, orClause := range phase.OrClauses {
+    orResult, err := e.executeOrClause(ctx, orClause, groups)
+    groups = append(groups, orResult)
+    groups = groups.Collapse(ctx)  // Join OR result with pattern results
+}
+```
+
+### 5. OR Clause Branch Execution (`datalog/executor/not_or.go`)
+
+```go
+// executeOrClause (lines 176-223)
+func (e *Executor) executeOrClause(ctx Context, clause *query.OrClause, available Relations) (Relation, error) {
+    var branchResults []Relation
+    var commonCols []query.Symbol
+
+    for i, branch := range clause.Branches {
+        // CRITICAL: Branches execute with nil binding (not constrained by available)
+        branchResult, err := e.executeInnerClauses(ctx, branch, nil)
+
+        // Track common columns across branches
+        if i == 0 {
+            commonCols = branchResult.Columns()
+        } else {
+            commonCols = intersect(commonCols, branchResult.Columns())
+        }
+        branchResults = append(branchResults, branchResult)
+    }
+
+    // Union all branch results, projecting to common columns
+    return unionRelations(branchResults, commonCols, e.options), nil
+}
+```
+
+**Key insight**: `executeInnerClauses(ctx, branch, nil)` passes `nil` as the binding. Each branch executes independently against the full database.
+
+### 6. Inner Clause Execution (`datalog/executor/not_or.go`)
+
+```go
+// executeInnerClauses (lines 257-335)
+func (e *Executor) executeInnerClauses(ctx Context, clauses []query.Clause, binding Relation) (Relation, error) {
+    var result Relations
+    if binding != nil {
+        result = Relations{binding}
+    }
+    // binding is nil for OR branches, so result starts empty
+
+    for _, clause := range clauses {
+        switch c := clause.(type) {
+        case *query.DataPattern:
+            rel, err := e.matcher.Match(c, result)  // result is empty!
+            // ...
+        }
+    }
+}
+```
+
+### 7. Pattern Matching (`datalog/storage/matcher_relations.go`)
+
+When `bindings` is nil or empty:
+
+```go
+// Match (lines 55-58)
+if bindings == nil || len(bindings) == 0 {
+    return m.matchUnboundAsRelation(pattern, columns, constraints)
+}
+```
+
+This scans the database directly:
+- Chooses index based on bound pattern elements (AVET for A+V bound)
+- Returns all matching datoms as a streaming relation
+- Columns come from `pattern.ExtractColumns()` (only variables)
+
+### 8. Relation Collapse/Join (`datalog/executor/relations.go`)
+
+After OR execution, `groups.Collapse(ctx)` joins relations:
+
+```go
+// Collapse (lines 130-187)
+func (rs Relations) Collapse(ctx Context) Relations {
+    for len(remaining) > 0 {
+        currentGroup := remaining[0]
+        for i := 0; i < len(remaining); i++ {
+            if hasSharedColumns(currentGroup, remaining[i]) {
+                currentGroup = ctx.JoinRelations(currentGroup, remaining[i], func() Relation {
+                    return currentGroup.Join(remaining[i])
+                })
+            }
+        }
+    }
+}
+```
+
+### 9. Hash Join (`datalog/executor/join.go`)
+
+The join is implemented as a hash join:
+
+1. **Determine common columns** (line 1181-1195 in relation.go)
+2. **Choose build vs probe relation** (lines 205-258):
+   - If left is streaming and right is materialized, right becomes build
+   - OR result (MaterializedRelation) becomes build side
+   - Pattern result (StreamingRelation) becomes probe side
+3. **Build hash table** from build relation (lines 260-477)
+4. **Probe phase** (lines 565-600):
+   - For each probe tuple, lookup key in hash table
+   - Only output tuples that have a match
+
+## Expected vs Actual Flow
+
+### Expected for Query with OR:
+
+1. Patterns produce: `[(task1, :type/a), (task2, :type/b), (task3, :type/c)]` with columns `[?t, ?type]`
+2. OR branch 1 `[?t :task/type :type/a]` produces: `[(task1)]` with columns `[?t]`
+3. OR branch 2 `[?t :task/type :type/b]` produces: `[(task2)]` with columns `[?t]`
+4. OR union: `[(task1), (task2)]` with columns `[?t]`
+5. Join on `?t`: `[(task1, :type/a), (task2, :type/b)]` - **2 tuples**
+
+### Actual Result:
+
+All 3 tuples are returned, suggesting the join is not filtering correctly.
+
+## Key Differences: Regular Pattern vs OR Branch
+
+**Regular pattern** `[?t :task/type :type/a]` in the non-OR query:
+- Executed via `e.matchPatternWithRelations(ctx, pattern, availableRelations)`
+- `availableRelations` contains prior binding tuples
+- Matcher uses bindings to constrain the scan
+- Result is already filtered
+
+**OR branch** `[?t :task/type :type/a]`:
+- Executed via `e.executeInnerClauses(ctx, branch, nil)` with **nil binding**
+- Matcher scans full database (no binding constraint)
+- Result must be joined later to filter
+
+## Root Cause Found
+
+**The bug had TWO causes** working together to create the failure:
+
+### 1. `realizePhase` Omitted OR/NOT Clauses
+
+The `realizePhase` function in `datalog/planner/types.go` (lines 687-769) builds the `Query.Where` clause from phase components but **NEVER added** OR clauses or NOT clauses:
+
+```go
+// realizePhase was adding only:
+// 1. Patterns
+// 2. Expressions
+// 3. Predicates
+// 4. Subqueries
+// MISSING: OrClauses, NotClauses, OrJoinClauses, NotJoinClauses
+```
+
+The Phase struct has separate fields for these (`Phase.OrClauses`, `Phase.NotClauses`, etc.), but `realizePhase` simply didn't include them in the generated Query.
+
+**Why it didn't error**: The OR clause was never in `Query.Where`, so `QueryExecutor.Execute` never saw it.
+
+### 2. `QueryExecutor.Execute` Lacked Cases for OR/NOT
+
+Even if the clauses had been included, `DefaultQueryExecutor.Execute` in `query_executor.go` only handled:
+- `*query.DataPattern`
+- `*query.Expression`
+- `query.Predicate`
+- `*query.SubqueryPattern`
+- `default` → error
+
+It had no cases for `*query.OrClause`, `*query.NotClause`, `*query.OrJoinClause`, or `*query.NotJoinClause`.
+
+### Evidence
+
+| Configuration | Result |
+|---------------|--------|
+| `UseQueryExecutor: false` (old executor) | **PASS** - 2 tuples |
+| `UseQueryExecutor: true` (new executor, default) | **FAIL** - 3 tuples |
+
+**Why the old executor worked**: It processed `Phase.OrClauses` directly in `applyExpressionsAndPredicates()`, bypassing the `Query.Where` clause entirely.
+
+## The Fix
+
+Two changes were made:
+
+### Fix 1: Update `realizePhase` (types.go)
+
+Added OR/NOT clause inclusion after subqueries:
+
+```go
+// 5. Add NOT clauses (anti-join filtering)
+for _, nc := range phase.NotClauses {
+    where = append(where, nc)
+}
+
+// 6. Add NOT-JOIN clauses
+for _, njc := range phase.NotJoinClauses {
+    where = append(where, njc)
+}
+
+// 7. Add OR clauses (union)
+for _, oc := range phase.OrClauses {
+    where = append(where, oc)
+}
+
+// 8. Add OR-JOIN clauses
+for _, ojc := range phase.OrJoinClauses {
+    where = append(where, ojc)
+}
+```
+
+### Fix 2: Add Cases to `QueryExecutor.Execute` (query_executor.go)
+
+Added switch cases for all four clause types:
+- `*query.OrClause` → execute branches, union results, append and collapse
+- `*query.OrJoinClause` → same with explicit join vars
+- `*query.NotClause` → anti-join filter on groups
+- `*query.NotJoinClause` → anti-join with explicit join vars
+
+Also added supporting methods:
+- `executeOrClause()`
+- `executeOrJoinClause()`
+- `executeNotClause()`
+- `executeNotJoinClause()`
+- `filterWithNotClause()`
+- `filterWithNotJoinClause()`
+- `executeInnerClauses()`
+
+## Why This Bug Snuck Through
+
+1. **Missing test coverage**: No test verified that the new QueryExecutor handled OR/NOT clauses
+2. **Silent failure mode**: Instead of erroring, the clauses were simply dropped during planning
+3. **Correct planner assignment**: The planner correctly assigned OR clauses to `Phase.OrClauses`, but the realization step dropped them
+4. **Backward compatibility path**: The old executor worked via a different code path, masking the issue
+
+## Lessons Learned
+
+1. **Test new execution paths explicitly**: When adding a new executor path (QueryExecutor), test ALL clause types
+2. **Realize() should be complete**: The realized Query should be semantically equivalent to the original
+3. **Use tracing/annotations**: The annotation system helped identify where execution diverged


### PR DESCRIPTION
When an OR clause contains expression branches (ground, arithmetic, etc.), the engine now uses fallback semantics instead of union semantics. Branches are tried in order and the first non-empty result is returned.

This enables default value patterns that were previously impossible:

  (or [?e :config/value ?v]
      [(ground "default") ?v])

Key changes:
- OrHasExpressions() detects when to use fallback vs union semantics
- executeOrClauseFallback() tries branches sequentially, returns first hit
- Expression support added to executeInnerClauses() for ground/arithmetic
- Fixed early return in applyExpressionsAndPredicates() for OR-only queries
- Added mutex protection for IndexedMemoryMatcher.options (race fix)
- Planner now creates phases for queries with only OR clauses

Pattern-only OR clauses continue to use standard Datalog union semantics.

See docs/reference/OR_FALLBACK_SEMANTICS.md for complete documentation.