### PR TITLE
Query Builder Ergonomics Improvements

### DIFF
--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -469,9 +469,9 @@ var PersonName = qb.Kw(":person/name")
 var PersonAge = qb.Kw(":person/age")
 
 // Variables created with NewVar() - same pointer = join
-e := qb.NewVar()
-name := qb.NewVar()
-age := qb.NewVar()
+e := qb.NewVar("e")
+name := qb.NewVar("name")
+age := qb.NewVar("age")
 
 q := qb.Query().
     Find(name, age).

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ tx.Commit()
 **Query it (Go-native):**
 
 ```go
-e := qb.NewVar()
-name := qb.NewVar()
-age := qb.NewVar()
+e := qb.NewVar("e")
+name := qb.NewVar("name")
+age := qb.NewVar("age")
 
 q := qb.Query().
     Find(name, age).
@@ -102,9 +102,9 @@ var (
     PersonAge  = qb.Kw(":person/age")
 )
 
-e := qb.NewVar()
-name := qb.NewVar()
-age := qb.NewVar()
+e := qb.NewVar("e")
+name := qb.NewVar("name")
+age := qb.NewVar("age")
 
 q := qb.Query().
     Find(name, age).

--- a/datalog/qb/README.md
+++ b/datalog/qb/README.md
@@ -28,10 +28,10 @@ var (
 
 // 2. Build queries with Go variables
 func FindAdultsInCity(db *storage.Database, city string) ([][]interface{}, error) {
-    e := qb.NewVar()
-    name := qb.NewVar()
-    age := qb.NewVar()
-    inputCity := qb.NewVar()
+    e := qb.NewVar("e")
+    name := qb.NewVar("name")
+    age := qb.NewVar("age")
+    inputCity := qb.NewVar("inputCity")
 
     q := qb.Query().
         Find(name, age).
@@ -53,9 +53,9 @@ func FindAdultsInCity(db *storage.Database, city string) ([][]interface{}, error
 **Go variable identity IS the join condition.**
 
 ```go
-e := qb.NewVar()    // This pointer...
-name := qb.NewVar()
-age := qb.NewVar()
+e := qb.NewVar("e")    // This pointer...
+name := qb.NewVar("name")
+age := qb.NewVar("age")
 
 qb.Pat(e, PersonName, name)  // ...used here
 qb.Pat(e, PersonAge, age)    // ...and here = JOIN
@@ -73,9 +73,9 @@ var (
     PersonAge  = qb.Kw(":person/age")
 )
 
-e := qb.NewVar()
-name := qb.NewVar()
-age := qb.NewVar()
+e := qb.NewVar("e")
+name := qb.NewVar("name")
+age := qb.NewVar("age")
 
 q := qb.Query().
     Find(name, age).

--- a/datalog/qb/builder.go
+++ b/datalog/qb/builder.go
@@ -234,9 +234,9 @@ func toClause(c interface{}) (query.Clause, error) {
 		return x.toClause(), nil
 	case *NotJoinClause:
 		return x.toClause(), nil
-	case *OrClause:
+	case *OrBuilder:
 		return x.toClause(), nil
-	case *OrJoinClause:
+	case *OrJoinBuilder:
 		return x.toClause(), nil
 	case *SubqueryBuilder:
 		return x.toClause(), nil

--- a/datalog/qb/builder.go
+++ b/datalog/qb/builder.go
@@ -21,7 +21,7 @@ type QueryBuilder struct {
 //
 // Example:
 //
-//	e, name, age := qb.NewVar(), qb.NewVar(), qb.NewVar()
+//	e, name, age := qb.NewVar("e"), qb.NewVar("name"), qb.NewVar("age")
 //	q := qb.Query().
 //	    Find(name, age).
 //	    Where(
@@ -60,7 +60,7 @@ func (b *QueryBuilder) Find(elements ...interface{}) *QueryBuilder {
 //
 // Example:
 //
-//	minAge := qb.NewVar()
+//	minAge := qb.NewVar("minAge")
 //	qb.Query().
 //	    Find(name).
 //	    In(qb.DB, qb.Scalar(minAge)).

--- a/datalog/qb/clause.go
+++ b/datalog/qb/clause.go
@@ -79,25 +79,30 @@ func (n *NotJoinClause) toClause() query.Clause {
 	}
 }
 
-// OrClause represents an OR (disjunction) clause.
-type OrClause struct {
+// OrBuilder accumulates branches for an OR clause.
+type OrBuilder struct {
 	branches [][]interface{}
 }
 
-// Or creates a disjunction clause (union).
-// Each branch is a slice of clauses; a match in any branch satisfies the OR.
+// Or starts building an OR clause.
+// Use Branch() to add branches.
 //
 // Example:
 //
-//	qb.Or(
-//	    []interface{}{qb.Eq(status, qb.V("active"))},
-//	    []interface{}{qb.Eq(status, qb.V("pending"))},
-//	)
-func Or(branches ...[]interface{}) *OrClause {
-	return &OrClause{branches: branches}
+//	qb.Or().
+//	    Branch(qb.Eq(status, qb.V("active"))).
+//	    Branch(qb.Eq(status, qb.V("pending")))
+func Or() *OrBuilder {
+	return &OrBuilder{}
 }
 
-func (o *OrClause) toClause() query.Clause {
+// Branch adds a branch with one or more clauses.
+func (o *OrBuilder) Branch(clauses ...interface{}) *OrBuilder {
+	o.branches = append(o.branches, clauses)
+	return o
+}
+
+func (o *OrBuilder) toClause() query.Clause {
 	qbranches := make([][]query.Clause, len(o.branches))
 	for i, branch := range o.branches {
 		qbranches[i] = make([]query.Clause, len(branch))
@@ -112,30 +117,31 @@ func (o *OrClause) toClause() query.Clause {
 	return &query.OrClause{Branches: qbranches}
 }
 
-// OrJoinClause represents an OR-JOIN clause with explicit join variables.
-type OrJoinClause struct {
+// OrJoinBuilder accumulates branches for an OR-JOIN clause.
+type OrJoinBuilder struct {
 	joinVars []*Var
 	branches [][]interface{}
 }
 
-// OrJoin creates a disjunction clause with explicit join variables.
+// OrJoin starts building an OR-JOIN clause with explicit join variables.
 // Only the specified variables are exposed from the union.
 //
 // Example:
 //
-//	qb.OrJoin([]*qb.Var{name},
-//	    []interface{}{
-//	        qb.Pat(e, PersonNickname, name),
-//	    },
-//	    []interface{}{
-//	        qb.Pat(e, PersonName, name),
-//	    },
-//	)
-func OrJoin(joinVars []*Var, branches ...[]interface{}) *OrJoinClause {
-	return &OrJoinClause{joinVars: joinVars, branches: branches}
+//	qb.OrJoin(name).
+//	    Branch(qb.Pat(e, PersonNickname, name)).
+//	    Branch(qb.Pat(e, PersonName, name))
+func OrJoin(joinVars ...*Var) *OrJoinBuilder {
+	return &OrJoinBuilder{joinVars: joinVars}
 }
 
-func (o *OrJoinClause) toClause() query.Clause {
+// Branch adds a branch with one or more clauses.
+func (o *OrJoinBuilder) Branch(clauses ...interface{}) *OrJoinBuilder {
+	o.branches = append(o.branches, clauses)
+	return o
+}
+
+func (o *OrJoinBuilder) toClause() query.Clause {
 	joinSyms := make([]query.Symbol, len(o.joinVars))
 	for i, v := range o.joinVars {
 		joinSyms[i] = v.Symbol()

--- a/datalog/qb/database_function.go
+++ b/datalog/qb/database_function.go
@@ -18,7 +18,7 @@ type GetElseBuilder struct {
 //
 // Example:
 //
-//	nickname := qb.NewVar()
+//	nickname := qb.NewVar("nickname")
 //	qb.GetElse(entity, PersonNickname, "Anonymous").As(nickname)
 //	// [(get-else $ ?entity :person/nickname "Anonymous") ?nickname]
 func GetElse(entity *Var, attr Attr, defaultVal interface{}) *GetElseBuilder {
@@ -53,7 +53,7 @@ type MissingBuilder struct {
 //
 // As an expression (bind boolean):
 //
-//	needsEmail := qb.NewVar()
+//	needsEmail := qb.NewVar("needsEmail")
 //	qb.Missing(entity, PersonEmail).As(needsEmail)
 //	// [(missing? $ ?entity :person/email) ?needs-email]
 func Missing(entity *Var, attr Attr) *MissingBuilder {
@@ -93,7 +93,7 @@ type GetSomeBuilder struct {
 //
 // Example:
 //
-//	displayName := qb.NewVar()
+//	displayName := qb.NewVar("displayName")
 //	qb.GetSome(entity, PersonNickname, PersonFullName, PersonEmail).As(displayName)
 //	// [(get-some $ ?entity :person/nickname :person/fullname :person/email) ?display-name]
 //

--- a/datalog/qb/doc.go
+++ b/datalog/qb/doc.go
@@ -92,5 +92,22 @@
 //	qb.Or().Branch(clauses...).Branch(clauses...)
 //	qb.OrJoin(joinVars...).Branch(clauses...).Branch(clauses...)
 //
+// # Subqueries
+//
+//	innerQ := qb.Query().
+//	    Find(qb.Max(salary)).
+//	    In(qb.DB, qb.Scalar(dept)).
+//	    Where(qb.Pat(e, EmpDept, dept), qb.Pat(e, EmpSalary, salary))
+//
+//	qb.Subquery(innerQ, dept).BindTuple(maxSalary)
+//
+// Subqueries have lexical scoping - reuse variable names like ?t across subqueries:
+//
+//	t, s := qb.NewVar("t"), qb.NewVar("s")
+//	subquery1 := qb.Query().Find(qb.Count(t)).In(qb.DB, qb.Scalar(s)).Where(...)
+//
+//	t, s = qb.NewVar("t"), qb.NewVar("s")  // reassign Go vars, same Datalog names
+//	subquery2 := qb.Query().Find(qb.Count(t)).In(qb.DB, qb.Scalar(s)).Where(...)
+//
 // See docs/reference/QUERY_BUILDER.md for complete documentation.
 package qb

--- a/datalog/qb/doc.go
+++ b/datalog/qb/doc.go
@@ -89,8 +89,8 @@
 //
 //	qb.Not(clauses...)
 //	qb.NotJoin(joinVars, clauses...)
-//	qb.Or(branch1, branch2, ...)
-//	qb.OrJoin(joinVars, branch1, branch2, ...)
+//	qb.Or().Branch(clauses...).Branch(clauses...)
+//	qb.OrJoin(joinVars...).Branch(clauses...).Branch(clauses...)
 //
 // See docs/reference/QUERY_BUILDER.md for complete documentation.
 package qb

--- a/datalog/qb/doc.go
+++ b/datalog/qb/doc.go
@@ -109,5 +109,34 @@
 //	t, s = qb.NewVar("t"), qb.NewVar("s")  // reassign Go vars, same Datalog names
 //	subquery2 := qb.Query().Find(qb.Count(t)).In(qb.DB, qb.Scalar(s)).Where(...)
 //
+// # Type-Safe Variables with QueryFor[T]
+//
+// QueryFor[T] derives query variables from struct tags, ensuring they match
+// what QueryInto expects. No more manual string synchronization:
+//
+//	// Define result struct once - tags drive both query building AND result mapping
+//	type PersonResult struct {
+//	    Name string `datalog:"?name"`
+//	    Age  int64  `datalog:"?age"`
+//	}
+//
+//	// Build query with type-safe field references
+//	q := qb.QueryFor[PersonResult]()
+//	f := &q.F
+//	e := qb.NewVar("e")
+//
+//	query := q.Where(
+//	    qb.Pat(e, PersonName, q.Find(&f.Name)),  // &f.Name -> ?name
+//	    qb.Pat(e, PersonAge, q.Find(&f.Age)),    // &f.Age -> ?age
+//	    qb.Gt(q.V(&f.Age), 21),                  // V() references without adding to Find
+//	).MustBuild()
+//
+//	// Results map directly to struct - tags guaranteed to match
+//	var results []PersonResult
+//	db.QueryInto(&results, query)
+//
+// q.Find(&f.Field) adds to Find clause, q.V(&f.Field) references only.
+// Rename a struct field -> compile error. Typo in tag -> caught by QueryInto tests.
+//
 // See docs/reference/QUERY_BUILDER.md for complete documentation.
 package qb

--- a/datalog/qb/doc.go
+++ b/datalog/qb/doc.go
@@ -16,9 +16,9 @@
 //
 // # Basic Usage
 //
-//	e := qb.NewVar()
-//	name := qb.NewVar()
-//	age := qb.NewVar()
+//	e := qb.NewVar("e")
+//	name := qb.NewVar("name")
+//	age := qb.NewVar("age")
 //
 //	q := qb.Query().
 //	    Find(name, age).
@@ -35,8 +35,8 @@
 //
 // Variables represent unknowns in queries. Same pointer = same logical variable:
 //
-//	e := qb.NewVar()
-//	name := qb.NewVar()
+//	e := qb.NewVar("e")
+//	name := qb.NewVar("name")
 //	// Using same variable in multiple patterns creates a join
 //
 // # Patterns

--- a/datalog/qb/expression.go
+++ b/datalog/qb/expression.go
@@ -30,7 +30,7 @@ type ArithBuilder struct {
 //
 // Example:
 //
-//	total := qb.NewVar()
+//	total := qb.NewVar("total")
 //	qb.Add(price, tax).As(total)  // [(+ ?price ?tax) ?total]
 func Add(left, right interface{}) *ArithBuilder {
 	return &ArithBuilder{op: query.OpAdd, left: left, right: right}
@@ -76,7 +76,7 @@ type StrBuilder struct {
 //
 // Example:
 //
-//	fullName := qb.NewVar()
+//	fullName := qb.NewVar("fullName")
 //	qb.Str(firstName, " ", lastName).As(fullName)
 func Str(parts ...interface{}) *StrBuilder {
 	return &StrBuilder{parts: parts}
@@ -104,7 +104,7 @@ type GroundBuilder struct {
 //
 // Example:
 //
-//	taxRate := qb.NewVar()
+//	taxRate := qb.NewVar("taxRate")
 //	qb.Ground(0.08).As(taxRate)  // [(ground 0.08) ?taxRate]
 func Ground(value interface{}) *GroundBuilder {
 	return &GroundBuilder{value: value}
@@ -128,7 +128,7 @@ type TupleGroundBuilder struct {
 //
 // Example:
 //
-//	a, b, c := qb.NewVar(), qb.NewVar(), qb.NewVar()
+//	a, b, c := qb.NewVar("a"), qb.NewVar("b"), qb.NewVar("c")
 //	qb.TupleGround(0, 0, 0).As(a, b, c)  // [(ground [0 0 0]) [?a ?b ?c]]
 func TupleGround(values ...interface{}) *TupleGroundBuilder {
 	return &TupleGroundBuilder{values: values}
@@ -190,7 +190,7 @@ type TimeBuilder struct {
 //
 // Example:
 //
-//	year := qb.NewVar()
+//	year := qb.NewVar("year")
 //	qb.Year(createdAt).As(year)
 func Year(timeVar *Var) *TimeBuilder {
 	return &TimeBuilder{field: "year", timeVar: timeVar}

--- a/datalog/qb/input.go
+++ b/datalog/qb/input.go
@@ -37,7 +37,7 @@ type scalarInput struct {
 //
 // Example:
 //
-//	minAge := qb.NewVar()
+//	minAge := qb.NewVar("minAge")
 //	q := qb.Query().
 //	    Find(name, age).
 //	    In(qb.DB, qb.Scalar(minAge)).
@@ -67,7 +67,7 @@ type collectionInput struct {
 //
 // Example:
 //
-//	id := qb.NewVar()
+//	id := qb.NewVar("id")
 //	q := qb.Query().
 //	    Find(name).
 //	    In(qb.DB, qb.Collection(id)).
@@ -93,7 +93,7 @@ type tupleInput struct {
 //
 // Example:
 //
-//	x, y := qb.NewVar(), qb.NewVar()
+//	x, y := qb.NewVar("x"), qb.NewVar("y")
 //	q := qb.Query().
 //	    Find(name).
 //	    In(qb.DB, qb.Tuple(x, y)).
@@ -123,7 +123,7 @@ type relationInput struct {
 //
 // Example:
 //
-//	x, y := qb.NewVar(), qb.NewVar()
+//	x, y := qb.NewVar("x"), qb.NewVar("y")
 //	q := qb.Query().
 //	    Find(name).
 //	    In(qb.DB, qb.Relation(x, y)).

--- a/datalog/qb/integration_test.go
+++ b/datalog/qb/integration_test.go
@@ -85,8 +85,8 @@ func TestIntegration_BasicQuery(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
 
 	q := qb.Query().
 		Find(name).
@@ -124,9 +124,9 @@ func TestIntegration_JoinQuery(t *testing.T) {
 	defer cleanup()
 
 	// Same `e` variable in both patterns = join on entity
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
 
 	q := qb.Query().
 		Find(name, age).
@@ -162,9 +162,9 @@ func TestIntegration_PredicateQuery(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
 
 	// Find people over 30
 	q := qb.Query().
@@ -206,10 +206,10 @@ func TestIntegration_MultiplePredicates(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
-	city := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
+	city := qb.NewVar("city")
 
 	// Find people in NYC who are over 25
 	q := qb.Query().
@@ -239,9 +239,9 @@ func TestIntegration_AggregationQuery(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	dept := qb.NewVar()
-	salary := qb.NewVar()
+	e := qb.NewVar("e")
+	dept := qb.NewVar("dept")
+	salary := qb.NewVar("salary")
 
 	// Sum salary by department
 	q := qb.Query().
@@ -288,9 +288,9 @@ func TestIntegration_CountAggregation(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	dept := qb.NewVar()
-	name := qb.NewVar()
+	e := qb.NewVar("e")
+	dept := qb.NewVar("dept")
+	name := qb.NewVar("name")
 
 	// Count people by department
 	q := qb.Query().
@@ -328,9 +328,9 @@ func TestIntegration_InputParameters(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	inputName := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	inputName := qb.NewVar("inputName")
+	age := qb.NewVar("age")
 
 	// Scalar input used directly in pattern - this is idiomatic Datalog
 	// The input variable is bound to the input value, then used to match patterns
@@ -368,9 +368,9 @@ func TestIntegration_CollectionInput(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	inputName := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	inputName := qb.NewVar("inputName")
+	age := qb.NewVar("age")
 
 	// Collection input - each value is iterated and used to match patterns
 	// [?inputName ...] means: for each value in the collection, bind ?inputName
@@ -410,9 +410,9 @@ func TestIntegration_OrderBy(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
 
 	q := qb.Query().
 		Find(name, age).
@@ -455,9 +455,9 @@ func TestIntegration_QueryInto(t *testing.T) {
 		Age  int64
 	}
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
 
 	q := qb.Query().
 		Find(name, age). // Position 0: Name, Position 1: Age
@@ -497,9 +497,9 @@ func TestIntegration_QueryOneInto(t *testing.T) {
 		Age  int64
 	}
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
 
 	// Query for Alice specifically
 	q := qb.Query().
@@ -539,9 +539,9 @@ func TestIntegration_QueryIntoWithAggregation(t *testing.T) {
 		Count int64   // Position 2: (count e)
 	}
 
-	e := qb.NewVar()
-	dept := qb.NewVar()
-	salary := qb.NewVar()
+	e := qb.NewVar("e")
+	dept := qb.NewVar("dept")
+	salary := qb.NewVar("salary")
 
 	q := qb.Query().
 		Find(dept, qb.Avg(salary), qb.Count(e)).
@@ -605,9 +605,9 @@ func TestIntegration_CompareWithEDN(t *testing.T) {
                   [(> ?age 30)]]`
 
 	// Built query
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
 
 	builtQuery := qb.Query().
 		Find(name, age).
@@ -662,8 +662,8 @@ func TestIntegration_ConstantValue(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
 
 	// Find people in NYC (constant value in pattern)
 	q := qb.Query().
@@ -690,9 +690,9 @@ func TestIntegration_BooleanPredicate(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	active := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	active := qb.NewVar("active")
 
 	// Find active people
 	q := qb.Query().
@@ -720,8 +720,8 @@ func TestIntegration_AvgAggregation(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	age := qb.NewVar("age")
 
 	// Average age of all people
 	q := qb.Query().
@@ -755,8 +755,8 @@ func TestIntegration_MinMaxAggregation(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	salary := qb.NewVar()
+	e := qb.NewVar("e")
+	salary := qb.NewVar("salary")
 
 	// Min and max salary (separate queries since we can't have two aggregates without grouping)
 	minQ := qb.Query().
@@ -799,10 +799,10 @@ func TestIntegration_ThreeWayJoin(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
-	city := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
+	city := qb.NewVar("city")
 
 	q := qb.Query().
 		Find(name, age, city).
@@ -840,9 +840,9 @@ func TestIntegration_Explain(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
 
 	q := qb.Query().
 		Find(name, age).
@@ -887,10 +887,10 @@ func TestIntegration_TupleInput(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	inputName := qb.NewVar()
-	inputAge := qb.NewVar()
-	city := qb.NewVar()
+	e := qb.NewVar("e")
+	inputName := qb.NewVar("inputName")
+	inputAge := qb.NewVar("inputAge")
+	city := qb.NewVar("city")
 
 	// Tuple input - binds a single tuple of values
 	// [[?inputName ?inputAge]] means: bind these two variables from a single input tuple
@@ -932,10 +932,10 @@ func TestIntegration_RelationInput(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	inputName := qb.NewVar()
-	inputCity := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	inputName := qb.NewVar("inputName")
+	inputCity := qb.NewVar("inputCity")
+	age := qb.NewVar("age")
 
 	// Relation input - binds multiple tuples, iterating over each
 	// [[?inputName ?inputCity] ...] means: for each tuple in the relation, bind both variables
@@ -979,10 +979,10 @@ func TestIntegration_RelationInputNoMatch(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	inputName := qb.NewVar()
-	inputCity := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	inputName := qb.NewVar("inputName")
+	inputCity := qb.NewVar("inputCity")
+	age := qb.NewVar("age")
 
 	q := qb.Query().
 		Find(inputName, inputCity, age).
@@ -1014,10 +1014,10 @@ func TestIntegration_MultipleScalarInputs(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	inputName := qb.NewVar()
-	inputCity := qb.NewVar()
-	age := qb.NewVar()
+	e := qb.NewVar("e")
+	inputName := qb.NewVar("inputName")
+	inputCity := qb.NewVar("inputCity")
+	age := qb.NewVar("age")
 
 	// Two scalar inputs
 	q := qb.Query().
@@ -1059,9 +1059,9 @@ func TestIntegration_CompareInputBindingsWithEDN(t *testing.T) {
 		              [?e :person/age ?age]]`
 
 		// Built query
-		e := qb.NewVar()
-		inputName := qb.NewVar()
-		age := qb.NewVar()
+		e := qb.NewVar("e")
+		inputName := qb.NewVar("inputName")
+		age := qb.NewVar("age")
 
 		builtQuery := qb.Query().
 			Find(inputName, age).
@@ -1100,9 +1100,9 @@ func TestIntegration_CompareInputBindingsWithEDN(t *testing.T) {
 		              [?e :person/age ?age]]`
 
 		// Built query
-		e := qb.NewVar()
-		inputName := qb.NewVar()
-		age := qb.NewVar()
+		e := qb.NewVar("e")
+		inputName := qb.NewVar("inputName")
+		age := qb.NewVar("age")
 
 		builtQuery := qb.Query().
 			Find(inputName, age).
@@ -1142,10 +1142,10 @@ func TestIntegration_CompareInputBindingsWithEDN(t *testing.T) {
 		              [?e :person/age ?age]]`
 
 		// Built query
-		e := qb.NewVar()
-		inputName := qb.NewVar()
-		inputCity := qb.NewVar()
-		age := qb.NewVar()
+		e := qb.NewVar("e")
+		inputName := qb.NewVar("inputName")
+		inputCity := qb.NewVar("inputCity")
+		age := qb.NewVar("age")
 
 		builtQuery := qb.Query().
 			Find(inputName, inputCity, age).
@@ -1191,10 +1191,10 @@ func TestIntegration_ComparisonBinding(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
-	isOver30 := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
+	isOver30 := qb.NewVar("isOver30")
 
 	// Bind comparison result to variable
 	q := qb.Query().
@@ -1256,10 +1256,10 @@ func TestIntegration_ComparisonBindingEDNEquivalence(t *testing.T) {
 	              [(> ?age 30) ?flag]]`
 
 	// Built query
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
-	flag := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
+	flag := qb.NewVar("flag")
 
 	builtQuery := qb.Query().
 		Find(name, age, flag).
@@ -1295,10 +1295,10 @@ func TestIntegration_ChainedComparisonBinding(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	age := qb.NewVar()
-	inRange := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	age := qb.NewVar("age")
+	inRange := qb.NewVar("inRange")
 
 	// Check if age is in range 26-34 (exclusive)
 	q := qb.Query().
@@ -1416,9 +1416,9 @@ func TestIntegration_GetElse(t *testing.T) {
 	db, cleanup := setupTestDBWithOptionalAttrs(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	nickname := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	nickname := qb.NewVar("nickname")
 
 	q := qb.Query().
 		Find(name, nickname).
@@ -1476,9 +1476,9 @@ func TestIntegration_GetElseEDNEquivalence(t *testing.T) {
 	              [(get-else $ ?e :person/nickname "Anonymous") ?nick]]`
 
 	// Built query
-	e := qb.NewVar()
-	name := qb.NewVar()
-	nick := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	nick := qb.NewVar("nick")
 
 	builtQuery := qb.Query().
 		Find(name, nick).
@@ -1513,8 +1513,8 @@ func TestIntegration_MissingPredicate(t *testing.T) {
 	db, cleanup := setupTestDBWithOptionalAttrs(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
 
 	// Find people who don't have email
 	q := qb.Query().
@@ -1561,8 +1561,8 @@ func TestIntegration_MissingPredicateEDNEquivalence(t *testing.T) {
 	              [(missing? $ ?e :person/email)]]`
 
 	// Built query
-	e := qb.NewVar()
-	name := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
 
 	builtQuery := qb.Query().
 		Find(name).
@@ -1597,9 +1597,9 @@ func TestIntegration_MissingExpression(t *testing.T) {
 	db, cleanup := setupTestDBWithOptionalAttrs(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	needsEmail := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	needsEmail := qb.NewVar("needsEmail")
 
 	// Bind missing? result to variable
 	q := qb.Query().
@@ -1651,9 +1651,9 @@ func TestIntegration_GetSome(t *testing.T) {
 	db, cleanup := setupTestDBWithOptionalAttrs(t)
 	defer cleanup()
 
-	e := qb.NewVar()
-	name := qb.NewVar()
-	displayName := qb.NewVar()
+	e := qb.NewVar("e")
+	name := qb.NewVar("name")
+	displayName := qb.NewVar("displayName")
 
 	// Get nickname, fallback to name, fallback to email
 	q := qb.Query().

--- a/datalog/qb/predicate.go
+++ b/datalog/qb/predicate.go
@@ -68,7 +68,7 @@ func (c *Comparison) toClause() query.Clause {
 //
 // Example:
 //
-//	hasItems := qb.NewVar()
+//	hasItems := qb.NewVar("hasItems")
 //	qb.Gt(count, 0).As(hasItems)  // [(> ?count 0) ?has-items]
 //
 // The result is a boolean: true if the comparison passes, false otherwise.
@@ -139,7 +139,7 @@ func (c *ChainedComparison) toClause() query.Clause {
 //
 // Example:
 //
-//	inRange := qb.NewVar()
+//	inRange := qb.NewVar("inRange")
 //	qb.Range(0, price, 100).As(inRange)  // [(< 0 ?price 100) ?in-range]
 //
 // The result is a boolean: true if all adjacent pairs satisfy the comparison.

--- a/datalog/qb/qb_test.go
+++ b/datalog/qb/qb_test.go
@@ -396,16 +396,15 @@ func TestTupleGroundInOr(t *testing.T) {
 	count, total := NewVar("count"), NewVar("total")
 
 	// Build an OR clause with a tuple ground fallback
-	orClause := Or(
-		[]interface{}{
+	orClause := Or().
+		Branch(
 			// First branch: some pattern
 			Pat(NewVar("e"), Kw(":dummy/attr"), NewVar("v")),
-		},
-		[]interface{}{
+		).
+		Branch(
 			// Second branch: tuple ground fallback
 			TupleGround(0, 0).As(count, total),
-		},
-	)
+		)
 
 	clause := orClause.toClause()
 	oc, ok := clause.(*query.OrClause)
@@ -561,10 +560,9 @@ func TestNotJoinClause(t *testing.T) {
 func TestOrClause(t *testing.T) {
 	status := NewVar("status")
 
-	orClause := Or(
-		[]interface{}{Eq(status, V("active"))},
-		[]interface{}{Eq(status, V("pending"))},
-	)
+	orClause := Or().
+		Branch(Eq(status, V("active"))).
+		Branch(Eq(status, V("pending")))
 
 	clause := orClause.toClause()
 	oc, ok := clause.(*query.OrClause)
@@ -583,10 +581,9 @@ func TestOrJoinClause(t *testing.T) {
 	PersonNickname := Kw(":person/nickname")
 	PersonName := Kw(":person/name")
 
-	orJoin := OrJoin([]*Var{name},
-		[]interface{}{Pat(e, PersonNickname, name)},
-		[]interface{}{Pat(e, PersonName, name)},
-	)
+	orJoin := OrJoin(name).
+		Branch(Pat(e, PersonNickname, name)).
+		Branch(Pat(e, PersonName, name))
 
 	clause := orJoin.toClause()
 	ojc, ok := clause.(*query.OrJoinClause)

--- a/datalog/qb/qb_test.go
+++ b/datalog/qb/qb_test.go
@@ -1445,3 +1445,214 @@ func TestComparisonBindingInQuery(t *testing.T) {
 		t.Errorf("Expected ComparisonFunction, got %T", expr.Function)
 	}
 }
+
+// TestQueryForBasic tests basic QueryFor usage
+func TestQueryForBasic(t *testing.T) {
+	type Result struct {
+		Name string `datalog:"?name"`
+		Age  int64  `datalog:"?age"`
+	}
+
+	q := QueryFor[Result]()
+	f := &q.F
+
+	PersonName := Kw(":person/name")
+	PersonAge := Kw(":person/age")
+	e := NewVar("e")
+
+	built, err := q.Where(
+		Pat(e, PersonName, q.Find(&f.Name)),
+		Pat(e, PersonAge, q.Find(&f.Age)),
+	).Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Verify Find clause has 2 elements
+	if len(built.Find) != 2 {
+		t.Errorf("Expected 2 find elements, got %d", len(built.Find))
+	}
+
+	// Verify find elements are ?name and ?age
+	fv0, ok := built.Find[0].(query.FindVariable)
+	if !ok {
+		t.Fatalf("Expected FindVariable, got %T", built.Find[0])
+	}
+	if fv0.Symbol != "?name" {
+		t.Errorf("Expected ?name, got %s", fv0.Symbol)
+	}
+
+	fv1, ok := built.Find[1].(query.FindVariable)
+	if !ok {
+		t.Fatalf("Expected FindVariable, got %T", built.Find[1])
+	}
+	if fv1.Symbol != "?age" {
+		t.Errorf("Expected ?age, got %s", fv1.Symbol)
+	}
+}
+
+// TestQueryForVvsFind tests that V() doesn't add to Find but Find() does
+func TestQueryForVvsFind(t *testing.T) {
+	type Result struct {
+		Person string `datalog:"?person"`
+		Name   string `datalog:"?name"`
+	}
+
+	q := QueryFor[Result]()
+	f := &q.F
+
+	PersonName := Kw(":person/name")
+
+	// Use V() for person (not in results), Find() for name
+	built, err := q.Where(
+		Pat(q.V(&f.Person), PersonName, q.Find(&f.Name)),
+	).Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Find should only have ?name, not ?person
+	if len(built.Find) != 1 {
+		t.Errorf("Expected 1 find element, got %d", len(built.Find))
+	}
+
+	fv, ok := built.Find[0].(query.FindVariable)
+	if !ok {
+		t.Fatalf("Expected FindVariable, got %T", built.Find[0])
+	}
+	if fv.Symbol != "?name" {
+		t.Errorf("Expected ?name, got %s", fv.Symbol)
+	}
+}
+
+// TestQueryForJoinSemantics tests that same field returns same *Var
+func TestQueryForJoinSemantics(t *testing.T) {
+	type Result struct {
+		Person string `datalog:"?person"`
+		Name   string `datalog:"?name"`
+		Age    int64  `datalog:"?age"`
+	}
+
+	q := QueryFor[Result]()
+	f := &q.F
+
+	// Same V(&f.Person) call should return same *Var
+	v1 := q.V(&f.Person)
+	v2 := q.V(&f.Person)
+
+	if v1 != v2 {
+		t.Error("Same field should return same *Var for join semantics")
+	}
+
+	// Same for Find
+	f1 := q.Find(&f.Name)
+	f2 := q.Find(&f.Name)
+
+	if f1 != f2 {
+		t.Error("Same field should return same *Var for join semantics")
+	}
+}
+
+// TestQueryForFindOrder tests that Find order matches call order
+func TestQueryForFindOrder(t *testing.T) {
+	type Result struct {
+		A string `datalog:"?a"`
+		B string `datalog:"?b"`
+		C string `datalog:"?c"`
+	}
+
+	q := QueryFor[Result]()
+	f := &q.F
+
+	// Call Find in order: C, A, B
+	q.Find(&f.C)
+	q.Find(&f.A)
+	q.Find(&f.B)
+
+	Dummy := Kw(":dummy")
+	e := NewVar("e")
+
+	built, err := q.Where(
+		Pat(e, Dummy, q.V(&f.A)),
+	).Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Find should be [?c, ?a, ?b] - call order, not struct order
+	if len(built.Find) != 3 {
+		t.Fatalf("Expected 3 find elements, got %d", len(built.Find))
+	}
+
+	expected := []string{"?c", "?a", "?b"}
+	for i, exp := range expected {
+		fv, ok := built.Find[i].(query.FindVariable)
+		if !ok {
+			t.Fatalf("Expected FindVariable at %d, got %T", i, built.Find[i])
+		}
+		if string(fv.Symbol) != exp {
+			t.Errorf("Find[%d]: expected %s, got %s", i, exp, fv.Symbol)
+		}
+	}
+}
+
+// TestQueryForIgnoresAggregateTag tests that aggregate tags are ignored
+func TestQueryForIgnoresAggregateTag(t *testing.T) {
+	type Result struct {
+		Dept   string  `datalog:"?dept"`
+		Salary int64   `datalog:"?salary"`
+		Avg    float64 `datalog:"(avg ?salary)"` // Should be ignored
+	}
+
+	q := QueryFor[Result]()
+	f := &q.F
+
+	// Should be able to get ?dept and ?salary
+	dept := q.V(&f.Dept)
+	salary := q.V(&f.Salary)
+
+	if dept.Symbol() != "?dept" {
+		t.Errorf("Expected ?dept, got %s", dept.Symbol())
+	}
+	if salary.Symbol() != "?salary" {
+		t.Errorf("Expected ?salary, got %s", salary.Symbol())
+	}
+
+	// Trying to get Avg should panic (no variable tag)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic when accessing field with aggregate tag")
+		}
+	}()
+	q.V(&f.Avg) // Should panic
+}
+
+// TestQueryForFindNoDuplicate tests that Find() doesn't duplicate
+func TestQueryForFindNoDuplicate(t *testing.T) {
+	type Result struct {
+		Name string `datalog:"?name"`
+	}
+
+	q := QueryFor[Result]()
+	f := &q.F
+
+	// Call Find multiple times
+	q.Find(&f.Name)
+	q.Find(&f.Name)
+	q.Find(&f.Name)
+
+	Dummy := Kw(":dummy")
+	e := NewVar("e")
+
+	built, err := q.Where(
+		Pat(e, Dummy, q.V(&f.Name)),
+	).Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Should still only have 1 find element
+	if len(built.Find) != 1 {
+		t.Errorf("Expected 1 find element, got %d", len(built.Find))
+	}
+}

--- a/datalog/qb/qb_test.go
+++ b/datalog/qb/qb_test.go
@@ -9,9 +9,9 @@ import (
 
 // TestNewVar tests that variables get unique IDs
 func TestNewVar(t *testing.T) {
-	v1 := NewVar()
-	v2 := NewVar()
-	v3 := NewVar()
+	v1 := NewVar("v1")
+	v2 := NewVar("v2")
+	v3 := NewVar("v3")
 
 	if v1.id == v2.id {
 		t.Error("v1 and v2 should have different IDs")
@@ -20,10 +20,10 @@ func TestNewVar(t *testing.T) {
 		t.Error("v2 and v3 should have different IDs")
 	}
 
-	// Symbol should start with ?v
+	// Symbol should be ?v1
 	sym1 := v1.Symbol()
-	if sym1[0] != '?' {
-		t.Errorf("Symbol should start with ?, got %s", sym1)
+	if sym1 != "?v1" {
+		t.Errorf("Symbol should be ?v1, got %s", sym1)
 	}
 }
 
@@ -77,8 +77,8 @@ func TestBlank(t *testing.T) {
 
 // TestPat tests 3-element pattern creation
 func TestPat(t *testing.T) {
-	e := NewVar()
-	name := NewVar()
+	e := NewVar("e")
+	name := NewVar("name")
 	PersonName := Kw(":person/name")
 
 	pat := Pat(e, PersonName, name)
@@ -96,9 +96,9 @@ func TestPat(t *testing.T) {
 
 // TestPat4 tests 4-element pattern creation (with tx)
 func TestPat4(t *testing.T) {
-	e := NewVar()
-	name := NewVar()
-	tx := NewVar()
+	e := NewVar("e")
+	name := NewVar("name")
+	tx := NewVar("tx")
 	PersonName := Kw(":person/name")
 
 	pat := Pat(e, PersonName, name, tx)
@@ -115,10 +115,10 @@ func TestPat4(t *testing.T) {
 
 // TestPat5 tests 5-element pattern creation (history with op)
 func TestPat5(t *testing.T) {
-	e := NewVar()
-	name := NewVar()
-	tx := NewVar()
-	op := NewVar()
+	e := NewVar("e")
+	name := NewVar("name")
+	tx := NewVar("tx")
+	op := NewVar("op")
 	PersonName := Kw(":person/name")
 
 	pat := Pat(e, PersonName, name, tx, op)
@@ -135,7 +135,7 @@ func TestPat5(t *testing.T) {
 
 // TestPatternWithValues tests pattern with constant values
 func TestPatternWithValues(t *testing.T) {
-	e := NewVar()
+	e := NewVar("e")
 	PersonName := Kw(":person/name")
 
 	pat := Pat(e, PersonName, V("Alice"))
@@ -161,8 +161,8 @@ func TestPatInvalidArity(t *testing.T) {
 
 // TestPat2 tests 2-element pattern (for input relations)
 func TestPat2(t *testing.T) {
-	name := NewVar()
-	age := NewVar()
+	name := NewVar("name")
+	age := NewVar("age")
 
 	pat := Pat(name, age)
 
@@ -178,7 +178,7 @@ func TestPat2(t *testing.T) {
 
 // TestPredicates tests comparison predicates
 func TestPredicates(t *testing.T) {
-	age := NewVar()
+	age := NewVar("age")
 
 	tests := []struct {
 		name string
@@ -209,7 +209,7 @@ func TestPredicates(t *testing.T) {
 
 // TestChainedComparison tests range predicates
 func TestChainedComparison(t *testing.T) {
-	x := NewVar()
+	x := NewVar("x")
 
 	// Range: 0 < x < 100
 	chain := Chained(query.OpLT, V(0), x, V(100))
@@ -229,7 +229,7 @@ func TestChainedComparison(t *testing.T) {
 
 // TestRange tests convenience range function
 func TestRange(t *testing.T) {
-	x := NewVar()
+	x := NewVar("x")
 
 	// Range: 10 < x < 20
 	chain := Range(V(10), x, V(20))
@@ -243,7 +243,7 @@ func TestRange(t *testing.T) {
 
 // TestAggregations tests aggregation functions
 func TestAggregations(t *testing.T) {
-	salary := NewVar()
+	salary := NewVar("salary")
 
 	tests := []struct {
 		name string
@@ -273,9 +273,9 @@ func TestAggregations(t *testing.T) {
 
 // TestArithmeticExpressions tests arithmetic expression builders
 func TestArithmeticExpressions(t *testing.T) {
-	a := NewVar()
-	b := NewVar()
-	result := NewVar()
+	a := NewVar("a")
+	b := NewVar("b")
+	result := NewVar("result")
 
 	tests := []struct {
 		name string
@@ -308,9 +308,9 @@ func TestArithmeticExpressions(t *testing.T) {
 
 // TestStrConcat tests string concatenation expression
 func TestStrConcat(t *testing.T) {
-	firstName := NewVar()
-	lastName := NewVar()
-	fullName := NewVar()
+	firstName := NewVar("firstName")
+	lastName := NewVar("lastName")
+	fullName := NewVar("fullName")
 
 	expr := Str(firstName, V(" "), lastName).As(fullName)
 
@@ -324,7 +324,7 @@ func TestStrConcat(t *testing.T) {
 
 // TestGround tests ground expression
 func TestGround(t *testing.T) {
-	taxRate := NewVar()
+	taxRate := NewVar("taxRate")
 
 	expr := Ground(0.08).As(taxRate)
 
@@ -341,7 +341,7 @@ func TestGround(t *testing.T) {
 
 // TestTupleGround tests tuple ground expression
 func TestTupleGround(t *testing.T) {
-	a, b, c := NewVar(), NewVar(), NewVar()
+	a, b, c := NewVar("a"), NewVar("b"), NewVar("c")
 
 	expr := TupleGround(0, 0, 0).As(a, b, c)
 
@@ -374,7 +374,7 @@ func TestTupleGround(t *testing.T) {
 
 // TestTupleGroundMixedTypes tests tuple ground with different value types
 func TestTupleGroundMixedTypes(t *testing.T) {
-	s, n := NewVar(), NewVar()
+	s, n := NewVar("s"), NewVar("n")
 
 	expr := TupleGround("hello", 42).As(s, n)
 
@@ -393,13 +393,13 @@ func TestTupleGroundMixedTypes(t *testing.T) {
 
 // TestTupleGroundInOr tests tuple ground in Or clause (primary use case)
 func TestTupleGroundInOr(t *testing.T) {
-	count, total := NewVar(), NewVar()
+	count, total := NewVar("count"), NewVar("total")
 
 	// Build an OR clause with a tuple ground fallback
 	orClause := Or(
 		[]interface{}{
 			// First branch: some pattern
-			Pat(NewVar(), Kw(":dummy/attr"), NewVar()),
+			Pat(NewVar("e"), Kw(":dummy/attr"), NewVar("v")),
 		},
 		[]interface{}{
 			// Second branch: tuple ground fallback
@@ -441,8 +441,8 @@ func TestTupleGroundInOr(t *testing.T) {
 
 // TestIdentity tests identity expression
 func TestIdentity(t *testing.T) {
-	original := NewVar()
-	alias := NewVar()
+	original := NewVar("original")
+	alias := NewVar("alias")
 
 	expr := Identity(original).As(alias)
 
@@ -456,8 +456,8 @@ func TestIdentity(t *testing.T) {
 
 // TestTimeExtraction tests time extraction functions
 func TestTimeExtraction(t *testing.T) {
-	createdAt := NewVar()
-	y := NewVar()
+	createdAt := NewVar("createdAt")
+	y := NewVar("y")
 
 	tests := []struct {
 		name  string
@@ -496,21 +496,21 @@ func TestInputSpecs(t *testing.T) {
 	}
 
 	// Test Scalar input
-	minAge := NewVar()
+	minAge := NewVar("minAge")
 	scalarSpec := Scalar(minAge).toInputSpec()
 	if _, ok := scalarSpec.(query.ScalarInput); !ok {
 		t.Errorf("Scalar should produce ScalarInput, got %T", scalarSpec)
 	}
 
 	// Test Collection input
-	id := NewVar()
+	id := NewVar("id")
 	collSpec := Collection(id).toInputSpec()
 	if _, ok := collSpec.(query.CollectionInput); !ok {
 		t.Errorf("Collection should produce CollectionInput, got %T", collSpec)
 	}
 
 	// Test Tuple input
-	x, y := NewVar(), NewVar()
+	x, y := NewVar("x"), NewVar("y")
 	tupleSpec := Tuple(x, y).toInputSpec()
 	if _, ok := tupleSpec.(query.TupleInput); !ok {
 		t.Errorf("Tuple should produce TupleInput, got %T", tupleSpec)
@@ -525,7 +525,7 @@ func TestInputSpecs(t *testing.T) {
 
 // TestNotClause tests NOT clause
 func TestNotClause(t *testing.T) {
-	e := NewVar()
+	e := NewVar("e")
 	PersonCity := Kw(":person/city")
 
 	notClause := Not(Pat(e, PersonCity, V("NYC")))
@@ -542,7 +542,7 @@ func TestNotClause(t *testing.T) {
 
 // TestNotJoinClause tests NOT-JOIN clause
 func TestNotJoinClause(t *testing.T) {
-	e := NewVar()
+	e := NewVar("e")
 	PersonStatus := Kw(":person/status")
 
 	notJoin := NotJoin([]*Var{e}, Pat(e, PersonStatus, V("banned")))
@@ -559,7 +559,7 @@ func TestNotJoinClause(t *testing.T) {
 
 // TestOrClause tests OR clause
 func TestOrClause(t *testing.T) {
-	status := NewVar()
+	status := NewVar("status")
 
 	orClause := Or(
 		[]interface{}{Eq(status, V("active"))},
@@ -578,8 +578,8 @@ func TestOrClause(t *testing.T) {
 
 // TestOrJoinClause tests OR-JOIN clause
 func TestOrJoinClause(t *testing.T) {
-	e := NewVar()
-	name := NewVar()
+	e := NewVar("e")
+	name := NewVar("name")
 	PersonNickname := Kw(":person/nickname")
 	PersonName := Kw(":person/name")
 
@@ -603,7 +603,7 @@ func TestOrJoinClause(t *testing.T) {
 
 // TestOrderSpecs tests ordering specifications
 func TestOrderSpecs(t *testing.T) {
-	name := NewVar()
+	name := NewVar("name")
 
 	// Test Asc
 	ascSpec := Asc(name)
@@ -620,9 +620,9 @@ func TestOrderSpecs(t *testing.T) {
 
 // TestQueryBuilder tests the main query builder
 func TestQueryBuilder(t *testing.T) {
-	e := NewVar()
-	name := NewVar()
-	age := NewVar()
+	e := NewVar("e")
+	name := NewVar("name")
+	age := NewVar("age")
 	PersonName := Kw(":person/name")
 	PersonAge := Kw(":person/age")
 
@@ -658,10 +658,10 @@ func TestQueryBuilder(t *testing.T) {
 
 // TestQueryBuilderWithInputs tests query builder with input parameters
 func TestQueryBuilderWithInputs(t *testing.T) {
-	e := NewVar()
-	name := NewVar()
-	age := NewVar()
-	minAge := NewVar()
+	e := NewVar("e")
+	name := NewVar("name")
+	age := NewVar("age")
+	minAge := NewVar("minAge")
 	PersonName := Kw(":person/name")
 	PersonAge := Kw(":person/age")
 
@@ -687,9 +687,9 @@ func TestQueryBuilderWithInputs(t *testing.T) {
 
 // TestQueryBuilderWithAggregation tests query builder with aggregation
 func TestQueryBuilderWithAggregation(t *testing.T) {
-	e := NewVar()
-	dept := NewVar()
-	salary := NewVar()
+	e := NewVar("e")
+	dept := NewVar("dept")
+	salary := NewVar("salary")
 	EmpDept := Kw(":employee/dept")
 	EmpSalary := Kw(":employee/salary")
 
@@ -731,13 +731,13 @@ func TestQueryBuilderMustBuild(t *testing.T) {
 // TestQueryBuilderValidation tests build validation
 func TestQueryBuilderValidation(t *testing.T) {
 	// No find elements
-	_, err := Query().Where(Eq(NewVar(), V(1))).Build()
+	_, err := Query().Where(Eq(NewVar("x"), V(1))).Build()
 	if err == nil {
 		t.Error("Expected error for query without find elements")
 	}
 
 	// No where clauses
-	_, err = Query().Find(NewVar()).Build()
+	_, err = Query().Find(NewVar("x")).Build()
 	if err == nil {
 		t.Error("Expected error for query without where clauses")
 	}
@@ -746,10 +746,10 @@ func TestQueryBuilderValidation(t *testing.T) {
 // TestSubquery tests subquery builder
 func TestSubquery(t *testing.T) {
 	// Inner query: find max salary for a department
-	dept := NewVar()
-	maxSalary := NewVar()
-	innerSalary := NewVar()
-	innerE := NewVar()
+	dept := NewVar("dept")
+	maxSalary := NewVar("maxSalary")
+	innerSalary := NewVar("innerSalary")
+	innerE := NewVar("innerE")
 	EmpDept := Kw(":employee/dept")
 	EmpSalary := Kw(":employee/salary")
 
@@ -770,9 +770,10 @@ func TestSubquery(t *testing.T) {
 		t.Fatalf("Expected *query.SubqueryPattern, got %T", clause)
 	}
 
-	// Should have 1 input
-	if len(sqp.Inputs) != 1 {
-		t.Errorf("Expected 1 input, got %d", len(sqp.Inputs))
+	// Should have 2 inputs: $ (database) and ?dept (scalar)
+	// The inner query declares In(DB, Scalar(dept)), so both must be passed
+	if len(sqp.Inputs) != 2 {
+		t.Errorf("Expected 2 inputs ($ and ?dept), got %d", len(sqp.Inputs))
 	}
 
 	// Should have tuple binding
@@ -783,9 +784,9 @@ func TestSubquery(t *testing.T) {
 
 // TestSubqueryRelationBinding tests subquery with relation binding
 func TestSubqueryRelationBinding(t *testing.T) {
-	dept := NewVar()
-	empName := NewVar()
-	innerE := NewVar()
+	dept := NewVar("dept")
+	empName := NewVar("empName")
+	innerE := NewVar("innerE")
 	EmpDept := Kw(":employee/dept")
 	EmpName := Kw(":employee/name")
 
@@ -809,9 +810,9 @@ func TestSubqueryRelationBinding(t *testing.T) {
 
 // TestSubqueryCollectionBinding tests subquery with collection binding
 func TestSubqueryCollectionBinding(t *testing.T) {
-	dept := NewVar()
-	empName := NewVar()
-	innerE := NewVar()
+	dept := NewVar("dept")
+	empName := NewVar("empName")
+	innerE := NewVar("innerE")
 	EmpDept := Kw(":employee/dept")
 	EmpName := Kw(":employee/name")
 
@@ -823,7 +824,7 @@ func TestSubqueryCollectionBinding(t *testing.T) {
 			Pat(innerE, EmpName, empName),
 		)
 
-	names := NewVar()
+	names := NewVar("names")
 	sub := Subquery(innerQ, dept).BindCollection(names)
 
 	clause := sub.toClause()
@@ -838,9 +839,9 @@ func TestSubqueryCollectionBinding(t *testing.T) {
 func TestVariableIdentityIsJoin(t *testing.T) {
 	// This is the key insight: using the same Go variable in multiple patterns
 	// creates a join condition
-	e := NewVar() // <-- This single variable
-	name := NewVar()
-	age := NewVar()
+	e := NewVar("e") // <-- This single variable
+	name := NewVar("name")
+	age := NewVar("age")
 	PersonName := Kw(":person/name")
 	PersonAge := Kw(":person/age")
 
@@ -872,8 +873,8 @@ func TestVariableIdentityIsJoin(t *testing.T) {
 
 // TestPatternWithDatalogKeyword tests pattern with datalog.Keyword directly
 func TestPatternWithDatalogKeyword(t *testing.T) {
-	e := NewVar()
-	name := NewVar()
+	e := NewVar("e")
+	name := NewVar("name")
 
 	// Can use datalog.Keyword directly
 	directKw := datalog.NewKeyword(":person/name")
@@ -890,7 +891,7 @@ func TestPatternWithDatalogKeyword(t *testing.T) {
 
 // TestPatternWithDatalogIdentity tests pattern with datalog.Identity directly
 func TestPatternWithDatalogIdentity(t *testing.T) {
-	name := NewVar()
+	name := NewVar("name")
 	PersonName := Kw(":person/name")
 
 	// Can use datalog.Identity directly for entity
@@ -909,20 +910,20 @@ func TestPatternWithDatalogIdentity(t *testing.T) {
 // TestComplexQuery tests a realistic complex query
 func TestComplexQuery(t *testing.T) {
 	// Find employees who earn more than the average in their department
-	e := NewVar()
-	dept := NewVar()
-	salary := NewVar()
-	name := NewVar()
-	avgSalary := NewVar()
+	e := NewVar("e")
+	dept := NewVar("dept")
+	salary := NewVar("salary")
+	name := NewVar("name")
+	avgSalary := NewVar("avgSalary")
 
 	EmpName := Kw(":employee/name")
 	EmpDept := Kw(":employee/dept")
 	EmpSalary := Kw(":employee/salary")
 
 	// Inner query to compute average salary per department
-	innerE := NewVar()
-	innerSalary := NewVar()
-	innerDept := NewVar()
+	innerE := NewVar("innerE")
+	innerSalary := NewVar("innerSalary")
+	innerDept := NewVar("innerDept")
 
 	innerQ := Query().
 		Find(Avg(innerSalary)).
@@ -966,8 +967,8 @@ func TestComplexQuery(t *testing.T) {
 
 // TestComparisonBindingAs tests all comparison operators with .As() binding
 func TestComparisonBindingAs(t *testing.T) {
-	a := NewVar()
-	result := NewVar()
+	a := NewVar("a")
+	result := NewVar("result")
 
 	tests := []struct {
 		name string
@@ -1009,9 +1010,9 @@ func TestComparisonBindingAs(t *testing.T) {
 
 // TestComparisonBindingTerms tests comparison binding with different term combinations
 func TestComparisonBindingTerms(t *testing.T) {
-	x := NewVar()
-	y := NewVar()
-	result := NewVar()
+	x := NewVar("x")
+	y := NewVar("y")
+	result := NewVar("result")
 
 	// Var vs Constant
 	expr1 := Gt(x, V(0)).As(result)
@@ -1049,8 +1050,8 @@ func TestComparisonBindingTerms(t *testing.T) {
 
 // TestChainedComparisonBindingAs tests chained comparison with .As() binding
 func TestChainedComparisonBindingAs(t *testing.T) {
-	x := NewVar()
-	result := NewVar()
+	x := NewVar("x")
+	result := NewVar("result")
 
 	// Chained with OpLT
 	chain := Chained(query.OpLT, V(0), x, V(100)).As(result)
@@ -1078,8 +1079,8 @@ func TestChainedComparisonBindingAs(t *testing.T) {
 
 // TestRangeBindingAs tests Range convenience function with .As() binding
 func TestRangeBindingAs(t *testing.T) {
-	x := NewVar()
-	inRange := NewVar()
+	x := NewVar("x")
+	inRange := NewVar("inRange")
 
 	// Range: 0 < x < 100
 	chain := Range(V(0), x, V(100)).As(inRange)
@@ -1094,8 +1095,8 @@ func TestRangeBindingAs(t *testing.T) {
 
 // TestRangeInclusiveBindingAs tests RangeInclusive convenience function with .As() binding
 func TestRangeInclusiveBindingAs(t *testing.T) {
-	rating := NewVar()
-	valid := NewVar()
+	rating := NewVar("rating")
+	valid := NewVar("valid")
 
 	// Range: 1 <= rating <= 5
 	chain := RangeInclusive(V(1), rating, V(5)).As(valid)
@@ -1110,8 +1111,8 @@ func TestRangeInclusiveBindingAs(t *testing.T) {
 
 // TestComparisonDualUse tests that comparisons work both as predicate and expression
 func TestComparisonDualUse(t *testing.T) {
-	x := NewVar()
-	flag := NewVar()
+	x := NewVar("x")
+	flag := NewVar("flag")
 
 	// As predicate (filter)
 	pred := Gt(x, V(0))
@@ -1130,8 +1131,8 @@ func TestComparisonDualUse(t *testing.T) {
 
 // TestChainedComparisonDualUse tests that chained comparisons work both as predicate and expression
 func TestChainedComparisonDualUse(t *testing.T) {
-	x := NewVar()
-	flag := NewVar()
+	x := NewVar("x")
+	flag := NewVar("flag")
 
 	// As predicate (filter)
 	pred := Range(V(0), x, V(100))
@@ -1154,8 +1155,8 @@ func TestChainedComparisonDualUse(t *testing.T) {
 
 // TestGetElse tests GetElse function builder
 func TestGetElse(t *testing.T) {
-	entity := NewVar()
-	result := NewVar()
+	entity := NewVar("entity")
+	result := NewVar("result")
 	PersonNickname := Kw(":person/nickname")
 
 	// GetElse with string default
@@ -1198,8 +1199,8 @@ func TestGetElse(t *testing.T) {
 
 // TestGetElseWithDifferentDefaults tests GetElse with various default value types
 func TestGetElseWithDifferentDefaults(t *testing.T) {
-	entity := NewVar()
-	result := NewVar()
+	entity := NewVar("entity")
+	result := NewVar("result")
 	attr := Kw(":test/attr")
 
 	tests := []struct {
@@ -1228,7 +1229,7 @@ func TestGetElseWithDifferentDefaults(t *testing.T) {
 
 // TestMissingAsPredicate tests Missing as a filter predicate (without .As())
 func TestMissingAsPredicate(t *testing.T) {
-	entity := NewVar()
+	entity := NewVar("entity")
 	PersonEmail := Kw(":person/email")
 
 	missing := Missing(entity, PersonEmail)
@@ -1258,8 +1259,8 @@ func TestMissingAsPredicate(t *testing.T) {
 
 // TestMissingAsExpression tests Missing as an expression (with .As())
 func TestMissingAsExpression(t *testing.T) {
-	entity := NewVar()
-	needsEmail := NewVar()
+	entity := NewVar("entity")
+	needsEmail := NewVar("needsEmail")
 	PersonEmail := Kw(":person/email")
 
 	missing := Missing(entity, PersonEmail).As(needsEmail)
@@ -1288,8 +1289,8 @@ func TestMissingAsExpression(t *testing.T) {
 
 // TestGetSome tests GetSome function builder
 func TestGetSome(t *testing.T) {
-	entity := NewVar()
-	displayName := NewVar()
+	entity := NewVar("entity")
+	displayName := NewVar("displayName")
 	PersonNickname := Kw(":person/nickname")
 	PersonFullName := Kw(":person/fullname")
 	PersonEmail := Kw(":person/email")
@@ -1335,8 +1336,8 @@ func TestGetSome(t *testing.T) {
 
 // TestGetSomeWithTwoAttrs tests GetSome with minimum required attributes
 func TestGetSomeWithTwoAttrs(t *testing.T) {
-	entity := NewVar()
-	result := NewVar()
+	entity := NewVar("entity")
+	result := NewVar("result")
 	AttrA := Kw(":attr/a")
 	AttrB := Kw(":attr/b")
 
@@ -1351,9 +1352,9 @@ func TestGetSomeWithTwoAttrs(t *testing.T) {
 
 // TestDatabaseFunctionInQuery tests using database functions in a complete query
 func TestDatabaseFunctionInQuery(t *testing.T) {
-	e := NewVar()
-	name := NewVar()
-	nickname := NewVar()
+	e := NewVar("e")
+	name := NewVar("name")
+	nickname := NewVar("nickname")
 	PersonName := Kw(":person/name")
 	PersonNickname := Kw(":person/nickname")
 
@@ -1386,8 +1387,8 @@ func TestDatabaseFunctionInQuery(t *testing.T) {
 
 // TestMissingPredicateInQuery tests using Missing as a predicate in a query
 func TestMissingPredicateInQuery(t *testing.T) {
-	e := NewVar()
-	name := NewVar()
+	e := NewVar("e")
+	name := NewVar("name")
 	PersonName := Kw(":person/name")
 	PersonEmail := Kw(":person/email")
 
@@ -1416,9 +1417,9 @@ func TestMissingPredicateInQuery(t *testing.T) {
 
 // TestComparisonBindingInQuery tests using comparison binding in a complete query
 func TestComparisonBindingInQuery(t *testing.T) {
-	e := NewVar()
-	count := NewVar()
-	hasItems := NewVar()
+	e := NewVar("e")
+	count := NewVar("count")
+	hasItems := NewVar("hasItems")
 	ItemCount := Kw(":item/count")
 
 	q, err := Query().

--- a/datalog/qb/query_for.go
+++ b/datalog/qb/query_for.go
@@ -1,0 +1,140 @@
+package qb
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// TypedQueryBuilder provides type-safe variable references from a result struct.
+// The struct's datalog tags define variable names.
+// Use QueryFor[T]() to create one.
+type TypedQueryBuilder[T any] struct {
+	F          T                // Zero-valued struct for field references
+	vars       map[uintptr]*Var // Cache: field offset -> *Var
+	findVars   []*Var           // Accumulated Find elements (ordered)
+	findSet    map[uintptr]bool // Track which fields added to Find
+	structInfo *structVarInfo   // Cached struct metadata
+}
+
+// structVarInfo caches struct field metadata for variable extraction
+type structVarInfo struct {
+	fields []fieldVarInfo
+}
+
+type fieldVarInfo struct {
+	offset uintptr
+	tag    string // The datalog tag value (e.g., "?name")
+}
+
+// QueryFor creates a new type-safe query builder for result type T.
+// The type parameter T should be a struct with datalog tags on fields.
+//
+// Example:
+//
+//	type Result struct {
+//	    Name string `datalog:"?name"`
+//	}
+//	q := QueryFor[Result]()
+func QueryFor[T any]() *TypedQueryBuilder[T] {
+	q := &TypedQueryBuilder[T]{
+		vars:    make(map[uintptr]*Var),
+		findSet: make(map[uintptr]bool),
+	}
+	q.structInfo = parseStructVarInfo[T]()
+	return q
+}
+
+// V returns the *Var for a field without adding it to Find.
+// Use for referencing variables that shouldn't appear in results.
+//
+// Example:
+//
+//	// Use entity in pattern but don't include in results
+//	Pat(q.V(&f.Person), PersonName, q.Find(&f.Name))
+func (q *TypedQueryBuilder[T]) V(fieldPtr any) *Var {
+	offset := q.fieldOffset(fieldPtr)
+
+	if v, ok := q.vars[offset]; ok {
+		return v
+	}
+
+	tag := q.findTag(offset)
+	v := NewVar(tag)
+	q.vars[offset] = v
+	return v
+}
+
+// Find returns the *Var for a field AND adds it to the Find clause.
+// First call for a field determines its position in Find.
+// Subsequent calls return the same *Var without duplicating in Find.
+//
+// Example:
+//
+//	// Add ?name to Find clause and use in pattern
+//	Pat(e, PersonName, q.Find(&f.Name))
+func (q *TypedQueryBuilder[T]) Find(fieldPtr any) *Var {
+	offset := q.fieldOffset(fieldPtr)
+	v := q.V(fieldPtr) // Get or create the Var
+
+	if !q.findSet[offset] {
+		q.findVars = append(q.findVars, v)
+		q.findSet[offset] = true
+	}
+	return v
+}
+
+// Where creates a QueryBuilder with the accumulated Find clause.
+// The Find clause contains variables added via Find() calls, in call order.
+func (q *TypedQueryBuilder[T]) Where(clauses ...interface{}) *QueryBuilder {
+	findElements := make([]interface{}, len(q.findVars))
+	for i, v := range q.findVars {
+		findElements[i] = v
+	}
+	return Query().Find(findElements...).Where(clauses...)
+}
+
+// fieldOffset computes the offset of fieldPtr from the struct base.
+func (q *TypedQueryBuilder[T]) fieldOffset(fieldPtr any) uintptr {
+	ptr := reflect.ValueOf(fieldPtr).Pointer()
+	base := reflect.ValueOf(&q.F).Pointer()
+	return ptr - base
+}
+
+// findTag looks up the datalog tag for a field by its offset.
+func (q *TypedQueryBuilder[T]) findTag(offset uintptr) string {
+	for _, f := range q.structInfo.fields {
+		if f.offset == offset {
+			return f.tag
+		}
+	}
+	panic(fmt.Sprintf("QueryFor: field at offset %d not found in struct (missing datalog tag?)", offset))
+}
+
+// parseStructVarInfo extracts field metadata from type T.
+func parseStructVarInfo[T any]() *structVarInfo {
+	var zero T
+	t := reflect.TypeOf(zero)
+
+	info := &structVarInfo{}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("datalog")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		// Must be a variable tag (starts with ?)
+		if !isVarTag(tag) {
+			continue
+		}
+		info.fields = append(info.fields, fieldVarInfo{
+			offset: field.Offset,
+			tag:    tag,
+		})
+	}
+	return info
+}
+
+// isVarTag checks if tag is a query variable (starts with ?).
+func isVarTag(tag string) bool {
+	return len(tag) > 0 && tag[0] == '?'
+}

--- a/datalog/qb/subquery.go
+++ b/datalog/qb/subquery.go
@@ -57,9 +57,9 @@ func (c collectionBind) toBindingForm() query.BindingForm {
 // Example:
 //
 //	// Inner query: find max salary for a department
-//	dept := qb.NewVar()
-//	maxSalary := qb.NewVar()
-//	innerSalary := qb.NewVar()
+//	dept := qb.NewVar("dept")
+//	maxSalary := qb.NewVar("maxSalary")
+//	innerSalary := qb.NewVar("innerSalary")
 //
 //	innerQ := qb.Query().
 //	    Find(qb.Max(innerSalary)).
@@ -113,10 +113,26 @@ func (s *SubqueryBuilder) toClause() query.Clause {
 		panic("subquery build failed: " + err.Error())
 	}
 
+	// Check if the inner query expects database input ($)
+	needsDB := false
+	for _, in := range innerQ.In {
+		if _, ok := in.(query.DatabaseInput); ok {
+			needsDB = true
+			break
+		}
+	}
+
 	// Convert input variables to pattern elements
-	inputs := make([]query.PatternElement, len(s.inputs))
-	for i, v := range s.inputs {
-		inputs[i] = query.Variable{Name: v.Symbol()}
+	// If the subquery expects DB, prepend $ to the inputs
+	var inputs []query.PatternElement
+	if needsDB {
+		inputs = make([]query.PatternElement, 0, len(s.inputs)+1)
+		inputs = append(inputs, query.Constant{Value: query.Symbol("$")})
+	} else {
+		inputs = make([]query.PatternElement, 0, len(s.inputs))
+	}
+	for _, v := range s.inputs {
+		inputs = append(inputs, query.Variable{Name: v.Symbol()})
 	}
 
 	// Convert binding form

--- a/datalog/qb/var.go
+++ b/datalog/qb/var.go
@@ -1,9 +1,9 @@
-// Package qb provides a fluent query builder for constructing Datalog queries
-// without string-based variable names. Go variable identity IS the join condition.
+// Package qb provides a fluent query builder for constructing Datalog queries.
+// Variable names are explicit and match struct tags for QueryInto compatibility.
 //
 // Example:
 //
-//	e, name, age := qb.NewVar(), qb.NewVar(), qb.NewVar()
+//	e, name, age := qb.NewVar("e"), qb.NewVar("name"), qb.NewVar("age")
 //	q := qb.Query().
 //	    Find(name, age).
 //	    Where(
@@ -14,7 +14,6 @@
 package qb
 
 import (
-	"fmt"
 	"sync/atomic"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
@@ -28,7 +27,7 @@ var varCounter atomic.Uint64
 //
 // Variables are created with NewVar() and reused across patterns:
 //
-//	e := qb.NewVar()
+//	e := qb.NewVar("e")
 //	qb.Pat(e, PersonName, name)  // e bound here
 //	qb.Pat(e, PersonAge, age)    // same e = implicit join
 type Var struct {
@@ -36,14 +35,22 @@ type Var struct {
 	name query.Symbol
 }
 
-// NewVar creates a new query variable with a unique identity.
-// The variable name is auto-generated (e.g., ?v1, ?v2).
+// NewVar creates a new query variable with the given name.
+// The name can be provided with or without the "?" prefix:
+//
+//	qb.NewVar("name")    // becomes ?name
+//	qb.NewVar("?name")   // also becomes ?name
+//
 // Join semantics come from using the same *Var instance in multiple places.
-func NewVar() *Var {
+func NewVar(name string) *Var {
 	id := varCounter.Add(1)
+	// Normalize: ensure name starts with ?
+	if len(name) > 0 && name[0] != '?' {
+		name = "?" + name
+	}
 	return &Var{
 		id:   id,
-		name: query.Symbol(fmt.Sprintf("?v%d", id)),
+		name: query.Symbol(name),
 	}
 }
 

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -375,7 +375,7 @@ func (d *Database) ClearPlanCache() {
 //
 // Example with query builder:
 //
-//	e, name := qb.NewVar(), qb.NewVar()
+//	e, name := qb.NewVar("e"), qb.NewVar("name")
 //	q := qb.Query().Find(name).Where(qb.Pat(e, PersonName, name)).MustBuild()
 //	results, err := db.ExecuteQuery(q)
 func (d *Database) ExecuteQuery(q interface{}) ([][]interface{}, error) {
@@ -401,7 +401,7 @@ func (d *Database) ExecuteQuery(q interface{}) ([][]interface{}, error) {
 //	)
 //
 //	// Scalar input with query builder
-//	e, name, minAge := qb.NewVar(), qb.NewVar(), qb.NewVar()
+//	e, name, minAge := qb.NewVar("e"), qb.NewVar("name"), qb.NewVar("minAge")
 //	q := qb.Query().Find(e).In(qb.DB, qb.Scalar(minAge)).Where(...).MustBuild()
 //	results, err := db.ExecuteQueryWithInputs(q, 25)
 //
@@ -640,7 +640,7 @@ func (d *Database) Analyze(queryInput interface{}, inputs ...interface{}) (*Anal
 //
 // Example with query builder:
 //
-//	e, name, age := qb.NewVar(), qb.NewVar(), qb.NewVar()
+//	e, name, age := qb.NewVar("e"), qb.NewVar("name"), qb.NewVar("age")
 //	q := qb.Query().Find(name, age).Where(qb.Pat(e, PersonName, name), qb.Pat(e, PersonAge, age)).MustBuild()
 //	err := db.QueryInto(&results, q)
 //

--- a/docs/bugs/SUBQUERY_MISSING_DB.md
+++ b/docs/bugs/SUBQUERY_MISSING_DB.md
@@ -1,0 +1,96 @@
+# Bug: qb.Subquery Does Not Pass Database to Correlated Subqueries
+
+## Summary
+
+When using `qb.Subquery()` with a subquery that declares `qb.DB` in its `In()` clause, the generated EDN omits the database `$` from the subquery invocation. This causes the subquery to receive incorrect inputs, breaking correlated subqueries.
+
+## Expected Behavior
+
+When a subquery is defined with `:in $ ?s` (database + scalar input), and invoked with a correlated variable, the generated EDN should pass both the database and the variable:
+
+```edn
+(q [:find (count ?t)
+    :in $ ?s
+    :where [?t :task/scenario ?s]
+           [?t :task/status :status/complete]]
+   $ ?scenario) [[?taskCount]]]
+;;  ^ database must be passed here
+```
+
+## Actual Behavior
+
+The query builder generates:
+
+```edn
+(q [:find (count ?t)
+    :in $ ?s
+    :where [?t :task/scenario ?s]
+           [?t :task/status :status/complete]]
+   ?scenario) [[?taskCount]]]
+;; ^ missing $ - only variable passed
+```
+
+This causes the subquery to misinterpret `?scenario` as the database, breaking correlation entirely. The subquery runs uncorrelated, returning global aggregates instead of per-row values.
+
+## Reproduction
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/wbrown/janus-datalog/datalog/qb"
+)
+
+func main() {
+	// Outer query variable
+	scenario := qb.NewVar("scenario")
+	taskCount := qb.NewVar("taskCount")
+
+	// Subquery with DB + scalar input
+	t := qb.NewVar("t")
+	s := qb.NewVar("s")
+	subquery := qb.Query().
+		Find(qb.Count(t)).
+		In(qb.DB, qb.Scalar(s)).  // Expects: database, then scalar
+		Where(
+			qb.Pat(t, qb.Kw(":task/scenario"), s),
+			qb.Pat(t, qb.Kw(":task/status"), qb.Kw(":status/complete")),
+		)
+
+	// Main query using correlated subquery
+	q := qb.Query().
+		Find(scenario, taskCount).
+		Where(
+			qb.Pat(scenario, qb.Kw(":scenario/id"), qb.NewVar("_")),
+			qb.Subquery(subquery, scenario).BindTuple(taskCount),
+		).
+		MustBuild()
+
+	fmt.Println("Generated:")
+	fmt.Println(q.String())
+	fmt.Println()
+	fmt.Println("Expected the subquery call to be:")
+	fmt.Println("  (q [...] $ ?scenario) [[?taskCount]]")
+	fmt.Println()
+	fmt.Println("But got:")
+	fmt.Println("  (q [...] ?scenario) [[?taskCount]]")
+	fmt.Println()
+	fmt.Println("The $ is missing!")
+}
+```
+
+## Impact
+
+This bug makes correlated subqueries unusable via the query builder. The workaround is to use raw EDN strings.
+
+## Suggested Fix
+
+In `qb.Subquery()`, when generating the subquery invocation, check if the subquery's `In()` clause includes `qb.DB`. If so, automatically prepend `$` to the inputs list in the generated EDN.
+
+Alternatively, require explicit `qb.DB` in the `Subquery()` call:
+```go
+qb.Subquery(subquery, qb.DB, scenario).BindTuple(taskCount)
+```
+
+The first option (automatic) is cleaner since the subquery already declares it needs the database.

--- a/docs/proposals/query-builder-ergonomics.md
+++ b/docs/proposals/query-builder-ergonomics.md
@@ -1,0 +1,435 @@
+# Query Builder Ergonomics Proposal
+
+## Problem Statement
+
+The current query builder (`qb`) works well for simple queries but becomes verbose and error-prone for complex queries with multiple subqueries, OR fallbacks, and many variables.
+
+Pain points observed in real usage:
+
+1. **Variable declaration noise** - Every variable requires explicit `qb.NewVar("name")` declaration
+2. **No compile-time safety** - Variable names are strings; typos cause runtime failures
+3. **Subquery variable pollution** - Multiple subqueries need unique variable names (`t, t2, t3, t4`)
+4. **Clunky OR syntax** - `[]interface{}{}` wrappers are verbose and ugly
+5. **Find/struct tag mismatch** - Easy to have variable names that don't match QueryInto struct tags
+
+## Proposal 1: Type-Safe Field References with QueryFor[T]
+
+### Concept
+
+Use the result struct itself to provide type-safe variable references. The struct's `datalog` tags define variable names, and pointer-to-field provides compile-time safety.
+
+### API Design
+
+```go
+type QueryFor[T any] struct {
+    F        T                    // zero-valued struct for field references
+    vars     map[uintptr]*Var     // cache: offset -> *Var
+    findVars []*Var               // accumulated Find elements
+    findSet  map[uintptr]bool     // deduplication
+}
+
+// V returns the *Var for a field (reference only, does not add to Find)
+func (q *QueryFor[T]) V(fieldPtr any) *Var
+
+// Find returns the *Var AND adds it to the Find clause
+// First call for a field determines its position in Find
+// Subsequent calls return same *Var without duplicating
+func (q *QueryFor[T]) Find(fieldPtr any) *Var
+```
+
+### Usage Examples
+
+**Basic query:**
+
+```go
+type PersonResult struct {
+    Person datalog.Identity `datalog:"?person"`
+    Name   string           `datalog:"?name"`
+    Age    int64            `datalog:"?age"`
+}
+
+q := qb.QueryFor[PersonResult]()
+f := &q.F
+
+query := q.Where(
+    qb.Pat(q.Find(&f.Person), attrPersonName, q.Find(&f.Name)),
+    qb.Pat(q.V(&f.Person), attrPersonAge, q.Find(&f.Age)),
+    qb.Gt(q.V(&f.Age), 21),
+).MustBuild()
+
+// Generated Find: [?person, ?name, ?age] (order of first q.Find() calls)
+```
+
+**With explicit Find (both modes supported):**
+
+```go
+// Mode 1: Explicit Find at root
+q.Find(q.V(&f.Person), q.V(&f.Name)).
+    Where(...)
+
+// Mode 2: Accumulated from q.Find() calls in Where
+q.Where(
+    qb.Pat(q.Find(&f.Person), attr, q.Find(&f.Name)),
+)
+
+// Mode 3: Mixed - explicit plus accumulated
+q.Find(q.V(&f.Person)).
+    Where(
+        qb.Pat(q.V(&f.Person), attr, q.Find(&f.Name)),
+    )
+// Find = [?person, ?name]
+```
+
+**With OR fallback:**
+
+```go
+q.Where(
+    qb.Pat(q.Find(&f.Scenario), attrScenarioID, q.Find(&f.ID)),
+    qb.Or().
+        Branch(
+            qb.Subquery(statsQuery, q.V(&f.Scenario)).BindTuple(
+                q.Find(&f.TaskCount), q.Find(&f.TotalTokens),
+            ),
+        ).
+        Branch(
+            // Fallback uses V() - vars already in Find from first branch
+            qb.TupleGround(0, 0).As(
+                q.V(&f.TaskCount), q.V(&f.TotalTokens),
+            ),
+        ),
+)
+```
+
+### Implementation Notes
+
+The `V()` and `Find()` methods use reflection to:
+1. Compute pointer offset from struct base address
+2. Find the corresponding struct field
+3. Extract the `datalog` tag
+4. Create/cache a `*Var` with that name
+
+```go
+func (q *QueryFor[T]) V(fieldPtr any) *Var {
+    ptr := reflect.ValueOf(fieldPtr).Pointer()
+    base := reflect.ValueOf(&q.F).Pointer()
+    offset := ptr - base
+
+    if v, ok := q.vars[offset]; ok {
+        return v
+    }
+
+    // Find field by offset, extract datalog tag
+    t := reflect.TypeOf(q.F)
+    for i := 0; i < t.NumField(); i++ {
+        field := t.Field(i)
+        if field.Offset == uintptr(offset) {
+            tag := field.Tag.Get("datalog")
+            v := NewVar(tag)
+            q.vars[offset] = v
+            return v
+        }
+    }
+    panic("field not found in struct")
+}
+```
+
+### What This Solves
+
+- **Type safety**: Rename a struct field and the code won't compile
+- **Tag consistency**: Variable names automatically match struct tags
+- **QueryInto compatibility**: Guaranteed to work since names come from same source
+
+### What Remains Separate
+
+- Subquery internal variables (not in result struct)
+- Intermediate variables used only within the query
+- Attribute constants
+
+---
+
+## Proposal 2: Builder Pattern for OR/OrJoin
+
+### Design Principle
+
+**Users should never write `interface{}` or `[]interface{}` in query builder code.**
+
+### Audit of Current API
+
+Most `interface{}` usage is acceptable because it's hidden in variadic parameters:
+
+| Function | Signature | User Writes | OK? |
+|----------|-----------|-------------|-----|
+| `Find` | `Find(elements ...interface{})` | `Find(name, age)` | Yes |
+| `Where` | `Where(clauses ...interface{})` | `Where(c1, c2)` | Yes |
+| `In` | `In(specs ...interface{})` | `In(qb.DB, qb.Scalar(x))` | Yes |
+| `Not` | `Not(clauses ...interface{})` | `Not(clause)` | Yes |
+| `NotJoin` | `NotJoin(vars []*Var, clauses ...interface{})` | `NotJoin(vars, c1)` | Yes |
+| `Pat` | `Pat(args ...interface{})` | `Pat(e, attr, v)` | Yes |
+| `Lt/Gt/Eq` | `Lt(left, right interface{})` | `Lt(age, 21)` | Yes |
+| `Str` | `Str(parts ...interface{})` | `Str(a, " ", b)` | Yes |
+| **`Or`** | `Or(branches ...[]interface{})` | `Or([]interface{}{...})` | **No** |
+| **`OrJoin`** | `OrJoin(vars, branches ...[]interface{})` | `OrJoin(v, []interface{}{...})` | **No** |
+
+Only `Or` and `OrJoin` require users to write `[]interface{}{}` explicitly.
+
+### Current (Verbose)
+
+```go
+qb.Or(
+    []interface{}{clause1, clause2},
+    []interface{}{clause3, clause4},
+)
+```
+
+### Proposed: Builder Pattern
+
+Use method chaining consistent with the rest of qb:
+
+```go
+qb.Or().
+    Branch(clause1, clause2).
+    Branch(clause3, clause4)
+```
+
+### API Design
+
+```go
+// OrBuilder accumulates branches for an OR clause.
+type OrBuilder struct {
+    branches [][]interface{}
+}
+
+// Or starts building an OR clause.
+func Or() *OrBuilder {
+    return &OrBuilder{}
+}
+
+// Branch adds a branch with one or more clauses.
+func (o *OrBuilder) Branch(clauses ...interface{}) *OrBuilder {
+    o.branches = append(o.branches, clauses)
+    return o
+}
+
+// toClause implements Clause interface - no explicit Build() needed.
+func (o *OrBuilder) toClause() query.Clause { ... }
+
+// OrJoinBuilder for OR with explicit join variables.
+type OrJoinBuilder struct {
+    joinVars []*Var
+    branches [][]interface{}
+}
+
+// OrJoin starts building an OR-JOIN clause with join variables.
+func OrJoin(joinVars ...*Var) *OrJoinBuilder {
+    return &OrJoinBuilder{joinVars: joinVars}
+}
+
+// Branch adds a branch with one or more clauses.
+func (o *OrJoinBuilder) Branch(clauses ...interface{}) *OrJoinBuilder {
+    o.branches = append(o.branches, clauses)
+    return o
+}
+```
+
+### Usage Examples
+
+**Simple OR:**
+
+```go
+qb.Or().
+    Branch(qb.Eq(status, qb.V("active"))).
+    Branch(qb.Eq(status, qb.V("pending")))
+```
+
+**OR with fallback (subquery with default):**
+
+```go
+qb.Or().
+    Branch(qb.Subquery(statsQuery, scenario).BindTuple(taskCount, totalTokens)).
+    Branch(qb.TupleGround(0, 0).As(taskCount, totalTokens))
+```
+
+**OR-JOIN:**
+
+```go
+qb.OrJoin(name).
+    Branch(qb.Pat(e, PersonNickname, name)).
+    Branch(qb.Pat(e, PersonName, name))
+```
+
+**Multi-clause branches:**
+
+```go
+qb.Or().
+    Branch(
+        qb.Pat(user, UserTier, qb.Kw(":tier/premium")),
+        qb.Pat(user, UserStatus, qb.Kw(":status/active")),
+    ).
+    Branch(
+        qb.Pat(user, UserRole, qb.Kw(":role/admin")),
+    )
+```
+
+**Nested OR:**
+
+```go
+qb.Or().
+    Branch(qb.Pat(user, UserStatus, qb.Kw(":status/active"))).
+    Branch(
+        qb.Or().
+            Branch(qb.Pat(user, UserTier, qb.Kw(":tier/premium"))).
+            Branch(qb.Pat(user, UserTier, qb.Kw(":tier/enterprise"))),
+        qb.Not(qb.Pat(user, UserStatus, qb.Kw(":status/banned"))),
+    )
+```
+
+**In a full query:**
+
+```go
+qb.Query().
+    Find(scenario, taskCount).
+    Where(
+        qb.Pat(scenario, ScenarioName, name),
+        qb.Or().
+            Branch(qb.Subquery(statsQuery, scenario).BindTuple(taskCount)).
+            Branch(qb.TupleGround(0).As(taskCount)),
+    ).
+    Build()
+```
+
+### Why Builder Pattern
+
+1. **Consistent with qb style** - Everything else uses method chaining
+2. **No explicit slice types** - `[]interface{}{}` completely eliminated
+3. **Reads naturally** - "Or, branch A, branch B"
+4. **Composable** - Nested Or is just another clause in a Branch
+5. **No terminal method needed** - OrBuilder implements Clause directly
+
+---
+
+## Proposal 3: Subquery Variable Naming
+
+### Non-Problem
+
+This initially seemed like a problem but isn't. Consider this anti-pattern:
+
+```go
+// Anti-pattern: unique Datalog names for each subquery
+t, s := qb.NewVar("t"), qb.NewVar("s")
+t2, s2 := qb.NewVar("t2"), qb.NewVar("s2")
+t3, s3 := qb.NewVar("t3"), qb.NewVar("s3")
+```
+
+This is unnecessary. **Datalog subqueries have lexical scoping.** The `?t` inside one subquery is completely independent of `?t` in another subquery.
+
+Compare to the equivalent EDN, which reuses `?t` and `?s` freely:
+
+```edn
+(or [(q [:find (count ?t) (sum ?tok)
+         :in $ ?s
+         :where [?t :task/scenario ?s] ...]
+        $ ?scenario) [[?taskCount ?totalTokens]]]
+    [(ground [0 0]) [?taskCount ?totalTokens]])
+
+(or [(q [:find (count ?t)
+         :in $ ?s
+         :where [?t :task/scenario ?s]
+                [?t :task/key :scenario/opening] ...]
+        $ ?scenario) [[?openingCount]]]
+    [(ground 0) ?openingCount])
+```
+
+Both subqueries use `?t` and `?s`. No conflict because each subquery is its own scope.
+
+### Correct Pattern
+
+Reuse the same Datalog variable names. Reassign the Go variables between subqueries:
+
+```go
+// Task stats subquery
+t, s := qb.NewVar("t"), qb.NewVar("s")
+tok, dur := qb.NewVar("tok"), qb.NewVar("dur")
+
+taskStatsSubquery := qb.Query().
+    Find(qb.Count(t), qb.Sum(tok), qb.Sum(dur)).
+    In(qb.DB, qb.Scalar(s)).
+    Where(
+        qb.Pat(t, attrTaskScenario, s),
+        qb.Pat(t, attrTaskStatus, kwStatusComplete),
+        qb.GetElse(t, attrTaskTokenCount, 0).As(tok),
+        qb.GetElse(t, attrTaskDuration, 0).As(dur),
+    )
+
+// Opening count subquery - reassign Go vars, reuse Datalog names
+t, s = qb.NewVar("t"), qb.NewVar("s")
+
+openingCountSubquery := qb.Query().
+    Find(qb.Count(t)).
+    In(qb.DB, qb.Scalar(s)).
+    Where(
+        qb.Pat(t, attrTaskScenario, s),
+        qb.Pat(t, attrTaskKey, kwScenarioOpening),
+        qb.Pat(t, attrTaskStatus, kwStatusComplete),
+    )
+```
+
+Both subqueries generate `?t` and `?s` in their EDN output. Datalog's lexical scoping keeps them separate.
+
+### Key Insight
+
+**Go variable uniqueness and Datalog variable uniqueness are separate concerns.**
+
+- Go variables must be unique within Go scope (function/block)
+- Datalog variables are scoped per subquery
+
+You can reassign Go variables (`t, s = ...`) between subqueries while keeping the Datalog names (`?t`, `?s`) the same. This matches how you'd write it in EDN.
+
+### Alternative: Helper Functions
+
+For complex queries, extract subqueries into helper functions:
+
+```go
+func buildTaskStatsSubquery() *qb.QueryBuilder {
+    t, s := qb.NewVar("t"), qb.NewVar("s")
+    tok, dur := qb.NewVar("tok"), qb.NewVar("dur")
+
+    return qb.Query().
+        Find(qb.Count(t), qb.Sum(tok), qb.Sum(dur)).
+        In(qb.DB, qb.Scalar(s)).
+        Where(...)
+}
+
+func buildOpeningCountSubquery() *qb.QueryBuilder {
+    t, s := qb.NewVar("t"), qb.NewVar("s")
+
+    return qb.Query().
+        Find(qb.Count(t)).
+        In(qb.DB, qb.Scalar(s)).
+        Where(...)
+}
+```
+
+Each function has its own Go scope, and each subquery uses the natural `?t`, `?s` names.
+
+### Recommendation
+
+No API changes needed. Document the pattern:
+1. Reuse Datalog variable names (`?t`, `?s`) across subqueries
+2. Reassign Go variables between subquery definitions, or use helper functions
+3. Don't create artificial unique names like `?t2`, `?t3`
+
+---
+
+## Summary
+
+| Proposal | Complexity | Value | Recommendation |
+|----------|------------|-------|----------------|
+| QueryFor[T] with V()/Find() | Medium | High | Implement |
+| Builder pattern for OR/OrJoin | Low-Medium | High | Implement |
+| Subquery variable naming | None | High | Document the pattern |
+
+### Implementation Order
+
+1. **Builder pattern for OR/OrJoin** - Eliminates `[]interface{}{}`, consistent with qb style
+2. **Subquery variable naming** - Documentation only, clarifies a common confusion
+3. **QueryFor[T]** - Larger change, high value, implement after OR builder

--- a/docs/reference/QUERY_BUILDER.md
+++ b/docs/reference/QUERY_BUILDER.md
@@ -16,9 +16,9 @@ var (
 
 func FindAdults(db *storage.Database) ([][]interface{}, error) {
     // Variables are created per-query - same pointer = same logical variable
-    e := qb.NewVar()
-    name := qb.NewVar()
-    age := qb.NewVar()
+    e := qb.NewVar("e")
+    name := qb.NewVar("name")
+    age := qb.NewVar("age")
 
     q := qb.Query().
         Find(name, age).
@@ -86,9 +86,9 @@ q := qb.Query().
 Variables represent unknowns in your query. The same `*Var` pointer used in multiple places creates a join condition.
 
 ```go
-e := qb.NewVar()
-name := qb.NewVar()
-age := qb.NewVar()
+e := qb.NewVar("e")
+name := qb.NewVar("name")
+age := qb.NewVar("age")
 
 // Same variable in multiple patterns = join
 qb.Pat(e, PersonName, name)
@@ -167,7 +167,7 @@ qb.Chained(query.OpLT, a, b, c, d)  // a < b < c < d
 Comparisons can also **bind their boolean result** to a variable using `.As()`:
 
 ```go
-hasItems := qb.NewVar()
+hasItems := qb.NewVar("hasItems")
 
 q := qb.Query().
     Find(name, count, hasItems).
@@ -217,7 +217,7 @@ Expressions compute values and bind them to variables:
 ### Arithmetic
 
 ```go
-total := qb.NewVar()
+total := qb.NewVar("total")
 qb.Add(price, tax).As(total)
 qb.Sub(gross, deductions).As(net)
 qb.Mul(quantity, unitPrice).As(lineTotal)
@@ -227,21 +227,21 @@ qb.Div(total, count).As(average)
 ### String Concatenation
 
 ```go
-fullName := qb.NewVar()
+fullName := qb.NewVar("fullName")
 qb.Str(firstName, " ", lastName).As(fullName)
 ```
 
 ### Ground Values
 
 ```go
-constant := qb.NewVar()
+constant := qb.NewVar("constant")
 qb.Ground(42).As(constant)
 ```
 
 ### Time Extraction
 
 ```go
-y := qb.NewVar()
+y := qb.NewVar("y")
 qb.Year(timestamp).As(y)
 qb.Month(timestamp).As(m)
 qb.Day(timestamp).As(d)
@@ -259,7 +259,7 @@ Database functions access entity attributes with special semantics for missing v
 Returns an attribute value, or a default if the attribute is missing:
 
 ```go
-nickname := qb.NewVar()
+nickname := qb.NewVar("nickname")
 
 q := qb.Query().
     Find(name, nickname).
@@ -295,7 +295,7 @@ Equivalent EDN: `[(missing? $ ?e :person/email)]`
 **As an expression** (bind boolean result):
 
 ```go
-needsEmail := qb.NewVar()
+needsEmail := qb.NewVar("needsEmail")
 
 q := qb.Query().
     Find(name, needsEmail).
@@ -317,7 +317,7 @@ Equivalent EDN: `[(missing? $ ?e :person/email) ?needs-email]`
 Returns the first available attribute from a list (useful for display names, fallbacks):
 
 ```go
-displayName := qb.NewVar()
+displayName := qb.NewVar("displayName")
 
 q := qb.Query().
     Find(name, displayName).
@@ -357,8 +357,8 @@ qb.Relation(nameVar, ageVar)
 ### Scalar Input Example
 
 ```go
-inputName := qb.NewVar()
-age := qb.NewVar()
+inputName := qb.NewVar("inputName")
+age := qb.NewVar("age")
 
 q := qb.Query().
     Find(inputName, age).
@@ -376,8 +376,8 @@ results, err := db.ExecuteQueryWithInputs(q, "Alice")
 ### Collection Input Example
 
 ```go
-inputName := qb.NewVar()
-age := qb.NewVar()
+inputName := qb.NewVar("inputName")
+age := qb.NewVar("age")
 
 q := qb.Query().
     Find(inputName, age).
@@ -395,9 +395,9 @@ results, err := db.ExecuteQueryWithInputs(q, []string{"Alice", "Bob", "Charlie"}
 ### Relation Input Example
 
 ```go
-inputName := qb.NewVar()
-inputCity := qb.NewVar()
-age := qb.NewVar()
+inputName := qb.NewVar("inputName")
+inputCity := qb.NewVar("inputCity")
+age := qb.NewVar("age")
 
 q := qb.Query().
     Find(inputName, inputCity, age).
@@ -475,7 +475,7 @@ innerQ := qb.Query().
     )
 
 // Outer query uses subquery
-maxSalary := qb.NewVar()
+maxSalary := qb.NewVar("maxSalary")
 q := qb.Query().
     Find(name, maxSalary).
     Where(
@@ -541,9 +541,9 @@ type PersonResult struct {
 }
 
 func FindAdults(db *storage.Database) ([]PersonResult, error) {
-    e := qb.NewVar()
-    name := qb.NewVar()
-    age := qb.NewVar()
+    e := qb.NewVar("e")
+    name := qb.NewVar("name")
+    age := qb.NewVar("age")
 
     q := qb.Query().
         Find(name, age).
@@ -566,9 +566,9 @@ For queries that return exactly one result:
 
 ```go
 func FindPerson(db *storage.Database, personName string) (*PersonResult, error) {
-    e := qb.NewVar()
-    name := qb.NewVar()
-    age := qb.NewVar()
+    e := qb.NewVar("e")
+    name := qb.NewVar("name")
+    age := qb.NewVar("age")
 
     q := qb.Query().
         Find(name, age).
@@ -603,9 +603,9 @@ type DeptStats struct {
 }
 
 func GetDeptStats(db *storage.Database) ([]DeptStats, error) {
-    emp := qb.NewVar()
-    dept := qb.NewVar()
-    salary := qb.NewVar()
+    emp := qb.NewVar("emp")
+    dept := qb.NewVar("dept")
+    salary := qb.NewVar("salary")
 
     q := qb.Query().
         Find(dept, qb.Avg(salary), qb.Count(emp)).
@@ -644,10 +644,10 @@ func main() {
     defer db.Close()
 
     // Find adults in specific cities
-    e := qb.NewVar()
-    name := qb.NewVar()
-    age := qb.NewVar()
-    city := qb.NewVar()
+    e := qb.NewVar("e")
+    name := qb.NewVar("name")
+    age := qb.NewVar("age")
+    city := qb.NewVar("city")
 
     q := qb.Query().
         Find(name, age, city).
@@ -678,7 +678,7 @@ func main() {
 
 | Type | Purpose | Example |
 |------|---------|---------|
-| `*Var` | Query variable | `e := qb.NewVar()` |
+| `*Var` | Query variable | `e := qb.NewVar("e")` |
 | `Attr` | Keyword attribute | `PersonName := qb.Kw(":person/name")` |
 | `Val` | Constant value | `qb.V("NYC")`, `qb.V(42)` |
 

--- a/docs/reference/QUERY_BUILDER.md
+++ b/docs/reference/QUERY_BUILDER.md
@@ -660,6 +660,79 @@ func GetDeptStats(db *storage.Database) ([]DeptStats, error) {
 }
 ```
 
+### QueryFor[T] - Type-Safe Variables
+
+The manual approach above has a subtle problem: variable names in `qb.NewVar()` must exactly match the `datalog` struct tags, but nothing enforces this at compile time. Typos cause silent failures.
+
+**QueryFor[T]** solves this by deriving variables directly from struct tags:
+
+```go
+// Define result struct once - tags drive BOTH query building AND result mapping
+type PersonResult struct {
+    Name string `datalog:"?name"`
+    Age  int64  `datalog:"?age"`
+}
+
+func FindAdults(db *storage.Database) ([]PersonResult, error) {
+    // QueryFor derives variables from struct tags
+    q := qb.QueryFor[PersonResult]()
+    f := &q.F
+    e := qb.NewVar("e")
+
+    query := q.Where(
+        qb.Pat(e, PersonName, q.Find(&f.Name)),  // &f.Name -> ?name
+        qb.Pat(e, PersonAge, q.Find(&f.Age)),    // &f.Age -> ?age
+        qb.Gt(q.V(&f.Age), 18),                  // V() references without adding to Find
+    ).MustBuild()
+
+    // Results map directly to struct - tags guaranteed to match
+    var results []PersonResult
+    err := db.QueryInto(&results, query)
+    return results, err
+}
+```
+
+**Key methods:**
+- `q.Find(&f.Field)` - Returns `*Var` AND adds to Find clause
+- `q.V(&f.Field)` - Returns `*Var` without adding to Find (for predicates, join patterns)
+
+**Why this is safer:**
+- Rename struct field → compile error forces you to update all usages
+- Typo in `datalog` tag → caught when QueryInto tests fail
+- No string duplication between query and result mapping
+
+**With aggregations:**
+
+```go
+type DeptStats struct {
+    Dept      string  `datalog:"?dept"`
+    Salary    int64   `datalog:"?salary"`  // base variable
+    AvgSalary float64 // no tag - positional mapping from Find order
+    Count     int64   // no tag - positional mapping from Find order
+    Emp       int64   `datalog:"?emp"`     // base variable
+}
+
+func GetDeptStats(db *storage.Database) ([]DeptStats, error) {
+    q := qb.QueryFor[DeptStats]()
+    f := &q.F
+    e := qb.NewVar("e")
+
+    // V() gives the variable, you wrap it in aggregation
+    query := qb.Query().
+        Find(q.V(&f.Dept), qb.Avg(q.V(&f.Salary)), qb.Count(q.V(&f.Emp))).
+        Where(
+            qb.Pat(e, EmpDept, q.V(&f.Dept)),
+            qb.Pat(e, EmpSalary, q.V(&f.Salary)),
+            qb.Pat(e, EmpID, q.V(&f.Emp)),
+        ).
+        MustBuild()
+
+    var stats []DeptStats
+    err := db.QueryInto(&stats, query)
+    return stats, err
+}
+```
+
 ## Complete Example
 
 ```go
@@ -720,6 +793,7 @@ func main() {
 | `*Var` | Query variable | `e := qb.NewVar("e")` |
 | `Attr` | Keyword attribute | `PersonName := qb.Kw(":person/name")` |
 | `Val` | Constant value | `qb.V("NYC")`, `qb.V(42)` |
+| `*TypedQueryBuilder[T]` | Type-safe builder | `q := qb.QueryFor[PersonResult]()` |
 
 ### Pattern Building
 

--- a/docs/reference/QUERY_BUILDER.md
+++ b/docs/reference/QUERY_BUILDER.md
@@ -489,6 +489,47 @@ Binding forms:
 - `BindRelation(vars...)` - multiple rows `[[?a ?b] ...]`
 - `BindCollection(v)` - single column `[?a ...]`
 
+### Variable Scoping in Subqueries
+
+Datalog subqueries have **lexical scoping** - variables inside a subquery are independent of variables in other subqueries, even if they have the same name. This means you can reuse natural variable names like `?t` and `?s` across subqueries:
+
+```go
+// Good: Reuse Datalog variable names, reassign Go variables between subqueries
+t, s := qb.NewVar("t"), qb.NewVar("s")
+tok, dur := qb.NewVar("tok"), qb.NewVar("dur")
+
+taskStatsQuery := qb.Query().
+    Find(qb.Count(t), qb.Sum(tok), qb.Sum(dur)).
+    In(qb.DB, qb.Scalar(s)).
+    Where(
+        qb.Pat(t, TaskScenario, s),
+        qb.Pat(t, TaskTokens, tok),
+        qb.Pat(t, TaskDuration, dur),
+    )
+
+// Reassign Go variables for second subquery - Datalog names stay the same
+t, s = qb.NewVar("t"), qb.NewVar("s")
+
+openingCountQuery := qb.Query().
+    Find(qb.Count(t)).
+    In(qb.DB, qb.Scalar(s)).
+    Where(
+        qb.Pat(t, TaskScenario, s),
+        qb.Pat(t, TaskKey, KeyOpening),
+    )
+```
+
+Both subqueries generate `?t` and `?s` in their EDN. Datalog's lexical scoping keeps them separate.
+
+**Avoid** creating artificial unique names - this is unnecessary and clutters code:
+
+```go
+// Bad: Unnecessary unique variable names
+t1, s1 := qb.NewVar("t1"), qb.NewVar("s1")
+t2, s2 := qb.NewVar("t2"), qb.NewVar("s2")
+t3, s3 := qb.NewVar("t3"), qb.NewVar("s3")
+```
+
 ## Building Queries
 
 ```go

--- a/docs/reference/QUERY_BUILDER.md
+++ b/docs/reference/QUERY_BUILDER.md
@@ -440,16 +440,14 @@ Match any of several alternatives:
 
 ```go
 // Match NYC or LA
-qb.Or(
-    []interface{}{qb.Pat(e, PersonCity, qb.V("NYC"))},
-    []interface{}{qb.Pat(e, PersonCity, qb.V("LA"))},
-)
+qb.Or().
+    Branch(qb.Pat(e, PersonCity, qb.V("NYC"))).
+    Branch(qb.Pat(e, PersonCity, qb.V("LA")))
 
 // OR with join variables
-qb.OrJoin([]*qb.Var{e, city},
-    []interface{}{qb.Pat(e, PersonCity, city), qb.Eq(city, "NYC")},
-    []interface{}{qb.Pat(e, PersonCity, city), qb.Eq(city, "LA")},
-)
+qb.OrJoin(e, city).
+    Branch(qb.Pat(e, PersonCity, city), qb.Eq(city, "NYC")).
+    Branch(qb.Pat(e, PersonCity, city), qb.Eq(city, "LA"))
 ```
 
 ## Ordering
@@ -750,8 +748,8 @@ func main() {
 |----------|----------------|
 | `qb.Not(clauses...)` | `(not ...)` |
 | `qb.NotJoin(vars, clauses...)` | `(not-join [vars] ...)` |
-| `qb.Or(branch1, branch2)` | `(or ...)` |
-| `qb.OrJoin(vars, branch1, branch2)` | `(or-join [vars] ...)` |
+| `qb.Or().Branch(...).Branch(...)` | `(or ...)` |
+| `qb.OrJoin(vars...).Branch(...).Branch(...)` | `(or-join [vars] ...)` |
 
 ### Ordering
 

--- a/docs/reference/TUPLE_GROUND.md
+++ b/docs/reference/TUPLE_GROUND.md
@@ -57,12 +57,9 @@ Without tuple ground, the fallback requires N separate expressions:
 ```go
 count, tokens, duration := qb.NewVar("count"), qb.NewVar("tokens"), qb.NewVar("duration")
 
-qb.Or(
-    []interface{}{/* subquery branch */},
-    []interface{}{
-        qb.TupleGround(0, 0, 0).As(count, tokens, duration),
-    },
-)
+qb.Or().
+    Branch(/* subquery branch */).
+    Branch(qb.TupleGround(0, 0, 0).As(count, tokens, duration))
 ```
 
 ## Scalar Ground (unchanged)

--- a/docs/reference/TUPLE_GROUND.md
+++ b/docs/reference/TUPLE_GROUND.md
@@ -55,7 +55,7 @@ Without tuple ground, the fallback requires N separate expressions:
 ## Query Builder (qb)
 
 ```go
-count, tokens, duration := qb.NewVar(), qb.NewVar(), qb.NewVar()
+count, tokens, duration := qb.NewVar("count"), qb.NewVar("tokens"), qb.NewVar("duration")
 
 qb.Or(
     []interface{}{/* subquery branch */},

--- a/docs/wip/GO_FUNCTIONS_AND_RULES.md
+++ b/docs/wip/GO_FUNCTIONS_AND_RULES.md
@@ -45,8 +45,8 @@ func InRange(a, b Vec3, r float64) bool {
     return a.DistanceTo(b) < r
 }
 
-playerPos := qb.NewVar()
-rangeVar := qb.NewVar()
+playerPos := qb.NewVar("playerPos")
+rangeVar := qb.NewVar("rangeVar")
 
 q := qb.Query().
     Find(e).
@@ -68,7 +68,7 @@ func CalculateDamage(base, armor int64, multiplier float64) int64 {
     return int64(float64(base-armor) * multiplier)
 }
 
-finalDamage := qb.NewVar()
+finalDamage := qb.NewVar("finalDamage")
 
 q := qb.Query().
     Find(target, finalDamage).
@@ -171,11 +171,11 @@ func ApplyDamage(current, damage int64) int64 {
     return current - damage
 }
 
-attack := qb.NewVar()
-target := qb.NewVar()
-damage := qb.NewVar()
-currentHealth := qb.NewVar()
-newHealth := qb.NewVar()
+attack := qb.NewVar("attack")
+target := qb.NewVar("target")
+damage := qb.NewVar("damage")
+currentHealth := qb.NewVar("currentHealth")
+newHealth := qb.NewVar("newHealth")
 
 damageRule := qb.Rule().
     When(
@@ -194,8 +194,8 @@ damageRule := qb.Rule().
 **Death detection rule**:
 
 ```go
-entity := qb.NewVar()
-health := qb.NewVar()
+entity := qb.NewVar("entity")
+health := qb.NewVar("health")
 
 deathRule := qb.Rule().
     When(
@@ -476,7 +476,7 @@ qb.Rule().
 ### New Entity Creation
 
 ```go
-newEntity := qb.NewVar()
+newEntity := qb.NewVar("newEntity")
 
 qb.Rule().
     When(...).

--- a/tests/subquery_db_bug_test.go
+++ b/tests/subquery_db_bug_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog/qb"
+)
+
+// TestSubqueryMissingDB demonstrates that qb.Subquery does not pass
+// the database ($) to correlated subqueries that declare qb.DB in their In() clause.
+func TestSubqueryMissingDB(t *testing.T) {
+	// Outer query variable
+	scenario := qb.NewVar("scenario")
+	taskCount := qb.NewVar("taskCount")
+
+	// Subquery with DB + scalar input
+	task := qb.NewVar("t")
+	s := qb.NewVar("s")
+	subquery := qb.Query().
+		Find(qb.Count(task)).
+		In(qb.DB, qb.Scalar(s)). // Expects: database, then scalar
+		Where(
+			qb.Pat(task, qb.Kw(":task/scenario"), s),
+			qb.Pat(task, qb.Kw(":task/status"), qb.Kw(":status/complete")),
+		)
+
+	// Main query using correlated subquery
+	q := qb.Query().
+		Find(scenario, taskCount).
+		Where(
+			qb.Pat(scenario, qb.Kw(":scenario/id"), qb.NewVar("id")),
+			qb.Subquery(subquery, scenario).BindTuple(taskCount),
+		).
+		MustBuild()
+
+	generated := q.String()
+
+	// The subquery call should include $ before ?scenario
+	// Expected: (q [...] $ ?scenario) [[?taskCount]]
+	// Actual:   (q [...] ?scenario) [[?taskCount]]
+
+	if !strings.Contains(generated, "$ ?scenario) [[?taskCount]]") {
+		t.Errorf("Subquery invocation missing database $\n\nGenerated:\n%s\n\nExpected to contain: $ ?scenario) [[?taskCount]]", generated)
+	}
+}
+
+// TestSubqueryWithDBGeneratesCorrectEDN verifies the fix once applied.
+func TestSubqueryWithDBGeneratesCorrectEDN(t *testing.T) {
+	outer := qb.NewVar("outer")
+	result := qb.NewVar("result")
+
+	inner := qb.NewVar("inner")
+	input := qb.NewVar("input")
+	subq := qb.Query().
+		Find(qb.Count(inner)).
+		In(qb.DB, qb.Scalar(input)).
+		Where(
+			qb.Pat(inner, qb.Kw(":ref"), input),
+		)
+
+	q := qb.Query().
+		Find(outer, result).
+		Where(
+			qb.Pat(outer, qb.Kw(":id"), qb.NewVar("_")),
+			qb.Subquery(subq, outer).BindTuple(result),
+		).
+		MustBuild()
+
+	generated := q.String()
+
+	// After the fix, this should pass
+	if !strings.Contains(generated, "$ ?outer) [[?result]]") {
+		t.Skipf("Bug not yet fixed - subquery missing $ in: %s", generated)
+	}
+}

--- a/tests/tuple_ground_test.go
+++ b/tests/tuple_ground_test.go
@@ -415,17 +415,16 @@ func TestTupleGroundQBInOr(t *testing.T) {
 		Find(scenario, name, taskCount).
 		Where(
 			qb.Pat(scenario, ScenarioName, name),
-			qb.Or(
-				// Branch 1: scenario has task with count
-				[]interface{}{
+			qb.Or().
+				Branch(
+					// Branch 1: scenario has task with count
 					qb.Pat(scenario, ScenarioTask, task),
 					qb.Pat(task, TaskCount, taskCount),
-				},
-				// Branch 2: fallback with tuple ground
-				[]interface{}{
+				).
+				Branch(
+					// Branch 2: fallback with tuple ground
 					qb.TupleGround(int64(0)).As(taskCount),
-				},
-			),
+				),
 		).MustBuild()
 
 	t.Logf("Query built: %s", q.String())

--- a/tests/tuple_ground_test.go
+++ b/tests/tuple_ground_test.go
@@ -314,13 +314,13 @@ func TestTupleGroundQB(t *testing.T) {
 	}
 
 	// Build query using qb with TupleGround
-	a, b, c := qb.NewVar(), qb.NewVar(), qb.NewVar()
+	a, b, c := qb.NewVar("a"), qb.NewVar("b"), qb.NewVar("c")
 	TestName := qb.Kw(":test/name")
 
 	q := qb.Query().
 		Find(a, b, c).
 		Where(
-			qb.Pat(qb.NewVar(), TestName, qb.Blank()),
+			qb.Pat(qb.NewVar("_e"), TestName, qb.Blank()),
 			qb.TupleGround(int64(1), int64(2), int64(3)).As(a, b, c),
 		).MustBuild()
 
@@ -403,9 +403,9 @@ func TestTupleGroundQBInOr(t *testing.T) {
 	}
 
 	// Build query with OR fallback using TupleGround
-	scenario, name := qb.NewVar(), qb.NewVar()
-	taskCount := qb.NewVar()
-	task := qb.NewVar() // Shared task variable
+	scenario, name := qb.NewVar("scenario"), qb.NewVar("name")
+	taskCount := qb.NewVar("taskCount")
+	task := qb.NewVar("task") // Shared task variable
 
 	ScenarioName := qb.Kw(":scenario/name")
 	ScenarioTask := qb.Kw(":scenario/task")


### PR DESCRIPTION
This PR improves the `qb` (query builder) package with better APIs and type safety.

## Summary

- Require explicit variable names in `NewVar()` for QueryInto compatibility
- Fix subquery DB passing bug
- Replace slice-based Or/OrJoin with builder pattern
- Add `QueryFor[T]` for type-safe variable references from struct tags

## Changes

### 1. Explicit Variable Names (`NewVar`)

`qb.NewVar()` now requires an explicit name parameter:

```go
// Before: auto-generated names like ?v1, ?v2
e := qb.NewVar()
name := qb.NewVar()

// After: explicit names that match QueryInto struct tags
e := qb.NewVar("e")
name := qb.NewVar("name")
```

**Why:** Auto-generated names caused silent mismatches with `QueryInto` struct tags. If your struct has `datalog:"?name"` but the query generated `?v2`, binding fails silently.

### 2. Subquery DB Passing Fix

`qb.Subquery()` now automatically passes `$` to correlated subqueries that declare `qb.DB` in their `In()` clause.

```go
innerQ := qb.Query().
    Find(qb.Max(salary)).
    In(qb.DB, qb.Scalar(dept)).  // declares DB dependency
    Where(...)

// Before: $ was omitted, correlation failed silently
// After: $ automatically included in subquery invocation
qb.Subquery(innerQ, dept).BindTuple(maxSalary)
```

### 3. Or/OrJoin Builder Pattern

Replaced awkward slice syntax with fluent builder pattern:

```go
// Before: verbose []interface{}{} wrappers
qb.Or(
    []interface{}{qb.Pat(e, PersonCity, qb.V("NYC"))},
    []interface{}{qb.Pat(e, PersonCity, qb.V("LA"))},
)

qb.OrJoin([]*qb.Var{e, city},
    []interface{}{...},
    []interface{}{...},
)

// After: clean method chaining
qb.Or().
    Branch(qb.Pat(e, PersonCity, qb.V("NYC"))).
    Branch(qb.Pat(e, PersonCity, qb.V("LA")))

qb.OrJoin(e, city).
    Branch(...).
    Branch(...)
```

### 4. QueryFor[T] - Type-Safe Variables

New `QueryFor[T]` derives query variables from struct `datalog` tags, ensuring they match what `QueryInto` expects:

```go
type PersonResult struct {
    Name string `datalog:"?name"`
    Age  int64  `datalog:"?age"`
}

q := qb.QueryFor[PersonResult]()
f := &q.F
e := qb.NewVar("e")

query := q.Where(
    qb.Pat(e, PersonName, q.Find(&f.Name)),  // &f.Name -> ?name
    qb.Pat(e, PersonAge, q.Find(&f.Age)),    // &f.Age -> ?age
    qb.Gt(q.V(&f.Age), 18),                  // V() references without adding to Find
).MustBuild()

var results []PersonResult
db.QueryInto(&results, query)  // tags guaranteed to match
```

**Key methods:**
- `q.Find(&f.Field)` - Returns `*Var` AND adds to Find clause
- `q.V(&f.Field)` - Returns `*Var` without adding to Find (for predicates, joins)

**Benefits:**
- Rename struct field -> compile error forces update
- Typo in tag -> caught when QueryInto tests fail
- No string duplication between query and result mapping

### 5. Subquery Variable Scoping Documentation

Documents that Datalog subqueries have lexical scoping, so you can reuse natural variable names across subqueries by reassigning Go variables:

```go
t, s := qb.NewVar("t"), qb.NewVar("s")
subquery1 := qb.Query().Find(qb.Count(t)).In(qb.DB, qb.Scalar(s)).Where(...)

t, s = qb.NewVar("t"), qb.NewVar("s")  // reassign, same Datalog names
subquery2 := qb.Query().Find(qb.Count(t)).In(qb.DB, qb.Scalar(s)).Where(...)
```

## Files Changed

| File | Description |
|------|-------------|
| `datalog/qb/var.go` | NewVar now requires explicit name |
| `datalog/qb/subquery.go` | Auto-pass $ to correlated subqueries |
| `datalog/qb/clause.go` | Or/OrJoin builder pattern |
| `datalog/qb/query_for.go` | New QueryFor[T] implementation |
| `datalog/qb/doc.go` | Package documentation updates |
| `datalog/qb/qb_test.go` | Tests for all new functionality |
| `datalog/qb/integration_test.go` | Updated to use explicit var names |
| `docs/reference/QUERY_BUILDER.md` | Comprehensive documentation |
| `docs/reference/TUPLE_GROUND.md` | Updated Or syntax |
| `docs/bugs/SUBQUERY_MISSING_DB.md` | Bug documentation |
| `docs/proposals/query-builder-ergonomics.md` | Design proposal |

## Testing

All existing tests updated and passing. New tests added for:
- QueryFor basic usage
- V() vs Find() distinction
- Join semantics (same field returns same *Var)
- Find order matches call order
- Aggregate tags ignored
- Find() deduplication