### PR TITLE
Add pull-in-query integration and query builder pull patterns

### DIFF
--- a/datalog/executor/pull.go
+++ b/datalog/executor/pull.go
@@ -130,10 +130,14 @@ func (pe *PullExecutor) processSpec(entity datalog.Identity, spec query.PullAttr
 		}
 
 	case *query.PullLimitExpr:
-		// For cardinality-many (future), limit results
-		// Currently just lookup single value
-		if val, ok := pe.lookupAttribute(entity, s.Attr); ok {
-			result[query.KeyName(s.Attr)] = val
+		// Get all values and apply limit
+		// Using limit implies cardinality-many expectation
+		values := pe.lookupAllValues(entity, s.Attr)
+		if len(values) > s.Limit && s.Limit > 0 {
+			values = values[:s.Limit]
+		}
+		if len(values) > 0 {
+			result[query.KeyName(s.Attr)] = values
 		}
 
 	case *query.PullDefaultExpr:

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -1009,6 +1009,12 @@ func (e *DefaultQueryExecutor) executePulls(rel Relation, find []query.FindEleme
 				return nil, fmt.Errorf("pull failed for %s: %w", pull.Variable, err)
 			}
 
+			// Add the entity ID to the pull result so it can be mapped to struct fields
+			// tagged with datalog:"db/id" or datalog:":db/id"
+			if pulled != nil {
+				pulled[query.DBIDKey] = entity
+			}
+
 			// Replace entity with pulled map (nil if entity not found)
 			newTuple[colIdx] = pulled
 		}

--- a/datalog/qb/pull.go
+++ b/datalog/qb/pull.go
@@ -1,0 +1,163 @@
+package qb
+
+import (
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// PullExpr represents a pull expression for use in Find().
+// Pull expressions retrieve attributes of an entity.
+type PullExpr struct {
+	variable *Var
+	pattern  *query.PullPattern
+}
+
+// PullSpec is the interface for pull pattern specifications.
+// Implementations: Attr (simple attribute), PullLimit, PullDefault, PullRef
+type PullSpec interface {
+	toPullAttrSpec() query.PullAttrSpec
+}
+
+// Make Attr implement PullSpec so it can be used directly in Pull()
+func (a Attr) toPullAttrSpec() query.PullAttrSpec {
+	return &query.PullAttribute{Attr: a.kw}
+}
+
+// PullLimit represents a limit expression for cardinality-many attributes.
+type PullLimit struct {
+	keyword datalog.Keyword
+	limit   int
+}
+
+func (p PullLimit) toPullAttrSpec() query.PullAttrSpec {
+	return &query.PullLimitExpr{Attr: p.keyword, Limit: p.limit}
+}
+
+// PullDefault represents a default value for missing attributes.
+type PullDefault struct {
+	keyword      datalog.Keyword
+	defaultValue interface{}
+}
+
+func (p PullDefault) toPullAttrSpec() query.PullAttrSpec {
+	return &query.PullDefaultExpr{Attr: p.keyword, Default: p.defaultValue}
+}
+
+// PullRef represents a nested reference pull (follows ref and pulls nested attrs).
+type PullRef struct {
+	keyword datalog.Keyword
+	specs   []PullSpec
+}
+
+func (p PullRef) toPullAttrSpec() query.PullAttrSpec {
+	nestedSpecs := make([]query.PullAttrSpec, len(p.specs))
+	for i, spec := range p.specs {
+		nestedSpecs[i] = spec.toPullAttrSpec()
+	}
+	return &query.PullMapSpec{
+		Attr:    p.keyword,
+		Pattern: &query.PullPattern{Specs: nestedSpecs},
+	}
+}
+
+// Limit creates a limit expression for cardinality-many attributes.
+//
+// Example:
+//
+//	PersonTags := qb.Kw(":person/tags")
+//	Pull(e, PersonName, Limit(PersonTags, 5))
+//	// → (pull ?e [:person/name (limit :person/tags 5)])
+func Limit(attr interface{}, limit int) PullLimit {
+	return PullLimit{keyword: attrToKeyword(attr), limit: limit}
+}
+
+// Default creates a default value spec for missing attributes.
+//
+// Example:
+//
+//	PersonStatus := qb.Kw(":person/status")
+//	Pull(e, PersonName, Default(PersonStatus, "active"))
+//	// → (pull ?e [:person/name (default :person/status "active")])
+func Default(attr interface{}, defaultValue interface{}) PullDefault {
+	return PullDefault{keyword: attrToKeyword(attr), defaultValue: defaultValue}
+}
+
+// Ref creates a nested reference pull that follows a ref attribute
+// and pulls nested attributes from the referenced entity.
+//
+// Example:
+//
+//	PersonDept := qb.Kw(":person/dept")
+//	DeptName := qb.Kw(":dept/name")
+//	DeptCode := qb.Kw(":dept/code")
+//	Pull(e, PersonName, Ref(PersonDept, DeptName, DeptCode))
+//	// → (pull ?e [:person/name {:person/dept [:dept/name :dept/code]}])
+func Ref(attr interface{}, specs ...PullSpec) PullRef {
+	return PullRef{keyword: attrToKeyword(attr), specs: specs}
+}
+
+// Pull creates a pull expression for use in Find().
+//
+// With no arguments, pulls all attributes (wildcard):
+//
+//	Pull(e)  // → (pull ?e [*])
+//
+// With specific attributes (use Kw to define attributes):
+//
+//	PersonName := qb.Kw(":person/name")
+//	PersonAge := qb.Kw(":person/age")
+//	Pull(e, PersonName, PersonAge)
+//	// → (pull ?e [:person/name :person/age])
+//
+// With limit, default, and nested refs:
+//
+//	Pull(e,
+//	    PersonName,
+//	    Limit(PersonTags, 5),
+//	    Default(PersonStatus, "active"),
+//	    Ref(PersonDept, DeptName),
+//	)
+func Pull(v *Var, specs ...PullSpec) PullExpr {
+	var pattern *query.PullPattern
+
+	if len(specs) == 0 {
+		// No specs = wildcard [*]
+		pattern = &query.PullPattern{
+			Specs: []query.PullAttrSpec{&query.PullWildcard{}},
+		}
+	} else {
+		// Convert specs to query.PullAttrSpec
+		attrSpecs := make([]query.PullAttrSpec, len(specs))
+		for i, spec := range specs {
+			attrSpecs[i] = spec.toPullAttrSpec()
+		}
+		pattern = &query.PullPattern{Specs: attrSpecs}
+	}
+
+	return PullExpr{
+		variable: v,
+		pattern:  pattern,
+	}
+}
+
+// toFindElement converts PullExpr to a query.FindElement
+func (p PullExpr) toFindElement() query.FindElement {
+	return query.FindPull{
+		Variable: p.variable.Symbol(),
+		Pattern:  p.pattern,
+	}
+}
+
+// attrToKeyword converts Attr or string to a datalog.Keyword
+func attrToKeyword(v interface{}) datalog.Keyword {
+	switch k := v.(type) {
+	case Attr:
+		return k.kw
+	case datalog.Keyword:
+		return k
+	case string:
+		return datalog.NewKeyword(k)
+	default:
+		panic("expected Attr, Keyword, or string for pull attribute")
+	}
+}

--- a/datalog/qb/pull_test.go
+++ b/datalog/qb/pull_test.go
@@ -1,0 +1,330 @@
+package qb
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+func TestPull_Wildcard(t *testing.T) {
+	e := NewVar("e")
+	pull := Pull(e)
+
+	elem := pull.toFindElement()
+	findPull, ok := elem.(query.FindPull)
+	if !ok {
+		t.Fatalf("expected FindPull, got %T", elem)
+	}
+
+	if findPull.Variable.String() != "?e" {
+		t.Errorf("expected variable ?e, got %s", findPull.Variable.String())
+	}
+
+	if len(findPull.Pattern.Specs) != 1 {
+		t.Fatalf("expected 1 spec, got %d", len(findPull.Pattern.Specs))
+	}
+
+	if _, ok := findPull.Pattern.Specs[0].(*query.PullWildcard); !ok {
+		t.Errorf("expected PullWildcard, got %T", findPull.Pattern.Specs[0])
+	}
+}
+
+func TestPull_SpecificAttributes(t *testing.T) {
+	e := NewVar("e")
+	PersonName := Kw(":person/name")
+	PersonAge := Kw(":person/age")
+
+	pull := Pull(e, PersonName, PersonAge)
+
+	elem := pull.toFindElement()
+	findPull, ok := elem.(query.FindPull)
+	if !ok {
+		t.Fatalf("expected FindPull, got %T", elem)
+	}
+
+	if len(findPull.Pattern.Specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(findPull.Pattern.Specs))
+	}
+
+	attr1, ok := findPull.Pattern.Specs[0].(*query.PullAttribute)
+	if !ok {
+		t.Fatalf("expected PullAttribute, got %T", findPull.Pattern.Specs[0])
+	}
+	if attr1.Attr.String() != ":person/name" {
+		t.Errorf("expected :person/name, got %s", attr1.Attr.String())
+	}
+
+	attr2, ok := findPull.Pattern.Specs[1].(*query.PullAttribute)
+	if !ok {
+		t.Fatalf("expected PullAttribute, got %T", findPull.Pattern.Specs[1])
+	}
+	if attr2.Attr.String() != ":person/age" {
+		t.Errorf("expected :person/age, got %s", attr2.Attr.String())
+	}
+}
+
+func TestPull_Limit(t *testing.T) {
+	e := NewVar("e")
+	PersonName := Kw(":person/name")
+	PersonTags := Kw(":person/tags")
+
+	pull := Pull(e, PersonName, Limit(PersonTags, 5))
+
+	elem := pull.toFindElement()
+	findPull := elem.(query.FindPull)
+
+	if len(findPull.Pattern.Specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(findPull.Pattern.Specs))
+	}
+
+	limitExpr, ok := findPull.Pattern.Specs[1].(*query.PullLimitExpr)
+	if !ok {
+		t.Fatalf("expected PullLimitExpr, got %T", findPull.Pattern.Specs[1])
+	}
+	if limitExpr.Attr.String() != ":person/tags" {
+		t.Errorf("expected :person/tags, got %s", limitExpr.Attr.String())
+	}
+	if limitExpr.Limit != 5 {
+		t.Errorf("expected limit=5, got %d", limitExpr.Limit)
+	}
+}
+
+func TestPull_LimitWithString(t *testing.T) {
+	e := NewVar("e")
+	// Test that strings also work
+	pull := Pull(e, Limit(":person/tags", 3))
+
+	elem := pull.toFindElement()
+	findPull := elem.(query.FindPull)
+
+	limitExpr := findPull.Pattern.Specs[0].(*query.PullLimitExpr)
+	if limitExpr.Attr.String() != ":person/tags" {
+		t.Errorf("expected :person/tags, got %s", limitExpr.Attr.String())
+	}
+	if limitExpr.Limit != 3 {
+		t.Errorf("expected limit=3, got %d", limitExpr.Limit)
+	}
+}
+
+func TestPull_Default(t *testing.T) {
+	e := NewVar("e")
+	PersonName := Kw(":person/name")
+	PersonStatus := Kw(":person/status")
+
+	pull := Pull(e, PersonName, Default(PersonStatus, "active"))
+
+	elem := pull.toFindElement()
+	findPull := elem.(query.FindPull)
+
+	if len(findPull.Pattern.Specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(findPull.Pattern.Specs))
+	}
+
+	defaultExpr, ok := findPull.Pattern.Specs[1].(*query.PullDefaultExpr)
+	if !ok {
+		t.Fatalf("expected PullDefaultExpr, got %T", findPull.Pattern.Specs[1])
+	}
+	if defaultExpr.Attr.String() != ":person/status" {
+		t.Errorf("expected :person/status, got %s", defaultExpr.Attr.String())
+	}
+	if defaultExpr.Default != "active" {
+		t.Errorf("expected default='active', got %v", defaultExpr.Default)
+	}
+}
+
+func TestPull_NestedRef(t *testing.T) {
+	e := NewVar("e")
+	PersonName := Kw(":person/name")
+	PersonDept := Kw(":person/dept")
+	DeptName := Kw(":dept/name")
+	DeptCode := Kw(":dept/code")
+
+	pull := Pull(e,
+		PersonName,
+		Ref(PersonDept, DeptName, DeptCode),
+	)
+
+	elem := pull.toFindElement()
+	findPull := elem.(query.FindPull)
+
+	if len(findPull.Pattern.Specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(findPull.Pattern.Specs))
+	}
+
+	mapSpec, ok := findPull.Pattern.Specs[1].(*query.PullMapSpec)
+	if !ok {
+		t.Fatalf("expected PullMapSpec, got %T", findPull.Pattern.Specs[1])
+	}
+	if mapSpec.Attr.String() != ":person/dept" {
+		t.Errorf("expected :person/dept, got %s", mapSpec.Attr.String())
+	}
+
+	// Check nested pattern
+	if len(mapSpec.Pattern.Specs) != 2 {
+		t.Fatalf("expected 2 nested specs, got %d", len(mapSpec.Pattern.Specs))
+	}
+
+	nestedAttr1, ok := mapSpec.Pattern.Specs[0].(*query.PullAttribute)
+	if !ok {
+		t.Fatalf("expected PullAttribute, got %T", mapSpec.Pattern.Specs[0])
+	}
+	if nestedAttr1.Attr.String() != ":dept/name" {
+		t.Errorf("expected :dept/name, got %s", nestedAttr1.Attr.String())
+	}
+}
+
+func TestPull_DeepNesting(t *testing.T) {
+	// Test deeply nested refs
+	e := NewVar("e")
+	PersonCompany := Kw(":person/company")
+	CompanyName := Kw(":company/name")
+	CompanyCEO := Kw(":company/ceo")
+	PersonName := Kw(":person/name")
+
+	pull := Pull(e,
+		Ref(PersonCompany,
+			CompanyName,
+			Ref(CompanyCEO,
+				PersonName,
+			),
+		),
+	)
+
+	elem := pull.toFindElement()
+	findPull := elem.(query.FindPull)
+
+	mapSpec := findPull.Pattern.Specs[0].(*query.PullMapSpec)
+	if mapSpec.Attr.String() != ":person/company" {
+		t.Errorf("expected :person/company, got %s", mapSpec.Attr.String())
+	}
+
+	// Check second level nesting
+	nestedMapSpec, ok := mapSpec.Pattern.Specs[1].(*query.PullMapSpec)
+	if !ok {
+		t.Fatalf("expected nested PullMapSpec, got %T", mapSpec.Pattern.Specs[1])
+	}
+	if nestedMapSpec.Attr.String() != ":company/ceo" {
+		t.Errorf("expected :company/ceo, got %s", nestedMapSpec.Attr.String())
+	}
+
+	// Check deepest level
+	deepAttr := nestedMapSpec.Pattern.Specs[0].(*query.PullAttribute)
+	if deepAttr.Attr.String() != ":person/name" {
+		t.Errorf("expected :person/name, got %s", deepAttr.Attr.String())
+	}
+}
+
+func TestPull_InQuery(t *testing.T) {
+	e := NewVar("e")
+	name := NewVar("name")
+	PersonName := Kw(":person/name")
+	PersonAge := Kw(":person/age")
+
+	// Build a query with pull in Find
+	q := Query().
+		Find(Pull(e, PersonName, PersonAge)).
+		Where(
+			Pat(e, PersonName, name),
+		).
+		MustBuild()
+
+	if len(q.Find) != 1 {
+		t.Fatalf("expected 1 find element, got %d", len(q.Find))
+	}
+
+	findPull, ok := q.Find[0].(query.FindPull)
+	if !ok {
+		t.Fatalf("expected FindPull, got %T", q.Find[0])
+	}
+
+	if len(findPull.Pattern.Specs) != 2 {
+		t.Errorf("expected 2 pull specs, got %d", len(findPull.Pattern.Specs))
+	}
+}
+
+func TestPull_MixedFind(t *testing.T) {
+	e := NewVar("e")
+	name := NewVar("name")
+	PersonName := Kw(":person/name")
+	PersonAge := Kw(":person/age")
+
+	// Mix regular variable and pull in Find
+	q := Query().
+		Find(name, Pull(e, PersonAge)).
+		Where(
+			Pat(e, PersonName, name),
+		).
+		MustBuild()
+
+	if len(q.Find) != 2 {
+		t.Fatalf("expected 2 find elements, got %d", len(q.Find))
+	}
+
+	// First should be variable
+	if _, ok := q.Find[0].(query.FindVariable); !ok {
+		t.Errorf("expected FindVariable, got %T", q.Find[0])
+	}
+
+	// Second should be pull
+	if _, ok := q.Find[1].(query.FindPull); !ok {
+		t.Errorf("expected FindPull, got %T", q.Find[1])
+	}
+}
+
+func TestPull_PatternString(t *testing.T) {
+	e := NewVar("e")
+	PersonName := Kw(":person/name")
+	PersonAge := Kw(":person/age")
+	PersonTags := Kw(":person/tags")
+	PersonStatus := Kw(":person/status")
+	PersonDept := Kw(":person/dept")
+	DeptName := Kw(":dept/name")
+
+	tests := []struct {
+		name     string
+		pull     PullExpr
+		expected string
+	}{
+		{
+			name:     "wildcard",
+			pull:     Pull(e),
+			expected: "(pull ?e [*])",
+		},
+		{
+			name:     "single attr",
+			pull:     Pull(e, PersonName),
+			expected: "(pull ?e [:person/name])",
+		},
+		{
+			name:     "multiple attrs",
+			pull:     Pull(e, PersonName, PersonAge),
+			expected: "(pull ?e [:person/name :person/age])",
+		},
+		{
+			name:     "with limit",
+			pull:     Pull(e, Limit(PersonTags, 5)),
+			expected: "(pull ?e [(limit :person/tags 5)])",
+		},
+		{
+			name:     "with default",
+			pull:     Pull(e, Default(PersonStatus, "active")),
+			expected: "(pull ?e [(default :person/status active)])",
+		},
+		{
+			name:     "nested ref",
+			pull:     Pull(e, Ref(PersonDept, DeptName)),
+			expected: "(pull ?e [{:person/dept [:dept/name]}])",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elem := tt.pull.toFindElement()
+			findPull := elem.(query.FindPull)
+			got := findPull.String()
+			if got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}

--- a/datalog/query/pull.go
+++ b/datalog/query/pull.go
@@ -116,6 +116,20 @@ func KeyName(k datalog.Keyword) string {
 	return s
 }
 
+// KeyNameFromString returns the attribute name without the leading colon
+// e.g., ":entity/name" -> "entity/name", "entity/name" -> "entity/name"
+func KeyNameFromString(s string) string {
+	if len(s) > 0 && s[0] == ':' {
+		return s[1:]
+	}
+	return s
+}
+
+// DBIDKey is the map key for entity ID in pull results.
+// This corresponds to the :db/id attribute but without the leading colon,
+// consistent with how all pull result keys are formatted.
+const DBIDKey = "db/id"
+
 // ============================================================================
 // Resolved Pull Types
 // ============================================================================

--- a/datalog/reflect/query_reader.go
+++ b/datalog/reflect/query_reader.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
 // Errors for query result mapping
@@ -33,13 +34,26 @@ type QueryFieldMapping struct {
 
 // QueryResultMapper handles query result -> struct conversion
 type QueryResultMapper struct {
-	elemType reflect.Type
-	mappings []QueryFieldMapping
+	elemType      reflect.Type
+	mappings      []QueryFieldMapping // Query variable mappings (with ColIndex set)
+	pullMappings  []QueryFieldMapping // Attribute tag mappings (for pull result maps)
+	isPullMapping bool                // true if struct uses ONLY attribute-style tags
 }
 
 // NewQueryResultMapper creates a mapper from struct type and :find column names.
 // The findColumns should be the string representations of FindElements
 // (e.g., "?name", "(sum ?salary)").
+//
+// The mapper supports three modes:
+// 1. Query-style tags only (`datalog:"?name"`) - maps query result columns to struct fields
+// 2. Attribute-style tags only (`datalog:"person/name"`) - maps pull result maps to struct fields
+// 3. Mixed mode - both query-style AND attribute-style tags in the same struct
+//
+// For pure attribute-style structs, the query should return a pull expression column
+// like `[:find (pull ?e [*]) :where ...]`.
+//
+// For mixed mode, use queries like `[:find ?name (pull ?e [:person/age]) :where ...]`
+// where query variables map to their columns and attribute tags map from the pull result.
 func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryResultMapper, error) {
 	// Handle pointer to struct
 	if elemType.Kind() == reflect.Ptr {
@@ -56,10 +70,10 @@ func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryRe
 		colIndex[col] = i
 	}
 
-	// Parse struct fields
-	mappings := make([]QueryFieldMapping, 0)
-	hasTagged := false
-	hasUntagged := false
+	// Parse struct fields into query mappings and attribute (pull) mappings
+	queryMappings := make([]QueryFieldMapping, 0)
+	pullMappings := make([]QueryFieldMapping, 0)
+	untaggedMappings := make([]QueryFieldMapping, 0)
 
 	for i := 0; i < elemType.NumField(); i++ {
 		field := elemType.Field(i)
@@ -71,8 +85,8 @@ func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryRe
 
 		tag := field.Tag.Get("datalog")
 
-		// Skip fields marked with "-" or ID fields
-		if tag == "-" || strings.HasSuffix(tag, ",id") {
+		// Skip fields marked with "-" or starting with "-," (e.g., "-,id" for legacy compat)
+		if tag == "-" || strings.HasPrefix(tag, "-,") {
 			continue
 		}
 
@@ -86,7 +100,6 @@ func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryRe
 		// Check if this is a query symbol tag (starts with ? or ()
 		if isQueryTag(tag) {
 			mapping.Tag = tag
-			hasTagged = true
 
 			// Look up column index
 			idx, found := colIndex[tag]
@@ -95,37 +108,81 @@ func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryRe
 					ErrSymbolNotFound, field.Name, tag, findColumns)
 			}
 			mapping.ColIndex = idx
+			queryMappings = append(queryMappings, mapping)
 		} else if tag == "" {
 			// No tag - will use positional mapping
-			hasUntagged = true
+			untaggedMappings = append(untaggedMappings, mapping)
 		} else {
-			// Has a tag but it's an attribute tag (e.g., "person/name"), not a query tag
-			// Skip this field for query mapping
-			continue
+			// Has an attribute-style tag (e.g., "person/name", "db/id")
+			// These are used for pull result mapping
+			mapping.Tag = tag
+			pullMappings = append(pullMappings, mapping)
 		}
-
-		mappings = append(mappings, mapping)
 	}
 
-	// Check for mixed tags
-	if hasTagged && hasUntagged {
+	hasQueryTags := len(queryMappings) > 0
+	hasAttributeTags := len(pullMappings) > 0
+	hasUntagged := len(untaggedMappings) > 0
+
+	// Check for mixed query tags and untagged fields (not allowed)
+	if hasQueryTags && hasUntagged {
 		return nil, fmt.Errorf("%w: either all fields should have query tags (e.g., `datalog:\"?name\"`) or none",
 			ErrMixedTags)
 	}
 
-	// Apply positional mapping if no tags
-	if hasUntagged {
-		for i := range mappings {
-			if i < len(findColumns) {
-				mappings[i].ColIndex = i
-				mappings[i].Tag = findColumns[i] // For error messages
-			}
-		}
+	// Pure pull mapping mode: only attribute-style tags
+	if hasAttributeTags && !hasQueryTags && !hasUntagged {
+		return &QueryResultMapper{
+			elemType:      elemType,
+			mappings:      nil,
+			pullMappings:  pullMappings,
+			isPullMapping: true,
+		}, nil
 	}
 
+	// Mixed mode: query tags AND attribute tags
+	// Query variables map from tuple columns, attribute tags map from pull result in tuple
+	if hasQueryTags && hasAttributeTags {
+		return &QueryResultMapper{
+			elemType:      elemType,
+			mappings:      queryMappings,
+			pullMappings:  pullMappings,
+			isPullMapping: false,
+		}, nil
+	}
+
+	// Pure query mode: only query tags
+	if hasQueryTags {
+		return &QueryResultMapper{
+			elemType:      elemType,
+			mappings:      queryMappings,
+			pullMappings:  nil,
+			isPullMapping: false,
+		}, nil
+	}
+
+	// Positional mapping: no tags at all
+	if hasUntagged {
+		for i := range untaggedMappings {
+			if i < len(findColumns) {
+				untaggedMappings[i].ColIndex = i
+				untaggedMappings[i].Tag = findColumns[i] // For error messages
+			}
+		}
+		return &QueryResultMapper{
+			elemType:      elemType,
+			mappings:      untaggedMappings,
+			pullMappings:  nil,
+			isPullMapping: false,
+		}, nil
+	}
+
+	// No fields to map
 	return &QueryResultMapper{
-		elemType: elemType,
-		mappings: mappings,
+		elemType:      elemType,
+		mappings:      nil,
+		pullMappings:  nil,
+		isPullMapping: false,
 	}, nil
 }
 
@@ -159,6 +216,19 @@ func (m *QueryResultMapper) MapTuple(tuple []interface{}, dest reflect.Value) er
 		return fmt.Errorf("expected struct, got %s", dest.Kind())
 	}
 
+	// Pure pull mapping mode: expect a map value in the tuple
+	if m.isPullMapping {
+		if len(tuple) == 0 {
+			return fmt.Errorf("pull mapping expects at least one column, got empty tuple")
+		}
+		pullMap := m.findPullMap(tuple)
+		if pullMap == nil {
+			return fmt.Errorf("pull mapping expects map[string]interface{} in tuple, got %T", tuple[0])
+		}
+		return m.mapPullResult(pullMap, dest)
+	}
+
+	// Map query variable fields from tuple columns
 	for _, mapping := range m.mappings {
 		if mapping.ColIndex < 0 || mapping.ColIndex >= len(tuple) {
 			continue // Skip unmapped or out-of-range columns
@@ -169,6 +239,53 @@ func (m *QueryResultMapper) MapTuple(tuple []interface{}, dest reflect.Value) er
 
 		if err := setQueryValue(fieldVal, mapping.FieldType, value); err != nil {
 			return fmt.Errorf("field %s (tag %s): %w", mapping.FieldName, mapping.Tag, err)
+		}
+	}
+
+	// Mixed mode: also map attribute-tagged fields from pull result in tuple
+	if len(m.pullMappings) > 0 {
+		pullMap := m.findPullMap(tuple)
+		if pullMap != nil {
+			if err := m.mapPullResult(pullMap, dest); err != nil {
+				return err
+			}
+		}
+		// If no pull map found but we have pull mappings, leave those fields as zero values
+		// This is lenient - user might have attribute tags but no pull in this particular query
+	}
+
+	return nil
+}
+
+// findPullMap searches for the first map[string]interface{} in the tuple
+func (m *QueryResultMapper) findPullMap(tuple []interface{}) map[string]interface{} {
+	for _, val := range tuple {
+		if pm, ok := val.(map[string]interface{}); ok {
+			return pm
+		}
+	}
+	return nil
+}
+
+// mapPullResult populates a struct from a pull result map using attribute-style tags.
+// All attributes are treated uniformly - the entity ID uses tag "db/id" or ":db/id"
+// just like any other attribute (e.g., "person/name" or ":person/name").
+func (m *QueryResultMapper) mapPullResult(pullMap map[string]interface{}, dest reflect.Value) error {
+	for _, mapping := range m.pullMappings {
+		// Normalize the tag to map key format (strip leading colon if present)
+		// This matches how pull results store keys via query.KeyName()
+		attrKey := query.KeyNameFromString(mapping.Tag)
+
+		// Look up value in pull map
+		val, ok := pullMap[attrKey]
+		if !ok {
+			// Field not in pull result - leave as zero value
+			continue
+		}
+
+		fieldVal := dest.Field(mapping.FieldIndex)
+		if err := setQueryValue(fieldVal, mapping.FieldType, val); err != nil {
+			return fmt.Errorf("field %s (attr %s): %w", mapping.FieldName, attrKey, err)
 		}
 	}
 
@@ -340,9 +457,40 @@ func setQueryValue(fieldVal reflect.Value, fieldType reflect.Type, value interfa
 				return fmt.Errorf("expected []byte, got %T", value)
 			}
 			fieldVal.SetBytes(b)
-		} else {
-			return fmt.Errorf("unsupported slice type: %s", fieldType)
+			return nil
 		}
+
+		// Handle slice values from pull results (cardinality-many attributes)
+		// Pull returns []interface{} that we need to convert to the target type
+		srcSlice, ok := value.([]interface{})
+		if !ok {
+			// Value might already be the correct slice type
+			srcVal := reflect.ValueOf(value)
+			if srcVal.Kind() == reflect.Slice {
+				// Try direct assignment if types match
+				if srcVal.Type().AssignableTo(fieldType) {
+					fieldVal.Set(srcVal)
+					return nil
+				}
+				// Convert element by element
+				srcSlice = make([]interface{}, srcVal.Len())
+				for i := 0; i < srcVal.Len(); i++ {
+					srcSlice[i] = srcVal.Index(i).Interface()
+				}
+			} else {
+				return fmt.Errorf("expected slice, got %T", value)
+			}
+		}
+
+		// Create new slice and populate
+		elemType := fieldType.Elem()
+		newSlice := reflect.MakeSlice(fieldType, len(srcSlice), len(srcSlice))
+		for i, elem := range srcSlice {
+			if err := setQueryValue(newSlice.Index(i), elemType, elem); err != nil {
+				return fmt.Errorf("slice element %d: %w", i, err)
+			}
+		}
+		fieldVal.Set(newSlice)
 
 	default:
 		return fmt.Errorf("unsupported type: %s", fieldType)

--- a/datalog/reflect/query_reader_test.go
+++ b/datalog/reflect/query_reader_test.go
@@ -166,21 +166,35 @@ func TestNewQueryResultMapper_SymbolNotFound(t *testing.T) {
 	}
 }
 
-func TestNewQueryResultMapper_SkipsAttributeTags(t *testing.T) {
+func TestNewQueryResultMapper_MixedMode(t *testing.T) {
+	// WithAttrTag has: ID (skipped with "-,id"), Name (attribute tag), Age (query tag)
+	// This tests mixed mode: query tags in mappings, attribute tags in pullMappings
 	findColumns := []string{"?age"}
 	mapper, err := NewQueryResultMapper(reflect.TypeOf(WithAttrTag{}), findColumns)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should only have 1 mapping (the ?age field)
-	// The "person/name" field should be skipped (attribute tag, not query tag)
-	// The "-,id" field should be skipped
+	// Should have 1 query mapping (the ?age field)
 	if len(mapper.mappings) != 1 {
 		t.Errorf("expected 1 mapping, got %d", len(mapper.mappings))
 	}
 	if mapper.mappings[0].Tag != "?age" {
 		t.Errorf("expected ?age mapping, got %s", mapper.mappings[0].Tag)
+	}
+
+	// Should have 1 pull mapping (the "person/name" field)
+	// The "-,id" field is skipped because of the "-" prefix
+	if len(mapper.pullMappings) != 1 {
+		t.Errorf("expected 1 pullMapping, got %d", len(mapper.pullMappings))
+	}
+	if len(mapper.pullMappings) > 0 && mapper.pullMappings[0].Tag != "person/name" {
+		t.Errorf("expected person/name pullMapping, got %s", mapper.pullMappings[0].Tag)
+	}
+
+	// Not pure pull mode since we have query tags
+	if mapper.isPullMapping {
+		t.Error("expected isPullMapping=false for mixed mode struct")
 	}
 }
 
@@ -574,6 +588,381 @@ func TestKeywordPtrTypeMatch(t *testing.T) {
 
 	if result.Keyword != kw {
 		t.Errorf("Keyword pointers should match: input=%p result=%p", kw, result.Keyword)
+	}
+}
+
+// =============================================================================
+// Pull Mapping Tests
+// =============================================================================
+
+// EntityStruct simulates an entity struct with attribute-style tags (for pull result mapping)
+// Note: ID uses "db/id" (or ":db/id") like any other attribute - no special handling needed
+type EntityStruct struct {
+	ID       datalog.Identity `datalog:"db/id"`
+	Name     string           `datalog:"person/name"`
+	Age      int64            `datalog:"person/age"`
+	Email    string           `datalog:"person/email"`
+	Active   bool             `datalog:"person/active"`
+	Category datalog.Keyword  `datalog:"person/category"`
+}
+
+// EntityWithSlices tests cardinality-many attributes
+type EntityWithSlices struct {
+	ID   datalog.Identity   `datalog:"db/id"`
+	Name string             `datalog:"person/name"`
+	Tags []string           `datalog:"person/tags"`
+	Refs []datalog.Identity `datalog:"person/refs"`
+}
+
+func TestNewQueryResultMapper_PullMapping(t *testing.T) {
+	// When struct has only attribute-style tags, isPullMapping should be true
+	findColumns := []string{"(pull ?e [*])"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(EntityStruct{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mapper.isPullMapping {
+		t.Error("expected isPullMapping=true for attribute-tagged struct")
+	}
+
+	// Should have pull mappings for all fields (stored in pullMappings, not mappings)
+	if len(mapper.pullMappings) != 6 {
+		t.Errorf("expected 6 pullMappings (ID, Name, Age, Email, Active, Category), got %d", len(mapper.pullMappings))
+	}
+
+	// mappings should be empty for pure pull mode
+	if len(mapper.mappings) != 0 {
+		t.Errorf("expected 0 mappings in pure pull mode, got %d", len(mapper.mappings))
+	}
+}
+
+func TestMapTuple_PullResult(t *testing.T) {
+	findColumns := []string{"(pull ?e [*])"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(EntityStruct{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Simulate a pull result map
+	// Pull executor uses keys WITHOUT colon prefix (e.g., "person/name" not ":person/name")
+	id := datalog.NewIdentity("test:alice")
+	category := datalog.NewKeyword(":category/admin")
+	pullMap := map[string]interface{}{
+		"db/id":          id,
+		"person/name":    "Alice",
+		"person/age":     int64(30),
+		"person/email":   "alice@example.com",
+		"person/active":  true,
+		"person/category": category,
+	}
+
+	tuple := []interface{}{pullMap}
+	var result EntityStruct
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.ID != id {
+		t.Errorf("ID mismatch: expected %v, got %v", id, result.ID)
+	}
+	if result.Name != "Alice" {
+		t.Errorf("Name mismatch: expected Alice, got %s", result.Name)
+	}
+	if result.Age != 30 {
+		t.Errorf("Age mismatch: expected 30, got %d", result.Age)
+	}
+	if result.Email != "alice@example.com" {
+		t.Errorf("Email mismatch: expected alice@example.com, got %s", result.Email)
+	}
+	if result.Active != true {
+		t.Errorf("Active mismatch: expected true, got %v", result.Active)
+	}
+	if result.Category != category {
+		t.Errorf("Category mismatch: expected %v, got %v", category, result.Category)
+	}
+}
+
+func TestMapTuple_PullResult_WithSlices(t *testing.T) {
+	findColumns := []string{"(pull ?e [*])"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(EntityWithSlices{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Simulate a pull result with cardinality-many values
+	// Pull executor uses keys WITHOUT colon prefix
+	id := datalog.NewIdentity("test:bob")
+	ref1 := datalog.NewIdentity("test:ref1")
+	ref2 := datalog.NewIdentity("test:ref2")
+	pullMap := map[string]interface{}{
+		"db/id":       id,
+		"person/name": "Bob",
+		"person/tags": []interface{}{"admin", "developer", "reviewer"},
+		"person/refs": []interface{}{ref1, ref2},
+	}
+
+	tuple := []interface{}{pullMap}
+	var result EntityWithSlices
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.ID != id {
+		t.Errorf("ID mismatch: expected %v, got %v", id, result.ID)
+	}
+	if result.Name != "Bob" {
+		t.Errorf("Name mismatch: expected Bob, got %s", result.Name)
+	}
+	if len(result.Tags) != 3 {
+		t.Errorf("Tags length mismatch: expected 3, got %d", len(result.Tags))
+	} else {
+		expected := []string{"admin", "developer", "reviewer"}
+		for i, tag := range expected {
+			if result.Tags[i] != tag {
+				t.Errorf("Tag[%d] mismatch: expected %s, got %s", i, tag, result.Tags[i])
+			}
+		}
+	}
+	if len(result.Refs) != 2 {
+		t.Errorf("Refs length mismatch: expected 2, got %d", len(result.Refs))
+	} else {
+		if result.Refs[0] != ref1 || result.Refs[1] != ref2 {
+			t.Errorf("Refs mismatch: expected [%v, %v], got %v", ref1, ref2, result.Refs)
+		}
+	}
+}
+
+func TestMapAll_PullResults(t *testing.T) {
+	findColumns := []string{"(pull ?e [*])"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(EntityStruct{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Pull executor uses keys WITHOUT colon prefix
+	id1 := datalog.NewIdentity("test:alice")
+	id2 := datalog.NewIdentity("test:bob")
+	tuples := [][]interface{}{
+		{map[string]interface{}{
+			"db/id":       id1,
+			"person/name": "Alice",
+			"person/age":  int64(30),
+		}},
+		{map[string]interface{}{
+			"db/id":       id2,
+			"person/name": "Bob",
+			"person/age":  int64(25),
+		}},
+	}
+
+	var results []EntityStruct
+	sliceVal := reflect.ValueOf(&results).Elem()
+	if err := mapper.MapAll(tuples, sliceVal); err != nil {
+		t.Fatalf("MapAll failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Name != "Alice" || results[0].Age != 30 {
+		t.Errorf("first result incorrect: %+v", results[0])
+	}
+	if results[1].Name != "Bob" || results[1].Age != 25 {
+		t.Errorf("second result incorrect: %+v", results[1])
+	}
+}
+
+func TestMapTuple_PullResult_MissingFields(t *testing.T) {
+	// Test that missing fields in pull result are left as zero values
+	findColumns := []string{"(pull ?e [*])"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(EntityStruct{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Pull result with only some fields
+	// Pull executor uses keys WITHOUT colon prefix
+	id := datalog.NewIdentity("test:charlie")
+	pullMap := map[string]interface{}{
+		"db/id":       id,
+		"person/name": "Charlie",
+		// age, email, active, category are missing
+	}
+
+	tuple := []interface{}{pullMap}
+	var result EntityStruct
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.ID != id {
+		t.Errorf("ID mismatch: expected %v, got %v", id, result.ID)
+	}
+	if result.Name != "Charlie" {
+		t.Errorf("Name mismatch: expected Charlie, got %s", result.Name)
+	}
+	if result.Age != 0 {
+		t.Errorf("Age should be zero value, got %d", result.Age)
+	}
+	if result.Email != "" {
+		t.Errorf("Email should be empty, got %s", result.Email)
+	}
+	if result.Active != false {
+		t.Errorf("Active should be false, got %v", result.Active)
+	}
+}
+
+// =============================================================================
+// Mixed Mode Tests - Query variables AND attribute tags in same struct
+// =============================================================================
+
+// MixedModeStruct has both query variable tags and attribute tags
+type MixedModeStruct struct {
+	// Query variable - comes from tuple column
+	Name string `datalog:"?name"`
+	// Attribute tags - come from pull result map in tuple
+	ID  datalog.Identity `datalog:"db/id"`
+	Age int64            `datalog:"person/age"`
+}
+
+func TestMapTuple_MixedMode(t *testing.T) {
+	// Simulates: [:find ?name (pull ?e [:db/id :person/age]) :where [?e :person/name ?name]]
+	findColumns := []string{"?name", "(pull ?e [:db/id :person/age])"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(MixedModeStruct{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify mapper state
+	if mapper.isPullMapping {
+		t.Error("expected isPullMapping=false for mixed mode")
+	}
+	if len(mapper.mappings) != 1 {
+		t.Errorf("expected 1 query mapping, got %d", len(mapper.mappings))
+	}
+	if len(mapper.pullMappings) != 2 {
+		t.Errorf("expected 2 pull mappings, got %d", len(mapper.pullMappings))
+	}
+
+	// Create a tuple with query value and pull result map
+	id := datalog.NewIdentity("test:alice")
+	pullMap := map[string]interface{}{
+		"db/id":      id,
+		"person/age": int64(30),
+	}
+	tuple := []interface{}{"Alice", pullMap}
+
+	var result MixedModeStruct
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	// Verify query variable was mapped
+	if result.Name != "Alice" {
+		t.Errorf("Name: expected 'Alice', got %q", result.Name)
+	}
+
+	// Verify pull attributes were mapped
+	if result.ID != id {
+		t.Errorf("ID: expected %v, got %v", id, result.ID)
+	}
+	if result.Age != 30 {
+		t.Errorf("Age: expected 30, got %d", result.Age)
+	}
+}
+
+func TestMapTuple_MixedMode_NoPullMap(t *testing.T) {
+	// Test that mixed mode gracefully handles tuple without pull map
+	findColumns := []string{"?name"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(MixedModeStruct{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Tuple with only query value, no pull map
+	tuple := []interface{}{"Bob"}
+
+	var result MixedModeStruct
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	// Query variable should be mapped
+	if result.Name != "Bob" {
+		t.Errorf("Name: expected 'Bob', got %q", result.Name)
+	}
+
+	// Pull attributes should remain zero values (no pull map in tuple)
+	if result.ID != nil {
+		t.Errorf("ID: expected nil, got %v", result.ID)
+	}
+	if result.Age != 0 {
+		t.Errorf("Age: expected 0, got %d", result.Age)
+	}
+}
+
+func TestMapTuple_MixedMode_PullMapFirst(t *testing.T) {
+	// Test with pull map as first column: [:find (pull ?e [*]) ?name ...]
+	findColumns := []string{"(pull ?e [*])", "?name"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(MixedModeStruct{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	id := datalog.NewIdentity("test:charlie")
+	pullMap := map[string]interface{}{
+		"db/id":      id,
+		"person/age": int64(25),
+	}
+	// Pull map first, then query value
+	tuple := []interface{}{pullMap, "Charlie"}
+
+	var result MixedModeStruct
+	if err := mapper.MapTuple(tuple, reflect.ValueOf(&result).Elem()); err != nil {
+		t.Fatalf("MapTuple failed: %v", err)
+	}
+
+	if result.Name != "Charlie" {
+		t.Errorf("Name: expected 'Charlie', got %q", result.Name)
+	}
+	if result.ID != id {
+		t.Errorf("ID: expected %v, got %v", id, result.ID)
+	}
+	if result.Age != 25 {
+		t.Errorf("Age: expected 25, got %d", result.Age)
+	}
+}
+
+func TestMapAll_MixedMode(t *testing.T) {
+	findColumns := []string{"?name", "(pull ?e [*])"}
+	mapper, err := NewQueryResultMapper(reflect.TypeOf(MixedModeStruct{}), findColumns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	id1 := datalog.NewIdentity("test:alice")
+	id2 := datalog.NewIdentity("test:bob")
+	tuples := [][]interface{}{
+		{"Alice", map[string]interface{}{"db/id": id1, "person/age": int64(30)}},
+		{"Bob", map[string]interface{}{"db/id": id2, "person/age": int64(25)}},
+	}
+
+	var results []MixedModeStruct
+	sliceVal := reflect.ValueOf(&results).Elem()
+	if err := mapper.MapAll(tuples, sliceVal); err != nil {
+		t.Fatalf("MapAll failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	if results[0].Name != "Alice" || results[0].Age != 30 || results[0].ID != id1 {
+		t.Errorf("first result incorrect: %+v", results[0])
+	}
+	if results[1].Name != "Bob" || results[1].Age != 25 || results[1].ID != id2 {
+		t.Errorf("second result incorrect: %+v", results[1])
 	}
 }
 

--- a/datalog/storage/pull_integration_test.go
+++ b/datalog/storage/pull_integration_test.go
@@ -121,6 +121,45 @@ func TestPullIntegration_StandaloneAPI(t *testing.T) {
 		}
 	})
 
+	// Test limit on cardinality-many attribute
+	t.Run("LimitCardinalityMany", func(t *testing.T) {
+		// Create entity with multiple tags
+		taggedEntity := datalog.NewIdentity("user:tagged")
+		tx2 := db.NewTransaction()
+		tx2.Add(taggedEntity, datalog.NewKeyword(":user/name"), "Tagged User")
+		tx2.Add(taggedEntity, datalog.NewKeyword(":user/tag"), "tag1")
+		tx2.Add(taggedEntity, datalog.NewKeyword(":user/tag"), "tag2")
+		tx2.Add(taggedEntity, datalog.NewKeyword(":user/tag"), "tag3")
+		tx2.Add(taggedEntity, datalog.NewKeyword(":user/tag"), "tag4")
+		tx2.Add(taggedEntity, datalog.NewKeyword(":user/tag"), "tag5")
+		if _, err := tx2.Commit(); err != nil {
+			t.Fatalf("failed to commit: %v", err)
+		}
+
+		// Pull with limit
+		result, err := db.Pull(taggedEntity, `[:user/name (limit :user/tag 2)]`)
+		if err != nil {
+			t.Fatalf("pull failed: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+
+		// Check name
+		if result["user/name"] != "Tagged User" {
+			t.Errorf("expected name='Tagged User', got %v", result["user/name"])
+		}
+
+		// Check tags are limited to 2
+		tags, ok := result["user/tag"].([]interface{})
+		if !ok {
+			t.Fatalf("expected tags to be []interface{}, got %T", result["user/tag"])
+		}
+		if len(tags) != 2 {
+			t.Errorf("expected 2 tags (limited), got %d: %v", len(tags), tags)
+		}
+	})
+
 	// Test non-existent entity
 	t.Run("NonExistentEntity", func(t *testing.T) {
 		nonExistent := datalog.NewIdentity("user:nonexistent")

--- a/datalog/storage/query_into_test.go
+++ b/datalog/storage/query_into_test.go
@@ -713,3 +713,177 @@ func TestQueryOneInto_ScalarMultipleResults(t *testing.T) {
 		t.Errorf("expected ErrMultipleResults, got %v", err)
 	}
 }
+
+// =============================================================================
+// Pull Mapping Tests - QueryInto with pull expressions
+// =============================================================================
+
+// PullResult maps attributes from a pull expression result
+type PullResult struct {
+	ID   datalog.Identity `datalog:"db/id"`
+	Name string           `datalog:"person/name"`
+	Age  int64            `datalog:"person/age"`
+}
+
+// MixedModeResult combines query variables with pull attributes
+type MixedModeResult struct {
+	// Query variable - comes from tuple column
+	PersonName string `datalog:"?name"`
+	// Attribute tags - come from pull result map in tuple
+	ID  datalog.Identity `datalog:"db/id"`
+	Age int64            `datalog:"person/age"`
+}
+
+func TestQueryInto_PullExpression(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	// Query with pull expression - returns entity attributes as map
+	var results []PullResult
+	err := db.QueryInto(&results, `
+		[:find (pull ?e [:db/id :person/name :person/age])
+		 :where [?e :person/name ?name]
+		        [(= ?name "Alice")]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	result := results[0]
+	if result.Name != "Alice" {
+		t.Errorf("expected Name='Alice', got %q", result.Name)
+	}
+	if result.Age != 30 {
+		t.Errorf("expected Age=30, got %d", result.Age)
+	}
+	if result.ID == nil {
+		t.Error("expected ID to be non-nil")
+	}
+}
+
+func TestQueryInto_PullWildcard(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	// Query with pull wildcard - returns all entity attributes
+	var results []PullResult
+	err := db.QueryInto(&results, `
+		[:find (pull ?e [*])
+		 :where [?e :person/name "Bob"]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	result := results[0]
+	if result.Name != "Bob" {
+		t.Errorf("expected Name='Bob', got %q", result.Name)
+	}
+	if result.Age != 25 {
+		t.Errorf("expected Age=25, got %d", result.Age)
+	}
+}
+
+func TestQueryInto_MixedMode(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	// Mixed mode: query variable + pull expression
+	// This tests the full flow: query -> executor -> pull -> struct mapping
+	var results []MixedModeResult
+	err := db.QueryInto(&results, `
+		[:find ?name (pull ?e [:db/id :person/age])
+		 :where [?e :person/name ?name]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryInto failed: %v", err)
+	}
+
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(results))
+	}
+
+	// Check that both query variable and pull attributes are mapped
+	foundAlice := false
+	for _, r := range results {
+		if r.PersonName == "Alice" {
+			foundAlice = true
+			if r.Age != 30 {
+				t.Errorf("Alice: expected Age=30, got %d", r.Age)
+			}
+			if r.ID == nil {
+				t.Error("Alice: expected ID to be non-nil")
+			}
+		}
+	}
+
+	if !foundAlice {
+		t.Error("expected to find Alice in results")
+	}
+}
+
+func TestQueryOneInto_PullExpression(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	var result PullResult
+	found, err := db.QueryOneInto(&result, `
+		[:find (pull ?e [*])
+		 :where [?e :person/name "Alice"]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryOneInto failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true")
+	}
+
+	if result.Name != "Alice" {
+		t.Errorf("expected Name='Alice', got %q", result.Name)
+	}
+	if result.Age != 30 {
+		t.Errorf("expected Age=30, got %d", result.Age)
+	}
+	if result.ID == nil {
+		t.Error("expected ID to be non-nil")
+	}
+}
+
+func TestQueryOneInto_MixedMode(t *testing.T) {
+	db, cleanup := createTestDatabaseWithPeople(t)
+	defer cleanup()
+
+	var result MixedModeResult
+	found, err := db.QueryOneInto(&result, `
+		[:find ?name (pull ?e [:db/id :person/age])
+		 :where [?e :person/name ?name]
+		        [(= ?name "Bob")]]
+	`)
+	if err != nil {
+		t.Fatalf("QueryOneInto failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true")
+	}
+
+	// Check query variable
+	if result.PersonName != "Bob" {
+		t.Errorf("expected PersonName='Bob', got %q", result.PersonName)
+	}
+
+	// Check pull attributes
+	if result.Age != 25 {
+		t.Errorf("expected Age=25, got %d", result.Age)
+	}
+	if result.ID == nil {
+		t.Error("expected ID to be non-nil")
+	}
+}


### PR DESCRIPTION
This adds comprehensive support for pull expressions in queries and the query builder, along with mapping pull results to Go structs via QueryInto.

## Pull Executor Fixes
- Fix PullLimitExpr to properly limit cardinality-many attributes
- Add db/id to pull results for entity ID mapping to structs

## Query Builder Pull Patterns
- Add PullSpec interface for composable pull specifications
- Add Limit(attr, n) for limiting cardinality-many results
- Add Default(attr, value) for default values on missing attributes
- Add Ref(attr, specs...) for nested reference pulls
- Update Pull(v, specs...) to accept variadic specs
- Attr type now implements PullSpec for use in Pull()

Example:
```golang
  Pull(e, PersonName, Limit(PersonTags, 5), Ref(PersonDept, DeptName)) // → (pull ?e [:person/name (limit :person/tags 5) {:person/dept [:dept/name]}])
  ```

## QueryInto Pull Mapping
- Add pure pull mode: structs with only attribute tags (e.g., `datalog:"person/name"`)
- Add mixed mode: structs with both query variable AND attribute tags
- Add DBIDKey constant for consistent entity ID handling
- Handle cardinality-many slice values from pull results