### PR TITLE
Replace `Symbol` string type with interned pointer type; add `Symbol` as database storage value type

### DIFF
--- a/datalog/annotations/relation_renderer.go
+++ b/datalog/annotations/relation_renderer.go
@@ -29,7 +29,7 @@ func (r *RelationRenderer) RenderRelation(rel RelationInfo) string {
 	// Build attribute list
 	attrStrs := make([]string, len(rel.Attrs))
 	for i, attr := range rel.Attrs {
-		attrStrs[i] = string(attr)
+		attrStrs[i] = attr.String()
 	}
 	attrList := strings.Join(attrStrs, " ")
 

--- a/datalog/compare.go
+++ b/datalog/compare.go
@@ -57,6 +57,15 @@ func CompareValues(left, right interface{}) int {
 		return -1
 	}
 
+	// Handle Symbol comparison - use the Compare method which handles nil
+	if sym1, ok := left.(Symbol); ok {
+		if sym2, ok := right.(Symbol); ok {
+			return sym1.Compare(sym2)
+		}
+		// Symbol vs non-Symbol: type mismatch
+		return -1
+	}
+
 	// Handle numeric comparisons
 	switch l := left.(type) {
 	case int:
@@ -267,6 +276,14 @@ func ValuesEqual(a, b interface{}) bool {
 		return false
 	}
 
+	// Symbol comparison - pointer equality since all Symbols are interned
+	if sym1, ok := a.(Symbol); ok {
+		if sym2, ok := b.(Symbol); ok {
+			return sym1.Equal(sym2)
+		}
+		return false
+	}
+
 	// Quick check for identity (after dereferencing and special type handling)
 	if a == b {
 		return true
@@ -297,6 +314,8 @@ func stringValue(v interface{}) string {
 	case Identity:
 		return val.String()
 	case Keyword:
+		return val.String()
+	case Symbol:
 		return val.String()
 	default:
 		// Use fmt.Sprintf for other types

--- a/datalog/compare_test.go
+++ b/datalog/compare_test.go
@@ -224,3 +224,43 @@ func TestNilKeywordHandling(t *testing.T) {
 		}
 	})
 }
+
+func TestSymbolCompareValues(t *testing.T) {
+	a := NewSymbol("alpha")
+	b := NewSymbol("beta")
+	a2 := NewSymbol("alpha")
+
+	// Same symbol (interned pointer equality)
+	if cmp := CompareValues(a, a2); cmp != 0 {
+		t.Errorf("CompareValues(alpha, alpha) = %d, want 0", cmp)
+	}
+
+	// Different symbols
+	if cmp := CompareValues(a, b); cmp >= 0 {
+		t.Errorf("CompareValues(alpha, beta) = %d, want < 0", cmp)
+	}
+	if cmp := CompareValues(b, a); cmp <= 0 {
+		t.Errorf("CompareValues(beta, alpha) = %d, want > 0", cmp)
+	}
+
+	// Symbol vs non-Symbol
+	if cmp := CompareValues(a, "alpha"); cmp >= 0 {
+		t.Errorf("CompareValues(symbol, string) = %d, want < 0 (type mismatch)", cmp)
+	}
+}
+
+func TestSymbolValuesEqual(t *testing.T) {
+	a := NewSymbol("test-fn")
+	b := NewSymbol("test-fn")
+	c := NewSymbol("other-fn")
+
+	if !ValuesEqual(a, b) {
+		t.Error("ValuesEqual(same symbol, same symbol) should be true")
+	}
+	if ValuesEqual(a, c) {
+		t.Error("ValuesEqual(different symbols) should be false")
+	}
+	if ValuesEqual(a, "test-fn") {
+		t.Error("ValuesEqual(symbol, string) should be false")
+	}
+}

--- a/datalog/executor/aggregation.go
+++ b/datalog/executor/aggregation.go
@@ -257,7 +257,7 @@ func executeSingleAggregation(rel Relation, aggregates []query.FindAggregate) Re
 	resultColumns := make([]query.Symbol, len(aggregates))
 	for i, agg := range aggregates {
 		// Use String() method which handles conditional vs unconditional formatting
-		resultColumns[i] = query.Symbol(agg.String())
+		resultColumns[i] = datalog.NewSymbol(agg.String())
 	}
 
 	// Relational theory: empty input → empty output
@@ -401,7 +401,7 @@ func executeGroupedAggregation(rel Relation, groupByVars []query.Symbol, aggrega
 				i, agg.Function, agg.Arg, agg.Predicate, agg.IsConditional(), agg.String())
 		}
 		// Use String() method which handles conditional vs unconditional formatting
-		resultColumns[len(groupByVars)+i] = query.Symbol(agg.String())
+		resultColumns[len(groupByVars)+i] = datalog.NewSymbol(agg.String())
 	}
 
 	opts := rel.Options()
@@ -562,7 +562,7 @@ func (r *StreamingAggregateRelation) Columns() []query.Symbol {
 	copy(resultColumns, r.groupByVars)
 	for i, agg := range r.aggregates {
 		// Use String() method which handles conditional vs unconditional formatting
-		resultColumns[len(r.groupByVars)+i] = query.Symbol(agg.String())
+		resultColumns[len(r.groupByVars)+i] = datalog.NewSymbol(agg.String())
 	}
 	return resultColumns
 }

--- a/datalog/executor/aggregation_test.go
+++ b/datalog/executor/aggregation_test.go
@@ -5,11 +5,13 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestExecuteAggregations(t *testing.T) {
 	// Create test data
-	columns := []query.Symbol{"?name", "?age", "?score"}
+	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?score")}
 	tuples := []Tuple{
 		{"Alice", int64(30), 85.5},
 		{"Bob", int64(25), 92.0},
@@ -28,10 +30,10 @@ func TestExecuteAggregations(t *testing.T) {
 		{
 			name: "no aggregates - just projection",
 			findElements: []query.FindElement{
-				query.FindVariable{Symbol: "?name"},
-				query.FindVariable{Symbol: "?age"},
+				query.FindVariable{Symbol: datalog.NewSymbol("?name")},
+				query.FindVariable{Symbol: datalog.NewSymbol("?age")},
 			},
-			expectedCols: []query.Symbol{"?name", "?age"},
+			expectedCols: []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age")},
 			expectedRows: 4,
 			validate: func(t *testing.T, result Relation) {
 				// Should have all 4 rows with just name and age
@@ -43,9 +45,9 @@ func TestExecuteAggregations(t *testing.T) {
 		{
 			name: "single aggregation - count",
 			findElements: []query.FindElement{
-				query.FindAggregate{Function: "count", Arg: "?name"},
+				query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?name")},
 			},
-			expectedCols: []query.Symbol{"(count ?name)"},
+			expectedCols: []query.Symbol{datalog.NewSymbol("(count ?name)")},
 			expectedRows: 1,
 			validate: func(t *testing.T, result Relation) {
 				it := result.Iterator()
@@ -61,9 +63,9 @@ func TestExecuteAggregations(t *testing.T) {
 		{
 			name: "single aggregation - avg",
 			findElements: []query.FindElement{
-				query.FindAggregate{Function: "avg", Arg: "?age"},
+				query.FindAggregate{Function: "avg", Arg: datalog.NewSymbol("?age")},
 			},
-			expectedCols: []query.Symbol{"(avg ?age)"},
+			expectedCols: []query.Symbol{datalog.NewSymbol("(avg ?age)")},
 			expectedRows: 1,
 			validate: func(t *testing.T, result Relation) {
 				it := result.Iterator()
@@ -79,9 +81,9 @@ func TestExecuteAggregations(t *testing.T) {
 		{
 			name: "single aggregation - max",
 			findElements: []query.FindElement{
-				query.FindAggregate{Function: "max", Arg: "?score"},
+				query.FindAggregate{Function: "max", Arg: datalog.NewSymbol("?score")},
 			},
-			expectedCols: []query.Symbol{"(max ?score)"},
+			expectedCols: []query.Symbol{datalog.NewSymbol("(max ?score)")},
 			expectedRows: 1,
 			validate: func(t *testing.T, result Relation) {
 				it := result.Iterator()
@@ -97,11 +99,11 @@ func TestExecuteAggregations(t *testing.T) {
 		{
 			name: "grouped aggregation - age groups",
 			findElements: []query.FindElement{
-				query.FindVariable{Symbol: "?age"},
-				query.FindAggregate{Function: "count", Arg: "?name"},
-				query.FindAggregate{Function: "avg", Arg: "?score"},
+				query.FindVariable{Symbol: datalog.NewSymbol("?age")},
+				query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?name")},
+				query.FindAggregate{Function: "avg", Arg: datalog.NewSymbol("?score")},
 			},
-			expectedCols: []query.Symbol{"?age", "(count ?name)", "(avg ?score)"},
+			expectedCols: []query.Symbol{datalog.NewSymbol("?age"), datalog.NewSymbol("(count ?name)"), datalog.NewSymbol("(avg ?score)")},
 			expectedRows: 3, // 3 unique ages: 25, 30, 35
 			validate: func(t *testing.T, result Relation) {
 				// Find the row for age 25 (should have count=2, avg=90)
@@ -128,11 +130,11 @@ func TestExecuteAggregations(t *testing.T) {
 		{
 			name: "multiple aggregates",
 			findElements: []query.FindElement{
-				query.FindAggregate{Function: "min", Arg: "?age"},
-				query.FindAggregate{Function: "max", Arg: "?age"},
-				query.FindAggregate{Function: "sum", Arg: "?score"},
+				query.FindAggregate{Function: "min", Arg: datalog.NewSymbol("?age")},
+				query.FindAggregate{Function: "max", Arg: datalog.NewSymbol("?age")},
+				query.FindAggregate{Function: "sum", Arg: datalog.NewSymbol("?score")},
 			},
-			expectedCols: []query.Symbol{"(min ?age)", "(max ?age)", "(sum ?score)"},
+			expectedCols: []query.Symbol{datalog.NewSymbol("(min ?age)"), datalog.NewSymbol("(max ?age)"), datalog.NewSymbol("(sum ?score)")},
 			expectedRows: 1,
 			validate: func(t *testing.T, result Relation) {
 				it := result.Iterator()
@@ -176,7 +178,7 @@ func TestExecuteAggregations(t *testing.T) {
 }
 
 func TestProjectColumns(t *testing.T) {
-	columns := []query.Symbol{"?a", "?b", "?c", "?d"}
+	columns := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c"), datalog.NewSymbol("?d")}
 	tuples := []Tuple{
 		{1, 2, 3, 4},
 		{5, 6, 7, 8},
@@ -192,8 +194,8 @@ func TestProjectColumns(t *testing.T) {
 	}{
 		{
 			name:         "project subset",
-			projectCols:  []query.Symbol{"?a", "?c"},
-			expectedCols: []query.Symbol{"?a", "?c"},
+			projectCols:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?c")},
+			expectedCols: []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?c")},
 			expectedVals: [][]interface{}{
 				{1, 3},
 				{5, 7},
@@ -202,8 +204,8 @@ func TestProjectColumns(t *testing.T) {
 		},
 		{
 			name:         "project reordered",
-			projectCols:  []query.Symbol{"?d", "?b"},
-			expectedCols: []query.Symbol{"?d", "?b"},
+			projectCols:  []query.Symbol{datalog.NewSymbol("?d"), datalog.NewSymbol("?b")},
+			expectedCols: []query.Symbol{datalog.NewSymbol("?d"), datalog.NewSymbol("?b")},
 			expectedVals: [][]interface{}{
 				{4, 2},
 				{8, 6},
@@ -212,8 +214,8 @@ func TestProjectColumns(t *testing.T) {
 		},
 		{
 			name:         "project all",
-			projectCols:  []query.Symbol{"?a", "?b", "?c", "?d"},
-			expectedCols: []query.Symbol{"?a", "?b", "?c", "?d"},
+			projectCols:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c"), datalog.NewSymbol("?d")},
+			expectedCols: []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c"), datalog.NewSymbol("?d")},
 			expectedVals: [][]interface{}{
 				{1, 2, 3, 4},
 				{5, 6, 7, 8},
@@ -274,7 +276,7 @@ func TestAggregationWithTimeValues(t *testing.T) {
 	date2 := time.Date(2023, 6, 10, 0, 0, 0, 0, time.UTC)
 	date3 := time.Date(2023, 3, 20, 0, 0, 0, 0, time.UTC)
 
-	columns := []query.Symbol{"?name", "?date"}
+	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?date")}
 	tuples := []Tuple{
 		{"Alice", date1},
 		{"Bob", date2},
@@ -284,8 +286,8 @@ func TestAggregationWithTimeValues(t *testing.T) {
 
 	// Test min/max with dates
 	result := ExecuteAggregations(rel, []query.FindElement{
-		query.FindAggregate{Function: "min", Arg: "?date"},
-		query.FindAggregate{Function: "max", Arg: "?date"},
+		query.FindAggregate{Function: "min", Arg: datalog.NewSymbol("?date")},
+		query.FindAggregate{Function: "max", Arg: datalog.NewSymbol("?date")},
 	})
 
 	if result.Size() != 1 {
@@ -329,12 +331,12 @@ func TestStringifyValue(t *testing.T) {
 func TestEmptyRelationAggregation(t *testing.T) {
 	// Test aggregation on empty relation
 	// Following relational theory (C.J. Date): empty input → empty output (no NULL)
-	emptyRel := NewMaterializedRelation([]query.Symbol{"?x"}, []Tuple{})
+	emptyRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x")}, []Tuple{})
 
 	// Following pure relational theory, aggregates on empty relations return empty results
 	// This is consistent with Datomic philosophy: attributes exist or don't exist, no NULL placeholders
 	result := ExecuteAggregations(emptyRel, []query.FindElement{
-		query.FindAggregate{Function: "count", Arg: "?x"},
+		query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?x")},
 	})
 
 	if result.Size() != 0 {
@@ -343,10 +345,10 @@ func TestEmptyRelationAggregation(t *testing.T) {
 
 	// Other aggregates on empty also return empty results
 	result = ExecuteAggregations(emptyRel, []query.FindElement{
-		query.FindAggregate{Function: "sum", Arg: "?x"},
-		query.FindAggregate{Function: "avg", Arg: "?x"},
-		query.FindAggregate{Function: "min", Arg: "?x"},
-		query.FindAggregate{Function: "max", Arg: "?x"},
+		query.FindAggregate{Function: "sum", Arg: datalog.NewSymbol("?x")},
+		query.FindAggregate{Function: "avg", Arg: datalog.NewSymbol("?x")},
+		query.FindAggregate{Function: "min", Arg: datalog.NewSymbol("?x")},
+		query.FindAggregate{Function: "max", Arg: datalog.NewSymbol("?x")},
 	})
 
 	if result.Size() != 0 {

--- a/datalog/executor/annotated_matcher.go
+++ b/datalog/executor/annotated_matcher.go
@@ -59,7 +59,7 @@ func (m *AnnotatedMatcher) Match(pattern *query.DataPattern, bindings Relations)
 			bindingCols := bindingRel.Columns()
 			bindingColumns = make([]string, len(bindingCols))
 			for i, col := range bindingCols {
-				bindingColumns[i] = string(col)
+				bindingColumns[i] = col.String()
 			}
 			bindingSize = bindingRel.Size()
 		}
@@ -86,7 +86,7 @@ func (m *AnnotatedMatcher) Match(pattern *query.DataPattern, bindings Relations)
 		// Add symbol order information for rendering
 		symbolOrder := make([]string, len(result.Columns()))
 		for i, col := range result.Columns() {
-			symbolOrder[i] = string(col)
+			symbolOrder[i] = col.String()
 		}
 		data["symbol.order"] = symbolOrder
 	}
@@ -121,7 +121,7 @@ func (m *AnnotatedMatcher) MatchWithConstraints(
 				bindingCols := bindingRel.Columns()
 				bindingColumns = make([]string, len(bindingCols))
 				for i, col := range bindingCols {
-					bindingColumns[i] = string(col)
+					bindingColumns[i] = col.String()
 				}
 				bindingSize = bindingRel.Size()
 			}
@@ -148,7 +148,7 @@ func (m *AnnotatedMatcher) MatchWithConstraints(
 
 			symbolOrder := make([]string, len(result.Columns()))
 			for i, col := range result.Columns() {
-				symbolOrder[i] = string(col)
+				symbolOrder[i] = col.String()
 			}
 			data["symbol.order"] = symbolOrder
 		}

--- a/datalog/executor/annotated_matcher_test.go
+++ b/datalog/executor/annotated_matcher_test.go
@@ -41,7 +41,7 @@ func TestWrapMatcher_NilHandler(t *testing.T) {
 	// Arrange
 	mock := &testMatcher{
 		matchResult: NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{1}, {2}, {3}},
 		),
 	}
@@ -59,7 +59,7 @@ func TestWrapMatcher_ZeroOverheadWhenDisabled(t *testing.T) {
 	// Arrange
 	mock := &testMatcher{
 		matchResult: NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{1}, {2}, {3}},
 		),
 	}
@@ -69,9 +69,9 @@ func TestWrapMatcher_ZeroOverheadWhenDisabled(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?x"},
+			query.Variable{Name: datalog.NewSymbol("?x")},
 			query.Constant{Value: datalog.NewKeyword(":attr")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -100,7 +100,7 @@ func TestWrapMatcher_BasicAnnotation(t *testing.T) {
 	// Arrange
 	mock := &testMatcher{
 		matchResult: NewMaterializedRelation(
-			[]query.Symbol{"?x", "?v"},
+			[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?v")},
 			[]Tuple{{1, "a"}, {2, "b"}},
 		),
 	}
@@ -118,9 +118,9 @@ func TestWrapMatcher_BasicAnnotation(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?x"},
+			query.Variable{Name: datalog.NewSymbol("?x")},
 			query.Constant{Value: datalog.NewKeyword(":attr")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -185,9 +185,9 @@ func TestWrapMatcher_WithError(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?x"},
+			query.Variable{Name: datalog.NewSymbol("?x")},
 			query.Constant{Value: datalog.NewKeyword(":attr")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -221,7 +221,7 @@ func TestWrapMatcher_WithBindings(t *testing.T) {
 	// Arrange
 	mock := &testMatcher{
 		matchResult: NewMaterializedRelation(
-			[]query.Symbol{"?x", "?v"},
+			[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?v")},
 			[]Tuple{{1, "a"}},
 		),
 	}
@@ -239,15 +239,15 @@ func TestWrapMatcher_WithBindings(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?x"},
+			query.Variable{Name: datalog.NewSymbol("?x")},
 			query.Constant{Value: datalog.NewKeyword(":attr")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
 	// Create binding relation
 	bindingRel := NewMaterializedRelation(
-		[]query.Symbol{"?x"},
+		[]query.Symbol{datalog.NewSymbol("?x")},
 		[]Tuple{{1}, {2}, {3}},
 	)
 
@@ -284,7 +284,7 @@ func TestWrapMatcher_PredicateAwareInterface(t *testing.T) {
 	mock := &testPredicateMatcher{
 		testMatcher: testMatcher{
 			matchResult: NewMaterializedRelation(
-				[]query.Symbol{"?x"},
+				[]query.Symbol{datalog.NewSymbol("?x")},
 				[]Tuple{{1}},
 			),
 		},
@@ -309,7 +309,7 @@ func TestWrapMatcher_PredicateAwareInterface(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?x"},
+			query.Variable{Name: datalog.NewSymbol("?x")},
 			query.Constant{Value: datalog.NewKeyword(":attr")},
 			query.Constant{Value: 42},
 		},
@@ -349,7 +349,7 @@ func TestWrapMatcher_TransparentForAllInterfaces(t *testing.T) {
 
 	mock := &testMatcher{
 		matchResult: NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{1}},
 		),
 	}
@@ -376,16 +376,16 @@ func BenchmarkWrapMatcher_Overhead(b *testing.B) {
 	// Measure the overhead of decoration
 	mock := &testMatcher{
 		matchResult: NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{1}, {2}, {3}},
 		),
 	}
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?x"},
+			query.Variable{Name: datalog.NewSymbol("?x")},
 			query.Constant{Value: datalog.NewKeyword(":attr")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 

--- a/datalog/executor/benchmark_test.go
+++ b/datalog/executor/benchmark_test.go
@@ -12,7 +12,7 @@ import (
 // Benchmark expression evaluation
 func BenchmarkExpressionEvaluation(b *testing.B) {
 	// Create test data
-	columns := []query.Symbol{"?x", "?y", "?z"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 	tuples := make([]Tuple, 1000)
 	for i := 0; i < 1000; i++ {
 		tuples[i] = Tuple{int64(i), int64(i * 2), float64(i) * 1.5}
@@ -22,10 +22,10 @@ func BenchmarkExpressionEvaluation(b *testing.B) {
 	expr := &query.Expression{
 		Function: &query.ArithmeticFunction{
 			Op:    query.OpAdd,
-			Left:  query.VariableTerm{Symbol: "?x"},
-			Right: query.VariableTerm{Symbol: "?y"},
+			Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
+			Right: query.VariableTerm{Symbol: datalog.NewSymbol("?y")},
 		},
-		Binding: query.Symbol("?sum"),
+		Binding: datalog.NewSymbol("?sum"),
 	}
 
 	b.ResetTimer()
@@ -38,7 +38,7 @@ func BenchmarkExpressionEvaluation(b *testing.B) {
 // Benchmark aggregation operations
 func BenchmarkAggregation(b *testing.B) {
 	// Create test data with groups
-	columns := []query.Symbol{"?group", "?value"}
+	columns := []query.Symbol{datalog.NewSymbol("?group"), datalog.NewSymbol("?value")}
 	tuples := make([]Tuple, 10000)
 	for i := 0; i < 10000; i++ {
 		tuples[i] = Tuple{int64(i % 100), float64(i)}
@@ -47,7 +47,7 @@ func BenchmarkAggregation(b *testing.B) {
 
 	b.Run("single_aggregation", func(b *testing.B) {
 		findElements := []query.FindElement{
-			query.FindAggregate{Function: "sum", Arg: "?value"},
+			query.FindAggregate{Function: "sum", Arg: datalog.NewSymbol("?value")},
 		}
 
 		b.ResetTimer()
@@ -59,9 +59,9 @@ func BenchmarkAggregation(b *testing.B) {
 
 	b.Run("grouped_aggregation", func(b *testing.B) {
 		findElements := []query.FindElement{
-			query.FindVariable{Symbol: "?group"},
-			query.FindAggregate{Function: "sum", Arg: "?value"},
-			query.FindAggregate{Function: "avg", Arg: "?value"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?group")},
+			query.FindAggregate{Function: "sum", Arg: datalog.NewSymbol("?value")},
+			query.FindAggregate{Function: "avg", Arg: datalog.NewSymbol("?value")},
 		}
 
 		b.ResetTimer()
@@ -73,7 +73,7 @@ func BenchmarkAggregation(b *testing.B) {
 
 	b.Run("projection_only", func(b *testing.B) {
 		findElements := []query.FindElement{
-			query.FindVariable{Symbol: "?group"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?group")},
 		}
 
 		b.ResetTimer()
@@ -128,7 +128,7 @@ func BenchmarkFullQuery(b *testing.B) {
 
 // Benchmark time-based aggregations
 func BenchmarkTimeAggregation(b *testing.B) {
-	columns := []query.Symbol{"?date", "?value"}
+	columns := []query.Symbol{datalog.NewSymbol("?date"), datalog.NewSymbol("?value")}
 	tuples := make([]Tuple, 1000)
 	baseTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 
@@ -141,9 +141,9 @@ func BenchmarkTimeAggregation(b *testing.B) {
 	rel := NewMaterializedRelation(columns, tuples)
 
 	findElements := []query.FindElement{
-		query.FindAggregate{Function: "min", Arg: "?date"},
-		query.FindAggregate{Function: "max", Arg: "?date"},
-		query.FindAggregate{Function: "sum", Arg: "?value"},
+		query.FindAggregate{Function: "min", Arg: datalog.NewSymbol("?date")},
+		query.FindAggregate{Function: "max", Arg: datalog.NewSymbol("?date")},
+		query.FindAggregate{Function: "sum", Arg: datalog.NewSymbol("?value")},
 	}
 
 	b.ResetTimer()

--- a/datalog/executor/buffered_iterator_test.go
+++ b/datalog/executor/buffered_iterator_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestBufferedIterator(t *testing.T) {
@@ -268,7 +270,7 @@ func TestStreamingRelationWithBuffering(t *testing.T) {
 			{1, "alice", 100},
 			{2, "bob", 200},
 		}
-		columns := []query.Symbol{"?id", "?name", "?score"}
+		columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score")}
 
 		source := newMockIterator(tuples)
 		rel := NewStreamingRelationWithOptions(columns, source, opts)
@@ -306,7 +308,7 @@ func TestStreamingRelationWithBuffering(t *testing.T) {
 
 	t.Run("EfficientIsEmpty", func(t *testing.T) {
 		tuples := []Tuple{{1, "alice"}}
-		columns := []query.Symbol{"?id", "?name"}
+		columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name")}
 
 		source := newMockIterator(tuples)
 		// Use EnableTrueStreaming=true for this test since we're testing that IsEmpty() is efficient

--- a/datalog/executor/conditional_aggregate_internal_test.go
+++ b/datalog/executor/conditional_aggregate_internal_test.go
@@ -5,13 +5,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestConditionalAggregateInternalInfrastructure tests the internal conditional aggregate
 // execution infrastructure (used by query rewriter, NOT exposed to users)
 func TestConditionalAggregateInternalInfrastructure(t *testing.T) {
 	// Create a simple relation with hour, filter, and value columns
-	columns := []query.Symbol{"?hour", "?filter", "?value"}
+	columns := []query.Symbol{datalog.NewSymbol("?hour"), datalog.NewSymbol("?filter"), datalog.NewSymbol("?value")}
 	tuples := []Tuple{
 		{int64(10), true, 100.0},
 		{int64(10), true, 102.0},
@@ -22,11 +24,11 @@ func TestConditionalAggregateInternalInfrastructure(t *testing.T) {
 
 	// Create find elements with conditional aggregate (internal use only)
 	findElements := []query.FindElement{
-		query.FindVariable{Symbol: "?hour"},
+		query.FindVariable{Symbol: datalog.NewSymbol("?hour")},
 		query.FindAggregate{
 			Function:  "min",
-			Arg:       "?value",
-			Predicate: "?filter", // Internal: filter on this column
+			Arg:       datalog.NewSymbol("?value"),
+			Predicate: datalog.NewSymbol("?filter"), // Internal: filter on this column
 		},
 	}
 
@@ -52,7 +54,7 @@ func TestConditionalAggregateInternalInfrastructure(t *testing.T) {
 // empty result set when no tuples match the filter predicate (relational theory)
 func TestConditionalAggregateEmptyResult(t *testing.T) {
 	// Create relation where all filter values are false
-	columns := []query.Symbol{"?filter", "?value"}
+	columns := []query.Symbol{datalog.NewSymbol("?filter"), datalog.NewSymbol("?value")}
 	tuples := []Tuple{
 		{false, 10.0},
 		{false, 20.0},
@@ -64,8 +66,8 @@ func TestConditionalAggregateEmptyResult(t *testing.T) {
 	findElements := []query.FindElement{
 		query.FindAggregate{
 			Function:  "min",
-			Arg:       "?value",
-			Predicate: "?filter", // All false - no matches
+			Arg:       datalog.NewSymbol("?value"),
+			Predicate: datalog.NewSymbol("?filter"), // All false - no matches
 		},
 	}
 
@@ -79,7 +81,7 @@ func TestConditionalAggregateEmptyResult(t *testing.T) {
 // TestConditionalAggregateMixedTypes tests multiple aggregates with different predicates
 func TestConditionalAggregateMixedTypes(t *testing.T) {
 	// Create relation with multiple filter columns
-	columns := []query.Symbol{"?early", "?late", "?price"}
+	columns := []query.Symbol{datalog.NewSymbol("?early"), datalog.NewSymbol("?late"), datalog.NewSymbol("?price")}
 	tuples := []Tuple{
 		{true, false, 100.0}, // Early
 		{true, false, 102.0}, // Early
@@ -92,13 +94,13 @@ func TestConditionalAggregateMixedTypes(t *testing.T) {
 	findElements := []query.FindElement{
 		query.FindAggregate{
 			Function:  "min",
-			Arg:       "?price",
-			Predicate: "?early", // Min of early prices
+			Arg:       datalog.NewSymbol("?price"),
+			Predicate: datalog.NewSymbol("?early"), // Min of early prices
 		},
 		query.FindAggregate{
 			Function:  "max",
-			Arg:       "?price",
-			Predicate: "?late", // Max of late prices
+			Arg:       datalog.NewSymbol("?price"),
+			Predicate: datalog.NewSymbol("?late"), // Max of late prices
 		},
 	}
 

--- a/datalog/executor/constraints_impl.go
+++ b/datalog/executor/constraints_impl.go
@@ -42,6 +42,11 @@ func (c *equalityConstraint) Evaluate(datom *datalog.Datom) bool {
 			dv, ok := datom.V.(bool)
 			return ok && dv == bv
 		}
+		// Fast path for symbol comparisons (pointer equality via interning)
+		if sv, ok := c.value.(datalog.Symbol); ok {
+			dv, ok := datom.V.(datalog.Symbol)
+			return ok && dv == sv
+		}
 		return datalog.ValuesEqual(datom.V, c.value)
 	case 3: // Transaction
 		if tx, ok := c.value.(uint64); ok {
@@ -226,6 +231,16 @@ func valuesEqual(a, b interface{}) bool {
 		}
 		if s, ok := b.(string); ok {
 			return kw1.String() == s
+		}
+	}
+
+	// Handle Symbol comparison
+	if sym1, ok := a.(datalog.Symbol); ok {
+		if sym2, ok := b.(datalog.Symbol); ok {
+			return sym1.Equal(sym2)
+		}
+		if s, ok := b.(string); ok {
+			return sym1.String() == s
 		}
 	}
 

--- a/datalog/executor/context.go
+++ b/datalog/executor/context.go
@@ -254,7 +254,7 @@ func (c *AnnotatedContext) MatchPattern(pattern query.Pattern, fn func() ([]data
 		// Check each element for variables
 		for _, elem := range dp.Elements {
 			if v, ok := elem.(query.Variable); ok {
-				symbolOrder = append(symbolOrder, string(v.Name))
+				symbolOrder = append(symbolOrder, v.Name.String())
 			}
 		}
 
@@ -291,7 +291,7 @@ func (c *AnnotatedContext) MatchPatternWithBindings(pattern query.Pattern, input
 		// Check each element for variables
 		for _, elem := range dp.Elements {
 			if v, ok := elem.(query.Variable); ok {
-				symbolOrder = append(symbolOrder, string(v.Name))
+				symbolOrder = append(symbolOrder, v.Name.String())
 			}
 		}
 
@@ -410,21 +410,21 @@ func (c *AnnotatedContext) JoinRelations(left, right Relation, fn func() Relatio
 	if left != nil {
 		leftAttrs := make([]string, len(left.Columns()))
 		for i, col := range left.Columns() {
-			leftAttrs[i] = string(col)
+			leftAttrs[i] = col.String()
 		}
 		data["left.attrs"] = leftAttrs
 	}
 	if right != nil {
 		rightAttrs := make([]string, len(right.Columns()))
 		for i, col := range right.Columns() {
-			rightAttrs[i] = string(col)
+			rightAttrs[i] = col.String()
 		}
 		data["right.attrs"] = rightAttrs
 	}
 	if result != nil {
 		resultAttrs := make([]string, len(result.Columns()))
 		for i, col := range result.Columns() {
-			resultAttrs[i] = string(col)
+			resultAttrs[i] = col.String()
 		}
 		data["result.attrs"] = resultAttrs
 	}

--- a/datalog/executor/datom_test.go
+++ b/datalog/executor/datom_test.go
@@ -23,8 +23,8 @@ func TestDatomIterator(t *testing.T) {
 	}
 
 	// Test extracting just entity and value
-	userSym := query.Symbol("?user")
-	valueSym := query.Symbol("?value")
+	userSym := datalog.NewSymbol("?user")
+	valueSym := datalog.NewSymbol("?value")
 	binding := PatternBinding{
 		EntitySym: &userSym,
 		ValueSym:  &valueSym,
@@ -84,10 +84,10 @@ func TestDatomRelation(t *testing.T) {
 	}
 
 	// Create relation with all fields bound
-	eSym := query.Symbol("?e")
-	aSym := query.Symbol("?a")
-	vSym := query.Symbol("?v")
-	txSym := query.Symbol("?tx")
+	eSym := datalog.NewSymbol("?e")
+	aSym := datalog.NewSymbol("?a")
+	vSym := datalog.NewSymbol("?v")
+	txSym := datalog.NewSymbol("?tx")
 	binding := PatternBinding{
 		EntitySym:    &eSym,
 		AttributeSym: &aSym,
@@ -144,9 +144,9 @@ func TestDatomJoinScenario(t *testing.T) {
 	}
 
 	// Create relations
-	userSym := query.Symbol("?user")
-	nameSym := query.Symbol("?name")
-	ageSym := query.Symbol("?age")
+	userSym := datalog.NewSymbol("?user")
+	nameSym := datalog.NewSymbol("?name")
+	ageSym := datalog.NewSymbol("?age")
 
 	nameRel := NewDatomRelation(namePattern, PatternBinding{
 		EntitySym: &userSym,
@@ -159,7 +159,7 @@ func TestDatomJoinScenario(t *testing.T) {
 	})
 
 	// Join on ?user
-	joined := nameRel.HashJoin(ageRel, []query.Symbol{"?user"})
+	joined := nameRel.HashJoin(ageRel, []query.Symbol{datalog.NewSymbol("?user")})
 
 	// Debug: Check what we have before join
 	t.Logf("nameRel size: %d", nameRel.Size())
@@ -187,7 +187,7 @@ func TestDatomJoinScenario(t *testing.T) {
 
 	// Verify columns
 	cols := joined.Columns()
-	expectedCols := []query.Symbol{"?user", "?name", "?age"}
+	expectedCols := []query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age")}
 	if len(cols) != len(expectedCols) {
 		t.Errorf("expected %d columns, got %d", len(expectedCols), len(cols))
 	}

--- a/datalog/executor/decorrelation_end_to_end_test.go
+++ b/datalog/executor/decorrelation_end_to_end_test.go
@@ -88,7 +88,7 @@ func TestDecorrelationEndToEnd(t *testing.T) {
 	}
 
 	// Check columns
-	expectedCols := []query.Symbol{"?hour", "?high", "?low"}
+	expectedCols := []query.Symbol{datalog.NewSymbol("?hour"), datalog.NewSymbol("?high"), datalog.NewSymbol("?low")}
 	if !columnsEqualTest(result.Columns(), expectedCols) {
 		t.Errorf("column mismatch:\n  got=%v\n  want=%v",
 			result.Columns(), expectedCols)

--- a/datalog/executor/decorrelation_executor.go
+++ b/datalog/executor/decorrelation_executor.go
@@ -30,7 +30,7 @@ type SubqueryGroup struct {
 func (cs CorrelationSignature) Hash() string {
 	varStrs := make([]string, len(cs.InputVars))
 	for i, v := range cs.InputVars {
-		varStrs[i] = string(v)
+		varStrs[i] = v.String()
 	}
 	sort.Strings(varStrs)
 
@@ -108,7 +108,7 @@ func extractCorrelationSignature(subq *query.SubqueryPattern) CorrelationSignatu
 	sortedVars := make([]query.Symbol, len(inputVars))
 	copy(sortedVars, inputVars)
 	sort.Slice(sortedVars, func(i, j int) bool {
-		return sortedVars[i] < sortedVars[j]
+		return sortedVars[i].Compare(sortedVars[j]) < 0
 	})
 
 	// Create pattern fingerprint from the nested query
@@ -504,7 +504,7 @@ func extractInputSymbols(subq *query.SubqueryPattern) []query.Symbol {
 			symbols = append(symbols, inp.Name)
 		case query.Constant:
 			// Check if it's a source marker
-			if sym, ok := inp.Value.(query.Symbol); ok && IsSourceSymbol(sym) {
+			if sym, ok := inp.Value.(query.Symbol); ok && sym.IsSource() {
 				symbols = append(symbols, sym)
 			}
 		}
@@ -529,7 +529,7 @@ func createBatchedInputRelation(inputSymbols []query.Symbol, combinations []map[
 	// Filter out source markers from columns
 	var columns []query.Symbol
 	for _, sym := range inputSymbols {
-		if !IsSourceSymbol(sym) {
+		if !sym.IsSource() {
 			columns = append(columns, sym)
 		}
 	}

--- a/datalog/executor/decorrelation_executor_test.go
+++ b/datalog/executor/decorrelation_executor_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/wbrown/janus-datalog/datalog/parser"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestShouldDecorrelate(t *testing.T) {
@@ -193,21 +195,21 @@ func TestGetBatchableGroups(t *testing.T) {
 	groups := map[string]*SubqueryGroup{
 		"group1": {
 			Signature: CorrelationSignature{
-				InputVars:          []query.Symbol{"?sym", "?hr"},
+				InputVars:          []query.Symbol{datalog.NewSymbol("?sym"), datalog.NewSymbol("?hr")},
 				IsGroupedAggregate: true,
 			},
 			Indices: []int{0, 1}, // 2 subqueries - batchable
 		},
 		"group2": {
 			Signature: CorrelationSignature{
-				InputVars:          []query.Symbol{"?name"},
+				InputVars:          []query.Symbol{datalog.NewSymbol("?name")},
 				IsGroupedAggregate: false, // Pure aggregation - NOT batchable
 			},
 			Indices: []int{2, 3}, // 2 subqueries but wrong type
 		},
 		"group3": {
 			Signature: CorrelationSignature{
-				InputVars:          []query.Symbol{"?x"},
+				InputVars:          []query.Symbol{datalog.NewSymbol("?x")},
 				IsGroupedAggregate: true,
 			},
 			Indices: []int{4}, // Only 1 subquery - NOT batchable

--- a/datalog/executor/executor_subquery_datomic_test.go
+++ b/datalog/executor/executor_subquery_datomic_test.go
@@ -155,7 +155,7 @@ func TestSubqueryDatabaseAsConstant(t *testing.T) {
 
 			// Check if it's a constant with value $
 			if c, ok := firstInput.(query.Constant); ok {
-				if sym, ok := c.Value.(query.Symbol); ok && sym == "$" {
+				if sym, ok := c.Value.(query.Symbol); ok && sym == datalog.NewSymbol("$") {
 					// Good - $ is recognized as a constant symbol
 					t.Log("$ correctly recognized as constant symbol")
 				} else {

--- a/datalog/executor/executor_test.go
+++ b/datalog/executor/executor_test.go
@@ -29,14 +29,14 @@ func TestExecutorBasicQuery(t *testing.T) {
 	// Query: Find all names
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 		},
@@ -97,36 +97,36 @@ func TestExecutorJoinQuery(t *testing.T) {
 	// [?p3 :user/name ?name3]
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name1"},
-			query.FindVariable{Symbol: "?name3"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name1")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name3")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?p1"},
+					query.Variable{Name: datalog.NewSymbol("?p1")},
 					query.Constant{Value: friendAttr},
-					query.Variable{Name: "?p2"},
+					query.Variable{Name: datalog.NewSymbol("?p2")},
 				},
 			},
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?p2"},
+					query.Variable{Name: datalog.NewSymbol("?p2")},
 					query.Constant{Value: friendAttr},
-					query.Variable{Name: "?p3"},
+					query.Variable{Name: datalog.NewSymbol("?p3")},
 				},
 			},
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?p1"},
+					query.Variable{Name: datalog.NewSymbol("?p1")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name1"},
+					query.Variable{Name: datalog.NewSymbol("?name1")},
 				},
 			},
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?p3"},
+					query.Variable{Name: datalog.NewSymbol("?p3")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name3"},
+					query.Variable{Name: datalog.NewSymbol("?name3")},
 				},
 			},
 		},
@@ -173,26 +173,26 @@ func TestExecutorWithFilter(t *testing.T) {
 	// Query: Find people younger than 30
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: ageAttr},
-					query.Variable{Name: "?age"},
+					query.Variable{Name: datalog.NewSymbol("?age")},
 				},
 			},
 			&query.Comparison{
 				Op:    query.OpLT,
-				Left:  query.VariableTerm{Symbol: "?age"},
+				Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?age")},
 				Right: query.ConstantTerm{Value: int64(30)},
 			},
 		},
@@ -247,45 +247,45 @@ func TestExecutorMultipleFilters(t *testing.T) {
 	// Query: Find people aged 25-30 with salary > 50000
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name"},
-			query.FindVariable{Symbol: "?age"},
-			query.FindVariable{Symbol: "?salary"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?age")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?salary")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: ageAttr},
-					query.Variable{Name: "?age"},
+					query.Variable{Name: datalog.NewSymbol("?age")},
 				},
 			},
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: salaryAttr},
-					query.Variable{Name: "?salary"},
+					query.Variable{Name: datalog.NewSymbol("?salary")},
 				},
 			},
 			&query.Comparison{
 				Op:    query.OpGTE,
-				Left:  query.VariableTerm{Symbol: "?age"},
+				Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?age")},
 				Right: query.ConstantTerm{Value: int64(25)},
 			},
 			&query.Comparison{
 				Op:    query.OpLTE,
-				Left:  query.VariableTerm{Symbol: "?age"},
+				Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?age")},
 				Right: query.ConstantTerm{Value: int64(30)},
 			},
 			&query.Comparison{
 				Op:    query.OpGT,
-				Left:  query.VariableTerm{Symbol: "?salary"},
+				Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?salary")},
 				Right: query.ConstantTerm{Value: int64(50000)},
 			},
 		},
@@ -331,14 +331,14 @@ func TestExecutorEmptyResult(t *testing.T) {
 	// Query for non-existent attribute
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?email"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?email")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword(":user/email")},
-					query.Variable{Name: "?email"},
+					query.Variable{Name: datalog.NewSymbol("?email")},
 				},
 			},
 		},
@@ -357,7 +357,7 @@ func TestExecutorEmptyResult(t *testing.T) {
 
 func TestResultMethods(t *testing.T) {
 	result := NewMaterializedRelation(
-		[]query.Symbol{"?name", "?age"},
+		[]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age")},
 		[]Tuple{
 			{"Alice", int64(30)},
 			{"Bob", int64(25)},
@@ -384,27 +384,27 @@ func TestResultMethods(t *testing.T) {
 	}
 
 	// Test ColumnIndex
-	if idx := result.ColumnIndex("?name"); idx != 0 {
+	if idx := result.ColumnIndex(datalog.NewSymbol("?name")); idx != 0 {
 		t.Errorf("expected index 0 for ?name, got %d", idx)
 	}
-	if idx := result.ColumnIndex("?age"); idx != 1 {
+	if idx := result.ColumnIndex(datalog.NewSymbol("?age")); idx != 1 {
 		t.Errorf("expected index 1 for ?age, got %d", idx)
 	}
-	if idx := result.ColumnIndex("?missing"); idx != -1 {
+	if idx := result.ColumnIndex(datalog.NewSymbol("?missing")); idx != -1 {
 		t.Errorf("expected index -1 for missing column, got %d", idx)
 	}
 
 	// Test GetValue
-	if val, ok := result.GetValue(0, "?name"); !ok || val != "Alice" {
+	if val, ok := result.GetValue(0, datalog.NewSymbol("?name")); !ok || val != "Alice" {
 		t.Errorf("expected Alice, got %v", val)
 	}
-	if val, ok := result.GetValue(1, "?age"); !ok || val != int64(25) {
+	if val, ok := result.GetValue(1, datalog.NewSymbol("?age")); !ok || val != int64(25) {
 		t.Errorf("expected 25, got %v", val)
 	}
-	if _, ok := result.GetValue(0, "?missing"); ok {
+	if _, ok := result.GetValue(0, datalog.NewSymbol("?missing")); ok {
 		t.Error("expected false for missing column")
 	}
-	if _, ok := result.GetValue(2, "?name"); ok {
+	if _, ok := result.GetValue(2, datalog.NewSymbol("?name")); ok {
 		t.Error("expected false for out of bounds row")
 	}
 }

--- a/datalog/executor/executor_utils.go
+++ b/datalog/executor/executor_utils.go
@@ -61,7 +61,7 @@ func extractFindColumns(findElements []query.FindElement) []query.Symbol {
 		case query.FindVariable:
 			columns = append(columns, e.Symbol)
 		case query.FindAggregate:
-			columns = append(columns, query.Symbol(e.String()))
+			columns = append(columns, datalog.NewSymbol(e.String()))
 		}
 	}
 	return columns

--- a/datalog/executor/filter_test.go
+++ b/datalog/executor/filter_test.go
@@ -19,66 +19,66 @@ func TestComparisonFilter(t *testing.T) {
 			name: "less than integer - true",
 			filter: ComparisonFilter{
 				Function: "<",
-				Symbol:   "?age",
+				Symbol:   datalog.NewSymbol("?age"),
 				Value:    int64(30),
 			},
 			tuple:    Tuple{int64(25)},
-			columns:  []query.Symbol{"?age"},
+			columns:  []query.Symbol{datalog.NewSymbol("?age")},
 			expected: true,
 		},
 		{
 			name: "less than integer - false",
 			filter: ComparisonFilter{
 				Function: "<",
-				Symbol:   "?age",
+				Symbol:   datalog.NewSymbol("?age"),
 				Value:    int64(30),
 			},
 			tuple:    Tuple{int64(35)},
-			columns:  []query.Symbol{"?age"},
+			columns:  []query.Symbol{datalog.NewSymbol("?age")},
 			expected: false,
 		},
 		{
 			name: "equals string",
 			filter: ComparisonFilter{
 				Function: "=",
-				Symbol:   "?name",
+				Symbol:   datalog.NewSymbol("?name"),
 				Value:    "Alice",
 			},
 			tuple:    Tuple{"Alice"},
-			columns:  []query.Symbol{"?name"},
+			columns:  []query.Symbol{datalog.NewSymbol("?name")},
 			expected: true,
 		},
 		{
 			name: "not equals string",
 			filter: ComparisonFilter{
 				Function: "!=",
-				Symbol:   "?name",
+				Symbol:   datalog.NewSymbol("?name"),
 				Value:    "Alice",
 			},
 			tuple:    Tuple{"Bob"},
-			columns:  []query.Symbol{"?name"},
+			columns:  []query.Symbol{datalog.NewSymbol("?name")},
 			expected: true,
 		},
 		{
 			name: "symbol not in columns",
 			filter: ComparisonFilter{
 				Function: "<",
-				Symbol:   "?missing",
+				Symbol:   datalog.NewSymbol("?missing"),
 				Value:    int64(30),
 			},
 			tuple:    Tuple{int64(25)},
-			columns:  []query.Symbol{"?age"},
+			columns:  []query.Symbol{datalog.NewSymbol("?age")},
 			expected: false,
 		},
 		{
 			name: "multiple columns",
 			filter: ComparisonFilter{
 				Function: ">=",
-				Symbol:   "?score",
+				Symbol:   datalog.NewSymbol("?score"),
 				Value:    3.5,
 			},
 			tuple:    Tuple{"Alice", 4.0},
-			columns:  []query.Symbol{"?name", "?score"},
+			columns:  []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?score")},
 			expected: true,
 		},
 	}
@@ -105,55 +105,55 @@ func TestBinaryFilterEvaluate(t *testing.T) {
 			name: "less than - true",
 			filter: BinaryFilter{
 				Function: "<",
-				Left:     "?x",
-				Right:    "?y",
+				Left:     datalog.NewSymbol("?x"),
+				Right:    datalog.NewSymbol("?y"),
 			},
 			tuple:    Tuple{int64(10), int64(20)},
-			columns:  []query.Symbol{"?x", "?y"},
+			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: true,
 		},
 		{
 			name: "greater than - false",
 			filter: BinaryFilter{
 				Function: ">",
-				Left:     "?x",
-				Right:    "?y",
+				Left:     datalog.NewSymbol("?x"),
+				Right:    datalog.NewSymbol("?y"),
 			},
 			tuple:    Tuple{int64(10), int64(20)},
-			columns:  []query.Symbol{"?x", "?y"},
+			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: false,
 		},
 		{
 			name: "equals - true",
 			filter: BinaryFilter{
 				Function: "=",
-				Left:     "?a",
-				Right:    "?b",
+				Left:     datalog.NewSymbol("?a"),
+				Right:    datalog.NewSymbol("?b"),
 			},
 			tuple:    Tuple{"test", "test"},
-			columns:  []query.Symbol{"?a", "?b"},
+			columns:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			expected: true,
 		},
 		{
 			name: "mixed types",
 			filter: BinaryFilter{
 				Function: "<",
-				Left:     "?x",
-				Right:    "?y",
+				Left:     datalog.NewSymbol("?x"),
+				Right:    datalog.NewSymbol("?y"),
 			},
 			tuple:    Tuple{int64(10), 20.5},
-			columns:  []query.Symbol{"?x", "?y"},
+			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: true,
 		},
 		{
 			name: "missing left symbol",
 			filter: BinaryFilter{
 				Function: "<",
-				Left:     "?missing",
-				Right:    "?y",
+				Left:     datalog.NewSymbol("?missing"),
+				Right:    datalog.NewSymbol("?y"),
 			},
 			tuple:    Tuple{int64(10)},
-			columns:  []query.Symbol{"?x"},
+			columns:  []query.Symbol{datalog.NewSymbol("?x")},
 			expected: false,
 		},
 	}
@@ -171,7 +171,7 @@ func TestBinaryFilterEvaluate(t *testing.T) {
 func TestFilterRelation(t *testing.T) {
 	// Create a test relation
 	rel := NewMaterializedRelation(
-		[]query.Symbol{"?person", "?age", "?city"},
+		[]query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")},
 		[]Tuple{
 			{"Alice", int64(30), "NYC"},
 			{"Bob", int64(25), "SF"},
@@ -184,7 +184,7 @@ func TestFilterRelation(t *testing.T) {
 	// Test with comparison filter
 	ageFilter := ComparisonFilter{
 		Function: "<",
-		Symbol:   "?age",
+		Symbol:   datalog.NewSymbol("?age"),
 		Value:    int64(30),
 	}
 
@@ -198,7 +198,7 @@ func TestFilterRelation(t *testing.T) {
 	// Test with missing symbol
 	missingFilter := ComparisonFilter{
 		Function: "=",
-		Symbol:   "?missing",
+		Symbol:   datalog.NewSymbol("?missing"),
 		Value:    "test",
 	}
 
@@ -259,24 +259,24 @@ func TestRequiredSymbols(t *testing.T) {
 	// Test ComparisonFilter
 	cf := ComparisonFilter{
 		Function: "<",
-		Symbol:   "?age",
+		Symbol:   datalog.NewSymbol("?age"),
 		Value:    30,
 	}
 
 	cfSyms := cf.RequiredSymbols()
-	if len(cfSyms) != 1 || cfSyms[0] != "?age" {
+	if len(cfSyms) != 1 || cfSyms[0] != datalog.NewSymbol("?age") {
 		t.Errorf("ComparisonFilter.RequiredSymbols() = %v, want [?age]", cfSyms)
 	}
 
 	// Test BinaryFilter
 	bf := BinaryFilter{
 		Function: ">",
-		Left:     "?x",
-		Right:    "?y",
+		Left:     datalog.NewSymbol("?x"),
+		Right:    datalog.NewSymbol("?y"),
 	}
 
 	bfSyms := bf.RequiredSymbols()
-	if len(bfSyms) != 2 || bfSyms[0] != "?x" || bfSyms[1] != "?y" {
+	if len(bfSyms) != 2 || bfSyms[0] != datalog.NewSymbol("?x") || bfSyms[1] != datalog.NewSymbol("?y") {
 		t.Errorf("BinaryFilter.RequiredSymbols() = %v, want [?x ?y]", bfSyms)
 	}
 }

--- a/datalog/executor/hash_join_bench_test.go
+++ b/datalog/executor/hash_join_bench_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // =============================================================================
@@ -25,8 +27,8 @@ func BenchmarkHashJoinBuildSize(b *testing.B) {
 	for _, buildSize := range buildSizes {
 		for _, dataSize := range dataSizes {
 			b.Run(fmt.Sprintf("build_%d/data_%d", buildSize, dataSize), func(b *testing.B) {
-				leftCols := []query.Symbol{"?x", "?name"}
-				rightCols := []query.Symbol{"?x", "?value"}
+				leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+				rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 				leftTuples := make([]Tuple, dataSize)
 				rightTuples := make([]Tuple, dataSize)
@@ -86,8 +88,8 @@ func BenchmarkHashJoinBuildSizeOptimal(b *testing.B) {
 	for _, buildSize := range buildSizes {
 		for _, dataSize := range dataSizes {
 			b.Run(fmt.Sprintf("build_%d/data_%d", buildSize, dataSize), func(b *testing.B) {
-				leftCols := []query.Symbol{"?x", "?name"}
-				rightCols := []query.Symbol{"?x", "?value"}
+				leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+				rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 				leftTuples := make([]Tuple, dataSize)
 				rightTuples := make([]Tuple, dataSize)
@@ -147,8 +149,8 @@ func BenchmarkHashJoinInputTypes(b *testing.B) {
 	sizes := []int{100, 1000, 5000}
 
 	for _, size := range sizes {
-		leftCols := []query.Symbol{"?x", "?name"}
-		rightCols := []query.Symbol{"?x", "?value"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+		rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 		leftTuples := make([]Tuple, size)
 		rightTuples := make([]Tuple, size)
@@ -266,8 +268,8 @@ func BenchmarkHashJoinMaterializedVsStreaming(b *testing.B) {
 	size := 1000
 
 	b.Run("materialized", func(b *testing.B) {
-		leftCols := []query.Symbol{"?x", "?name"}
-		rightCols := []query.Symbol{"?x", "?value"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+		rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 		leftTuples := make([]Tuple, size)
 		rightTuples := make([]Tuple, size)
@@ -294,8 +296,8 @@ func BenchmarkHashJoinMaterializedVsStreaming(b *testing.B) {
 	})
 
 	b.Run("streaming", func(b *testing.B) {
-		leftCols := []query.Symbol{"?x", "?name"}
-		rightCols := []query.Symbol{"?x", "?value"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+		rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 		leftTuples := make([]Tuple, size)
 		rightTuples := make([]Tuple, size)
@@ -341,8 +343,8 @@ func BenchmarkHashJoinStreaming(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
 			// Create two relations with common column
-			leftCols := []query.Symbol{"?x", "?name"}
-			rightCols := []query.Symbol{"?x", "?value"}
+			leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+			rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 			leftTuples := make([]Tuple, size)
 			rightTuples := make([]Tuple, size)
@@ -382,8 +384,8 @@ func BenchmarkHashJoinStreaming(b *testing.B) {
 // This is the common case - result is consumed once
 func BenchmarkHashJoinSingleIteration(b *testing.B) {
 	size := 1000
-	leftCols := []query.Symbol{"?x", "?name"}
-	rightCols := []query.Symbol{"?x", "?value"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+	rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 	leftTuples := make([]Tuple, size)
 	rightTuples := make([]Tuple, size)
@@ -418,8 +420,8 @@ func BenchmarkHashJoinStreamingInput(b *testing.B) {
 
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
-			leftCols := []query.Symbol{"?x", "?name"}
-			rightCols := []query.Symbol{"?x", "?value"}
+			leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+			rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 			leftTuples := make([]Tuple, size)
 			rightTuples := make([]Tuple, size)
@@ -475,8 +477,8 @@ func BenchmarkHashJoinLargeResult(b *testing.B) {
 
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
-			leftCols := []query.Symbol{"?x", "?data"}
-			rightCols := []query.Symbol{"?x", "?value"}
+			leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?data")}
+			rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 			leftTuples := make([]Tuple, size)
 			rightTuples := make([]Tuple, size)

--- a/datalog/executor/hash_join_presize_bench_test.go
+++ b/datalog/executor/hash_join_presize_bench_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/wbrown/janus-datalog/datalog/parser"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // BenchmarkHashJoinPreSizing compares hash join performance with and without pre-sizing
@@ -15,9 +17,9 @@ func BenchmarkHashJoinPreSizing(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("Size_%d", size), func(b *testing.B) {
 			// Create two relations to join
-			leftCols := []query.Symbol{"?a", "?b", "?c"}
-			rightCols := []query.Symbol{"?b", "?d"}
-			joinCols := []query.Symbol{"?b"}
+			leftCols := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
+			rightCols := []query.Symbol{datalog.NewSymbol("?b"), datalog.NewSymbol("?d")}
+			joinCols := []query.Symbol{datalog.NewSymbol("?b")}
 
 			// Generate test data
 			leftTuples := make([]Tuple, size)

--- a/datalog/executor/helpers.go
+++ b/datalog/executor/helpers.go
@@ -120,7 +120,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 	var bindingSymbols []query.Symbol
 	switch b := expr.Binding.(type) {
 	case query.Symbol:
-		if b != "" {
+		if b != nil {
 			bindingSymbols = []query.Symbol{b}
 		}
 	case query.TupleBinding:

--- a/datalog/executor/indexed_matcher_bench_test.go
+++ b/datalog/executor/indexed_matcher_bench_test.go
@@ -58,7 +58,7 @@ func BenchmarkPatternMatch_LinearVsIndexed(b *testing.B) {
 					Elements: []query.PatternElement{
 						query.Constant{Value: datalog.NewIdentity("bar50")},
 						query.Constant{Value: datalog.NewKeyword("price/open")},
-						query.Variable{Name: "?v"},
+						query.Variable{Name: datalog.NewSymbol("?v")},
 					},
 				},
 			},
@@ -67,8 +67,8 @@ func BenchmarkPatternMatch_LinearVsIndexed(b *testing.B) {
 				pattern: &query.DataPattern{
 					Elements: []query.PatternElement{
 						query.Constant{Value: datalog.NewIdentity("bar50")},
-						query.Variable{Name: "?a"},
-						query.Variable{Name: "?v"},
+						query.Variable{Name: datalog.NewSymbol("?a")},
+						query.Variable{Name: datalog.NewSymbol("?v")},
 					},
 				},
 			},
@@ -76,9 +76,9 @@ func BenchmarkPatternMatch_LinearVsIndexed(b *testing.B) {
 				name: "A_bound",
 				pattern: &query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?e"},
+						query.Variable{Name: datalog.NewSymbol("?e")},
 						query.Constant{Value: datalog.NewKeyword("price/open")},
-						query.Variable{Name: "?v"},
+						query.Variable{Name: datalog.NewSymbol("?v")},
 					},
 				},
 			},
@@ -86,8 +86,8 @@ func BenchmarkPatternMatch_LinearVsIndexed(b *testing.B) {
 				name: "V_bound",
 				pattern: &query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?e"},
-						query.Variable{Name: "?a"},
+						query.Variable{Name: datalog.NewSymbol("?e")},
+						query.Variable{Name: datalog.NewSymbol("?a")},
 						query.Constant{Value: int64(150)},
 					},
 				},
@@ -96,9 +96,9 @@ func BenchmarkPatternMatch_LinearVsIndexed(b *testing.B) {
 				name: "Nothing_bound",
 				pattern: &query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?e"},
-						query.Variable{Name: "?a"},
-						query.Variable{Name: "?v"},
+						query.Variable{Name: datalog.NewSymbol("?e")},
+						query.Variable{Name: datalog.NewSymbol("?a")},
+						query.Variable{Name: datalog.NewSymbol("?v")},
 					},
 				},
 			},
@@ -182,9 +182,9 @@ func BenchmarkOHLCStyle_LinearVsIndexed(b *testing.B) {
 		// Typical OHLC query pattern: [?bar :price/open ?open]
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?bar"},
+				query.Variable{Name: datalog.NewSymbol("?bar")},
 				query.Constant{Value: datalog.NewKeyword("price/open")},
-				query.Variable{Name: "?open"},
+				query.Variable{Name: datalog.NewSymbol("?open")},
 			},
 		}
 
@@ -233,8 +233,8 @@ func BenchmarkSingleEntityLookup(b *testing.B) {
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
 				query.Constant{Value: datalog.NewIdentity(fmt.Sprintf("bar%d", size/2))},
-				query.Variable{Name: "?a"},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?a")},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
@@ -282,9 +282,9 @@ func BenchmarkAttributeScan(b *testing.B) {
 		// Scan by attribute (typical aggregation pattern)
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: datalog.NewKeyword("price/high")},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
@@ -332,9 +332,9 @@ func BenchmarkWorstCase_FullScan(b *testing.B) {
 		// Full scan (nothing bound)
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
-				query.Variable{Name: "?a"},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
+				query.Variable{Name: datalog.NewSymbol("?a")},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 

--- a/datalog/executor/indexed_memory_matcher_test.go
+++ b/datalog/executor/indexed_memory_matcher_test.go
@@ -78,7 +78,7 @@ func TestIndexedMatcher_StrategySelection(t *testing.T) {
 				Elements: []query.PatternElement{
 					query.Constant{Value: datalog.NewIdentity("e1")},
 					query.Constant{Value: datalog.NewKeyword("name")},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			expectedType: "EA-index",
@@ -88,8 +88,8 @@ func TestIndexedMatcher_StrategySelection(t *testing.T) {
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
 					query.Constant{Value: datalog.NewIdentity("e1")},
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			expectedType: "E-index",
@@ -98,9 +98,9 @@ func TestIndexedMatcher_StrategySelection(t *testing.T) {
 			// [?e :name ?v] - A bound
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword("name")},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			expectedType: "A-index",
@@ -109,8 +109,8 @@ func TestIndexedMatcher_StrategySelection(t *testing.T) {
 			// [?e ?a "Alice"] - V bound
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
-					query.Variable{Name: "?a"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
 					query.Constant{Value: "Alice"},
 				},
 			},
@@ -120,9 +120,9 @@ func TestIndexedMatcher_StrategySelection(t *testing.T) {
 			// [?e ?a ?v] - Nothing bound
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			expectedType: "linear-scan",
@@ -165,7 +165,7 @@ func TestIndexedMatcher_CorrectnessVsLinear(t *testing.T) {
 				Elements: []query.PatternElement{
 					query.Constant{Value: datalog.NewIdentity("person1")},
 					query.Constant{Value: datalog.NewKeyword("name")},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 		},
@@ -174,8 +174,8 @@ func TestIndexedMatcher_CorrectnessVsLinear(t *testing.T) {
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
 					query.Constant{Value: datalog.NewIdentity("person1")},
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 		},
@@ -183,9 +183,9 @@ func TestIndexedMatcher_CorrectnessVsLinear(t *testing.T) {
 			name: "A bound",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword("name")},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 		},
@@ -193,8 +193,8 @@ func TestIndexedMatcher_CorrectnessVsLinear(t *testing.T) {
 			name: "V bound (string)",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
-					query.Variable{Name: "?a"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
 					query.Constant{Value: "Alice"},
 				},
 			},
@@ -203,8 +203,8 @@ func TestIndexedMatcher_CorrectnessVsLinear(t *testing.T) {
 			name: "V bound (int64)",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
-					query.Variable{Name: "?a"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
 					query.Constant{Value: int64(30)},
 				},
 			},
@@ -213,8 +213,8 @@ func TestIndexedMatcher_CorrectnessVsLinear(t *testing.T) {
 			name: "V bound (bool)",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
-					query.Variable{Name: "?a"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
 					query.Constant{Value: true},
 				},
 			},
@@ -223,9 +223,9 @@ func TestIndexedMatcher_CorrectnessVsLinear(t *testing.T) {
 			name: "Nothing bound (full scan)",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 		},
@@ -274,9 +274,9 @@ func TestIndexedMatcher_EdgeCases(t *testing.T) {
 		matcher := NewIndexedMemoryMatcher([]datalog.Datom{})
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
-				query.Variable{Name: "?a"},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
+				query.Variable{Name: datalog.NewSymbol("?a")},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
@@ -298,9 +298,9 @@ func TestIndexedMatcher_EdgeCases(t *testing.T) {
 		matcher := NewIndexedMemoryMatcher(datoms)
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: datalog.NewKeyword("name")},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
@@ -335,8 +335,8 @@ func TestIndexedMatcher_EdgeCases(t *testing.T) {
 		// Search for specific value - should only match exact value
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
-				query.Variable{Name: "?a"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
+				query.Variable{Name: datalog.NewSymbol("?a")},
 				query.Constant{Value: "test1"},
 			},
 		}
@@ -389,15 +389,15 @@ func TestIndexedMatcher_WithBindings(t *testing.T) {
 		{datalog.NewIdentity("p1")},
 	}
 	bindings := Relations{
-		NewMaterializedRelation([]query.Symbol{"?e"}, bindingTuples),
+		NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, bindingTuples),
 	}
 
 	// Pattern: [?e :age ?v]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword("age")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -450,9 +450,9 @@ func TestIndexedMatcher_WithConstraints(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword("timestamp")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 

--- a/datalog/executor/iterator_composition_test.go
+++ b/datalog/executor/iterator_composition_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // mockIterator provides test data for iterator composition tests
@@ -45,7 +47,7 @@ func TestFilterIterator(t *testing.T) {
 		{4, "diana", 35},
 		{5, "eve", 30},
 	}
-	columns := []query.Symbol{"?id", "?name", "?age"}
+	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age")}
 
 	// Test filtering by age
 	source := newMockIterator(tuples)
@@ -77,8 +79,8 @@ func TestProjectIterator(t *testing.T) {
 		{2, "bob", 30, "LA"},
 		{3, "charlie", 25, "Chicago"},
 	}
-	sourceColumns := []query.Symbol{"?id", "?name", "?age", "?city"}
-	targetColumns := []query.Symbol{"?name", "?city"} // Project name and city only
+	sourceColumns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
+	targetColumns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?city")} // Project name and city only
 
 	// Create projection iterator
 	// Wrap tuples in a relation for ProjectIterator
@@ -207,7 +209,7 @@ func TestComposedIterators(t *testing.T) {
 		{3, "charlie", 25, 1200},
 		{4, "diana", 35, 2000},
 	}
-	columns := []query.Symbol{"?id", "?name", "?age", "?salary"}
+	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?salary")}
 
 	// Step 1: Filter by age >= 30
 	source := newMockIterator(tuples)
@@ -217,7 +219,7 @@ func TestComposedIterators(t *testing.T) {
 	filterIter := NewFilterIterator(source, columns, filter)
 
 	// Step 2: Project name and salary only
-	projectedColumns := []query.Symbol{"?name", "?salary"}
+	projectedColumns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?salary")}
 	projIndices := []int{1, 3} // Manually specify indices for test
 	projIter := &ProjectIterator{
 		source:     filterIter,
@@ -266,7 +268,7 @@ func TestStreamingRelationWithComposition(t *testing.T) {
 		{3, "charlie", 25},
 		{4, "diana", 35},
 	}
-	columns := []query.Symbol{"?id", "?name", "?age"}
+	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age")}
 
 	// Create a StreamingRelation
 	source := newMockIterator(tuples)
@@ -286,7 +288,7 @@ func TestStreamingRelationWithComposition(t *testing.T) {
 	assert.IsType(t, &StreamingRelation{}, filtered)
 
 	// Project columns
-	projected, err := filtered.Project([]query.Symbol{"?name", "?age"})
+	projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age")})
 	assert.NoError(t, err)
 	assert.IsType(t, &StreamingRelation{}, projected)
 
@@ -317,12 +319,12 @@ func TestPredicateFilterIterator(t *testing.T) {
 		{3, 30},
 		{4, 40},
 	}
-	columns := []query.Symbol{"?x", "?y"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 	// Create a comparison predicate (y > 20)
 	pred := &query.Comparison{
 		Op:    query.OpGT,
-		Left:  query.VariableTerm{Symbol: "?y"},
+		Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?y")},
 		Right: query.ConstantTerm{Value: 20},
 	}
 
@@ -352,17 +354,17 @@ func TestFunctionEvaluatorIterator(t *testing.T) {
 		{30, 40},
 		{50, 60},
 	}
-	columns := []query.Symbol{"?x", "?y"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 	// Create an addition function (x + y)
 	fn := query.ArithmeticFunction{
 		Op:    query.OpAdd,
-		Left:  query.VariableTerm{Symbol: "?x"},
-		Right: query.VariableTerm{Symbol: "?y"},
+		Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
+		Right: query.VariableTerm{Symbol: datalog.NewSymbol("?y")},
 	}
 
 	source := newMockIterator(tuples)
-	evalIter := NewFunctionEvaluatorIterator(source, columns, fn, "?sum")
+	evalIter := NewFunctionEvaluatorIterator(source, columns, fn, datalog.NewSymbol("?sum"))
 
 	// Collect results with new column
 	var results []Tuple
@@ -389,7 +391,7 @@ func BenchmarkIteratorComposition(b *testing.B) {
 	for i := 0; i < 10000; i++ {
 		tuples = append(tuples, Tuple{i, i * 2, i * 3})
 	}
-	columns := []query.Symbol{"?x", "?y", "?z"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 	b.Run("Composed", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -403,7 +405,7 @@ func BenchmarkIteratorComposition(b *testing.B) {
 
 			// Wrap in a relation for projection
 			filteredRel := NewStreamingRelation(columns, filterIter)
-			projIter := NewProjectIterator(filteredRel, columns, []query.Symbol{"?x", "?z"})
+			projIter := NewProjectIterator(filteredRel, columns, []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")})
 
 			transform := func(t Tuple) Tuple {
 				return Tuple{t[0], t[1].(int) * 10}

--- a/datalog/executor/join.go
+++ b/datalog/executor/join.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"fmt"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -280,8 +281,8 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 	// We'll verify the actual type on the first tuple during iteration
 	txIndex := -1
 	for i, col := range buildRel.Columns() {
-		if col == query.Symbol("?tx") || col == query.Symbol("?t") ||
-			col == query.Symbol("?txid") || col == query.Symbol("?transaction") {
+		if col == datalog.NewSymbol("?tx") || col == datalog.NewSymbol("?t") ||
+			col == datalog.NewSymbol("?txid") || col == datalog.NewSymbol("?transaction") {
 			txIndex = i
 			if opts.EnableDebugLogging {
 				fmt.Printf("[HashJoin] Found potential tx column %s at index %d\n", col, i)

--- a/datalog/executor/join_correctness_test.go
+++ b/datalog/executor/join_correctness_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestJoinCorrectness validates that asymmetric and symmetric joins produce identical, correct results
@@ -14,8 +16,8 @@ func TestJoinCorrectness(t *testing.T) {
 
 	for _, size := range sizes {
 		t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
-			leftCols := []query.Symbol{"?x", "?name"}
-			rightCols := []query.Symbol{"?x", "?value"}
+			leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+			rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 			leftTuples := make([]Tuple, size)
 			rightTuples := make([]Tuple, size)
@@ -56,8 +58,8 @@ func TestJoinCorrectness(t *testing.T) {
 
 // TestJoinCorrectnessWithMismatches tests partial joins where not all tuples match
 func TestJoinCorrectnessWithMismatches(t *testing.T) {
-	leftCols := []query.Symbol{"?x", "?name"}
-	rightCols := []query.Symbol{"?x", "?value"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+	rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 	// Left has IDs 0-99, Right has IDs 50-149
 	// Expected matches: 50-99 (50 results)
@@ -103,8 +105,8 @@ func TestJoinCorrectnessEarlyTermination(t *testing.T) {
 	size := 10000
 	limit := 100
 
-	leftCols := []query.Symbol{"?x", "?name"}
-	rightCols := []query.Symbol{"?x", "?value"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+	rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 	leftTuples := make([]Tuple, size)
 	rightTuples := make([]Tuple, size)

--- a/datalog/executor/join_test.go
+++ b/datalog/executor/join_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestHashJoin(t *testing.T) {
 	// Left relation: people and their departments
-	leftCols := []query.Symbol{"?person", "?dept"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?dept")}
 	leftTuples := []Tuple{
 		{"Alice", "Engineering"},
 		{"Bob", "Sales"},
@@ -18,7 +20,7 @@ func TestHashJoin(t *testing.T) {
 	left := NewMaterializedRelation(leftCols, leftTuples)
 
 	// Right relation: departments and their locations
-	rightCols := []query.Symbol{"?dept", "?location"}
+	rightCols := []query.Symbol{datalog.NewSymbol("?dept"), datalog.NewSymbol("?location")}
 	rightTuples := []Tuple{
 		{"Engineering", "Building A"},
 		{"Sales", "Building B"},
@@ -27,7 +29,7 @@ func TestHashJoin(t *testing.T) {
 	right := NewMaterializedRelation(rightCols, rightTuples)
 
 	// Join on ?dept
-	joined := left.HashJoin(right, []query.Symbol{"?dept"})
+	joined := left.HashJoin(right, []query.Symbol{datalog.NewSymbol("?dept")})
 
 	// Expected: 3 results (no Marketing people)
 	if joined.Size() != 3 {
@@ -35,7 +37,7 @@ func TestHashJoin(t *testing.T) {
 	}
 
 	// Check columns
-	expectedCols := []query.Symbol{"?person", "?dept", "?location"}
+	expectedCols := []query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?dept"), datalog.NewSymbol("?location")}
 	if !reflect.DeepEqual(joined.Columns(), expectedCols) {
 		t.Errorf("expected columns %v, got %v", expectedCols, joined.Columns())
 	}
@@ -57,7 +59,7 @@ func TestHashJoin(t *testing.T) {
 
 func TestJoinMultipleColumns(t *testing.T) {
 	// Test joining on multiple columns
-	leftCols := []query.Symbol{"?a", "?b", "?c"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
 	leftTuples := []Tuple{
 		{1, 2, "x"},
 		{1, 3, "y"},
@@ -65,7 +67,7 @@ func TestJoinMultipleColumns(t *testing.T) {
 	}
 	left := NewMaterializedRelation(leftCols, leftTuples)
 
-	rightCols := []query.Symbol{"?a", "?b", "?d"}
+	rightCols := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?d")}
 	rightTuples := []Tuple{
 		{1, 2, "foo"},
 		{1, 3, "bar"},
@@ -74,7 +76,7 @@ func TestJoinMultipleColumns(t *testing.T) {
 	right := NewMaterializedRelation(rightCols, rightTuples)
 
 	// Join on both ?a and ?b
-	joined := left.HashJoin(right, []query.Symbol{"?a", "?b"})
+	joined := left.HashJoin(right, []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")})
 
 	// Should match: (1,2) and (1,3)
 	if joined.Size() != 2 {
@@ -94,15 +96,15 @@ func TestJoinMultipleColumns(t *testing.T) {
 
 func TestEmptyJoin(t *testing.T) {
 	// Join with no common values
-	leftCols := []query.Symbol{"?x", "?y"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	leftTuples := []Tuple{{1, 2}, {3, 4}}
 	left := NewMaterializedRelation(leftCols, leftTuples)
 
-	rightCols := []query.Symbol{"?y", "?z"}
+	rightCols := []query.Symbol{datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 	rightTuples := []Tuple{{5, 6}, {7, 8}}
 	right := NewMaterializedRelation(rightCols, rightTuples)
 
-	joined := left.HashJoin(right, []query.Symbol{"?y"})
+	joined := left.HashJoin(right, []query.Symbol{datalog.NewSymbol("?y")})
 
 	if !joined.IsEmpty() {
 		t.Error("expected empty join result")
@@ -111,11 +113,11 @@ func TestEmptyJoin(t *testing.T) {
 
 func TestCrossProduct(t *testing.T) {
 	// Test cross product (no common columns)
-	leftCols := []query.Symbol{"?a"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?a")}
 	leftTuples := []Tuple{{"x"}, {"y"}}
 	left := NewMaterializedRelation(leftCols, leftTuples)
 
-	rightCols := []query.Symbol{"?b"}
+	rightCols := []query.Symbol{datalog.NewSymbol("?b")}
 	rightTuples := []Tuple{{1}, {2}}
 	right := NewMaterializedRelation(rightCols, rightTuples)
 
@@ -141,7 +143,7 @@ func TestCrossProduct(t *testing.T) {
 
 func TestSemiJoin(t *testing.T) {
 	// Left: all people
-	leftCols := []query.Symbol{"?person", "?dept"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?dept")}
 	leftTuples := []Tuple{
 		{"Alice", "Engineering"},
 		{"Bob", "Sales"},
@@ -151,7 +153,7 @@ func TestSemiJoin(t *testing.T) {
 	left := NewMaterializedRelation(leftCols, leftTuples)
 
 	// Right: active departments
-	rightCols := []query.Symbol{"?dept"}
+	rightCols := []query.Symbol{datalog.NewSymbol("?dept")}
 	rightTuples := []Tuple{
 		{"Engineering"},
 		{"Sales"},
@@ -159,7 +161,7 @@ func TestSemiJoin(t *testing.T) {
 	right := NewMaterializedRelation(rightCols, rightTuples)
 
 	// Semi-join: people in active departments
-	result := left.SemiJoin(right, []query.Symbol{"?dept"})
+	result := left.SemiJoin(right, []query.Symbol{datalog.NewSymbol("?dept")})
 
 	if result.Size() != 3 {
 		t.Errorf("expected 3 people in active departments, got %d", result.Size())
@@ -176,7 +178,7 @@ func TestSemiJoin(t *testing.T) {
 
 func TestAntiJoin(t *testing.T) {
 	// Same setup as SemiJoin
-	leftCols := []query.Symbol{"?person", "?dept"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?dept")}
 	leftTuples := []Tuple{
 		{"Alice", "Engineering"},
 		{"Bob", "Sales"},
@@ -185,7 +187,7 @@ func TestAntiJoin(t *testing.T) {
 	}
 	left := NewMaterializedRelation(leftCols, leftTuples)
 
-	rightCols := []query.Symbol{"?dept"}
+	rightCols := []query.Symbol{datalog.NewSymbol("?dept")}
 	rightTuples := []Tuple{
 		{"Engineering"},
 		{"Sales"},
@@ -193,7 +195,7 @@ func TestAntiJoin(t *testing.T) {
 	right := NewMaterializedRelation(rightCols, rightTuples)
 
 	// Anti-join: people NOT in active departments
-	result := left.AntiJoin(right, []query.Symbol{"?dept"})
+	result := left.AntiJoin(right, []query.Symbol{datalog.NewSymbol("?dept")})
 
 	if result.Size() != 1 {
 		t.Errorf("expected 1 person not in active departments, got %d", result.Size())

--- a/datalog/executor/multi_match_optimization_test.go
+++ b/datalog/executor/multi_match_optimization_test.go
@@ -158,9 +158,9 @@ func TestMultiMatchOptimization(t *testing.T) {
 		// Pattern: [?e :entity/value ?v]
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: valueAttr},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
@@ -171,7 +171,7 @@ func TestMultiMatchOptimization(t *testing.T) {
 
 		for _, entity := range entities {
 			// Create single-row relation
-			singleRel := NewMaterializedRelation([]query.Symbol{"?e"}, []Tuple{{entity}})
+			singleRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, []Tuple{{entity}})
 
 			results, err := matcher.MatchWithRelation(pattern, singleRel)
 			if err != nil {
@@ -206,14 +206,14 @@ func TestMultiMatchOptimization(t *testing.T) {
 		}
 
 		// Create multi-row relation with all entities
-		multiRel := NewMaterializedRelation([]query.Symbol{"?e"}, tuples)
+		multiRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, tuples)
 
 		// Pattern: [?e :entity/value ?v]
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: valueAttr},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
@@ -248,16 +248,16 @@ func TestMultiMatchOptimization(t *testing.T) {
 
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: valueAttr},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
 		// Method 1: Individual calls
 		var individualResults []datalog.Datom
 		for _, e := range entities {
-			rel := NewMaterializedRelation([]query.Symbol{"?e"}, []Tuple{{e}})
+			rel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, []Tuple{{e}})
 			results, _ := matcher.MatchWithRelation(pattern, rel)
 			individualResults = append(individualResults, results...)
 		}
@@ -270,7 +270,7 @@ func TestMultiMatchOptimization(t *testing.T) {
 		for _, e := range entities {
 			tuples = append(tuples, Tuple{e})
 		}
-		multiRel := NewMaterializedRelation([]query.Symbol{"?e"}, tuples)
+		multiRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, tuples)
 		multiResults, _ := matcher.MatchWithRelation(pattern, multiRel)
 
 		// Compare results

--- a/datalog/executor/multi_row_binding_test.go
+++ b/datalog/executor/multi_row_binding_test.go
@@ -31,7 +31,7 @@ func TestMultiRowRelationBinding(t *testing.T) {
 	t.Run("MultipleEntityBinding", func(t *testing.T) {
 		// Create a relation with multiple entities
 		bindingRel := NewMaterializedRelation(
-			[]query.Symbol{"?user"},
+			[]query.Symbol{datalog.NewSymbol("?user")},
 			[]Tuple{
 				{alice},
 				{bob},
@@ -42,9 +42,9 @@ func TestMultiRowRelationBinding(t *testing.T) {
 		// Pattern: [?user :user/age ?age]
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?user"},
+				query.Variable{Name: datalog.NewSymbol("?user")},
 				query.Constant{Value: ageAttr},
-				query.Variable{Name: "?age"},
+				query.Variable{Name: datalog.NewSymbol("?age")},
 			},
 		}
 
@@ -54,7 +54,7 @@ func TestMultiRowRelationBinding(t *testing.T) {
 
 		// Check columns
 		cols := results.Columns()
-		assert.Equal(t, []query.Symbol{"?user", "?age"}, cols)
+		assert.Equal(t, []query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?age")}, cols)
 
 		// Check we got the right data
 		foundUsers := make(map[string]int64)
@@ -86,7 +86,7 @@ func TestMultiRowRelationBinding(t *testing.T) {
 	t.Run("MultipleValueBinding", func(t *testing.T) {
 		// Create a relation with ages to look for
 		bindingRel := NewMaterializedRelation(
-			[]query.Symbol{"?age"},
+			[]query.Symbol{datalog.NewSymbol("?age")},
 			[]Tuple{
 				{int64(25)},
 				{int64(35)},
@@ -96,9 +96,9 @@ func TestMultiRowRelationBinding(t *testing.T) {
 		// Pattern: [?user :user/age ?age]
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?user"},
+				query.Variable{Name: datalog.NewSymbol("?user")},
 				query.Constant{Value: ageAttr},
-				query.Variable{Name: "?age"},
+				query.Variable{Name: datalog.NewSymbol("?age")},
 			},
 		}
 
@@ -154,7 +154,7 @@ func TestMultiRowRelationBinding(t *testing.T) {
 
 		// Create a binding relation with category and price range
 		bindingRel := NewMaterializedRelation(
-			[]query.Symbol{"?category", "?minPrice"},
+			[]query.Symbol{datalog.NewSymbol("?category"), datalog.NewSymbol("?minPrice")},
 			[]Tuple{
 				{"Electronics", 150.0}, // Only expensive electronics
 				{"Books", 10.0},        // All books over $10
@@ -164,9 +164,9 @@ func TestMultiRowRelationBinding(t *testing.T) {
 		// First pattern: [?p :product/category ?category]
 		catPattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?p"},
+				query.Variable{Name: datalog.NewSymbol("?p")},
 				query.Constant{Value: categoryAttr},
-				query.Variable{Name: "?category"},
+				query.Variable{Name: datalog.NewSymbol("?category")},
 			},
 		}
 
@@ -188,9 +188,9 @@ func TestMultiRowRelationBinding(t *testing.T) {
 		// Now match prices
 		pricePattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?p"},
+				query.Variable{Name: datalog.NewSymbol("?p")},
 				query.Constant{Value: priceAttr},
-				query.Variable{Name: "?price"},
+				query.Variable{Name: datalog.NewSymbol("?price")},
 			},
 		}
 
@@ -223,9 +223,9 @@ func TestRelationBasedPatternMatching(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":foo")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 

--- a/datalog/executor/not_or_test.go
+++ b/datalog/executor/not_or_test.go
@@ -32,21 +32,21 @@ func TestNotClause(t *testing.T) {
 	// [:find ?name :where [?e :user/name ?name] (not [?e :user/archived true])]
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			&query.NotClause{
 				Clauses: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: archivedAttr},
 							query.Constant{Value: true},
 						},
@@ -100,21 +100,21 @@ func TestNotClauseNoMatches(t *testing.T) {
 	// Query: Find non-archived users (no one is archived)
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			&query.NotClause{
 				Clauses: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: archivedAttr},
 							query.Constant{Value: true},
 						},
@@ -156,21 +156,21 @@ func TestNotClauseAllMatch(t *testing.T) {
 	// Query: Find non-archived users (everyone is archived)
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			&query.NotClause{
 				Clauses: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: archivedAttr},
 							query.Constant{Value: true},
 						},
@@ -217,29 +217,29 @@ func TestNotJoinClause(t *testing.T) {
 	// [:find ?name :where [?e :user/name ?name] (not-join [?e] [?e :user/archived true] [?e :user/deleted true])]
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			&query.NotJoinClause{
-				JoinVars: []query.Symbol{"?e"},
+				JoinVars: []query.Symbol{datalog.NewSymbol("?e")},
 				Clauses: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: archivedAttr},
 							query.Constant{Value: true},
 						},
 					},
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: deletedAttr},
 							query.Constant{Value: true},
 						},
@@ -293,14 +293,14 @@ func TestOrClause(t *testing.T) {
 	// [:find ?name :where [?e :user/name ?name] (or [?e :user/status "active"] [?e :user/status "pending"])]
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			&query.OrClause{
@@ -308,7 +308,7 @@ func TestOrClause(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: statusAttr},
 								query.Constant{Value: "active"},
 							},
@@ -317,7 +317,7 @@ func TestOrClause(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: statusAttr},
 								query.Constant{Value: "pending"},
 							},
@@ -377,23 +377,23 @@ func TestOrJoinClause(t *testing.T) {
 	// [:find ?name :where [?e :user/name ?name] (or-join [?e] [?e :user/status "active"] [?e :admin/status "enabled"])]
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?name"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			&query.OrJoinClause{
-				JoinVars: []query.Symbol{"?e"},
+				JoinVars: []query.Symbol{datalog.NewSymbol("?e")},
 				Branches: [][]query.Clause{
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: userStatusAttr},
 								query.Constant{Value: "active"},
 							},
@@ -402,7 +402,7 @@ func TestOrJoinClause(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: adminStatusAttr},
 								query.Constant{Value: "enabled"},
 							},
@@ -452,16 +452,16 @@ func TestOrFallbackWithGroundExpressionDirectQueryExecutor(t *testing.T) {
 			{
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?e"},
+						query.Variable{Name: datalog.NewSymbol("?e")},
 						query.Constant{Value: datalog.NewKeyword(":nonexistent/attr")},
-						query.Variable{Name: "?x"},
+						query.Variable{Name: datalog.NewSymbol("?x")},
 					},
 				},
 			},
 			{
 				&query.Expression{
 					Function: &query.GroundFunction{Value: int64(0)},
-					Binding:  query.Symbol("?x"),
+					Binding:  datalog.NewSymbol("?x"),
 				},
 			},
 		},
@@ -469,7 +469,7 @@ func TestOrFallbackWithGroundExpressionDirectQueryExecutor(t *testing.T) {
 
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?x"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?x")},
 		},
 		Where: []query.Clause{orClause},
 	}
@@ -496,7 +496,7 @@ func TestOrFallbackWithGroundExpression(t *testing.T) {
 	// Since no data exists, should fall back to ground(0)
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?x"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?x")},
 		},
 		Where: []query.Clause{
 			&query.OrClause{
@@ -504,16 +504,16 @@ func TestOrFallbackWithGroundExpression(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: datalog.NewKeyword(":nonexistent/attr")},
-								query.Variable{Name: "?x"},
+								query.Variable{Name: datalog.NewSymbol("?x")},
 							},
 						},
 					},
 					{
 						&query.Expression{
 							Function: &query.GroundFunction{Value: int64(0)},
-							Binding:  query.Symbol("?x"),
+							Binding:  datalog.NewSymbol("?x"),
 						},
 					},
 				},
@@ -555,7 +555,7 @@ func TestOrFallbackFirstBranchMatches(t *testing.T) {
 	// First branch should match, so we should get "Alice", not "fallback"
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?x"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?x")},
 		},
 		Where: []query.Clause{
 			&query.OrClause{
@@ -563,16 +563,16 @@ func TestOrFallbackFirstBranchMatches(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: nameAttr},
-								query.Variable{Name: "?x"},
+								query.Variable{Name: datalog.NewSymbol("?x")},
 							},
 						},
 					},
 					{
 						&query.Expression{
 							Function: &query.GroundFunction{Value: "fallback"},
-							Binding:  query.Symbol("?x"),
+							Binding:  datalog.NewSymbol("?x"),
 						},
 					},
 				},
@@ -609,7 +609,7 @@ func TestOrFallbackMultipleBranches(t *testing.T) {
 
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?x"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?x")},
 		},
 		Where: []query.Clause{
 			&query.OrClause{
@@ -617,25 +617,25 @@ func TestOrFallbackMultipleBranches(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: nonexistent1},
-								query.Variable{Name: "?x"},
+								query.Variable{Name: datalog.NewSymbol("?x")},
 							},
 						},
 					},
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: nonexistent2},
-								query.Variable{Name: "?x"},
+								query.Variable{Name: datalog.NewSymbol("?x")},
 							},
 						},
 					},
 					{
 						&query.Expression{
 							Function: &query.GroundFunction{Value: "default"},
-							Binding:  query.Symbol("?x"),
+							Binding:  datalog.NewSymbol("?x"),
 						},
 					},
 				},
@@ -677,7 +677,7 @@ func TestOrFallbackWithArithmeticExpression(t *testing.T) {
 	// Pattern won't match, so should get 2 from arithmetic
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?x"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?x")},
 		},
 		Where: []query.Clause{
 			&query.OrClause{
@@ -685,9 +685,9 @@ func TestOrFallbackWithArithmeticExpression(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: datalog.NewKeyword(":nonexistent/attr")},
-								query.Variable{Name: "?x"},
+								query.Variable{Name: datalog.NewSymbol("?x")},
 							},
 						},
 					},
@@ -698,7 +698,7 @@ func TestOrFallbackWithArithmeticExpression(t *testing.T) {
 								Left:  query.ConstantTerm{Value: int64(1)},
 								Right: query.ConstantTerm{Value: int64(1)},
 							},
-							Binding: query.Symbol("?x"),
+							Binding: datalog.NewSymbol("?x"),
 						},
 					},
 				},
@@ -746,7 +746,7 @@ func TestOrFallbackPatternOnlyUnionSemantics(t *testing.T) {
 	// Pattern-only OR should return BOTH Alice and Bob (union semantics)
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?e"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?e")},
 		},
 		Where: []query.Clause{
 			&query.OrClause{
@@ -754,7 +754,7 @@ func TestOrFallbackPatternOnlyUnionSemantics(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: activeAttr},
 								query.Constant{Value: true},
 							},
@@ -763,7 +763,7 @@ func TestOrFallbackPatternOnlyUnionSemantics(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: premiumAttr},
 								query.Constant{Value: true},
 							},
@@ -802,7 +802,7 @@ func TestOrFallbackPatternWithStreamingRelation(t *testing.T) {
 	// Pattern should match, returning "Alice"
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?x"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?x")},
 		},
 		Where: []query.Clause{
 			&query.OrClause{
@@ -810,16 +810,16 @@ func TestOrFallbackPatternWithStreamingRelation(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: nameAttr},
-								query.Variable{Name: "?x"},
+								query.Variable{Name: datalog.NewSymbol("?x")},
 							},
 						},
 					},
 					{
 						&query.Expression{
 							Function: &query.GroundFunction{Value: "fallback"},
-							Binding:  query.Symbol("?x"),
+							Binding:  datalog.NewSymbol("?x"),
 						},
 					},
 				},
@@ -866,12 +866,12 @@ func TestOrFallbackWithSubqueryPattern(t *testing.T) {
 				&query.SubqueryPattern{
 					Query: &query.Query{
 						Find: []query.FindElement{
-							query.FindAggregate{Function: "count", Arg: "?t"},
+							query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?t")},
 						},
 						Where: []query.Clause{
 							&query.DataPattern{
 								Elements: []query.PatternElement{
-									query.Variable{Name: "?t"},
+									query.Variable{Name: datalog.NewSymbol("?t")},
 									query.Constant{Value: statusAttr},
 									query.Constant{Value: completeStatus},
 								},
@@ -879,13 +879,13 @@ func TestOrFallbackWithSubqueryPattern(t *testing.T) {
 						},
 					},
 					Inputs:  []query.PatternElement{query.Constant{Value: "db"}},
-					Binding: query.TupleBinding{Variables: []query.Symbol{"?count"}},
+					Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?count")}},
 				},
 			},
 			{
 				&query.Expression{
 					Function: &query.GroundFunction{Value: int64(0)},
-					Binding:  query.Symbol("?count"),
+					Binding:  datalog.NewSymbol("?count"),
 				},
 			},
 		},
@@ -893,7 +893,7 @@ func TestOrFallbackWithSubqueryPattern(t *testing.T) {
 
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?count"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?count")},
 		},
 		Where: []query.Clause{orClause},
 	}
@@ -972,23 +972,23 @@ func TestOrFallbackWithSubqueryPatternAndVariableInput(t *testing.T) {
 				&query.SubqueryPattern{
 					Query: &query.Query{
 						Find: []query.FindElement{
-							query.FindAggregate{Function: "count", Arg: "?t"},
+							query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?t")},
 						},
 						In: []query.InputSpec{
-							query.DatabaseInput{Name: query.Symbol("$")},
-							query.ScalarInput{Symbol: "?s"},
+							query.DatabaseInput{Name: datalog.NewSymbol("$")},
+							query.ScalarInput{Symbol: datalog.NewSymbol("?s")},
 						},
 						Where: []query.Clause{
 							&query.DataPattern{
 								Elements: []query.PatternElement{
-									query.Variable{Name: "?t"},
+									query.Variable{Name: datalog.NewSymbol("?t")},
 									query.Constant{Value: taskScenarioAttr},
-									query.Variable{Name: "?s"},
+									query.Variable{Name: datalog.NewSymbol("?s")},
 								},
 							},
 							&query.DataPattern{
 								Elements: []query.PatternElement{
-									query.Variable{Name: "?t"},
+									query.Variable{Name: datalog.NewSymbol("?t")},
 									query.Constant{Value: taskStatusAttr},
 									query.Constant{Value: completeStatus},
 								},
@@ -996,16 +996,16 @@ func TestOrFallbackWithSubqueryPatternAndVariableInput(t *testing.T) {
 						},
 					},
 					Inputs: []query.PatternElement{
-						query.Constant{Value: query.Symbol("$")},
-						query.Variable{Name: "?scenario"},
+						query.Constant{Value: datalog.NewSymbol("$")},
+						query.Variable{Name: datalog.NewSymbol("?scenario")},
 					},
-					Binding: query.TupleBinding{Variables: []query.Symbol{"?count"}},
+					Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?count")}},
 				},
 			},
 			{
 				&query.Expression{
 					Function: &query.GroundFunction{Value: int64(0)},
-					Binding:  query.Symbol("?count"),
+					Binding:  datalog.NewSymbol("?count"),
 				},
 			},
 		},
@@ -1013,16 +1013,16 @@ func TestOrFallbackWithSubqueryPatternAndVariableInput(t *testing.T) {
 
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?scenario"},
-			query.FindVariable{Symbol: "?count"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?scenario")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?count")},
 		},
 		Where: []query.Clause{
 			// First, bind ?scenario from the database
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?scenario"},
+					query.Variable{Name: datalog.NewSymbol("?scenario")},
 					query.Constant{Value: scenarioAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			// Then OR with subquery and fallback
@@ -1099,16 +1099,16 @@ func TestOrFallbackWithPatternAndTupleGround(t *testing.T) {
 			{
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?scenario"},
+						query.Variable{Name: datalog.NewSymbol("?scenario")},
 						query.Constant{Value: taskAttr},
-						query.Variable{Name: "?task"},
+						query.Variable{Name: datalog.NewSymbol("?task")},
 					},
 				},
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?task"},
+						query.Variable{Name: datalog.NewSymbol("?task")},
 						query.Constant{Value: countAttr},
-						query.Variable{Name: "?taskCount"},
+						query.Variable{Name: datalog.NewSymbol("?taskCount")},
 					},
 				},
 			},
@@ -1116,7 +1116,7 @@ func TestOrFallbackWithPatternAndTupleGround(t *testing.T) {
 			{
 				&query.Expression{
 					Function: &query.GroundFunction{Value: []interface{}{int64(0)}},
-					Binding:  query.TupleBinding{Variables: []query.Symbol{"?taskCount"}},
+					Binding:  query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?taskCount")}},
 				},
 			},
 		},
@@ -1124,16 +1124,16 @@ func TestOrFallbackWithPatternAndTupleGround(t *testing.T) {
 
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?scenario"},
-			query.FindVariable{Symbol: "?name"},
-			query.FindVariable{Symbol: "?taskCount"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?scenario")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?taskCount")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?scenario"},
+					query.Variable{Name: datalog.NewSymbol("?scenario")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			orClause,
@@ -1214,16 +1214,16 @@ func TestOrFallbackWithPatternAndScalarGround(t *testing.T) {
 			{
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?scenario"},
+						query.Variable{Name: datalog.NewSymbol("?scenario")},
 						query.Constant{Value: taskAttr},
-						query.Variable{Name: "?task"},
+						query.Variable{Name: datalog.NewSymbol("?task")},
 					},
 				},
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?task"},
+						query.Variable{Name: datalog.NewSymbol("?task")},
 						query.Constant{Value: countAttr},
-						query.Variable{Name: "?taskCount"},
+						query.Variable{Name: datalog.NewSymbol("?taskCount")},
 					},
 				},
 			},
@@ -1231,7 +1231,7 @@ func TestOrFallbackWithPatternAndScalarGround(t *testing.T) {
 			{
 				&query.Expression{
 					Function: &query.GroundFunction{Value: int64(0)},
-					Binding:  query.Symbol("?taskCount"),
+					Binding:  datalog.NewSymbol("?taskCount"),
 				},
 			},
 		},
@@ -1239,16 +1239,16 @@ func TestOrFallbackWithPatternAndScalarGround(t *testing.T) {
 
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?scenario"},
-			query.FindVariable{Symbol: "?name"},
-			query.FindVariable{Symbol: "?taskCount"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?scenario")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?taskCount")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?scenario"},
+					query.Variable{Name: datalog.NewSymbol("?scenario")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?name"},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			orClause,
@@ -1308,12 +1308,12 @@ func TestOrFallbackWithSubqueryPatternEmpty(t *testing.T) {
 				&query.SubqueryPattern{
 					Query: &query.Query{
 						Find: []query.FindElement{
-							query.FindAggregate{Function: "count", Arg: "?t"},
+							query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?t")},
 						},
 						Where: []query.Clause{
 							&query.DataPattern{
 								Elements: []query.PatternElement{
-									query.Variable{Name: "?t"},
+									query.Variable{Name: datalog.NewSymbol("?t")},
 									query.Constant{Value: statusAttr},
 									query.Constant{Value: completeStatus},
 								},
@@ -1321,13 +1321,13 @@ func TestOrFallbackWithSubqueryPatternEmpty(t *testing.T) {
 						},
 					},
 					Inputs:  []query.PatternElement{query.Constant{Value: "db"}},
-					Binding: query.TupleBinding{Variables: []query.Symbol{"?count"}},
+					Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?count")}},
 				},
 			},
 			{
 				&query.Expression{
 					Function: &query.GroundFunction{Value: int64(0)},
-					Binding:  query.Symbol("?count"),
+					Binding:  datalog.NewSymbol("?count"),
 				},
 			},
 		},
@@ -1335,7 +1335,7 @@ func TestOrFallbackWithSubqueryPatternEmpty(t *testing.T) {
 
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: "?count"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?count")},
 		},
 		Where: []query.Clause{orClause},
 	}

--- a/datalog/executor/ohlc_subquery_performance_test.go
+++ b/datalog/executor/ohlc_subquery_performance_test.go
@@ -378,7 +378,7 @@ func BenchmarkRelationInputParallel(b *testing.B) {
 			}
 		}
 	}
-	inputRel := NewMaterializedRelation([]query.Symbol{"?n", "?y", "?m"}, inputTuples)
+	inputRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y"), datalog.NewSymbol("?m")}, inputTuples)
 
 	b.Run("Sequential", func(b *testing.B) {
 		seqExec := NewExecutor(matcher)

--- a/datalog/executor/or_fallback_relation.go
+++ b/datalog/executor/or_fallback_relation.go
@@ -125,7 +125,7 @@ func collectBranchOutputSymbols(branch []query.Clause) []query.Symbol {
 		case *query.Expression:
 			switch b := clause.Binding.(type) {
 			case query.Symbol:
-				if b != "" && !seen[b] {
+				if b != nil && !seen[b] {
 					seen[b] = true
 					outputs = append(outputs, b)
 				}
@@ -225,7 +225,7 @@ func (r *OrFallbackRelation) Get(i int) Tuple {
 func (r *OrFallbackRelation) String() string {
 	var symbols []string
 	for _, col := range r.Columns() {
-		symbols = append(symbols, string(col))
+		symbols = append(symbols, col.String())
 	}
 	return fmt.Sprintf("OrFallbackRelation([%s], streaming)", strings.Join(symbols, " "))
 }

--- a/datalog/executor/parallel_subquery_test.go
+++ b/datalog/executor/parallel_subquery_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/wbrown/janus-datalog/datalog/planner"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestParallelSubqueryConfiguration tests configuration flags
@@ -34,10 +36,10 @@ func Skip_TestParallelSubqueryConfiguration(t *testing.T) {
 func TestCombineSubqueryResults(t *testing.T) {
 	// Create test subquery plan
 	subqPlan := planner.SubqueryPlan{
-		Inputs: []query.Symbol{"?x"},
+		Inputs: []query.Symbol{datalog.NewSymbol("?x")},
 		Subquery: &query.SubqueryPattern{
 			Binding: query.TupleBinding{
-				Variables: []query.Symbol{"?result"},
+				Variables: []query.Symbol{datalog.NewSymbol("?result")},
 			},
 		},
 	}
@@ -56,7 +58,7 @@ func TestCombineSubqueryResults(t *testing.T) {
 			name: "single result",
 			results: []Relation{
 				NewMaterializedRelation(
-					[]query.Symbol{"?x", "?result"},
+					[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?result")},
 					[]Tuple{{1, "a"}},
 				),
 			},
@@ -66,15 +68,15 @@ func TestCombineSubqueryResults(t *testing.T) {
 			name: "multiple results",
 			results: []Relation{
 				NewMaterializedRelation(
-					[]query.Symbol{"?x", "?result"},
+					[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?result")},
 					[]Tuple{{1, "a"}},
 				),
 				NewMaterializedRelation(
-					[]query.Symbol{"?x", "?result"},
+					[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?result")},
 					[]Tuple{{2, "b"}},
 				),
 				NewMaterializedRelation(
-					[]query.Symbol{"?x", "?result"},
+					[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?result")},
 					[]Tuple{{3, "c"}},
 				),
 			},
@@ -84,11 +86,11 @@ func TestCombineSubqueryResults(t *testing.T) {
 			name: "results with multiple tuples",
 			results: []Relation{
 				NewMaterializedRelation(
-					[]query.Symbol{"?x", "?result"},
+					[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?result")},
 					[]Tuple{{1, "a"}, {1, "a2"}},
 				),
 				NewMaterializedRelation(
-					[]query.Symbol{"?x", "?result"},
+					[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?result")},
 					[]Tuple{{2, "b"}, {2, "b2"}},
 				),
 			},
@@ -98,12 +100,12 @@ func TestCombineSubqueryResults(t *testing.T) {
 			name: "with nil results",
 			results: []Relation{
 				NewMaterializedRelation(
-					[]query.Symbol{"?x", "?result"},
+					[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?result")},
 					[]Tuple{{1, "a"}},
 				),
 				nil,
 				NewMaterializedRelation(
-					[]query.Symbol{"?x", "?result"},
+					[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?result")},
 					[]Tuple{{2, "b"}},
 				),
 			},

--- a/datalog/executor/pattern_match_test.go
+++ b/datalog/executor/pattern_match_test.go
@@ -34,9 +34,9 @@ func TestPatternMatching(t *testing.T) {
 			name: "match all with variables",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			expected: 5,
@@ -46,8 +46,8 @@ func TestPatternMatching(t *testing.T) {
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
 					query.Constant{Value: alice},
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			expected: 3,
@@ -56,9 +56,9 @@ func TestPatternMatching(t *testing.T) {
 			name: "match specific attribute",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: nameAttr},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			expected: 2,
@@ -67,8 +67,8 @@ func TestPatternMatching(t *testing.T) {
 			name: "match specific value",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
-					query.Variable{Name: "?a"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
 					query.Constant{Value: "Alice"},
 				},
 			},
@@ -78,7 +78,7 @@ func TestPatternMatching(t *testing.T) {
 			name: "match entity reference value",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: friendAttr},
 					query.Constant{Value: bob},
 				},
@@ -91,7 +91,7 @@ func TestPatternMatching(t *testing.T) {
 				Elements: []query.PatternElement{
 					query.Blank{},
 					query.Constant{Value: ageAttr},
-					query.Variable{Name: "?age"},
+					query.Variable{Name: datalog.NewSymbol("?age")},
 				},
 			},
 			expected: 2,
@@ -100,9 +100,9 @@ func TestPatternMatching(t *testing.T) {
 			name: "match specific transaction",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 					query.Constant{Value: uint64(2)},
 				},
 			},
@@ -160,10 +160,10 @@ func TestDatomToRelationExtraction(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?user"},
+			query.Variable{Name: datalog.NewSymbol("?user")},
 			query.Constant{Value: nameAttr},
-			query.Variable{Name: "?name"},
-			query.Variable{Name: "?tx"},
+			query.Variable{Name: datalog.NewSymbol("?name")},
+			query.Variable{Name: datalog.NewSymbol("?tx")},
 		},
 	}
 
@@ -177,7 +177,7 @@ func TestDatomToRelationExtraction(t *testing.T) {
 	}
 
 	// Check column names
-	expectedCols := []query.Symbol{"?user", "?name", "?tx"}
+	expectedCols := []query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?name"), datalog.NewSymbol("?tx")}
 	for i, col := range columns {
 		if col != expectedCols[i] {
 			t.Errorf("expected column %d to be %s, got %s", i, expectedCols[i], col)
@@ -219,9 +219,9 @@ func TestPatternToRelation(t *testing.T) {
 	// Pattern: [?user :user/name ?name]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?user"},
+			query.Variable{Name: datalog.NewSymbol("?user")},
 			query.Constant{Value: nameAttr},
-			query.Variable{Name: "?name"},
+			query.Variable{Name: datalog.NewSymbol("?name")},
 		},
 	}
 
@@ -232,7 +232,7 @@ func TestPatternToRelation(t *testing.T) {
 	if len(cols) != 2 {
 		t.Errorf("expected 2 columns, got %d", len(cols))
 	}
-	if cols[0] != "?user" || cols[1] != "?name" {
+	if cols[0] != datalog.NewSymbol("?user") || cols[1] != datalog.NewSymbol("?name") {
 		t.Errorf("unexpected columns: %v", cols)
 	}
 
@@ -281,7 +281,7 @@ func TestMatchWithStringConstants(t *testing.T) {
 		Elements: []query.PatternElement{
 			query.Constant{Value: "user:alice"}, // String instead of Identity
 			query.Constant{Value: ":user/name"}, // String instead of Keyword
-			query.Variable{Name: "?name"},
+			query.Variable{Name: datalog.NewSymbol("?name")},
 		},
 	}
 

--- a/datalog/executor/peak_memory_test.go
+++ b/datalog/executor/peak_memory_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestPeakMemoryFullConsumption measures actual peak memory for full consumption
@@ -15,8 +17,8 @@ func TestPeakMemoryFullConsumption(t *testing.T) {
 
 	for _, size := range sizes {
 		t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
-			leftCols := []query.Symbol{"?x", "?name"}
-			rightCols := []query.Symbol{"?x", "?value"}
+			leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+			rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 			leftTuples := make([]Tuple, size)
 			rightTuples := make([]Tuple, size)

--- a/datalog/executor/predicate_classifier.go
+++ b/datalog/executor/predicate_classifier.go
@@ -284,7 +284,7 @@ func (pc *PredicateClassifier) convertFunctionPredicate(fp *query.FunctionPredic
 			return nil
 		}
 
-		position, found := patternVars[query.Symbol(timeVar.Name)]
+		position, found := patternVars[timeVar.Name]
 		if !found {
 			return nil
 		}
@@ -299,7 +299,7 @@ func (pc *PredicateClassifier) convertFunctionPredicate(fp *query.FunctionPredic
 		case query.Variable:
 			// Check if this variable is bound (in Available from previous phases)
 			for _, sym := range pc.phase.Available {
-				if sym == query.Symbol(e.Name) {
+				if sym == e.Name {
 					// Variable is bound from previous phase
 					// We'd need the actual value at execution time
 					// For now, we can't push this down statically

--- a/datalog/executor/predicate_pushdown_test.go
+++ b/datalog/executor/predicate_pushdown_test.go
@@ -12,9 +12,9 @@ import (
 func TestConvertPlannerConstraints(t *testing.T) {
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?b"},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/volume")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 

--- a/datalog/executor/prepended_relation.go
+++ b/datalog/executor/prepended_relation.go
@@ -64,7 +64,7 @@ func (r *PrependedRelation) Get(i int) Tuple {
 func (r *PrependedRelation) String() string {
 	var symbols []string
 	for _, col := range r.columns {
-		symbols = append(symbols, string(col))
+		symbols = append(symbols, col.String())
 	}
 	return fmt.Sprintf("PrependedRelation([%s], streaming)", strings.Join(symbols, " "))
 }

--- a/datalog/executor/pull.go
+++ b/datalog/executor/pull.go
@@ -193,7 +193,7 @@ func (pe *PullExecutor) lookupAttributeViaPattern(entity datalog.Identity, attr 
 		Elements: []query.PatternElement{
 			query.Constant{Value: entity},
 			query.Constant{Value: attr},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -209,8 +209,9 @@ func (pe *PullExecutor) lookupAttributeViaPattern(entity datalog.Identity, attr 
 	if it.Next() {
 		tuple := it.Tuple()
 		cols := rel.Columns()
+		symV := datalog.NewSymbol("?v")
 		for i, col := range cols {
-			if col == "?v" && i < len(tuple) {
+			if col == symV && i < len(tuple) {
 				return tuple[i], true
 			}
 		}
@@ -237,8 +238,8 @@ func (pe *PullExecutor) getAllAttributesInternal(entity datalog.Identity) ([]dat
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
 			query.Constant{Value: entity},
-			query.Variable{Name: "?a"},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?a")},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -253,12 +254,14 @@ func (pe *PullExecutor) getAllAttributesInternal(entity datalog.Identity) ([]dat
 
 	// Find column indices
 	cols := rel.Columns()
+	symA := datalog.NewSymbol("?a")
+	symV := datalog.NewSymbol("?v")
 	aIdx := -1
 	vIdx := -1
 	for i, col := range cols {
-		if col == "?a" {
+		if col == symA {
 			aIdx = i
-		} else if col == "?v" {
+		} else if col == symV {
 			vIdx = i
 		}
 	}
@@ -519,7 +522,7 @@ func (pe *PullExecutor) lookupAllValuesInternal(entity datalog.Identity, attr da
 		Elements: []query.PatternElement{
 			query.Constant{Value: entity},
 			query.Constant{Value: attr},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -530,9 +533,10 @@ func (pe *PullExecutor) lookupAllValuesInternal(entity datalog.Identity, attr da
 
 	// Find value column index
 	cols := rel.Columns()
+	symV := datalog.NewSymbol("?v")
 	vIdx := -1
 	for i, col := range cols {
-		if col == "?v" {
+		if col == symV {
 			vIdx = i
 			break
 		}

--- a/datalog/executor/pull_benchmark_test.go
+++ b/datalog/executor/pull_benchmark_test.go
@@ -181,7 +181,7 @@ func BenchmarkPull_VsManualQuery(b *testing.B) {
 					Elements: []query.PatternElement{
 						query.Constant{Value: alice},
 						query.Constant{Value: attr},
-						query.Variable{Name: "?v"},
+						query.Variable{Name: datalog.NewSymbol("?v")},
 					},
 				}
 				rel, err := matcher.Match(pattern, nil)

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -366,7 +366,7 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 			return []Relation{NewMaterializedRelationWithOptions(columns, []Tuple{tuple}, e.options)}, nil
 
 		case query.Symbol:
-			if binding == "" {
+			if binding == nil {
 				return groups, nil
 			}
 			columns := []query.Symbol{binding}
@@ -425,7 +425,7 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 				}
 				bindingValues = values
 			case query.Symbol:
-				if binding != "" {
+				if binding != nil {
 					bindingCols = []query.Symbol{binding}
 					bindingValues = []interface{}{result}
 				}
@@ -561,7 +561,7 @@ func (e *DefaultQueryExecutor) executeSubquery(ctx Context, subq *query.Subquery
 			inputSymbols = append(inputSymbols, inp.Name)
 		case query.Constant:
 			// Check if it's a source marker
-			if sym, ok := inp.Value.(query.Symbol); ok && IsSourceSymbol(sym) {
+			if sym, ok := inp.Value.(query.Symbol); ok && sym.IsSource() {
 				inputSymbols = append(inputSymbols, sym)
 			}
 			// Other constants don't need extraction
@@ -1432,7 +1432,7 @@ func collectOrBranchRequiredSymbols(clause *query.OrClause) []query.Symbol {
 			case *query.Expression:
 				switch b := clause.Binding.(type) {
 				case query.Symbol:
-					if b != "" {
+					if b != nil {
 						branchProvides[b] = true
 					}
 				case query.TupleBinding:

--- a/datalog/executor/query_executor_test.go
+++ b/datalog/executor/query_executor_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // MockMatcher implements PatternMatcher for testing
@@ -42,7 +44,7 @@ func TestProductRelation(t *testing.T) {
 
 	t.Run("single relation passthrough", func(t *testing.T) {
 		r1 := NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{int64(1)}, {int64(2)}},
 		)
 		product := Relations([]Relation{r1}).Product()
@@ -53,11 +55,11 @@ func TestProductRelation(t *testing.T) {
 
 	t.Run("cartesian product", func(t *testing.T) {
 		r1 := NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{int64(1)}, {int64(2)}},
 		)
 		r2 := NewMaterializedRelation(
-			[]query.Symbol{"?y"},
+			[]query.Symbol{datalog.NewSymbol("?y")},
 			[]Tuple{{int64(10)}, {int64(20)}, {int64(30)}},
 		)
 
@@ -73,7 +75,7 @@ func TestProductRelation(t *testing.T) {
 		if len(cols) != 2 {
 			t.Errorf("Expected 2 columns, got %d", len(cols))
 		}
-		if cols[0] != "?x" || cols[1] != "?y" {
+		if cols[0] != datalog.NewSymbol("?x") || cols[1] != datalog.NewSymbol("?y") {
 			t.Errorf("Expected columns [?x ?y], got %v", cols)
 		}
 
@@ -102,9 +104,9 @@ func TestProductRelation(t *testing.T) {
 	})
 
 	t.Run("three relation product", func(t *testing.T) {
-		r1 := NewMaterializedRelation([]query.Symbol{"?x"}, []Tuple{{int64(1)}, {int64(2)}})
-		r2 := NewMaterializedRelation([]query.Symbol{"?y"}, []Tuple{{int64(10)}, {int64(20)}})
-		r3 := NewMaterializedRelation([]query.Symbol{"?z"}, []Tuple{{int64(100)}})
+		r1 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x")}, []Tuple{{int64(1)}, {int64(2)}})
+		r2 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?y")}, []Tuple{{int64(10)}, {int64(20)}})
+		r3 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?z")}, []Tuple{{int64(100)}})
 
 		product := Relations([]Relation{r1, r2, r3}).Product()
 
@@ -124,7 +126,7 @@ func TestProductRelation(t *testing.T) {
 // TestExecutePattern tests pattern execution
 func TestExecutePattern(t *testing.T) {
 	mockResult := NewMaterializedRelation(
-		[]query.Symbol{"?e", "?v"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")},
 		[]Tuple{
 			{int64(1), "Alice"},
 			{int64(2), "Bob"},
@@ -142,9 +144,9 @@ func TestExecutePattern(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: ":person/name"},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -166,7 +168,7 @@ func TestExecuteExpression(t *testing.T) {
 
 		// Create a relation with ?x
 		r := NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{int64(5)}, {int64(10)}},
 		)
 
@@ -174,10 +176,10 @@ func TestExecuteExpression(t *testing.T) {
 		expr := &query.Expression{
 			Function: &query.ArithmeticFunction{
 				Op:    query.OpAdd,
-				Left:  query.VariableTerm{Symbol: "?x"},
+				Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
 				Right: query.ConstantTerm{Value: int64(100)},
 			},
-			Binding: query.Symbol("?y"),
+			Binding: datalog.NewSymbol("?y"),
 		}
 
 		groups, err := executor.executeExpression(ctx, expr, []Relation{r})
@@ -206,17 +208,17 @@ func TestExecuteExpression(t *testing.T) {
 		ctx := NewContext(nil)
 
 		// Two disjoint relations
-		r1 := NewMaterializedRelation([]query.Symbol{"?x"}, []Tuple{{int64(1)}, {int64(2)}})
-		r2 := NewMaterializedRelation([]query.Symbol{"?y"}, []Tuple{{int64(10)}, {int64(20)}})
+		r1 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x")}, []Tuple{{int64(1)}, {int64(2)}})
+		r2 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?y")}, []Tuple{{int64(10)}, {int64(20)}})
 
 		// Expression: [(+ ?x ?y) ?z] - requires both ?x and ?y
 		expr := &query.Expression{
 			Function: &query.ArithmeticFunction{
 				Op:    query.OpAdd,
-				Left:  query.VariableTerm{Symbol: "?x"},
-				Right: query.VariableTerm{Symbol: "?y"},
+				Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
+				Right: query.VariableTerm{Symbol: datalog.NewSymbol("?y")},
 			},
-			Binding: query.Symbol("?z"),
+			Binding: datalog.NewSymbol("?z"),
 		}
 
 		groups, err := executor.executeExpression(ctx, expr, []Relation{r1, r2})
@@ -250,14 +252,14 @@ func TestExecutePredicate(t *testing.T) {
 
 		// Create relation with ?x
 		r := NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{int64(5)}, {int64(15)}, {int64(25)}},
 		)
 
 		// Predicate: [(< ?x 20)]
 		pred := &query.Comparison{
 			Op:    query.OpLT,
-			Left:  query.VariableTerm{Symbol: "?x"},
+			Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
 			Right: query.ConstantTerm{Value: int64(20)},
 		}
 
@@ -284,7 +286,7 @@ func TestExecuteAggregates(t *testing.T) {
 		matchFunc: func(pattern *query.DataPattern, bindings Relations) (Relation, error) {
 			// Return test data
 			return NewMaterializedRelation(
-				[]query.Symbol{"?person", "?value"},
+				[]query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?value")},
 				[]Tuple{
 					{"Alice", int64(100)},
 					{"Alice", int64(200)},
@@ -301,18 +303,18 @@ func TestExecuteAggregates(t *testing.T) {
 		// Query: [:find ?person (sum ?value)]
 		q := &query.Query{
 			Find: []query.FindElement{
-				query.FindVariable{Symbol: "?person"},
+				query.FindVariable{Symbol: datalog.NewSymbol("?person")},
 				query.FindAggregate{
 					Function: "sum",
-					Arg:      "?value",
+					Arg:      datalog.NewSymbol("?value"),
 				},
 			},
 			Where: []query.Clause{
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?person"},
+						query.Variable{Name: datalog.NewSymbol("?person")},
 						query.Constant{Value: ":person/value"},
-						query.Variable{Name: "?value"},
+						query.Variable{Name: datalog.NewSymbol("?value")},
 					},
 				},
 			},
@@ -340,21 +342,21 @@ func TestExecuteAggregates(t *testing.T) {
 			Find: []query.FindElement{
 				query.FindAggregate{
 					Function: "sum",
-					Arg:      "?value",
+					Arg:      datalog.NewSymbol("?value"),
 				},
 			},
 			Where: []query.Clause{
 				&query.DataPattern{Elements: []query.PatternElement{
-					query.Variable{Name: "?e1"},
+					query.Variable{Name: datalog.NewSymbol("?e1")},
 					query.Constant{Value: ":person/name"},
-					query.Variable{Name: "?n"},
+					query.Variable{Name: datalog.NewSymbol("?n")},
 				}},
 			},
 		}
 
 		// Manually set up disjoint groups (this simulates the error case)
-		r1 := NewMaterializedRelation([]query.Symbol{"?x"}, []Tuple{{int64(1)}})
-		r2 := NewMaterializedRelation([]query.Symbol{"?y"}, []Tuple{{int64(2)}})
+		r1 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x")}, []Tuple{{int64(1)}})
+		r2 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?y")}, []Tuple{{int64(2)}})
 
 		// Try to aggregate with pre-existing disjoint groups
 		_, err := executor.Execute(ctx, q, []Relation{r1, r2})
@@ -373,7 +375,7 @@ func TestEndToEndQueries(t *testing.T) {
 			if c, ok := attr.(query.Constant); ok {
 				if c.Value == ":person/age" {
 					return NewMaterializedRelation(
-						[]query.Symbol{"?person", "?age"},
+						[]query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?age")},
 						[]Tuple{
 							{"Alice", int64(30)},
 							{"Bob", int64(25)},
@@ -392,20 +394,20 @@ func TestEndToEndQueries(t *testing.T) {
 		// Query: [:find ?person ?age :where [?person :person/age ?age] [(> ?age 26)]]
 		q := &query.Query{
 			Find: []query.FindElement{
-				query.FindVariable{Symbol: "?person"},
-				query.FindVariable{Symbol: "?age"},
+				query.FindVariable{Symbol: datalog.NewSymbol("?person")},
+				query.FindVariable{Symbol: datalog.NewSymbol("?age")},
 			},
 			Where: []query.Clause{
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?person"},
+						query.Variable{Name: datalog.NewSymbol("?person")},
 						query.Constant{Value: ":person/age"},
-						query.Variable{Name: "?age"},
+						query.Variable{Name: datalog.NewSymbol("?age")},
 					},
 				},
 				&query.Comparison{
 					Op:    query.OpGT,
-					Left:  query.VariableTerm{Symbol: "?age"},
+					Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?age")},
 					Right: query.ConstantTerm{Value: int64(26)},
 				},
 			},
@@ -439,7 +441,7 @@ func TestExecuteTupleGround(t *testing.T) {
 			Function: &query.GroundFunction{
 				Value: []interface{}{int64(1), int64(2), int64(3)},
 			},
-			Binding: query.TupleBinding{Variables: []query.Symbol{"?a", "?b", "?c"}},
+			Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}},
 		}
 
 		groups, err := executor.executeExpression(ctx, expr, nil)
@@ -461,7 +463,7 @@ func TestExecuteTupleGround(t *testing.T) {
 		if len(cols) != 3 {
 			t.Errorf("Expected 3 columns, got %d", len(cols))
 		}
-		expected := []query.Symbol{"?a", "?b", "?c"}
+		expected := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
 		for i, exp := range expected {
 			if cols[i] != exp {
 				t.Errorf("Column %d = %v, want %v", i, cols[i], exp)
@@ -489,7 +491,7 @@ func TestExecuteTupleGround(t *testing.T) {
 
 		// Create a relation with ?x
 		r := NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{int64(10)}, {int64(20)}},
 		)
 
@@ -498,7 +500,7 @@ func TestExecuteTupleGround(t *testing.T) {
 			Function: &query.GroundFunction{
 				Value: []interface{}{int64(0), int64(0)},
 			},
-			Binding: query.TupleBinding{Variables: []query.Symbol{"?a", "?b"}},
+			Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")}},
 		}
 
 		groups, err := executor.executeExpression(ctx, expr, []Relation{r})
@@ -532,7 +534,7 @@ func TestExecuteTupleGround(t *testing.T) {
 			Function: &query.GroundFunction{
 				Value: []interface{}{int64(1), int64(2)}, // 2 values
 			},
-			Binding: query.TupleBinding{Variables: []query.Symbol{"?a", "?b", "?c"}}, // 3 vars
+			Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}}, // 3 vars
 		}
 
 		_, err := executor.executeExpression(ctx, expr, nil)

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -398,7 +398,7 @@ func (r *MaterializedRelation) String() string {
 	// Format as: Relation([?x ?y], N Tuples) with colors
 	var symbols []string
 	for _, col := range r.columns {
-		symbols = append(symbols, string(col))
+		symbols = append(symbols, col.String())
 	}
 
 	// Color the tuple count based on size
@@ -910,7 +910,7 @@ func (r *StreamingRelation) String() string {
 	// Format as: Relation([?x ?y], N Tuples) with colors
 	var symbols []string
 	for _, col := range r.columns {
-		symbols = append(symbols, string(col))
+		symbols = append(symbols, col.String())
 	}
 
 	// For streaming relations, we might not know the size

--- a/datalog/executor/relation_concurrent_test.go
+++ b/datalog/executor/relation_concurrent_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestConcurrentIteratorAccess verifies that multiple goroutines can safely
 // call Iterator() on the same Relation and iterate independently
 func TestConcurrentIteratorAccess(t *testing.T) {
-	columns := []query.Symbol{"?x", "?y"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{1, "a"},
 		{2, "b"},
@@ -111,7 +113,7 @@ func TestConcurrentIteratorAccess(t *testing.T) {
 // TestConcurrentStreamingMaterialization verifies that concurrent calls to
 // Iterator() on a StreamingRelation all see the same materialized data
 func TestConcurrentStreamingMaterialization(t *testing.T) {
-	columns := []query.Symbol{"?n"}
+	columns := []query.Symbol{datalog.NewSymbol("?n")}
 	tuples := []Tuple{{1}, {2}, {3}, {4}, {5}}
 
 	// Create streaming relation and materialize it for concurrent access

--- a/datalog/executor/relation_input_test.go
+++ b/datalog/executor/relation_input_test.go
@@ -54,7 +54,7 @@ func TestRelationInputIteration(t *testing.T) {
 
 		// Create input relation with name-year pairs
 		inputRel := NewMaterializedRelation(
-			[]query.Symbol{"?n", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")},
 			[]Tuple{
 				{"Alice", int64(2020)},
 				{"Alice", int64(2021)},
@@ -178,7 +178,7 @@ func TestRelationInputIterationParallel(t *testing.T) {
 
 		// Create input relation with name-year pairs
 		inputRel := NewMaterializedRelation(
-			[]query.Symbol{"?n", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")},
 			[]Tuple{
 				{"Alice", int64(2020)},
 				{"Alice", int64(2021)},
@@ -244,7 +244,7 @@ func TestRelationInputIterationParallel(t *testing.T) {
 
 		// Create input relation with name-year pairs
 		inputRel := NewMaterializedRelation(
-			[]query.Symbol{"?n", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")},
 			[]Tuple{
 				{"Alice", int64(2020)},
 				{"Alice", int64(2021)},
@@ -352,7 +352,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 		}
 
 		// Empty input relation
-		emptyRel := NewMaterializedRelation([]query.Symbol{"?n", "?y"}, []Tuple{})
+		emptyRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")}, []Tuple{})
 
 		result, err := exec.ExecuteWithRelations(ctx, parsed, []Relation{emptyRel})
 		if err != nil {
@@ -381,7 +381,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 
 		// Single tuple
 		singleRel := NewMaterializedRelation(
-			[]query.Symbol{"?n", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")},
 			[]Tuple{{"Alice", int64(2020)}},
 		)
 
@@ -412,7 +412,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 
 		// Non-matching tuples
 		noMatchRel := NewMaterializedRelation(
-			[]query.Symbol{"?n", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")},
 			[]Tuple{
 				{"Bob", int64(2020)},
 				{"Charlie", int64(2021)},
@@ -446,7 +446,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 
 		// Mix of matching and non-matching
 		mixedRel := NewMaterializedRelation(
-			[]query.Symbol{"?n", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")},
 			[]Tuple{
 				{"Alice", int64(2020)}, // matches
 				{"Bob", int64(2020)},   // no match
@@ -482,7 +482,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 
 		// Only 1 tuple with 100 workers (tests that excess workers don't cause issues)
 		smallRel := NewMaterializedRelation(
-			[]query.Symbol{"?n", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")},
 			[]Tuple{
 				{"Alice", int64(2020)},
 			},
@@ -554,7 +554,7 @@ func TestRelationInputParallelStress(t *testing.T) {
 				}
 			}
 		}
-		inputRel := NewMaterializedRelation([]query.Symbol{"?n", "?y", "?m"}, inputTuples)
+		inputRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y"), datalog.NewSymbol("?m")}, inputTuples)
 
 		// Execute and verify
 		result, err := exec.ExecuteWithRelations(ctx, parsed, []Relation{inputRel})
@@ -607,7 +607,7 @@ func TestRelationInputParallelStress(t *testing.T) {
 				inputTuples = append(inputTuples, Tuple{name, int64(year)})
 			}
 		}
-		inputRel := NewMaterializedRelation([]query.Symbol{"?n", "?y"}, inputTuples)
+		inputRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")}, inputTuples)
 
 		// Run 10 queries concurrently with parallel execution
 		errCh := make(chan error, 10)

--- a/datalog/executor/relation_materialize_test.go
+++ b/datalog/executor/relation_materialize_test.go
@@ -7,12 +7,14 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestLazyMaterializationBasic tests basic lazy materialization behavior
 func TestLazyMaterializationBasic(t *testing.T) {
 	// Create a streaming relation with 10 tuples
-	columns := []query.Symbol{"?x"}
+	columns := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := make([]Tuple, 10)
 	for i := 0; i < 10; i++ {
 		tuples[i] = Tuple{int64(i)}
@@ -81,7 +83,7 @@ func TestLazyMaterializationBasic(t *testing.T) {
 // TestConcurrentAccess tests that multiple goroutines can safely access a materialized relation
 func TestConcurrentAccess(t *testing.T) {
 	// Create a streaming relation with 1000 tuples
-	columns := []query.Symbol{"?x"}
+	columns := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := make([]Tuple, 1000)
 	for i := 0; i < 1000; i++ {
 		tuples[i] = Tuple{int64(i)}
@@ -164,7 +166,7 @@ func TestMaterializeAfterIterationPanics(t *testing.T) {
 	}()
 
 	// Create a streaming relation
-	columns := []query.Symbol{"?x"}
+	columns := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := []Tuple{{int64(1)}, {int64(2)}}
 	iter := &sliceIterator{tuples: tuples, pos: -1}
 
@@ -189,7 +191,7 @@ func TestDoubleIterationWithoutMaterializePanics(t *testing.T) {
 	}()
 
 	// Create a streaming relation
-	columns := []query.Symbol{"?x"}
+	columns := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := []Tuple{{int64(1)}, {int64(2)}}
 	iter := &sliceIterator{tuples: tuples, pos: -1}
 
@@ -208,7 +210,7 @@ func TestDoubleIterationWithoutMaterializePanics(t *testing.T) {
 // TestSizeBlocksWhileCaching tests that Size() blocks while caching is in progress
 func TestSizeBlocksWhileCaching(t *testing.T) {
 	// Create a streaming relation with 100 tuples
-	columns := []query.Symbol{"?x"}
+	columns := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := make([]Tuple, 100)
 	for i := 0; i < 100; i++ {
 		tuples[i] = Tuple{int64(i)}

--- a/datalog/executor/relation_predicate_test.go
+++ b/datalog/executor/relation_predicate_test.go
@@ -3,11 +3,13 @@ package executor
 import (
 	"github.com/wbrown/janus-datalog/datalog/query"
 	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestFilterWithPredicate(t *testing.T) {
 	// Create a test relation
-	columns := []query.Symbol{"?x", "?y", "?z"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 	tuples := []Tuple{
 		{1, 2, 3},
 		{4, 5, 6},
@@ -19,7 +21,7 @@ func TestFilterWithPredicate(t *testing.T) {
 	// Test with a comparison predicate
 	pred := &query.Comparison{
 		Op:    query.OpGT,
-		Left:  query.VariableTerm{Symbol: "?x"},
+		Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
 		Right: query.ConstantTerm{Value: int64(5)},
 	}
 
@@ -44,7 +46,7 @@ func TestFilterWithPredicate(t *testing.T) {
 
 func TestEvaluateFunction(t *testing.T) {
 	// Create a test relation
-	columns := []query.Symbol{"?x", "?y"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{int64(10), int64(20)},
 		{int64(5), int64(15)},
@@ -55,11 +57,11 @@ func TestEvaluateFunction(t *testing.T) {
 	// Test with an arithmetic function
 	fn := &query.ArithmeticFunction{
 		Op:    query.OpAdd,
-		Left:  query.VariableTerm{Symbol: "?x"},
-		Right: query.VariableTerm{Symbol: "?y"},
+		Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
+		Right: query.VariableTerm{Symbol: datalog.NewSymbol("?y")},
 	}
 
-	result := rel.EvaluateFunction(fn, "?sum")
+	result := rel.EvaluateFunction(fn, datalog.NewSymbol("?sum"))
 
 	// Should have 3 columns now
 	if len(result.Columns()) != 3 {
@@ -85,7 +87,7 @@ func TestEvaluateFunction(t *testing.T) {
 
 func TestChainedComparison(t *testing.T) {
 	// Test the variadic comparison with FilterWithPredicate
-	columns := []query.Symbol{"?x", "?y", "?z"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 	tuples := []Tuple{
 		{1, 5, 10},
 		{2, 3, 4}, // This one satisfies 2 < 3 < 4 < 5
@@ -98,9 +100,9 @@ func TestChainedComparison(t *testing.T) {
 	pred := &query.ChainedComparison{
 		Op: query.OpLT,
 		Terms: []query.Term{
-			query.VariableTerm{Symbol: "?x"},
-			query.VariableTerm{Symbol: "?y"},
-			query.VariableTerm{Symbol: "?z"},
+			query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
+			query.VariableTerm{Symbol: datalog.NewSymbol("?y")},
+			query.VariableTerm{Symbol: datalog.NewSymbol("?z")},
 			query.ConstantTerm{Value: int64(5)},
 		},
 	}

--- a/datalog/executor/relation_test.go
+++ b/datalog/executor/relation_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestMaterializedRelation(t *testing.T) {
-	columns := []query.Symbol{"?name", "?age", "?city"}
+	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
 	tuples := []Tuple{
 		{"Alice", 30, "NYC"},
 		{"Bob", 25, "LA"},
@@ -27,7 +29,7 @@ func TestMaterializedRelation(t *testing.T) {
 
 	// Test columns
 	cols := rel.Columns()
-	if len(cols) != 3 || cols[0] != "?name" || cols[1] != "?age" || cols[2] != "?city" {
+	if len(cols) != 3 || cols[0] != datalog.NewSymbol("?name") || cols[1] != datalog.NewSymbol("?age") || cols[2] != datalog.NewSymbol("?city") {
 		t.Errorf("unexpected columns: %v", cols)
 	}
 
@@ -50,7 +52,7 @@ func TestMaterializedRelation(t *testing.T) {
 }
 
 func TestEmptyRelation(t *testing.T) {
-	columns := []query.Symbol{"?x", "?y"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	rel := NewMaterializedRelation(columns, nil)
 
 	if !rel.IsEmpty() {
@@ -68,17 +70,17 @@ func TestEmptyRelation(t *testing.T) {
 }
 
 func TestColumnIndex(t *testing.T) {
-	columns := []query.Symbol{"?a", "?b", "?c"}
+	columns := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
 	rel := NewMaterializedRelation(columns, nil)
 
 	tests := []struct {
 		symbol   query.Symbol
 		expected int
 	}{
-		{"?a", 0},
-		{"?b", 1},
-		{"?c", 2},
-		{"?d", -1}, // not found
+		{datalog.NewSymbol("?a"), 0},
+		{datalog.NewSymbol("?b"), 1},
+		{datalog.NewSymbol("?c"), 2},
+		{datalog.NewSymbol("?d"), -1}, // not found
 	}
 
 	for _, tt := range tests {
@@ -90,8 +92,8 @@ func TestColumnIndex(t *testing.T) {
 }
 
 func TestCommonColumns(t *testing.T) {
-	rel1 := NewMaterializedRelation([]query.Symbol{"?a", "?b", "?c"}, nil)
-	rel2 := NewMaterializedRelation([]query.Symbol{"?b", "?c", "?d"}, nil)
+	rel1 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}, nil)
+	rel2 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?b"), datalog.NewSymbol("?c"), datalog.NewSymbol("?d")}, nil)
 
 	common := CommonColumns(rel1, rel2)
 
@@ -105,13 +107,13 @@ func TestCommonColumns(t *testing.T) {
 		commonSet[col] = true
 	}
 
-	if !commonSet["?b"] || !commonSet["?c"] {
+	if !commonSet[datalog.NewSymbol("?b")] || !commonSet[datalog.NewSymbol("?c")] {
 		t.Errorf("expected ?b and ?c in common columns, got %v", common)
 	}
 }
 
 func TestProject(t *testing.T) {
-	columns := []query.Symbol{"?name", "?age", "?city"}
+	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
 	tuples := []Tuple{
 		{"Alice", 30, "NYC"},
 		{"Bob", 25, "LA"},
@@ -120,14 +122,14 @@ func TestProject(t *testing.T) {
 	rel := NewMaterializedRelation(columns, tuples)
 
 	// Project to subset of columns using method
-	projected, err := rel.Project([]query.Symbol{"?name", "?city"})
+	projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?city")})
 	if err != nil {
 		t.Fatalf("Project failed: %v", err)
 	}
 
 	// Check columns
 	projCols := projected.Columns()
-	if len(projCols) != 2 || projCols[0] != "?name" || projCols[1] != "?city" {
+	if len(projCols) != 2 || projCols[0] != datalog.NewSymbol("?name") || projCols[1] != datalog.NewSymbol("?city") {
 		t.Errorf("unexpected projected columns: %v", projCols)
 	}
 
@@ -153,14 +155,14 @@ func TestProject(t *testing.T) {
 	}
 
 	// Test projecting non-existent column using method
-	_, err = rel.Project([]query.Symbol{"?nonexistent"})
+	_, err = rel.Project([]query.Symbol{datalog.NewSymbol("?nonexistent")})
 	if err == nil {
 		t.Fatal("Expected error when projecting non-existent column")
 	}
 }
 
 func TestSelect(t *testing.T) {
-	columns := []query.Symbol{"?name", "?age", "?city"}
+	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
 	tuples := []Tuple{
 		{"Alice", 30, "NYC"},
 		{"Bob", 25, "LA"},
@@ -209,7 +211,7 @@ func TestStreamingRelation(t *testing.T) {
 	}
 
 	it := &sliceIterator{tuples: tuples, pos: -1}
-	columns := []query.Symbol{"?letter", "?number"}
+	columns := []query.Symbol{datalog.NewSymbol("?letter"), datalog.NewSymbol("?number")}
 
 	rel := NewStreamingRelation(columns, it)
 

--- a/datalog/executor/relations_test.go
+++ b/datalog/executor/relations_test.go
@@ -5,20 +5,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestRelationsProject(t *testing.T) {
 	// Create test relations
 	r1 := NewMaterializedRelation(
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		[]Tuple{{1, 2}, {3, 4}},
 	)
 	r2 := NewMaterializedRelation(
-		[]query.Symbol{"?x", "?y", "?z"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
 		[]Tuple{{1, 2, 3}, {4, 5, 6}},
 	)
 	r3 := NewMaterializedRelation(
-		[]query.Symbol{"?a", "?b"},
+		[]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 		[]Tuple{{7, 8}},
 	)
 
@@ -31,22 +33,22 @@ func TestRelationsProject(t *testing.T) {
 	}{
 		{
 			name:     "exact match prefers fewer columns",
-			symbols:  []query.Symbol{"?x", "?y"},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: r1, // r1 has exactly these columns, r2 has extra
 		},
 		{
 			name:     "requires all symbols",
-			symbols:  []query.Symbol{"?x", "?z"},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")},
 			expected: r2, // only r2 has both ?x and ?z
 		},
 		{
 			name:     "no match returns nil",
-			symbols:  []query.Symbol{"?x", "?b"},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?b")},
 			expected: nil, // no single relation has both
 		},
 		{
 			name:     "single symbol matches smallest relation",
-			symbols:  []query.Symbol{"?x"},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x")},
 			expected: r1, // both r1 and r2 have ?x, but r1 has fewer columns
 		},
 	}
@@ -62,19 +64,19 @@ func TestRelationsProject(t *testing.T) {
 func TestRelationsFindBestForPattern(t *testing.T) {
 	// Create test relations
 	rEntity := NewMaterializedRelation(
-		[]query.Symbol{"?e"},
+		[]query.Symbol{datalog.NewSymbol("?e")},
 		[]Tuple{{1}, {2}, {3}}, // 3 rows
 	)
 	rAttribute := NewMaterializedRelation(
-		[]query.Symbol{"?a"},
+		[]query.Symbol{datalog.NewSymbol("?a")},
 		[]Tuple{{1}, {2}}, // 2 rows
 	)
 	rValue := NewMaterializedRelation(
-		[]query.Symbol{"?v"},
+		[]query.Symbol{datalog.NewSymbol("?v")},
 		[]Tuple{{1}, {2}, {3}, {4}}, // 4 rows
 	)
 	rEntityValue := NewMaterializedRelation(
-		[]query.Symbol{"?e", "?v"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")},
 		[]Tuple{{1, 10}, {2, 20}}, // 2 rows
 	)
 
@@ -88,7 +90,7 @@ func TestRelationsFindBestForPattern(t *testing.T) {
 			name: "prefers E binding",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: ":foo/bar"},
 					query.Constant{Value: 123},
 				},
@@ -101,8 +103,8 @@ func TestRelationsFindBestForPattern(t *testing.T) {
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
 					query.Constant{Value: 123},
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			relations: Relations{rAttribute, rValue},
@@ -112,9 +114,9 @@ func TestRelationsFindBestForPattern(t *testing.T) {
 			name: "prefers smaller relation on tie",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: ":foo/bar"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			relations: Relations{rEntity, rEntityValue},
@@ -124,9 +126,9 @@ func TestRelationsFindBestForPattern(t *testing.T) {
 			name: "returns nil for no matches",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?x"},
-					query.Variable{Name: "?y"},
-					query.Variable{Name: "?z"},
+					query.Variable{Name: datalog.NewSymbol("?x")},
+					query.Variable{Name: datalog.NewSymbol("?y")},
+					query.Variable{Name: datalog.NewSymbol("?z")},
 				},
 			},
 			relations: Relations{rEntity, rAttribute},
@@ -143,9 +145,9 @@ func TestRelationsFindBestForPattern(t *testing.T) {
 }
 
 func TestRelationsFindRelationsForSymbols(t *testing.T) {
-	r1 := NewMaterializedRelation([]query.Symbol{"?x", "?y"}, nil)
-	r2 := NewMaterializedRelation([]query.Symbol{"?y", "?z"}, nil)
-	r3 := NewMaterializedRelation([]query.Symbol{"?a", "?b"}, nil)
+	r1 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}, nil)
+	r2 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}, nil)
+	r3 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")}, nil)
 
 	relations := Relations{r1, r2, r3}
 
@@ -156,17 +158,17 @@ func TestRelationsFindRelationsForSymbols(t *testing.T) {
 	}{
 		{
 			name:     "finds relations with any symbol",
-			symbols:  []query.Symbol{"?x", "?z"},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")},
 			expected: 2, // r1 has ?x, r2 has ?z
 		},
 		{
 			name:     "finds overlapping relations",
-			symbols:  []query.Symbol{"?y"},
+			symbols:  []query.Symbol{datalog.NewSymbol("?y")},
 			expected: 2, // both r1 and r2 have ?y
 		},
 		{
 			name:     "returns empty for no matches",
-			symbols:  []query.Symbol{"?missing"},
+			symbols:  []query.Symbol{datalog.NewSymbol("?missing")},
 			expected: 0,
 		},
 	}
@@ -183,7 +185,7 @@ func TestRelationsCollapse(t *testing.T) {
 	t.Run("joins relations with shared columns", func(t *testing.T) {
 		// R1: ?person -> ?dept
 		r1 := NewMaterializedRelation(
-			[]query.Symbol{"?person", "?dept"},
+			[]query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?dept")},
 			[]Tuple{
 				{"Alice", "Engineering"},
 				{"Bob", "Sales"},
@@ -192,7 +194,7 @@ func TestRelationsCollapse(t *testing.T) {
 
 		// R2: ?dept -> ?building
 		r2 := NewMaterializedRelation(
-			[]query.Symbol{"?dept", "?building"},
+			[]query.Symbol{datalog.NewSymbol("?dept"), datalog.NewSymbol("?building")},
 			[]Tuple{
 				{"Engineering", "A"},
 				{"Sales", "B"},
@@ -202,7 +204,7 @@ func TestRelationsCollapse(t *testing.T) {
 
 		// R3: ?building -> ?floor
 		r3 := NewMaterializedRelation(
-			[]query.Symbol{"?building", "?floor"},
+			[]query.Symbol{datalog.NewSymbol("?building"), datalog.NewSymbol("?floor")},
 			[]Tuple{
 				{"A", 1},
 				{"B", 2},
@@ -228,17 +230,17 @@ func TestRelationsCollapse(t *testing.T) {
 	t.Run("returns multiple groups for disjoint relations", func(t *testing.T) {
 		// R1 and R3 share ?y, but R2 is disjoint
 		r1 := NewMaterializedRelation(
-			[]query.Symbol{"?x", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			[]Tuple{{1, 2}, {3, 4}},
 		)
 
 		r2 := NewMaterializedRelation(
-			[]query.Symbol{"?a", "?b"},
+			[]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			[]Tuple{{"foo", "bar"}, {"baz", "qux"}},
 		)
 
 		r3 := NewMaterializedRelation(
-			[]query.Symbol{"?y", "?z"},
+			[]query.Symbol{datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
 			[]Tuple{{2, 5}, {4, 6}},
 		)
 
@@ -268,12 +270,12 @@ func TestRelationsCollapse(t *testing.T) {
 	t.Run("returns empty for non-matching join", func(t *testing.T) {
 		// Relations share columns but values don't match
 		r1 := NewMaterializedRelation(
-			[]query.Symbol{"?x", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			[]Tuple{{1, 2}},
 		)
 
 		r2 := NewMaterializedRelation(
-			[]query.Symbol{"?y", "?z"},
+			[]query.Symbol{datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
 			[]Tuple{{3, 4}}, // ?y=3 doesn't match ?y=2
 		)
 
@@ -293,7 +295,7 @@ func TestRelationsCollapse(t *testing.T) {
 
 	t.Run("handles single relation", func(t *testing.T) {
 		r1 := NewMaterializedRelation(
-			[]query.Symbol{"?x"},
+			[]query.Symbol{datalog.NewSymbol("?x")},
 			[]Tuple{{1}, {2}},
 		)
 

--- a/datalog/executor/set_semantics_test.go
+++ b/datalog/executor/set_semantics_test.go
@@ -78,7 +78,7 @@ func setTestCollectTuples(rel Relation) []Tuple {
 
 func TestSetSemantics_MaterializedRelation(t *testing.T) {
 	t.Run("NewMaterializedRelation deduplicates", func(t *testing.T) {
-		columns := []query.Symbol{"?x", "?y"}
+		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 		tuples := []Tuple{
 			{1, "a"},
 			{2, "b"},
@@ -96,7 +96,7 @@ func TestSetSemantics_MaterializedRelation(t *testing.T) {
 	})
 
 	t.Run("NewMaterializedRelationWithOptions deduplicates", func(t *testing.T) {
-		columns := []query.Symbol{"?x"}
+		columns := []query.Symbol{datalog.NewSymbol("?x")}
 		tuples := []Tuple{
 			{"foo"},
 			{"bar"},
@@ -120,7 +120,7 @@ func TestSetSemantics_MaterializedRelation(t *testing.T) {
 func TestSetSemantics_Projection(t *testing.T) {
 	t.Run("MaterializedRelation.Project deduplicates", func(t *testing.T) {
 		// Create relation with distinct full tuples that become duplicates after projection
-		columns := []query.Symbol{"?e", "?v"}
+		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"entity1", "same_value"},
 			{"entity2", "same_value"}, // Different entity, same value
@@ -131,7 +131,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 		rel := NewMaterializedRelation(columns, tuples)
 
 		// Project to just ?v - should deduplicate
-		projected, err := rel.Project([]query.Symbol{"?v"})
+		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -145,7 +145,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 
 	t.Run("StreamingRelation.Project deduplicates", func(t *testing.T) {
 		// Create streaming relation with tuples that become duplicates after projection
-		columns := []query.Symbol{"?e", "?v"}
+		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"entity1", "value_a"},
 			{"entity2", "value_a"}, // Same value, different entity
@@ -159,7 +159,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 		rel := NewStreamingRelation(columns, iter)
 
 		// Project to just ?v - should deduplicate
-		projected, err := rel.Project([]query.Symbol{"?v"})
+		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -177,7 +177,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 
 	t.Run("Multiple column projection deduplicates", func(t *testing.T) {
 		// Project from 3 columns to 2 columns
-		columns := []query.Symbol{"?a", "?b", "?c"}
+		columns := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
 		tuples := []Tuple{
 			{1, "x", 100},
 			{1, "x", 200}, // Same ?a, ?b - different ?c
@@ -186,7 +186,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 		}
 
 		rel := NewMaterializedRelation(columns, tuples)
-		projected, err := rel.Project([]query.Symbol{"?a", "?b"})
+		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -206,7 +206,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 func TestSetSemantics_Joins(t *testing.T) {
 	t.Run("HashJoin produces no duplicates", func(t *testing.T) {
 		// Create relations where join could produce duplicates
-		leftCols := []query.Symbol{"?x", "?y"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 		leftTuples := []Tuple{
 			{1, "a"},
 			{1, "b"}, // Same ?x, different ?y
@@ -214,7 +214,7 @@ func TestSetSemantics_Joins(t *testing.T) {
 		}
 		left := NewMaterializedRelation(leftCols, leftTuples)
 
-		rightCols := []query.Symbol{"?x", "?z"}
+		rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")}
 		rightTuples := []Tuple{
 			{1, 100},
 			{1, 100}, // Duplicate in input (should be deduped by constructor)
@@ -222,12 +222,12 @@ func TestSetSemantics_Joins(t *testing.T) {
 		}
 		right := NewMaterializedRelation(rightCols, rightTuples)
 
-		joined := HashJoin(left, right, []query.Symbol{"?x"})
+		joined := HashJoin(left, right, []query.Symbol{datalog.NewSymbol("?x")})
 		assertNoDuplicates(t, "HashJoin", joined)
 	})
 
 	t.Run("SemiJoin produces no duplicates", func(t *testing.T) {
-		leftCols := []query.Symbol{"?x", "?y"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 		leftTuples := []Tuple{
 			{1, "a"},
 			{1, "b"},
@@ -235,19 +235,19 @@ func TestSetSemantics_Joins(t *testing.T) {
 		}
 		left := NewMaterializedRelation(leftCols, leftTuples)
 
-		rightCols := []query.Symbol{"?x"}
+		rightCols := []query.Symbol{datalog.NewSymbol("?x")}
 		rightTuples := []Tuple{
 			{1},
 			{1}, // Duplicate key
 		}
 		right := NewMaterializedRelation(rightCols, rightTuples)
 
-		joined := SemiJoin(left, right, []query.Symbol{"?x"})
+		joined := SemiJoin(left, right, []query.Symbol{datalog.NewSymbol("?x")})
 		assertNoDuplicates(t, "SemiJoin", joined)
 	})
 
 	t.Run("AntiJoin produces no duplicates", func(t *testing.T) {
-		leftCols := []query.Symbol{"?x", "?y"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 		leftTuples := []Tuple{
 			{1, "a"},
 			{2, "b"},
@@ -255,25 +255,25 @@ func TestSetSemantics_Joins(t *testing.T) {
 		}
 		left := NewMaterializedRelation(leftCols, leftTuples)
 
-		rightCols := []query.Symbol{"?x"}
+		rightCols := []query.Symbol{datalog.NewSymbol("?x")}
 		rightTuples := []Tuple{
 			{1},
 		}
 		right := NewMaterializedRelation(rightCols, rightTuples)
 
-		joined := AntiJoin(left, right, []query.Symbol{"?x"})
+		joined := AntiJoin(left, right, []query.Symbol{datalog.NewSymbol("?x")})
 		assertNoDuplicates(t, "AntiJoin", joined)
 	})
 
 	t.Run("Natural Join (via Join method) produces no duplicates", func(t *testing.T) {
-		leftCols := []query.Symbol{"?x", "?y"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 		leftTuples := []Tuple{
 			{1, "a"},
 			{2, "b"},
 		}
 		left := NewMaterializedRelation(leftCols, leftTuples)
 
-		rightCols := []query.Symbol{"?x", "?z"}
+		rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")}
 		rightTuples := []Tuple{
 			{1, 100},
 			{2, 200},
@@ -291,7 +291,7 @@ func TestSetSemantics_Joins(t *testing.T) {
 
 func TestSetSemantics_Union(t *testing.T) {
 	t.Run("UnionRelation deduplicates across relations", func(t *testing.T) {
-		cols := []query.Symbol{"?x", "?y"}
+		cols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 		// Create channel with relations that have overlapping tuples
 		ch := make(chan relationItem, 3)
@@ -332,7 +332,7 @@ func TestSetSemantics_Union(t *testing.T) {
 
 func TestSetSemantics_Filter(t *testing.T) {
 	t.Run("Filter preserves set semantics", func(t *testing.T) {
-		columns := []query.Symbol{"?x", "?y"}
+		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 		tuples := []Tuple{
 			{1, "a"},
 			{2, "b"},
@@ -385,7 +385,7 @@ func TestSetSemantics_Iterators(t *testing.T) {
 
 	t.Run("ProjectIterator should work with DedupIterator", func(t *testing.T) {
 		// This tests the fix: ProjectIterator output wrapped with DedupIterator
-		columns := []query.Symbol{"?e", "?v"}
+		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"e1", "same"},
 			{"e2", "same"},
@@ -396,7 +396,7 @@ func TestSetSemantics_Iterators(t *testing.T) {
 		rel := NewStreamingRelation(columns, source)
 
 		// Create project iterator
-		projIter := NewProjectIterator(rel, columns, []query.Symbol{"?v"})
+		projIter := NewProjectIterator(rel, columns, []query.Symbol{datalog.NewSymbol("?v")})
 
 		// Wrap with dedup (this is what the fix should do)
 		dedupIter := NewDedupIterator(projIter, 10)
@@ -423,7 +423,7 @@ func TestSetSemantics_EndToEnd(t *testing.T) {
 		// Multiple entities with the same attribute value should produce one result
 
 		// This is what comes from storage: multiple datoms with same value
-		columns := []query.Symbol{"?e", "?a", "?v"}
+		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"entity1", ":attr", "shared_value"},
 			{"entity2", ":attr", "shared_value"},
@@ -434,7 +434,7 @@ func TestSetSemantics_EndToEnd(t *testing.T) {
 		rel := NewMaterializedRelation(columns, tuples)
 
 		// Project to just ?v (like :find ?v)
-		projected, err := rel.Project([]query.Symbol{"?v"})
+		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -450,7 +450,7 @@ func TestSetSemantics_EndToEnd(t *testing.T) {
 
 	t.Run("Streaming query projection deduplicates", func(t *testing.T) {
 		// Same test but with streaming relation
-		columns := []query.Symbol{"?e", "?v"}
+		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"e1", "val1"},
 			{"e2", "val1"}, // duplicate value
@@ -463,7 +463,7 @@ func TestSetSemantics_EndToEnd(t *testing.T) {
 		rel := NewStreamingRelation(columns, iter)
 
 		// Project and materialize
-		projected, err := rel.Project([]query.Symbol{"?v"})
+		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -487,7 +487,7 @@ func TestSetSemantics_Aggregation(t *testing.T) {
 	t.Run("Aggregation receives deduplicated input", func(t *testing.T) {
 		// When aggregating, the input should be deduplicated
 		// This matters for COUNT - counting duplicates would be wrong
-		columns := []query.Symbol{"?group", "?value"}
+		columns := []query.Symbol{datalog.NewSymbol("?group"), datalog.NewSymbol("?value")}
 		tuples := []Tuple{
 			{"A", int64(10)},
 			{"A", int64(20)},
@@ -511,7 +511,7 @@ func TestSetSemantics_Aggregation(t *testing.T) {
 
 func TestSetSemantics_OperationChain(t *testing.T) {
 	t.Run("Filter then Project maintains set semantics", func(t *testing.T) {
-		columns := []query.Symbol{"?x", "?y", "?z"}
+		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 		tuples := []Tuple{
 			{1, "a", 100},
 			{2, "a", 200}, // Same ?y as above
@@ -527,7 +527,7 @@ func TestSetSemantics_OperationChain(t *testing.T) {
 		})
 
 		// Project to just ?y
-		projected, err := filtered.Project([]query.Symbol{"?y"})
+		projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?y")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -541,7 +541,7 @@ func TestSetSemantics_OperationChain(t *testing.T) {
 
 	t.Run("Join then Project maintains set semantics", func(t *testing.T) {
 		left := NewMaterializedRelation(
-			[]query.Symbol{"?x", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			[]Tuple{
 				{1, "a"},
 				{2, "a"}, // Same ?y
@@ -549,7 +549,7 @@ func TestSetSemantics_OperationChain(t *testing.T) {
 		)
 
 		right := NewMaterializedRelation(
-			[]query.Symbol{"?x", "?z"},
+			[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")},
 			[]Tuple{
 				{1, 100},
 				{2, 200},
@@ -559,7 +559,7 @@ func TestSetSemantics_OperationChain(t *testing.T) {
 		joined := left.Join(right)
 
 		// Project to just ?y, ?z
-		projected, err := joined.Project([]query.Symbol{"?y", "?z"})
+		projected, err := joined.Project([]query.Symbol{datalog.NewSymbol("?y"), datalog.NewSymbol("?z")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -574,12 +574,12 @@ func TestSetSemantics_OperationChain(t *testing.T) {
 
 func TestSetSemantics_EdgeCases(t *testing.T) {
 	t.Run("Empty relation has no duplicates", func(t *testing.T) {
-		rel := NewMaterializedRelation([]query.Symbol{"?x"}, []Tuple{})
+		rel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x")}, []Tuple{})
 		assertNoDuplicates(t, "Empty relation", rel)
 	})
 
 	t.Run("Single tuple relation has no duplicates", func(t *testing.T) {
-		rel := NewMaterializedRelation([]query.Symbol{"?x"}, []Tuple{{1}})
+		rel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x")}, []Tuple{{1}})
 		assertNoDuplicates(t, "Single tuple", rel)
 	})
 
@@ -590,7 +590,7 @@ func TestSetSemantics_EdgeCases(t *testing.T) {
 			{"same"},
 			{"same"},
 		}
-		rel := NewMaterializedRelation([]query.Symbol{"?x"}, tuples)
+		rel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x")}, tuples)
 
 		if rel.Size() != 1 {
 			t.Errorf("expected 1 unique tuple, got %d", rel.Size())
@@ -603,7 +603,7 @@ func TestSetSemantics_EdgeCases(t *testing.T) {
 			{nil, "a"}, // duplicate with nil
 			{nil, "b"},
 		}
-		rel := NewMaterializedRelation([]query.Symbol{"?x", "?y"}, tuples)
+		rel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}, tuples)
 
 		if rel.Size() != 2 {
 			t.Errorf("expected 2 unique tuples, got %d", rel.Size())
@@ -618,7 +618,7 @@ func TestSetSemantics_EdgeCases(t *testing.T) {
 			{1},
 			{int64(1)},
 		}
-		rel := NewMaterializedRelation([]query.Symbol{"?x"}, tuples)
+		rel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?x")}, tuples)
 
 		// These should all be considered different (type matters)
 		// Note: This depends on how TupleKey handles types
@@ -638,7 +638,7 @@ func TestSetSemantics_Contract_ProjectionAlwaysDeduplicates(t *testing.T) {
 	// SEMANTIC CONTRACT: Projection MUST deduplicate, regardless of input relation type.
 	// This is not an implementation detail - it's fundamental to relational algebra.
 
-	columns := []query.Symbol{"?a", "?b", "?c"}
+	columns := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
 	// Create tuples that are unique in full form but duplicate after projection
 	inputTuples := []Tuple{
 		{1, "x", 100},
@@ -659,7 +659,7 @@ func TestSetSemantics_Contract_ProjectionAlwaysDeduplicates(t *testing.T) {
 			createRel: func() Relation {
 				return NewMaterializedRelation(columns, inputTuples)
 			},
-			projectTo:  []query.Symbol{"?b"},
+			projectTo:  []query.Symbol{datalog.NewSymbol("?b")},
 			expectSize: 2, // "x" and "y"
 		},
 		{
@@ -668,7 +668,7 @@ func TestSetSemantics_Contract_ProjectionAlwaysDeduplicates(t *testing.T) {
 				iter := &sliceIterator{tuples: inputTuples, pos: -1}
 				return NewStreamingRelation(columns, iter)
 			},
-			projectTo:  []query.Symbol{"?b"},
+			projectTo:  []query.Symbol{datalog.NewSymbol("?b")},
 			expectSize: 2, // "x" and "y"
 		},
 		{
@@ -676,7 +676,7 @@ func TestSetSemantics_Contract_ProjectionAlwaysDeduplicates(t *testing.T) {
 			createRel: func() Relation {
 				return NewMaterializedRelation(columns, inputTuples)
 			},
-			projectTo:  []query.Symbol{"?a", "?b"},
+			projectTo:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			expectSize: 5, // All unique (a,b) pairs
 		},
 		{
@@ -685,7 +685,7 @@ func TestSetSemantics_Contract_ProjectionAlwaysDeduplicates(t *testing.T) {
 				iter := &sliceIterator{tuples: inputTuples, pos: -1}
 				return NewStreamingRelation(columns, iter)
 			},
-			projectTo:  []query.Symbol{"?a", "?b"},
+			projectTo:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			expectSize: 5, // All unique (a,b) pairs
 		},
 	}
@@ -717,7 +717,7 @@ func TestSetSemantics_Contract_JoinThenProjectDeduplicates(t *testing.T) {
 	t.Run("Hash join then project creates duplicates that must be removed", func(t *testing.T) {
 		// Two people in same city - joining then projecting to city should dedupe
 		left := NewMaterializedRelation(
-			[]query.Symbol{"?person", "?city"},
+			[]query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?city")},
 			[]Tuple{
 				{"alice", "NYC"},
 				{"bob", "NYC"}, // Same city
@@ -726,7 +726,7 @@ func TestSetSemantics_Contract_JoinThenProjectDeduplicates(t *testing.T) {
 		)
 
 		right := NewMaterializedRelation(
-			[]query.Symbol{"?city", "?population"},
+			[]query.Symbol{datalog.NewSymbol("?city"), datalog.NewSymbol("?population")},
 			[]Tuple{
 				{"NYC", 8000000},
 				{"LA", 4000000},
@@ -734,10 +734,10 @@ func TestSetSemantics_Contract_JoinThenProjectDeduplicates(t *testing.T) {
 		)
 
 		// Join on ?city
-		joined := HashJoin(left, right, []query.Symbol{"?city"})
+		joined := HashJoin(left, right, []query.Symbol{datalog.NewSymbol("?city")})
 
 		// Project to just ?city - should have 2 unique values
-		projected, err := joined.Project([]query.Symbol{"?city"})
+		projected, err := joined.Project([]query.Symbol{datalog.NewSymbol("?city")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -751,7 +751,7 @@ func TestSetSemantics_Contract_JoinThenProjectDeduplicates(t *testing.T) {
 
 	t.Run("Natural join then project", func(t *testing.T) {
 		left := NewMaterializedRelation(
-			[]query.Symbol{"?x", "?y"},
+			[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			[]Tuple{
 				{1, "a"},
 				{2, "a"}, // Same ?y
@@ -760,7 +760,7 @@ func TestSetSemantics_Contract_JoinThenProjectDeduplicates(t *testing.T) {
 		)
 
 		right := NewMaterializedRelation(
-			[]query.Symbol{"?x", "?z"},
+			[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")},
 			[]Tuple{
 				{1, 100},
 				{2, 200},
@@ -769,7 +769,7 @@ func TestSetSemantics_Contract_JoinThenProjectDeduplicates(t *testing.T) {
 		)
 
 		joined := left.Join(right)
-		projected, err := joined.Project([]query.Symbol{"?y"})
+		projected, err := joined.Project([]query.Symbol{datalog.NewSymbol("?y")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -786,7 +786,7 @@ func TestSetSemantics_Contract_FilterPreservesSetSemantics(t *testing.T) {
 	// SEMANTIC CONTRACT: Filter cannot introduce duplicates.
 	// Input is a set, output must be a set.
 
-	columns := []query.Symbol{"?x", "?y"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{1, "a"},
 		{2, "b"},
@@ -803,7 +803,7 @@ func TestSetSemantics_Contract_FilterPreservesSetSemantics(t *testing.T) {
 		})
 
 		// Project to ?y - should dedupe "a" (from row 3) and "b", "c"
-		projected, err := filtered.Project([]query.Symbol{"?y"})
+		projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?y")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -824,7 +824,7 @@ func TestSetSemantics_Contract_FilterPreservesSetSemantics(t *testing.T) {
 			return t[0].(int) > 1
 		})
 
-		projected, err := filtered.Project([]query.Symbol{"?y"})
+		projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?y")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -843,7 +843,7 @@ func TestSetSemantics_Contract_ChainedOperationsPreserveSetSemantics(t *testing.
 
 	t.Run("Complex operation chain", func(t *testing.T) {
 		rel1 := NewMaterializedRelation(
-			[]query.Symbol{"?a", "?b"},
+			[]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			[]Tuple{
 				{1, "x"},
 				{2, "x"},
@@ -853,7 +853,7 @@ func TestSetSemantics_Contract_ChainedOperationsPreserveSetSemantics(t *testing.
 		)
 
 		rel2 := NewMaterializedRelation(
-			[]query.Symbol{"?a", "?c"},
+			[]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?c")},
 			[]Tuple{
 				{1, 100},
 				{2, 200},
@@ -869,7 +869,7 @@ func TestSetSemantics_Contract_ChainedOperationsPreserveSetSemantics(t *testing.
 
 		joined := filtered.Join(rel2)
 
-		projected, err := joined.Project([]query.Symbol{"?b"})
+		projected, err := joined.Project([]query.Symbol{datalog.NewSymbol("?b")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
@@ -888,7 +888,7 @@ func TestSetSemantics_Contract_IteratorMultiplePassesSameResults(t *testing.T) {
 	// SEMANTIC CONTRACT: Multiple iterations over a relation must produce identical results.
 	// This ensures the relation behaves as a stable set, not a stream that changes.
 
-	columns := []query.Symbol{"?x"}
+	columns := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := []Tuple{{1}, {2}, {3}, {2}, {1}} // With duplicates
 
 	t.Run("MaterializedRelation multiple iterations", func(t *testing.T) {
@@ -943,7 +943,7 @@ func TestSetSemantics_StoragePattern(t *testing.T) {
 		}
 
 		// Convert to tuples as pattern matcher would
-		columns := []query.Symbol{"?e", "?v"}
+		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := make([]Tuple, len(datoms))
 		for i, d := range datoms {
 			tuples[i] = Tuple{d.E, d.V}
@@ -952,7 +952,7 @@ func TestSetSemantics_StoragePattern(t *testing.T) {
 		rel := NewMaterializedRelation(columns, tuples)
 
 		// Project to just ?v (the find clause)
-		projected, err := rel.Project([]query.Symbol{"?v"})
+		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}

--- a/datalog/executor/slice_source_test.go
+++ b/datalog/executor/slice_source_test.go
@@ -49,9 +49,9 @@ func TestSliceSource_Match(t *testing.T) {
 			name: "all keys",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?r"},
+					query.Variable{Name: datalog.NewSymbol("?r")},
 					query.Constant{Value: kw(":rule/key")},
-					query.Variable{Name: "?key"},
+					query.Variable{Name: datalog.NewSymbol("?key")},
 				},
 			},
 			wantSize: 2,
@@ -60,7 +60,7 @@ func TestSliceSource_Match(t *testing.T) {
 			name: "specific key",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?r"},
+					query.Variable{Name: datalog.NewSymbol("?r")},
 					query.Constant{Value: kw(":rule/key")},
 					query.Constant{Value: "region-lore"},
 				},
@@ -71,9 +71,9 @@ func TestSliceSource_Match(t *testing.T) {
 			name: "all dependencies",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?r"},
+					query.Variable{Name: datalog.NewSymbol("?r")},
 					query.Constant{Value: kw(":rule/depends-on")},
-					query.Variable{Name: "?dep"},
+					query.Variable{Name: datalog.NewSymbol("?dep")},
 				},
 			},
 			wantSize: 3, // world-lore, region, character
@@ -82,7 +82,7 @@ func TestSliceSource_Match(t *testing.T) {
 			name: "specific dependency",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?r"},
+					query.Variable{Name: datalog.NewSymbol("?r")},
 					query.Constant{Value: kw(":rule/depends-on")},
 					query.Constant{Value: "character"},
 				},
@@ -94,8 +94,8 @@ func TestSliceSource_Match(t *testing.T) {
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
 					query.Constant{Value: datalog.NewIdentity("slice:0")},
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			wantSize: 3, // key + 2 depends-on values
@@ -127,9 +127,9 @@ func TestSliceSource_EmptySlice(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: kw(":item/name")},
-			query.Variable{Name: "?name"},
+			query.Variable{Name: datalog.NewSymbol("?name")},
 		},
 	}
 
@@ -152,9 +152,9 @@ func TestSliceSourceImplementsPatternMatcher(t *testing.T) {
 	var pm PatternMatcher = source
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: kw(":item/name")},
-			query.Variable{Name: "?name"},
+			query.Variable{Name: datalog.NewSymbol("?name")},
 		},
 	}
 

--- a/datalog/executor/source_router.go
+++ b/datalog/executor/source_router.go
@@ -2,18 +2,10 @@ package executor
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
-
-// IsSourceSymbol returns true if the symbol is a data source marker (starts with "$").
-// All source symbols ($, $users, $perms, etc.) are database/source references,
-// not regular query variables or input columns.
-func IsSourceSymbol(sym query.Symbol) bool {
-	return strings.HasPrefix(string(sym), "$")
-}
 
 // SourceRouter routes pattern queries to PatternMatchers based on pattern.Source.
 // It implements PatternMatcher, so it can be used anywhere a PatternMatcher is expected.
@@ -39,8 +31,8 @@ func NewSourceRouter(sources map[query.Symbol]PatternMatcher) *SourceRouter {
 // based on pattern.Source. Empty source routes to "$" (the default).
 func (sr *SourceRouter) Match(pattern *query.DataPattern, bindings Relations) (Relation, error) {
 	sourceSym := pattern.Source
-	if sourceSym == "" {
-		sourceSym = query.Symbol("$")
+	if sourceSym == nil {
+		sourceSym = datalog.SymDollar
 	}
 
 	source, ok := sr.sources[sourceSym]
@@ -56,8 +48,8 @@ func (sr *SourceRouter) Match(pattern *query.DataPattern, bindings Relations) (R
 // if it supports predicate pushdown. Falls back to Match if it doesn't.
 func (sr *SourceRouter) MatchWithConstraints(pattern *query.DataPattern, bindings Relations, constraints []StorageConstraint) (Relation, error) {
 	sourceSym := pattern.Source
-	if sourceSym == "" {
-		sourceSym = query.Symbol("$")
+	if sourceSym == nil {
+		sourceSym = datalog.SymDollar
 	}
 
 	source, ok := sr.sources[sourceSym]
@@ -75,7 +67,7 @@ func (sr *SourceRouter) MatchWithConstraints(pattern *query.DataPattern, binding
 // source ($) for entity attribute lookups used by database functions
 // (get-else, missing?, get-some).
 func (sr *SourceRouter) LookupAttribute(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool) {
-	source, ok := sr.sources[query.Symbol("$")]
+	source, ok := sr.sources[datalog.SymDollar]
 	if !ok {
 		return nil, false
 	}

--- a/datalog/executor/source_router_test.go
+++ b/datalog/executor/source_router_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // mockPatternMatcher is a test helper for PatternMatcher
@@ -27,16 +29,16 @@ func TestSourceRouterRoutes(t *testing.T) {
 	mockPerms := &mockPatternMatcher{}
 
 	router := NewSourceRouter(map[query.Symbol]PatternMatcher{
-		query.Symbol("$users"): mockUsers,
-		query.Symbol("$perms"): mockPerms,
+		datalog.NewSymbol("$users"): mockUsers,
+		datalog.NewSymbol("$perms"): mockPerms,
 	})
 
 	pattern := &query.DataPattern{
-		Source: query.Symbol("$users"),
+		Source: datalog.NewSymbol("$users"),
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: ":attr"},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -54,11 +56,11 @@ func TestSourceRouterRoutes(t *testing.T) {
 	// Reset and route to $perms
 	mockUsers.wasCalled = false
 	pattern = &query.DataPattern{
-		Source: query.Symbol("$perms"),
+		Source: datalog.NewSymbol("$perms"),
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: ":attr"},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -78,16 +80,16 @@ func TestSourceRouterDefaultSource(t *testing.T) {
 	mockDefault := &mockPatternMatcher{}
 
 	router := NewSourceRouter(map[query.Symbol]PatternMatcher{
-		query.Symbol("$"): mockDefault,
+		datalog.NewSymbol("$"): mockDefault,
 	})
 
 	// Empty source should route to "$"
 	pattern := &query.DataPattern{
-		Source: "",
+		Source: nil,
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: ":attr"},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -102,15 +104,15 @@ func TestSourceRouterDefaultSource(t *testing.T) {
 
 func TestSourceRouterUnknownSource(t *testing.T) {
 	router := NewSourceRouter(map[query.Symbol]PatternMatcher{
-		query.Symbol("$"): &mockPatternMatcher{},
+		datalog.NewSymbol("$"): &mockPatternMatcher{},
 	})
 
 	pattern := &query.DataPattern{
-		Source: query.Symbol("$nonexistent"),
+		Source: datalog.NewSymbol("$nonexistent"),
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: ":attr"},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -124,15 +126,15 @@ func TestSourceRouterImplementsPatternMatcher(t *testing.T) {
 	// Verify SourceRouter can be used as a PatternMatcher
 	mockDefault := &mockPatternMatcher{}
 	router := NewSourceRouter(map[query.Symbol]PatternMatcher{
-		query.Symbol("$"): mockDefault,
+		datalog.NewSymbol("$"): mockDefault,
 	})
 
 	var pm PatternMatcher = router
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: ":attr"},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 

--- a/datalog/executor/streaming_aggregation_test.go
+++ b/datalog/executor/streaming_aggregation_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestStreamingAggregation verifies that streaming aggregation produces
@@ -11,7 +13,7 @@ import (
 func TestStreamingAggregation(t *testing.T) {
 	// Create a large relation to aggregate
 	// Include an ID to make each tuple unique (avoid deduplication)
-	columns := []query.Symbol{"?id", "?category", "?price"}
+	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?category"), datalog.NewSymbol("?price")}
 	tuples := make([]Tuple, 0, 10000)
 
 	// Generate 10,000 tuples across 10 categories
@@ -29,12 +31,12 @@ func TestStreamingAggregation(t *testing.T) {
 		rel := NewStreamingRelationWithOptions(columns, baseRel.Iterator(), opts)
 
 		findElements := []query.FindElement{
-			query.FindVariable{Symbol: "?category"},
-			query.FindAggregate{Function: "count", Arg: "?price"},
-			query.FindAggregate{Function: "sum", Arg: "?price"},
-			query.FindAggregate{Function: "avg", Arg: "?price"},
-			query.FindAggregate{Function: "min", Arg: "?price"},
-			query.FindAggregate{Function: "max", Arg: "?price"},
+			query.FindVariable{Symbol: datalog.NewSymbol("?category")},
+			query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?price")},
+			query.FindAggregate{Function: "sum", Arg: datalog.NewSymbol("?price")},
+			query.FindAggregate{Function: "avg", Arg: datalog.NewSymbol("?price")},
+			query.FindAggregate{Function: "min", Arg: datalog.NewSymbol("?price")},
+			query.FindAggregate{Function: "max", Arg: datalog.NewSymbol("?price")},
 		}
 
 		result := ExecuteAggregations(rel, findElements)
@@ -79,8 +81,8 @@ func TestStreamingAggregation(t *testing.T) {
 		rel := NewStreamingRelationWithOptions(columns, baseRel.Iterator(), opts)
 
 		findElements := []query.FindElement{
-			query.FindAggregate{Function: "count", Arg: "?price"},
-			query.FindAggregate{Function: "sum", Arg: "?price"},
+			query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?price")},
+			query.FindAggregate{Function: "sum", Arg: datalog.NewSymbol("?price")},
 		}
 
 		result := ExecuteAggregations(rel, findElements)
@@ -105,7 +107,7 @@ func TestStreamingAggregation(t *testing.T) {
 // produces identical results to batch aggregation
 func TestStreamingAggregationCorrectness(t *testing.T) {
 	// Create test data
-	columns := []query.Symbol{"?x", "?y"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{"A", 10.0},
 		{"A", 20.0},
@@ -117,12 +119,12 @@ func TestStreamingAggregationCorrectness(t *testing.T) {
 	baseRel := NewMaterializedRelation(columns, tuples)
 
 	findElements := []query.FindElement{
-		query.FindVariable{Symbol: "?x"},
-		query.FindAggregate{Function: "count", Arg: "?y"},
-		query.FindAggregate{Function: "sum", Arg: "?y"},
-		query.FindAggregate{Function: "avg", Arg: "?y"},
-		query.FindAggregate{Function: "min", Arg: "?y"},
-		query.FindAggregate{Function: "max", Arg: "?y"},
+		query.FindVariable{Symbol: datalog.NewSymbol("?x")},
+		query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?y")},
+		query.FindAggregate{Function: "sum", Arg: datalog.NewSymbol("?y")},
+		query.FindAggregate{Function: "avg", Arg: datalog.NewSymbol("?y")},
+		query.FindAggregate{Function: "min", Arg: datalog.NewSymbol("?y")},
+		query.FindAggregate{Function: "max", Arg: datalog.NewSymbol("?y")},
 	}
 
 	// Run with streaming
@@ -186,7 +188,7 @@ func TestStreamingAggregationCorrectness(t *testing.T) {
 
 // TestStreamingAggregationThreshold verifies that small relations use batch aggregation
 func TestStreamingAggregationThreshold(t *testing.T) {
-	columns := []query.Symbol{"?x", "?y"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 	// Small relation (below threshold)
 	smallTuples := []Tuple{
@@ -196,8 +198,8 @@ func TestStreamingAggregationThreshold(t *testing.T) {
 	}
 
 	findElements := []query.FindElement{
-		query.FindVariable{Symbol: "?x"},
-		query.FindAggregate{Function: "sum", Arg: "?y"},
+		query.FindVariable{Symbol: datalog.NewSymbol("?x")},
+		query.FindAggregate{Function: "sum", Arg: datalog.NewSymbol("?y")},
 	}
 
 	opts := ExecutorOptions{EnableStreamingAggregation: true}

--- a/datalog/executor/streaming_correctness_test.go
+++ b/datalog/executor/streaming_correctness_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestStreamingVsMaterializedCorrectness verifies that streaming and materialized
@@ -17,7 +19,7 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 		for i := 0; i < size; i++ {
 			tuples = append(tuples, Tuple{i, i * 2, i * 3})
 		}
-		columns := []query.Symbol{"?x", "?y", "?z"}
+		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 		// Test with materialized (EnableTrueStreaming=false)
 		matOpts := ExecutorOptions{
@@ -34,7 +36,7 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 		}))
 
 		// Project
-		matProjected, err := matFiltered.Project([]query.Symbol{"?x"})
+		matProjected, err := matFiltered.Project([]query.Symbol{datalog.NewSymbol("?x")})
 		assert.NoError(t, err)
 
 		// Collect results
@@ -63,7 +65,7 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 		}))
 
 		// Project
-		streamProjected, err := streamFiltered.Project([]query.Symbol{"?x"})
+		streamProjected, err := streamFiltered.Project([]query.Symbol{datalog.NewSymbol("?x")})
 		assert.NoError(t, err)
 
 		// Collect results
@@ -93,14 +95,14 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 			{2, "bob", 200},
 			{3, "charlie", 300},
 		}
-		leftColumns := []query.Symbol{"?id", "?name", "?score"}
+		leftColumns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score")}
 
 		rightTuples := []Tuple{
 			{"alice", "NYC"},
 			{"bob", "LA"},
 			{"charlie", "Chicago"},
 		}
-		rightColumns := []query.Symbol{"?name", "?city"}
+		rightColumns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?city")}
 
 		// Test with materialized
 		matOpts := ExecutorOptions{
@@ -111,8 +113,8 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 		matLeft := NewStreamingRelationWithOptions(leftColumns, newMockIterator(leftTuples), matOpts)
 		matRight := NewStreamingRelationWithOptions(rightColumns, newMockIterator(rightTuples), matOpts)
 
-		matJoined := HashJoinWithOptions(matLeft, matRight, []query.Symbol{"?name"}, matOpts)
-		matProjected, err := matJoined.Project([]query.Symbol{"?name", "?score", "?city"})
+		matJoined := HashJoinWithOptions(matLeft, matRight, []query.Symbol{datalog.NewSymbol("?name")}, matOpts)
+		matProjected, err := matJoined.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?score"), datalog.NewSymbol("?city")})
 		assert.NoError(t, err)
 
 		var matResults []Tuple
@@ -134,8 +136,8 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 		streamLeft := NewStreamingRelationWithOptions(leftColumns, newMockIterator(leftTuples), streamOpts)
 		streamRight := NewStreamingRelationWithOptions(rightColumns, newMockIterator(rightTuples), streamOpts)
 
-		streamJoined := HashJoinWithOptions(streamLeft, streamRight, []query.Symbol{"?name"}, streamOpts)
-		streamProjected, err := streamJoined.Project([]query.Symbol{"?name", "?score", "?city"})
+		streamJoined := HashJoinWithOptions(streamLeft, streamRight, []query.Symbol{datalog.NewSymbol("?name")}, streamOpts)
+		streamProjected, err := streamJoined.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?score"), datalog.NewSymbol("?city")})
 		assert.NoError(t, err)
 
 		var streamResults []Tuple

--- a/datalog/executor/streaming_integration_test.go
+++ b/datalog/executor/streaming_integration_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestStreamingIntegration(t *testing.T) {
@@ -24,7 +26,7 @@ func TestStreamingIntegration(t *testing.T) {
 			{4, "diana", 400},
 			{5, "eve", 500},
 		}
-		leftColumns := []query.Symbol{"?id", "?name", "?score"}
+		leftColumns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score")}
 
 		// Create test data for right relation
 		rightTuples := []Tuple{
@@ -33,7 +35,7 @@ func TestStreamingIntegration(t *testing.T) {
 			{"charlie", "Chicago", 35},
 			{"diana", "Boston", 40},
 		}
-		rightColumns := []query.Symbol{"?name", "?city", "?age"}
+		rightColumns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?city"), datalog.NewSymbol("?age")}
 
 		// Create streaming relations with options
 		leftIter := newMockIterator(leftTuples)
@@ -67,7 +69,7 @@ func TestStreamingIntegration(t *testing.T) {
 		assert.True(t, isStreaming, "Filter should return StreamingRelation")
 
 		// Perform join on ?name
-		joinCols := []query.Symbol{"?name"}
+		joinCols := []query.Symbol{datalog.NewSymbol("?name")}
 		joined := SymmetricHashJoin(filteredLeft, filteredRight, joinCols)
 
 		// Verify join returns streaming relation
@@ -75,7 +77,7 @@ func TestStreamingIntegration(t *testing.T) {
 		assert.True(t, isStreaming, "Join should return StreamingRelation")
 
 		// Project to keep only certain columns
-		projected, err := joined.Project([]query.Symbol{"?name", "?score", "?city"})
+		projected, err := joined.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?score"), datalog.NewSymbol("?city")})
 		assert.NoError(t, err)
 
 		// Verify projection returns streaming relation
@@ -127,17 +129,17 @@ func TestStreamingIntegration(t *testing.T) {
 			{3, "charlie"},
 		}
 		streamIter := newMockIterator(streamTuples)
-		streamRel := NewStreamingRelationWithOptions([]query.Symbol{"?id", "?name"}, streamIter, opts)
+		streamRel := NewStreamingRelationWithOptions([]query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name")}, streamIter, opts)
 
 		// Create materialized relation with options
 		matTuples := []Tuple{
 			{"alice", 100},
 			{"bob", 200},
 		}
-		matRel := NewMaterializedRelationWithOptions([]query.Symbol{"?name", "?value"}, matTuples, opts)
+		matRel := NewMaterializedRelationWithOptions([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?value")}, matTuples, opts)
 
 		// Join streaming with materialized
-		joinCols := []query.Symbol{"?name"}
+		joinCols := []query.Symbol{datalog.NewSymbol("?name")}
 		joined := HashJoin(streamRel, matRel, joinCols)
 
 		// Iterate results
@@ -168,7 +170,7 @@ func TestStreamingIntegration(t *testing.T) {
 			{50, 60},
 			{70, 80},
 		}
-		columns := []query.Symbol{"?x", "?y"}
+		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 		source := newMockIterator(tuples)
 		rel := NewStreamingRelationWithOptions(columns, source, opts)
@@ -176,7 +178,7 @@ func TestStreamingIntegration(t *testing.T) {
 		// Apply predicate filter (x > 30)
 		pred := &query.Comparison{
 			Op:    query.OpGT,
-			Left:  query.VariableTerm{Symbol: "?x"},
+			Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
 			Right: query.ConstantTerm{Value: 30},
 		}
 
@@ -213,7 +215,7 @@ func TestStreamingIntegration(t *testing.T) {
 			{10, 20},
 			{30, 40},
 		}
-		columns := []query.Symbol{"?x", "?y"}
+		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 		source := newMockIterator(tuples)
 		rel := NewStreamingRelationWithOptions(columns, source, opts)
@@ -221,18 +223,18 @@ func TestStreamingIntegration(t *testing.T) {
 		// Apply function evaluation (x + y)
 		fn := query.ArithmeticFunction{
 			Op:    query.OpAdd,
-			Left:  query.VariableTerm{Symbol: "?x"},
-			Right: query.VariableTerm{Symbol: "?y"},
+			Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?x")},
+			Right: query.VariableTerm{Symbol: datalog.NewSymbol("?y")},
 		}
 
-		withFunction := rel.EvaluateFunction(fn, "?sum")
+		withFunction := rel.EvaluateFunction(fn, datalog.NewSymbol("?sum"))
 
 		// Verify it's still streaming
 		_, isStreaming := withFunction.(*StreamingRelation)
 		assert.True(t, isStreaming)
 
 		// Check columns
-		assert.Equal(t, []query.Symbol{"?x", "?y", "?sum"}, withFunction.Columns())
+		assert.Equal(t, []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?sum")}, withFunction.Columns())
 
 		// Iterate results
 		it := withFunction.Iterator()
@@ -262,7 +264,7 @@ func TestStreamingIntegration(t *testing.T) {
 		for i := 0; i < 1000; i++ {
 			largeTuples = append(largeTuples, Tuple{i, i * 2, i * 3})
 		}
-		columns := []query.Symbol{"?x", "?y", "?z"}
+		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 		source := newMockIterator(largeTuples)
 		rel := NewStreamingRelationWithOptions(columns, source, opts)
@@ -274,7 +276,7 @@ func TestStreamingIntegration(t *testing.T) {
 		filtered := rel.Filter(filter)
 
 		// Project to single column
-		projected, err := filtered.Project([]query.Symbol{"?x"})
+		projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?x")})
 		assert.NoError(t, err)
 
 		// With streaming, this entire pipeline should process lazily
@@ -303,7 +305,7 @@ func BenchmarkStreamingVsMaterialized(b *testing.B) {
 	for i := 0; i < size; i++ {
 		tuples = append(tuples, Tuple{i, i * 2, i * 3})
 	}
-	columns := []query.Symbol{"?x", "?y", "?z"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 	b.Run("Materialized", func(b *testing.B) {
 		opts := ExecutorOptions{
@@ -322,7 +324,7 @@ func BenchmarkStreamingVsMaterialized(b *testing.B) {
 			}))
 
 			// Project
-			projected, _ := filtered.Project([]query.Symbol{"?x"})
+			projected, _ := filtered.Project([]query.Symbol{datalog.NewSymbol("?x")})
 
 			// Consume
 			it := projected.Iterator()
@@ -350,7 +352,7 @@ func BenchmarkStreamingVsMaterialized(b *testing.B) {
 			}))
 
 			// Project
-			projected, _ := filtered.Project([]query.Symbol{"?x"})
+			projected, _ := filtered.Project([]query.Symbol{datalog.NewSymbol("?x")})
 
 			// Consume
 			it := projected.Iterator()
@@ -381,7 +383,7 @@ func BenchmarkStreamingVsMaterialized(b *testing.B) {
 			}))
 
 			// Project
-			projected, _ := filtered.Project([]query.Symbol{"?x"})
+			projected, _ := filtered.Project([]query.Symbol{datalog.NewSymbol("?x")})
 
 			// Consume
 			it := projected.Iterator()

--- a/datalog/executor/streaming_join_test.go
+++ b/datalog/executor/streaming_join_test.go
@@ -4,13 +4,15 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestStreamingHashJoin(t *testing.T) {
 	// Test with streaming enabled - create relations with options
 	opts := ExecutorOptions{EnableStreamingJoins: true}
 	left := NewMaterializedRelationWithOptions(
-		[]query.Symbol{"?user", "?name"},
+		[]query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?name")},
 		[]Tuple{
 			{"u1", "Alice"},
 			{"u2", "Bob"},
@@ -19,7 +21,7 @@ func TestStreamingHashJoin(t *testing.T) {
 	)
 
 	right := NewMaterializedRelationWithOptions(
-		[]query.Symbol{"?user", "?age"},
+		[]query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?age")},
 		[]Tuple{
 			{"u1", 25},
 			{"u2", 30},
@@ -27,7 +29,7 @@ func TestStreamingHashJoin(t *testing.T) {
 		opts,
 	)
 
-	result := HashJoin(left, right, []query.Symbol{"?user"})
+	result := HashJoin(left, right, []query.Symbol{datalog.NewSymbol("?user")})
 
 	t.Logf("Result type: %T", result)
 	t.Logf("Result size: %d", result.Size())
@@ -51,7 +53,7 @@ func TestStreamingHashJoinChain(t *testing.T) {
 	// Test with streaming enabled - create relations with options
 	opts := ExecutorOptions{EnableStreamingJoins: true}
 	users := NewMaterializedRelationWithOptions(
-		[]query.Symbol{"?user", "?name"},
+		[]query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?name")},
 		[]Tuple{
 			{"u1", "Alice"},
 			{"u2", "Bob"},
@@ -60,7 +62,7 @@ func TestStreamingHashJoinChain(t *testing.T) {
 	)
 
 	ages := NewMaterializedRelationWithOptions(
-		[]query.Symbol{"?user", "?age"},
+		[]query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?age")},
 		[]Tuple{
 			{"u1", 25},
 			{"u2", 30},
@@ -69,7 +71,7 @@ func TestStreamingHashJoinChain(t *testing.T) {
 	)
 
 	depts := NewMaterializedRelationWithOptions(
-		[]query.Symbol{"?user", "?dept"},
+		[]query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?dept")},
 		[]Tuple{
 			{"u1", "Engineering"},
 			{"u2", "Sales"},
@@ -78,11 +80,11 @@ func TestStreamingHashJoinChain(t *testing.T) {
 	)
 
 	// First join
-	result1 := HashJoin(users, ages, []query.Symbol{"?user"})
+	result1 := HashJoin(users, ages, []query.Symbol{datalog.NewSymbol("?user")})
 	t.Logf("After first join: type=%T, size=%d", result1, result1.Size())
 
 	// Second join
-	result2 := HashJoin(result1, depts, []query.Symbol{"?user"})
+	result2 := HashJoin(result1, depts, []query.Symbol{datalog.NewSymbol("?user")})
 	t.Logf("After second join: type=%T, size=%d", result2, result2.Size())
 
 	// Materialize final result

--- a/datalog/executor/streaming_performance_demo_test.go
+++ b/datalog/executor/streaming_performance_demo_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestStreamingPerformanceDemo demonstrates the performance impact of streaming
@@ -96,7 +98,7 @@ func runPipeline(t *testing.T, size int, filterRatio float64, ops []string, opts
 	for i := 0; i < size; i++ {
 		tuples = append(tuples, Tuple{i, fmt.Sprintf("name%d", i), i * 10, i * 100})
 	}
-	columns := []query.Symbol{"?id", "?name", "?score", "?value"}
+	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score"), datalog.NewSymbol("?value")}
 
 	// Create initial relation with options
 	source := newMockIterator(tuples)
@@ -123,7 +125,7 @@ func runPipeline(t *testing.T, size int, filterRatio float64, ops []string, opts
 
 		case "project":
 			// Project to subset of columns
-			projected, err := current.Project([]query.Symbol{"?id", "?score"})
+			projected, err := current.Project([]query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?score")})
 			assert.NoError(t, err)
 			current = projected
 
@@ -136,8 +138,8 @@ func runPipeline(t *testing.T, size int, filterRatio float64, ops []string, opts
 				}
 			}
 			joinIter := newMockIterator(joinTuples)
-			joinRel := NewStreamingRelation([]query.Symbol{"?id", "?city"}, joinIter)
-			current = HashJoin(current, joinRel, []query.Symbol{"?id"})
+			joinRel := NewStreamingRelation([]query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?city")}, joinIter)
+			current = HashJoin(current, joinRel, []query.Symbol{datalog.NewSymbol("?id")})
 		}
 	}
 
@@ -202,7 +204,7 @@ func benchmarkScenarioWithOpts(b *testing.B, size int, filterRatio float64, opts
 	for i := 0; i < size; i++ {
 		tuples = append(tuples, Tuple{i, i * 10, i * 100})
 	}
-	columns := []query.Symbol{"?x", "?y", "?z"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 	source := newMockIterator(tuples)
 	rel := NewStreamingRelationWithOptions(columns, source, opts)
@@ -214,7 +216,7 @@ func benchmarkScenarioWithOpts(b *testing.B, size int, filterRatio float64, opts
 	}))
 
 	// Project
-	projected, _ := filtered.Project([]query.Symbol{"?x", "?z"})
+	projected, _ := filtered.Project([]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")})
 
 	// Consume
 	it := projected.Iterator()

--- a/datalog/executor/streaming_pipeline_bench_test.go
+++ b/datalog/executor/streaming_pipeline_bench_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // BenchmarkTimeToFirstResult measures how quickly each join strategy produces the first result
@@ -15,8 +17,8 @@ func BenchmarkTimeToFirstResult(b *testing.B) {
 	sizes := []int{1000, 10000}
 
 	for _, size := range sizes {
-		leftCols := []query.Symbol{"?x", "?name"}
-		rightCols := []query.Symbol{"?x", "?value"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+		rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 		leftTuples := make([]Tuple, size)
 		rightTuples := make([]Tuple, size)
@@ -108,8 +110,8 @@ func BenchmarkLimitQueries(b *testing.B) {
 	dataSize := 10000
 	limits := []int{10, 100, 1000}
 
-	leftCols := []query.Symbol{"?x", "?name"}
-	rightCols := []query.Symbol{"?x", "?value"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+	rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 	leftTuples := make([]Tuple, dataSize)
 	rightTuples := make([]Tuple, dataSize)
@@ -201,8 +203,8 @@ func BenchmarkLimitQueries(b *testing.B) {
 func BenchmarkPeakMemory(b *testing.B) {
 	size := 50000 // Large dataset to see memory difference
 
-	leftCols := []query.Symbol{"?x", "?name"}
-	rightCols := []query.Symbol{"?x", "?value"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+	rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 	leftTuples := make([]Tuple, size)
 	rightTuples := make([]Tuple, size)
@@ -330,8 +332,8 @@ func BenchmarkPeakMemory(b *testing.B) {
 func BenchmarkMultiStagePipeline(b *testing.B) {
 	size := 10000
 
-	leftCols := []query.Symbol{"?x", "?name"}
-	rightCols := []query.Symbol{"?x", "?value"}
+	leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+	rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 	leftTuples := make([]Tuple, size)
 	rightTuples := make([]Tuple, size)
@@ -379,7 +381,7 @@ func BenchmarkMultiStagePipeline(b *testing.B) {
 			})
 
 			// Project: drop the ID column
-			projected, err := filtered.Project([]query.Symbol{"?name", "?value"})
+			projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?value")})
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -431,7 +433,7 @@ func BenchmarkMultiStagePipeline(b *testing.B) {
 			})
 
 			// Project: drop the ID column
-			projected, err := filtered.Project([]query.Symbol{"?name", "?value"})
+			projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?value")})
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/datalog/executor/streaming_single_use_test.go
+++ b/datalog/executor/streaming_single_use_test.go
@@ -4,12 +4,14 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // TestStreamingRelationSingleUse verifies that StreamingRelation with EnableTrueStreaming
 // panics on second Iterator() call as expected
 func TestStreamingRelationSingleUse(t *testing.T) {
-	cols := []query.Symbol{query.Symbol("?x")}
+	cols := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := []Tuple{
 		Tuple{1},
 		Tuple{2},
@@ -47,7 +49,7 @@ func TestStreamingRelationSingleUse(t *testing.T) {
 // TestStreamingRelationSingleUseInJoin tests that joins don't call Iterator() twice
 func TestStreamingRelationSingleUseInJoin(t *testing.T) {
 	// Create two simple streaming relations
-	cols1 := []query.Symbol{query.Symbol("?x"), query.Symbol("?y")}
+	cols1 := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples1 := []Tuple{
 		Tuple{1, "a"},
 		Tuple{2, "b"},
@@ -57,7 +59,7 @@ func TestStreamingRelationSingleUseInJoin(t *testing.T) {
 	opts := ExecutorOptions{EnableTrueStreaming: true}
 	rel1 := NewStreamingRelationWithOptions(cols1, iter1, opts)
 
-	cols2 := []query.Symbol{query.Symbol("?y"), query.Symbol("?z")}
+	cols2 := []query.Symbol{datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 	tuples2 := []Tuple{
 		Tuple{"a", 10},
 		Tuple{"b", 20},
@@ -67,7 +69,7 @@ func TestStreamingRelationSingleUseInJoin(t *testing.T) {
 	rel2 := NewStreamingRelationWithOptions(cols2, iter2, opts)
 
 	// Join should work without panicking (single Iterator() call per relation)
-	joinCols := []query.Symbol{query.Symbol("?y")}
+	joinCols := []query.Symbol{datalog.NewSymbol("?y")}
 	result := HashJoin(rel1, rel2, joinCols)
 
 	// Verify result

--- a/datalog/executor/streaming_union_test.go
+++ b/datalog/executor/streaming_union_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestUnionBuilder_Streaming(t *testing.T) {
@@ -14,7 +16,7 @@ func TestUnionBuilder_Streaming(t *testing.T) {
 
 	// Create test relations
 	rel1 := NewMaterializedRelation(
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		[]Tuple{
 			{1, 2},
 			{3, 4},
@@ -22,7 +24,7 @@ func TestUnionBuilder_Streaming(t *testing.T) {
 	)
 
 	rel2 := NewMaterializedRelation(
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		[]Tuple{
 			{5, 6},
 			{7, 8},
@@ -30,7 +32,7 @@ func TestUnionBuilder_Streaming(t *testing.T) {
 	)
 
 	rel3 := NewMaterializedRelation(
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		[]Tuple{
 			{9, 10},
 		},
@@ -45,7 +47,7 @@ func TestUnionBuilder_Streaming(t *testing.T) {
 	}
 
 	// Verify columns
-	expectedColumns := []query.Symbol{"?x", "?y"}
+	expectedColumns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	if !symbolsEqual(result.Columns(), expectedColumns) {
 		t.Errorf("Expected columns %v, got %v", expectedColumns, result.Columns())
 	}
@@ -85,12 +87,12 @@ func TestUnionBuilder_Materialized(t *testing.T) {
 
 	// Create test relations
 	rel1 := NewMaterializedRelation(
-		[]query.Symbol{"?x"},
+		[]query.Symbol{datalog.NewSymbol("?x")},
 		[]Tuple{{1}, {2}},
 	)
 
 	rel2 := NewMaterializedRelation(
-		[]query.Symbol{"?x"},
+		[]query.Symbol{datalog.NewSymbol("?x")},
 		[]Tuple{{3}, {4}},
 	)
 
@@ -124,7 +126,7 @@ func TestUnionBuilder_SingleRelation(t *testing.T) {
 	builder := NewStreamingUnionBuilder(opts)
 
 	rel := NewMaterializedRelation(
-		[]query.Symbol{"?x"},
+		[]query.Symbol{datalog.NewSymbol("?x")},
 		[]Tuple{{1}, {2}},
 	)
 
@@ -158,19 +160,19 @@ func TestUnionBuilder_WithColumns_Matching(t *testing.T) {
 
 	// Relations with matching columns
 	rel1 := NewMaterializedRelation(
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		[]Tuple{{1, 2}},
 	)
 
 	rel2 := NewMaterializedRelation(
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		[]Tuple{{3, 4}},
 	)
 
 	// Union with matching columns
 	result, err := builder.UnionWithColumns(
 		[]Relation{rel1, rel2},
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 	)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -181,7 +183,7 @@ func TestUnionBuilder_WithColumns_Matching(t *testing.T) {
 	}
 
 	// Verify columns
-	if !symbolsEqual(result.Columns(), []query.Symbol{"?x", "?y"}) {
+	if !symbolsEqual(result.Columns(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
 		t.Errorf("Columns mismatch: %v", result.Columns())
 	}
 }
@@ -194,19 +196,19 @@ func TestUnionBuilder_WithColumns_NeedProjection(t *testing.T) {
 
 	// Relations with different column order
 	rel1 := NewMaterializedRelation(
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		[]Tuple{{1, 2}},
 	)
 
 	rel2 := NewMaterializedRelation(
-		[]query.Symbol{"?y", "?x"}, // Different order
+		[]query.Symbol{datalog.NewSymbol("?y"), datalog.NewSymbol("?x")}, // Different order
 		[]Tuple{{4, 3}},
 	)
 
 	// Union with specific column order
 	result, err := builder.UnionWithColumns(
 		[]Relation{rel1, rel2},
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 	)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -217,7 +219,7 @@ func TestUnionBuilder_WithColumns_NeedProjection(t *testing.T) {
 	}
 
 	// Verify columns are in requested order
-	if !symbolsEqual(result.Columns(), []query.Symbol{"?x", "?y"}) {
+	if !symbolsEqual(result.Columns(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
 		t.Errorf("Columns mismatch: %v", result.Columns())
 	}
 
@@ -242,7 +244,7 @@ func TestUnionBuilder_WithColumns_Empty(t *testing.T) {
 	// Empty relations with column spec
 	result, err := builder.UnionWithColumns(
 		[]Relation{},
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 	)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -253,7 +255,7 @@ func TestUnionBuilder_WithColumns_Empty(t *testing.T) {
 	}
 
 	// Should have correct columns
-	if !symbolsEqual(result.Columns(), []query.Symbol{"?x", "?y"}) {
+	if !symbolsEqual(result.Columns(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
 		t.Errorf("Columns mismatch: %v", result.Columns())
 	}
 }
@@ -265,20 +267,20 @@ func TestUnionBuilder_WithColumns_SingleRelation(t *testing.T) {
 	builder := NewStreamingUnionBuilder(opts)
 
 	rel := NewMaterializedRelation(
-		[]query.Symbol{"?y", "?x"}, // Different order
+		[]query.Symbol{datalog.NewSymbol("?y"), datalog.NewSymbol("?x")}, // Different order
 		[]Tuple{{2, 1}},
 	)
 
 	// Should project single relation to match columns
 	result, err := builder.UnionWithColumns(
 		[]Relation{rel},
-		[]query.Symbol{"?x", "?y"},
+		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 	)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if !symbolsEqual(result.Columns(), []query.Symbol{"?x", "?y"}) {
+	if !symbolsEqual(result.Columns(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
 		t.Errorf("Columns mismatch: %v", result.Columns())
 	}
 
@@ -297,20 +299,20 @@ func TestSymbolsEqual(t *testing.T) {
 	}{
 		{
 			name:     "equal",
-			a:        []query.Symbol{"?x", "?y"},
-			b:        []query.Symbol{"?x", "?y"},
+			a:        []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
+			b:        []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: true,
 		},
 		{
 			name:     "different_order",
-			a:        []query.Symbol{"?x", "?y"},
-			b:        []query.Symbol{"?y", "?x"},
+			a:        []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
+			b:        []query.Symbol{datalog.NewSymbol("?y"), datalog.NewSymbol("?x")},
 			expected: false,
 		},
 		{
 			name:     "different_length",
-			a:        []query.Symbol{"?x", "?y"},
-			b:        []query.Symbol{"?x"},
+			a:        []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
+			b:        []query.Symbol{datalog.NewSymbol("?x")},
 			expected: false,
 		},
 		{

--- a/datalog/executor/subquery.go
+++ b/datalog/executor/subquery.go
@@ -424,7 +424,7 @@ func getUniqueInputCombinations(rel Relation, inputSymbols []query.Symbol) []map
 	// Find column indices for input symbols
 	indices := make([]int, len(inputSymbols))
 	for i, sym := range inputSymbols {
-		if IsSourceSymbol(sym) {
+		if sym.IsSource() {
 			// Source marker - not a column, use special index
 			indices[i] = -1
 		} else {
@@ -451,10 +451,10 @@ func getUniqueInputCombinations(rel Relation, inputSymbols []query.Symbol) []map
 		keyParts := make([]string, len(inputSymbols))
 
 		for i, sym := range inputSymbols {
-			if IsSourceSymbol(sym) {
+			if sym.IsSource() {
 				// Source marker - pass it through as-is
 				values[sym] = sym
-				keyParts[i] = string(sym)
+				keyParts[i] = sym.String()
 			} else {
 				idx := indices[i]
 				if idx < len(tuple) {
@@ -496,7 +496,7 @@ func createInputRelationsFromPatternWithOptions(subq *query.SubqueryPattern, out
 			}
 		case query.Constant:
 			// Check if it's a source marker
-			if sym, ok := inp.Value.(query.Symbol); ok && IsSourceSymbol(sym) {
+			if sym, ok := inp.Value.(query.Symbol); ok && sym.IsSource() {
 				// Source marker - pass through
 				orderedValues = append(orderedValues, sym)
 			} else {
@@ -552,7 +552,7 @@ func createInputRelationsFromValuesWithOptions(q *query.Query, orderedValues []i
 			// Expect an explicit $ symbol at this position
 			if valueIndex < len(orderedValues) {
 				// Check if it's a source marker
-				if sym, ok := orderedValues[valueIndex].(query.Symbol); ok && IsSourceSymbol(sym) {
+				if sym, ok := orderedValues[valueIndex].(query.Symbol); ok && sym.IsSource() {
 					// Source marker present - skip it
 					valueIndex++
 				} else {
@@ -687,7 +687,7 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 		// Filter out source markers from input symbols - they're not real variables
 		var realInputSymbols []query.Symbol
 		for _, sym := range inputSymbols {
-			if !IsSourceSymbol(sym) {
+			if !sym.IsSource() {
 				realInputSymbols = append(realInputSymbols, sym)
 			}
 		}
@@ -750,7 +750,7 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 		// Filter out source markers from input symbols
 		var realInputSymbols []query.Symbol
 		for _, sym := range inputSymbols {
-			if !IsSourceSymbol(sym) {
+			if !sym.IsSource() {
 				realInputSymbols = append(realInputSymbols, sym)
 			}
 		}
@@ -798,7 +798,7 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 		// Filter out source markers from input symbols - they're not real variables
 		var realInputSymbols []query.Symbol
 		for _, sym := range inputSymbols {
-			if !IsSourceSymbol(sym) {
+			if !sym.IsSource() {
 				realInputSymbols = append(realInputSymbols, sym)
 			}
 		}
@@ -1026,7 +1026,7 @@ func executeBatchedSubqueryWithCombinations(ctx Context, parentExec *Executor, s
 			columns = append(columns, inp.Name)
 		case query.Constant:
 			// Skip source markers like $, $users, etc.
-			if sym, ok := inp.Value.(query.Symbol); ok && IsSourceSymbol(sym) {
+			if sym, ok := inp.Value.(query.Symbol); ok && sym.IsSource() {
 				continue
 			}
 		}

--- a/datalog/executor/subquery_batcher.go
+++ b/datalog/executor/subquery_batcher.go
@@ -29,7 +29,7 @@ func (b *SubqueryBatcher) BuildBatchedInput(
 		// Filter source markers from columns
 		var columns []query.Symbol
 		for _, sym := range inputSymbols {
-			if !IsSourceSymbol(sym) {
+			if !sym.IsSource() {
 				columns = append(columns, sym)
 			}
 		}
@@ -39,7 +39,7 @@ func (b *SubqueryBatcher) BuildBatchedInput(
 	// Filter to only the symbols we're passing (exclude source markers)
 	var columns []query.Symbol
 	for _, sym := range inputSymbols {
-		if !IsSourceSymbol(sym) {
+		if !sym.IsSource() {
 			columns = append(columns, sym)
 		}
 	}

--- a/datalog/executor/subquery_batcher_test.go
+++ b/datalog/executor/subquery_batcher_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestBatcher_BuildBatchedInput(t *testing.T) {
@@ -12,26 +14,26 @@ func TestBatcher_BuildBatchedInput(t *testing.T) {
 	// Create input combinations
 	combinations := []map[query.Symbol]interface{}{
 		{
-			"?sym":  "AAPL",
-			"?hour": int64(10),
+			datalog.NewSymbol("?sym"):  "AAPL",
+			datalog.NewSymbol("?hour"): int64(10),
 		},
 		{
-			"?sym":  "GOOGL",
-			"?hour": int64(11),
+			datalog.NewSymbol("?sym"):  "GOOGL",
+			datalog.NewSymbol("?hour"): int64(11),
 		},
 		{
-			"?sym":  "MSFT",
-			"?hour": int64(12),
+			datalog.NewSymbol("?sym"):  "MSFT",
+			datalog.NewSymbol("?hour"): int64(12),
 		},
 	}
 
-	inputSymbols := []query.Symbol{"$", "?sym", "?hour"}
+	inputSymbols := []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?sym"), datalog.NewSymbol("?hour")}
 
 	// Build batched input
 	rel := batcher.BuildBatchedInput(combinations, inputSymbols)
 
 	// Verify columns (should exclude $)
-	expectedColumns := []query.Symbol{"?sym", "?hour"}
+	expectedColumns := []query.Symbol{datalog.NewSymbol("?sym"), datalog.NewSymbol("?hour")}
 	columns := rel.Columns()
 	if len(columns) != len(expectedColumns) {
 		t.Fatalf("Expected %d columns, got %d", len(expectedColumns), len(columns))
@@ -70,11 +72,11 @@ func TestBatcher_BuildBatchedInput_SingleColumn(t *testing.T) {
 	batcher := NewSubqueryBatcher()
 
 	combinations := []map[query.Symbol]interface{}{
-		{"?sym": "AAPL"},
-		{"?sym": "GOOGL"},
+		{datalog.NewSymbol("?sym"): "AAPL"},
+		{datalog.NewSymbol("?sym"): "GOOGL"},
 	}
 
-	inputSymbols := []query.Symbol{"$", "?sym"}
+	inputSymbols := []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?sym")}
 
 	rel := batcher.BuildBatchedInput(combinations, inputSymbols)
 
@@ -82,7 +84,7 @@ func TestBatcher_BuildBatchedInput_SingleColumn(t *testing.T) {
 	if len(rel.Columns()) != 1 {
 		t.Fatalf("Expected 1 column, got %d", len(rel.Columns()))
 	}
-	if rel.Columns()[0] != "?sym" {
+	if rel.Columns()[0] != datalog.NewSymbol("?sym") {
 		t.Errorf("Expected column ?sym, got %v", rel.Columns()[0])
 	}
 
@@ -97,7 +99,7 @@ func TestBatcher_BuildBatchedInput_Empty(t *testing.T) {
 
 	// Empty combinations
 	combinations := []map[query.Symbol]interface{}{}
-	inputSymbols := []query.Symbol{"$", "?sym"}
+	inputSymbols := []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?sym")}
 
 	rel := batcher.BuildBatchedInput(combinations, inputSymbols)
 
@@ -116,12 +118,12 @@ func TestBatcher_BuildBatchedInput_MissingValue(t *testing.T) {
 	// Combination missing ?hour value
 	combinations := []map[query.Symbol]interface{}{
 		{
-			"?sym": "AAPL",
+			datalog.NewSymbol("?sym"): "AAPL",
 			// ?hour is missing
 		},
 	}
 
-	inputSymbols := []query.Symbol{"$", "?sym", "?hour"}
+	inputSymbols := []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?sym"), datalog.NewSymbol("?hour")}
 
 	rel := batcher.BuildBatchedInput(combinations, inputSymbols)
 
@@ -143,14 +145,14 @@ func TestBatcher_ExtractInputSymbols_ScalarInputs(t *testing.T) {
 	batcher := NewSubqueryBatcher()
 
 	inputs := []query.InputSpec{
-		query.DatabaseInput{Name: query.Symbol("$")},
-		query.ScalarInput{Symbol: "?sym"},
-		query.ScalarInput{Symbol: "?hour"},
+		query.DatabaseInput{Name: datalog.NewSymbol("$")},
+		query.ScalarInput{Symbol: datalog.NewSymbol("?sym")},
+		query.ScalarInput{Symbol: datalog.NewSymbol("?hour")},
 	}
 
 	symbols := batcher.ExtractInputSymbols(inputs)
 
-	expected := []query.Symbol{"$", "?sym", "?hour"}
+	expected := []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?sym"), datalog.NewSymbol("?hour")}
 	if len(symbols) != len(expected) {
 		t.Fatalf("Expected %d symbols, got %d", len(expected), len(symbols))
 	}
@@ -166,15 +168,15 @@ func TestBatcher_ExtractInputSymbols_RelationInput(t *testing.T) {
 	batcher := NewSubqueryBatcher()
 
 	inputs := []query.InputSpec{
-		query.DatabaseInput{Name: query.Symbol("$")},
+		query.DatabaseInput{Name: datalog.NewSymbol("$")},
 		query.RelationInput{
-			Symbols: []query.Symbol{"?sym", "?hour"},
+			Symbols: []query.Symbol{datalog.NewSymbol("?sym"), datalog.NewSymbol("?hour")},
 		},
 	}
 
 	symbols := batcher.ExtractInputSymbols(inputs)
 
-	expected := []query.Symbol{"$", "?sym", "?hour"}
+	expected := []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?sym"), datalog.NewSymbol("?hour")}
 	if len(symbols) != len(expected) {
 		t.Fatalf("Expected %d symbols, got %d", len(expected), len(symbols))
 	}
@@ -190,15 +192,15 @@ func TestBatcher_ExtractInputSymbols_TupleInput(t *testing.T) {
 	batcher := NewSubqueryBatcher()
 
 	inputs := []query.InputSpec{
-		query.DatabaseInput{Name: query.Symbol("$")},
+		query.DatabaseInput{Name: datalog.NewSymbol("$")},
 		query.TupleInput{
-			Symbols: []query.Symbol{"?x", "?y"},
+			Symbols: []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		},
 	}
 
 	symbols := batcher.ExtractInputSymbols(inputs)
 
-	expected := []query.Symbol{"$", "?x", "?y"}
+	expected := []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	if len(symbols) != len(expected) {
 		t.Fatalf("Expected %d symbols, got %d", len(expected), len(symbols))
 	}
@@ -214,13 +216,13 @@ func TestBatcher_ExtractInputSymbols_CollectionInput(t *testing.T) {
 	batcher := NewSubqueryBatcher()
 
 	inputs := []query.InputSpec{
-		query.DatabaseInput{Name: query.Symbol("$")},
-		query.CollectionInput{Symbol: "?values"},
+		query.DatabaseInput{Name: datalog.NewSymbol("$")},
+		query.CollectionInput{Symbol: datalog.NewSymbol("?values")},
 	}
 
 	symbols := batcher.ExtractInputSymbols(inputs)
 
-	expected := []query.Symbol{"$", "?values"}
+	expected := []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?values")}
 	if len(symbols) != len(expected) {
 		t.Fatalf("Expected %d symbols, got %d", len(expected), len(symbols))
 	}
@@ -236,15 +238,15 @@ func TestBatcher_ExtractInputSymbols_Mixed(t *testing.T) {
 	batcher := NewSubqueryBatcher()
 
 	inputs := []query.InputSpec{
-		query.DatabaseInput{Name: query.Symbol("$")},
-		query.ScalarInput{Symbol: "?x"},
-		query.CollectionInput{Symbol: "?ys"},
-		query.TupleInput{Symbols: []query.Symbol{"?a", "?b"}},
+		query.DatabaseInput{Name: datalog.NewSymbol("$")},
+		query.ScalarInput{Symbol: datalog.NewSymbol("?x")},
+		query.CollectionInput{Symbol: datalog.NewSymbol("?ys")},
+		query.TupleInput{Symbols: []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")}},
 	}
 
 	symbols := batcher.ExtractInputSymbols(inputs)
 
-	expected := []query.Symbol{"$", "?x", "?ys", "?a", "?b"}
+	expected := []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?x"), datalog.NewSymbol("?ys"), datalog.NewSymbol("?a"), datalog.NewSymbol("?b")}
 	if len(symbols) != len(expected) {
 		t.Fatalf("Expected %d symbols, got %d", len(expected), len(symbols))
 	}
@@ -272,15 +274,15 @@ func TestBatcher_ExtractRelationSymbols_WithRelationInput(t *testing.T) {
 	batcher := NewSubqueryBatcher()
 
 	inputs := []query.InputSpec{
-		query.DatabaseInput{Name: query.Symbol("$")},
+		query.DatabaseInput{Name: datalog.NewSymbol("$")},
 		query.RelationInput{
-			Symbols: []query.Symbol{"?sym", "?hour"},
+			Symbols: []query.Symbol{datalog.NewSymbol("?sym"), datalog.NewSymbol("?hour")},
 		},
 	}
 
 	symbols := batcher.ExtractRelationSymbols(inputs)
 
-	expected := []query.Symbol{"?sym", "?hour"}
+	expected := []query.Symbol{datalog.NewSymbol("?sym"), datalog.NewSymbol("?hour")}
 	if len(symbols) != len(expected) {
 		t.Fatalf("Expected %d symbols, got %d", len(expected), len(symbols))
 	}
@@ -296,8 +298,8 @@ func TestBatcher_ExtractRelationSymbols_WithoutRelationInput(t *testing.T) {
 	batcher := NewSubqueryBatcher()
 
 	inputs := []query.InputSpec{
-		query.DatabaseInput{Name: query.Symbol("$")},
-		query.ScalarInput{Symbol: "?sym"},
+		query.DatabaseInput{Name: datalog.NewSymbol("$")},
+		query.ScalarInput{Symbol: datalog.NewSymbol("?sym")},
 	}
 
 	symbols := batcher.ExtractRelationSymbols(inputs)

--- a/datalog/executor/subquery_decorrelation.go
+++ b/datalog/executor/subquery_decorrelation.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/planner"
 	"github.com/wbrown/janus-datalog/datalog/query"
@@ -347,7 +348,7 @@ func hashJoinWithMapping(left, right Relation, leftKeys, rightKeys []query.Symbo
 	var filteredLeftKeys, filteredRightKeys []query.Symbol
 	rightIdx := 0
 	for _, key := range leftKeys {
-		if IsSourceSymbol(key) {
+		if key.IsSource() {
 			continue
 		}
 		filteredLeftKeys = append(filteredLeftKeys, key)
@@ -584,16 +585,25 @@ func extractTimeRanges(inputRelation Relation, correlationKeys []query.Symbol) (
 	}
 
 	// Find column indices for time components
+	symYear := datalog.NewSymbol("?year")
+	symY := datalog.NewSymbol("?y")
+	symMonth := datalog.NewSymbol("?month")
+	symM := datalog.NewSymbol("?m")
+	symDay := datalog.NewSymbol("?day")
+	symD := datalog.NewSymbol("?d")
+	symHour := datalog.NewSymbol("?hour")
+	symH := datalog.NewSymbol("?h")
+	symHr := datalog.NewSymbol("?hr")
+
 	var colYearIdx, colMonthIdx, colDayIdx, colHourIdx int = -1, -1, -1, -1
 	for i, col := range cols {
-		colStr := string(col)
-		if colStr == "?year" || colStr == "?y" {
+		if col == symYear || col == symY {
 			colYearIdx = i
-		} else if colStr == "?month" || colStr == "?m" {
+		} else if col == symMonth || col == symM {
 			colMonthIdx = i
-		} else if colStr == "?day" || colStr == "?d" {
+		} else if col == symDay || col == symD {
 			colDayIdx = i
-		} else if colStr == "?hour" || colStr == "?h" || colStr == "?hr" {
+		} else if col == symHour || col == symH || col == symHr {
 			colHourIdx = i
 		}
 	}

--- a/datalog/executor/subquery_strategy_test.go
+++ b/datalog/executor/subquery_strategy_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestStrategySelector_Batched(t *testing.T) {
@@ -12,9 +14,9 @@ func TestStrategySelector_Batched(t *testing.T) {
 	// Query with RelationInput should use batched strategy
 	q := &query.Query{
 		In: []query.InputSpec{
-			query.DatabaseInput{Name: query.Symbol("$")},
+			query.DatabaseInput{Name: datalog.NewSymbol("$")},
 			query.RelationInput{
-				Symbols: []query.Symbol{"?sym"},
+				Symbols: []query.Symbol{datalog.NewSymbol("?sym")},
 			},
 		},
 	}
@@ -35,8 +37,8 @@ func TestStrategySelector_Parallel(t *testing.T) {
 	// Query without RelationInput but with many inputs should use parallel
 	q := &query.Query{
 		In: []query.InputSpec{
-			query.DatabaseInput{Name: query.Symbol("$")},
-			query.ScalarInput{Symbol: "?sym"},
+			query.DatabaseInput{Name: datalog.NewSymbol("$")},
+			query.ScalarInput{Symbol: datalog.NewSymbol("?sym")},
 		},
 	}
 
@@ -56,8 +58,8 @@ func TestStrategySelector_Sequential(t *testing.T) {
 	// Query without RelationInput and few inputs should use sequential
 	q := &query.Query{
 		In: []query.InputSpec{
-			query.DatabaseInput{Name: query.Symbol("$")},
-			query.ScalarInput{Symbol: "?sym"},
+			query.DatabaseInput{Name: datalog.NewSymbol("$")},
+			query.ScalarInput{Symbol: datalog.NewSymbol("?sym")},
 		},
 	}
 
@@ -77,8 +79,8 @@ func TestStrategySelector_ParallelDisabled(t *testing.T) {
 	// Many inputs but parallel disabled should use sequential
 	q := &query.Query{
 		In: []query.InputSpec{
-			query.DatabaseInput{Name: query.Symbol("$")},
-			query.ScalarInput{Symbol: "?sym"},
+			query.DatabaseInput{Name: datalog.NewSymbol("$")},
+			query.ScalarInput{Symbol: datalog.NewSymbol("?sym")},
 		},
 	}
 
@@ -97,8 +99,8 @@ func TestStrategySelector_CustomThreshold(t *testing.T) {
 
 	q := &query.Query{
 		In: []query.InputSpec{
-			query.DatabaseInput{Name: query.Symbol("$")},
-			query.ScalarInput{Symbol: "?sym"},
+			query.DatabaseInput{Name: datalog.NewSymbol("$")},
+			query.ScalarInput{Symbol: datalog.NewSymbol("?sym")},
 		},
 	}
 
@@ -135,9 +137,9 @@ func TestStrategySelector_DefaultThreshold(t *testing.T) {
 func TestCanBatchSubquery_WithRelationInput(t *testing.T) {
 	q := &query.Query{
 		In: []query.InputSpec{
-			query.DatabaseInput{Name: query.Symbol("$")},
+			query.DatabaseInput{Name: datalog.NewSymbol("$")},
 			query.RelationInput{
-				Symbols: []query.Symbol{"?sym", "?hr"},
+				Symbols: []query.Symbol{datalog.NewSymbol("?sym"), datalog.NewSymbol("?hr")},
 			},
 		},
 	}
@@ -152,7 +154,7 @@ func TestCanBatchSubquery_WithoutDatabase(t *testing.T) {
 	q := &query.Query{
 		In: []query.InputSpec{
 			query.RelationInput{
-				Symbols: []query.Symbol{"?sym"},
+				Symbols: []query.Symbol{datalog.NewSymbol("?sym")},
 			},
 		},
 	}
@@ -166,9 +168,9 @@ func TestCanBatchSubquery_OnlyVariables(t *testing.T) {
 	// Query with only scalar variable inputs cannot be batched
 	q := &query.Query{
 		In: []query.InputSpec{
-			query.DatabaseInput{Name: query.Symbol("$")},
-			query.ScalarInput{Symbol: "?sym"},
-			query.ScalarInput{Symbol: "?hr"},
+			query.DatabaseInput{Name: datalog.NewSymbol("$")},
+			query.ScalarInput{Symbol: datalog.NewSymbol("?sym")},
+			query.ScalarInput{Symbol: datalog.NewSymbol("?hr")},
 		},
 	}
 
@@ -220,9 +222,9 @@ func TestStrategySelector_BatchedTakesPrecedence(t *testing.T) {
 	// Query with RelationInput should use batched even if parallel conditions met
 	q := &query.Query{
 		In: []query.InputSpec{
-			query.DatabaseInput{Name: query.Symbol("$")},
+			query.DatabaseInput{Name: datalog.NewSymbol("$")},
 			query.RelationInput{
-				Symbols: []query.Symbol{"?sym"},
+				Symbols: []query.Symbol{datalog.NewSymbol("?sym")},
 			},
 		},
 	}

--- a/datalog/executor/symmetric_hash_join_bench_test.go
+++ b/datalog/executor/symmetric_hash_join_bench_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // BenchmarkSymmetricVsAsymmetricHashJoin compares symmetric and asymmetric hash joins
@@ -13,8 +15,8 @@ func BenchmarkSymmetricVsAsymmetricHashJoin(b *testing.B) {
 	sizes := []int{100, 1000, 5000}
 
 	for _, size := range sizes {
-		leftCols := []query.Symbol{"?x", "?name"}
-		rightCols := []query.Symbol{"?x", "?value"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+		rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 		leftTuples := make([]Tuple, size)
 		rightTuples := make([]Tuple, size)
@@ -107,8 +109,8 @@ func BenchmarkSymmetricHashJoinTableSize(b *testing.B) {
 	for _, dataSize := range sizes {
 		for _, tableSize := range tableSizes {
 			b.Run(fmt.Sprintf("data_%d/table_%d", dataSize, tableSize), func(b *testing.B) {
-				leftCols := []query.Symbol{"?x", "?name"}
-				rightCols := []query.Symbol{"?x", "?value"}
+				leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
+				rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
 				leftTuples := make([]Tuple, dataSize)
 				rightTuples := make([]Tuple, dataSize)

--- a/datalog/executor/symmetric_hash_join_test.go
+++ b/datalog/executor/symmetric_hash_join_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestSymmetricHashJoin(t *testing.T) {
@@ -16,7 +18,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		{3, "charlie", 300},
 		{4, "diana", 400},
 	}
-	leftColumns := []query.Symbol{"?id", "?name", "?score"}
+	leftColumns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score")}
 
 	// Test data for right relation
 	rightTuples := []Tuple{
@@ -25,7 +27,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		{"charlie", "Chicago", 35},
 		{"eve", "Miami", 28},
 	}
-	rightColumns := []query.Symbol{"?name", "?city", "?age"}
+	rightColumns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?city"), datalog.NewSymbol("?age")}
 
 	t.Run("BasicJoin", func(t *testing.T) {
 		// Create streaming relations
@@ -36,7 +38,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		rightRel := NewStreamingRelation(rightColumns, rightIter)
 
 		// Perform symmetric hash join on ?name
-		joinCols := []query.Symbol{"?name"}
+		joinCols := []query.Symbol{datalog.NewSymbol("?name")}
 		result := SymmetricHashJoin(leftRel, rightRel, joinCols)
 
 		// Collect results
@@ -54,7 +56,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		assert.Len(t, results, 3) // alice, bob, charlie match
 
 		// Check output columns
-		expectedCols := []query.Symbol{"?id", "?name", "?score", "?city", "?age"}
+		expectedCols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score"), datalog.NewSymbol("?city"), datalog.NewSymbol("?age")}
 		assert.Equal(t, expectedCols, result.Columns())
 
 		// Verify specific results (order may vary due to hash tables)
@@ -101,8 +103,8 @@ func TestSymmetricHashJoin(t *testing.T) {
 			{3, "charlie", "Chicago"}, // Different id, won't match
 		}
 
-		leftCols := []query.Symbol{"?id", "?name", "?score"}
-		rightCols := []query.Symbol{"?id", "?name", "?city"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score")}
+		rightCols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?city")}
 
 		leftIter := newMockIterator(leftTuples)
 		leftRel := NewStreamingRelation(leftCols, leftIter)
@@ -111,7 +113,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		rightRel := NewStreamingRelation(rightCols, rightIter)
 
 		// Join on both ?id and ?name
-		joinCols := []query.Symbol{"?id", "?name"}
+		joinCols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name")}
 		result := SymmetricHashJoin(leftRel, rightRel, joinCols)
 
 		// Collect results
@@ -145,7 +147,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		rightIter := newMockIterator(rightTuples)
 		rightRel := NewStreamingRelation(rightColumns, rightIter)
 
-		joinCols := []query.Symbol{"?name"}
+		joinCols := []query.Symbol{datalog.NewSymbol("?name")}
 		result := SymmetricHashJoin(emptyRel, rightRel, joinCols)
 
 		it := result.Iterator()
@@ -177,8 +179,8 @@ func TestSymmetricHashJoin(t *testing.T) {
 			{4, "diana"},
 		}
 
-		leftCols := []query.Symbol{"?id", "?name"}
-		rightCols := []query.Symbol{"?id", "?name2"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name")}
+		rightCols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name2")}
 
 		leftIter := newMockIterator(leftTuples)
 		leftRel := NewStreamingRelation(leftCols, leftIter)
@@ -187,7 +189,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		rightRel := NewStreamingRelation(rightCols, rightIter)
 
 		// Join on ?id which has no matches
-		joinCols := []query.Symbol{"?id"}
+		joinCols := []query.Symbol{datalog.NewSymbol("?id")}
 		result := SymmetricHashJoin(leftRel, rightRel, joinCols)
 
 		it := result.Iterator()
@@ -207,8 +209,8 @@ func TestSymmetricHashJoin(t *testing.T) {
 			{1, "Boston"}, // Same key, different value
 		}
 
-		leftCols := []query.Symbol{"?id", "?name"}
-		rightCols := []query.Symbol{"?id", "?city"}
+		leftCols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name")}
+		rightCols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?city")}
 
 		leftIter := newMockIterator(leftTuples)
 		leftRel := NewStreamingRelation(leftCols, leftIter)
@@ -216,7 +218,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		rightIter := newMockIterator(rightTuples)
 		rightRel := NewStreamingRelation(rightCols, rightIter)
 
-		joinCols := []query.Symbol{"?id"}
+		joinCols := []query.Symbol{datalog.NewSymbol("?id")}
 		result := SymmetricHashJoin(leftRel, rightRel, joinCols)
 
 		var results []Tuple
@@ -256,7 +258,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		rightIter := newMockIterator(rightTuples)
 		rightRel := NewStreamingRelationWithOptions(rightColumns, rightIter, opts)
 
-		joinCols := []query.Symbol{"?name"}
+		joinCols := []query.Symbol{datalog.NewSymbol("?name")}
 		result := SymmetricHashJoin(leftRel, rightRel, joinCols)
 
 		// Verify result is a StreamingRelation
@@ -275,7 +277,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 		rightRel := NewStreamingRelation(rightColumns, rightIter)
 
 		// Try to join on non-existent column
-		joinCols := []query.Symbol{"?nonexistent"}
+		joinCols := []query.Symbol{datalog.NewSymbol("?nonexistent")}
 		result := SymmetricHashJoin(leftRel, rightRel, joinCols)
 
 		// Should return empty relation
@@ -288,13 +290,13 @@ func TestSymmetricHashJoin(t *testing.T) {
 func TestChooseJoinStrategy(t *testing.T) {
 	// Create test relations
 	matTuples := []Tuple{{1, "a"}, {2, "b"}}
-	matColumns := []query.Symbol{"?x", "?y"}
+	matColumns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	matRel := NewMaterializedRelation(matColumns, matTuples)
 
 	streamIter := newMockIterator(matTuples)
 	streamRel := NewStreamingRelation(matColumns, streamIter)
 
-	joinCols := []query.Symbol{"?x"}
+	joinCols := []query.Symbol{datalog.NewSymbol("?x")}
 
 	t.Run("BothMaterialized", func(t *testing.T) {
 		opts := ExecutorOptions{}
@@ -337,9 +339,9 @@ func BenchmarkSymmetricHashJoin(b *testing.B) {
 		}
 	}
 
-	leftColumns := []query.Symbol{"?id", "?name", "?score"}
-	rightColumns := []query.Symbol{"?name", "?city"}
-	joinCols := []query.Symbol{"?name"}
+	leftColumns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score")}
+	rightColumns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?city")}
+	joinCols := []query.Symbol{datalog.NewSymbol("?name")}
 
 	b.Run("SymmetricHashJoin", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {

--- a/datalog/executor/table_formatter.go
+++ b/datalog/executor/table_formatter.go
@@ -74,7 +74,7 @@ func (tf *TableFormatter) formatTable(columns []query.Symbol, tuples []Tuple) st
 	// Set headers
 	headers := make([]string, len(columns))
 	for i, col := range columns {
-		headers[i] = string(col)
+		headers[i] = col.String()
 	}
 	table.Header(headers)
 

--- a/datalog/executor/table_formatter_test.go
+++ b/datalog/executor/table_formatter_test.go
@@ -21,7 +21,7 @@ func TestTableFormatter(t *testing.T) {
 	})
 
 	t.Run("FormatSimpleRelation", func(t *testing.T) {
-		columns := []query.Symbol{"?name", "?age", "?active"}
+		columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?active")}
 		tuples := []Tuple{
 			{"Alice", int64(30), true},
 			{"Bob", int64(25), false},
@@ -44,7 +44,7 @@ func TestTableFormatter(t *testing.T) {
 	})
 
 	t.Run("FormatWithDifferentTypes", func(t *testing.T) {
-		columns := []query.Symbol{"?entity", "?keyword", "?value", "?time"}
+		columns := []query.Symbol{datalog.NewSymbol("?entity"), datalog.NewSymbol("?keyword"), datalog.NewSymbol("?value"), datalog.NewSymbol("?time")}
 		testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
 		tuples := []Tuple{
@@ -89,7 +89,7 @@ func TestTableFormatter(t *testing.T) {
 	t.Run("FormatWithLongStrings", func(t *testing.T) {
 		formatter.MaxWidth = 20
 
-		columns := []query.Symbol{"?id", "?description"}
+		columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?description")}
 		longString := "This is a very long string that should be truncated because it exceeds the maximum width"
 
 		tuples := []Tuple{
@@ -108,7 +108,7 @@ func TestTableFormatter(t *testing.T) {
 	})
 
 	t.Run("FormatMarkdownTable", func(t *testing.T) {
-		columns := []query.Symbol{"?symbol", "?price", "?volume"}
+		columns := []query.Symbol{datalog.NewSymbol("?symbol"), datalog.NewSymbol("?price"), datalog.NewSymbol("?volume")}
 		tuples := []Tuple{
 			{"AAPL", 150.25, int64(1000000)},
 			{"GOOG", 2800.50, int64(500000)},
@@ -131,7 +131,7 @@ func TestTableFormatter(t *testing.T) {
 
 	t.Run("FormatResult", func(t *testing.T) {
 		result := NewMaterializedRelation(
-			[]query.Symbol{"?name", "?count"},
+			[]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?count")},
 			[]Tuple{
 				{"Alice", int64(5)},
 				{"Bob", int64(3)},
@@ -151,7 +151,7 @@ func TestTableFormatter(t *testing.T) {
 
 func TestPrintHelpers(t *testing.T) {
 	// Just test that these don't panic
-	columns := []query.Symbol{"?x", "?y"}
+	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{int64(1), "a"},
 		{int64(2), "b"},
@@ -177,7 +177,7 @@ func TestPrintHelpers(t *testing.T) {
 // This is a regression test for the CLI empty results bug.
 func TestTableFormatterTupleCopying(t *testing.T) {
 	// Create a relation with streaming behavior enabled
-	columns := []query.Symbol{"x", "y", "z"}
+	columns := []query.Symbol{datalog.NewSymbol("x"), datalog.NewSymbol("y"), datalog.NewSymbol("z")}
 	tuples := []Tuple{
 		{int64(1), int64(10), int64(100)},
 		{int64(2), int64(20), int64(200)},

--- a/datalog/executor/time_range_bench_test.go
+++ b/datalog/executor/time_range_bench_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 // BenchmarkExtractTimeRanges benchmarks the time range extraction with various sizes
@@ -52,11 +54,11 @@ func BenchmarkExtractTimeRanges(b *testing.B) {
 			var columns []query.Symbol
 			var correlationKeys []query.Symbol
 			if bm.daily {
-				columns = []query.Symbol{"?year", "?month", "?day"}
-				correlationKeys = []query.Symbol{"$", "?s", "?year", "?month", "?day"}
+				columns = []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day")}
+				correlationKeys = []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day")}
 			} else {
-				columns = []query.Symbol{"?year", "?month", "?day", "?hour"}
-				correlationKeys = []query.Symbol{"$", "?s", "?year", "?month", "?day", "?hour"}
+				columns = []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")}
+				correlationKeys = []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")}
 			}
 
 			inputRel := NewMaterializedRelation(columns, inputTuples)

--- a/datalog/executor/time_range_optimization_test.go
+++ b/datalog/executor/time_range_optimization_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestExtractTimeRanges(t *testing.T) {
@@ -24,8 +26,8 @@ func TestExtractTimeRanges(t *testing.T) {
 				{int64(2025), int64(6), int64(20), int64(10)}, // 2025-06-20 10:00
 				{int64(2025), int64(6), int64(20), int64(11)}, // 2025-06-20 11:00
 			},
-			inputColumns:    []query.Symbol{"?year", "?month", "?day", "?hour"},
-			correlationKeys: []query.Symbol{"$", "?s", "?year", "?month", "?day", "?hour"},
+			inputColumns:    []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")},
+			correlationKeys: []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")},
 			expectedRanges:  3,
 			description:     "Should extract 3 hourly ranges",
 		},
@@ -36,8 +38,8 @@ func TestExtractTimeRanges(t *testing.T) {
 				{int64(2025), int64(6), int64(21)}, // 2025-06-21
 				{int64(2025), int64(6), int64(22)}, // 2025-06-22
 			},
-			inputColumns:    []query.Symbol{"?year", "?month", "?day"},
-			correlationKeys: []query.Symbol{"$", "?s", "?year", "?month", "?day"},
+			inputColumns:    []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day")},
+			correlationKeys: []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day")},
 			expectedRanges:  3,
 			description:     "Should extract 3 daily ranges",
 		},
@@ -48,8 +50,8 @@ func TestExtractTimeRanges(t *testing.T) {
 				{int64(2025), int64(6), int64(20), int64(9)}, // Duplicate
 				{int64(2025), int64(6), int64(20), int64(10)},
 			},
-			inputColumns:    []query.Symbol{"?year", "?month", "?day", "?hour"},
-			correlationKeys: []query.Symbol{"$", "?s", "?year", "?month", "?day", "?hour"},
+			inputColumns:    []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")},
+			correlationKeys: []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")},
 			expectedRanges:  2,
 			description:     "Should deduplicate identical time ranges",
 		},
@@ -58,8 +60,8 @@ func TestExtractTimeRanges(t *testing.T) {
 			inputTuples: []Tuple{
 				{"CRWV", int64(100)},
 			},
-			inputColumns:    []query.Symbol{"?symbol", "?value"},
-			correlationKeys: []query.Symbol{"$", "?symbol", "?value"},
+			inputColumns:    []query.Symbol{datalog.NewSymbol("?symbol"), datalog.NewSymbol("?value")},
+			correlationKeys: []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?symbol"), datalog.NewSymbol("?value")},
 			expectNil:       true,
 			description:     "Should return nil for non-time-based queries",
 		},
@@ -68,8 +70,8 @@ func TestExtractTimeRanges(t *testing.T) {
 			inputTuples: []Tuple{
 				{int64(2025), int64(6)}, // Only year and month
 			},
-			inputColumns:    []query.Symbol{"?year", "?month"},
-			correlationKeys: []query.Symbol{"$", "?s", "?year", "?month"},
+			inputColumns:    []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month")},
+			correlationKeys: []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month")},
 			expectNil:       true,
 			description:     "Should return nil when missing required day component",
 		},
@@ -113,11 +115,11 @@ func TestTimeRangeGranularity(t *testing.T) {
 			{int64(2025), int64(6), int64(20), int64(9)},
 		}
 		inputRel := NewMaterializedRelation(
-			[]query.Symbol{"?year", "?month", "?day", "?hour"},
+			[]query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")},
 			inputTuples,
 		)
 
-		ranges, err := extractTimeRanges(inputRel, []query.Symbol{"$", "?s", "?year", "?month", "?day", "?hour"})
+		ranges, err := extractTimeRanges(inputRel, []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")})
 		if err != nil {
 			t.Fatalf("extractTimeRanges failed: %v", err)
 		}
@@ -143,11 +145,11 @@ func TestTimeRangeGranularity(t *testing.T) {
 			{int64(2025), int64(6), int64(20)},
 		}
 		inputRel := NewMaterializedRelation(
-			[]query.Symbol{"?year", "?month", "?day"},
+			[]query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day")},
 			inputTuples,
 		)
 
-		ranges, err := extractTimeRanges(inputRel, []query.Symbol{"$", "?s", "?year", "?month", "?day"})
+		ranges, err := extractTimeRanges(inputRel, []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day")})
 		if err != nil {
 			t.Fatalf("extractTimeRanges failed: %v", err)
 		}
@@ -176,11 +178,11 @@ func TestTimeRangeWithIntTypes(t *testing.T) {
 			{int(2025), int(6), int(20), int(9)},
 		}
 		inputRel := NewMaterializedRelation(
-			[]query.Symbol{"?year", "?month", "?day", "?hour"},
+			[]query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")},
 			inputTuples,
 		)
 
-		ranges, err := extractTimeRanges(inputRel, []query.Symbol{"$", "?s", "?year", "?month", "?day", "?hour"})
+		ranges, err := extractTimeRanges(inputRel, []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")})
 		if err != nil {
 			t.Fatalf("extractTimeRanges failed: %v", err)
 		}
@@ -200,11 +202,11 @@ func TestTimeRangeWithIntTypes(t *testing.T) {
 			{int64(2025), int(6), int64(20), int(9)},
 		}
 		inputRel := NewMaterializedRelation(
-			[]query.Symbol{"?year", "?month", "?day", "?hour"},
+			[]query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")},
 			inputTuples,
 		)
 
-		ranges, err := extractTimeRanges(inputRel, []query.Symbol{"$", "?s", "?year", "?month", "?day", "?hour"})
+		ranges, err := extractTimeRanges(inputRel, []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")})
 		if err != nil {
 			t.Fatalf("extractTimeRanges failed: %v", err)
 		}
@@ -232,11 +234,11 @@ func TestTimeRangeOptimization260Hours(t *testing.T) {
 	}
 
 	inputRel := NewMaterializedRelation(
-		[]query.Symbol{"?year", "?month", "?day", "?hour"},
+		[]query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")},
 		inputTuples,
 	)
 
-	ranges, err := extractTimeRanges(inputRel, []query.Symbol{"$", "?s", "?year", "?month", "?day", "?hour"})
+	ranges, err := extractTimeRanges(inputRel, []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")})
 	if err != nil {
 		t.Fatalf("extractTimeRanges failed: %v", err)
 	}

--- a/datalog/executor/variadic_test.go
+++ b/datalog/executor/variadic_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog/query"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestVariadicFilter(t *testing.T) {
@@ -19,13 +21,13 @@ func TestVariadicFilter(t *testing.T) {
 			filter: VariadicFilter{
 				Function: "<",
 				Args: []query.PatternElement{
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?b"},
-					query.Variable{Name: "?c"},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?b")},
+					query.Variable{Name: datalog.NewSymbol("?c")},
 				},
 			},
 			tuple:    Tuple{1, 5, 10},
-			columns:  []query.Symbol{"?a", "?b", "?c"},
+			columns:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
 			expected: true,
 		},
 		{
@@ -33,13 +35,13 @@ func TestVariadicFilter(t *testing.T) {
 			filter: VariadicFilter{
 				Function: "<",
 				Args: []query.PatternElement{
-					query.Variable{Name: "?a"},
-					query.Variable{Name: "?b"},
-					query.Variable{Name: "?c"},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?b")},
+					query.Variable{Name: datalog.NewSymbol("?c")},
 				},
 			},
 			tuple:    Tuple{10, 5, 1},
-			columns:  []query.Symbol{"?a", "?b", "?c"},
+			columns:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
 			expected: false,
 		},
 		{
@@ -48,12 +50,12 @@ func TestVariadicFilter(t *testing.T) {
 				Function: "<=",
 				Args: []query.PatternElement{
 					query.Constant{Value: int64(0)},
-					query.Variable{Name: "?x"},
+					query.Variable{Name: datalog.NewSymbol("?x")},
 					query.Constant{Value: int64(100)},
 				},
 			},
 			tuple:    Tuple{50},
-			columns:  []query.Symbol{"?x"},
+			columns:  []query.Symbol{datalog.NewSymbol("?x")},
 			expected: true,
 		},
 		{
@@ -62,12 +64,12 @@ func TestVariadicFilter(t *testing.T) {
 				Function: "<=",
 				Args: []query.PatternElement{
 					query.Constant{Value: int64(0)},
-					query.Variable{Name: "?x"},
+					query.Variable{Name: datalog.NewSymbol("?x")},
 					query.Constant{Value: int64(100)},
 				},
 			},
 			tuple:    Tuple{150},
-			columns:  []query.Symbol{"?x"},
+			columns:  []query.Symbol{datalog.NewSymbol("?x")},
 			expected: false,
 		},
 		{
@@ -75,13 +77,13 @@ func TestVariadicFilter(t *testing.T) {
 			filter: VariadicFilter{
 				Function: "=",
 				Args: []query.PatternElement{
-					query.Variable{Name: "?x"},
-					query.Variable{Name: "?y"},
-					query.Variable{Name: "?z"},
+					query.Variable{Name: datalog.NewSymbol("?x")},
+					query.Variable{Name: datalog.NewSymbol("?y")},
+					query.Variable{Name: datalog.NewSymbol("?z")},
 				},
 			},
 			tuple:    Tuple{42, 42, 42},
-			columns:  []query.Symbol{"?x", "?y", "?z"},
+			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
 			expected: true,
 		},
 		{
@@ -89,13 +91,13 @@ func TestVariadicFilter(t *testing.T) {
 			filter: VariadicFilter{
 				Function: "=",
 				Args: []query.PatternElement{
-					query.Variable{Name: "?x"},
-					query.Variable{Name: "?y"},
-					query.Variable{Name: "?z"},
+					query.Variable{Name: datalog.NewSymbol("?x")},
+					query.Variable{Name: datalog.NewSymbol("?y")},
+					query.Variable{Name: datalog.NewSymbol("?z")},
 				},
 			},
 			tuple:    Tuple{42, 42, 43},
-			columns:  []query.Symbol{"?x", "?y", "?z"},
+			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
 			expected: false,
 		},
 		{
@@ -104,13 +106,13 @@ func TestVariadicFilter(t *testing.T) {
 				Function: "<",
 				Args: []query.PatternElement{
 					query.Constant{Value: int64(0)},
-					query.Variable{Name: "?x"},
-					query.Variable{Name: "?y"},
+					query.Variable{Name: datalog.NewSymbol("?x")},
+					query.Variable{Name: datalog.NewSymbol("?y")},
 					query.Constant{Value: int64(100)},
 				},
 			},
 			tuple:    Tuple{10, 20},
-			columns:  []query.Symbol{"?x", "?y"},
+			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: true,
 		},
 	}
@@ -130,14 +132,14 @@ func TestVariadicFilterRequiredSymbols(t *testing.T) {
 		Function: "<",
 		Args: []query.PatternElement{
 			query.Constant{Value: int64(0)},
-			query.Variable{Name: "?x"},
-			query.Variable{Name: "?y"},
+			query.Variable{Name: datalog.NewSymbol("?x")},
+			query.Variable{Name: datalog.NewSymbol("?y")},
 			query.Constant{Value: int64(100)},
 		},
 	}
 
 	symbols := filter.RequiredSymbols()
-	expected := []query.Symbol{"?x", "?y"}
+	expected := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 	if len(symbols) != len(expected) {
 		t.Fatalf("RequiredSymbols() returned %d symbols, want %d", len(symbols), len(expected))

--- a/datalog/intern.go
+++ b/datalog/intern.go
@@ -7,15 +7,15 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/codec"
 )
 
-// KeywordIntern provides keyword interning to avoid repeated allocations
+// keywordInternCache provides keyword interning to avoid repeated allocations
 // Uses sync.Map for lock-free concurrent reads
 // Cache key is [32]byte (null-padded) to match storage format
-type KeywordIntern struct {
+type keywordInternCache struct {
 	cache sync.Map // map[[32]byte]Keyword
 }
 
 // Global keyword intern instance
-var keywordIntern = &KeywordIntern{}
+var keywordIntern = &keywordInternCache{}
 
 // InternKeyword returns an interned keyword instance.
 // Pads the string to 32 bytes for cache key lookup.
@@ -70,14 +70,14 @@ func Kws(strs ...string) []Keyword {
 	return result
 }
 
-// IdentityIntern provides identity interning to avoid repeated allocations
+// identityInternCache provides identity interning to avoid repeated allocations
 // Uses sync.Map for lock-free concurrent reads
-type IdentityIntern struct {
+type identityInternCache struct {
 	cache sync.Map // map[[20]byte]Identity (Identity is *identity)
 }
 
 // Global identity intern instance
-var identityIntern = &IdentityIntern{}
+var identityIntern = &identityInternCache{}
 
 // InternIdentity returns an interned identity instance.
 // Since all Identity constructors now intern automatically, this is effectively
@@ -120,9 +120,39 @@ func InternIdentityFromHash(hash [20]byte) Identity {
 	return actual.(Identity)
 }
 
-// ClearInterns clears both keyword and identity intern caches
+// symbolInternCache provides symbol interning to avoid repeated allocations
+// Uses sync.Map for lock-free concurrent reads
+// Cache key is string (no storage format constraint for symbols)
+type symbolInternCache struct {
+	cache sync.Map // map[string]Symbol
+}
+
+// Global symbol intern instance
+var symbolIntern = &symbolInternCache{}
+
+// internSymbol returns an interned symbol instance.
+// Uses string keys since symbols have no storage format constraint.
+func internSymbol(s string) Symbol {
+	// Fast path: load existing (lock-free)
+	if val, ok := symbolIntern.cache.Load(s); ok {
+		return val.(Symbol)
+	}
+
+	// Slow path: create and store
+	sym := &symbol{value: s}
+	actual, _ := symbolIntern.cache.LoadOrStore(s, sym)
+	return actual.(Symbol)
+}
+
+// Pre-interned common symbols for hot paths
+var SymDollar = internSymbol("$")
+
+// ClearInterns clears keyword, identity, and symbol intern caches
 // Useful for testing or when memory needs to be reclaimed
 func ClearInterns() {
-	keywordIntern = &KeywordIntern{}
-	identityIntern = &IdentityIntern{}
+	keywordIntern = &keywordInternCache{}
+	identityIntern = &identityInternCache{}
+	symbolIntern = &symbolInternCache{}
+	// Re-intern pre-interned symbols so they remain valid
+	SymDollar = internSymbol("$")
 }

--- a/datalog/parser/clause_test.go
+++ b/datalog/parser/clause_test.go
@@ -1,8 +1,10 @@
 package parser
 
 import (
-	"github.com/wbrown/janus-datalog/datalog/query"
 	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
 func TestParserCreatesClauseStructure(t *testing.T) {
@@ -53,7 +55,7 @@ func TestParserCreatesClauseStructure(t *testing.T) {
 	}
 
 	if expr, ok := q.Where[3].(*query.Expression); ok {
-		if binding, ok := expr.Binding.(query.Symbol); !ok || binding != "?sum" {
+		if binding, ok := expr.Binding.(query.Symbol); !ok || binding != datalog.NewSymbol("?sum") {
 			t.Errorf("Expected binding ?sum, got %v", expr.Binding)
 		}
 		if _, ok := expr.Function.(*query.ArithmeticFunction); !ok {

--- a/datalog/parser/database_function_test.go
+++ b/datalog/parser/database_function_test.go
@@ -38,7 +38,7 @@ func TestParseGetElse(t *testing.T) {
 				if getElse.Default != "Unknown" {
 					t.Errorf("expected default 'Unknown', got %v", getElse.Default)
 				}
-				if binding, ok := expr.Binding.(query.Symbol); !ok || binding != "?name" {
+				if binding, ok := expr.Binding.(query.Symbol); !ok || binding != datalog.NewSymbol("?name") {
 					t.Errorf("expected binding ?name, got %v", expr.Binding)
 				}
 			},
@@ -170,7 +170,7 @@ func TestParseMissingAttr(t *testing.T) {
 				if missing.Attr.String() != ":entity/name" {
 					t.Errorf("expected attr :entity/name, got %s", missing.Attr.String())
 				}
-				if binding, ok := expr.Binding.(query.Symbol); !ok || binding != "?is_missing" {
+				if binding, ok := expr.Binding.(query.Symbol); !ok || binding != datalog.NewSymbol("?is_missing") {
 					t.Errorf("expected binding ?is_missing, got %v", expr.Binding)
 				}
 			},
@@ -302,33 +302,33 @@ func TestParseGetSome(t *testing.T) {
 func TestDatabaseFunctionRequiredSymbols(t *testing.T) {
 	// Test that RequiredSymbols correctly identifies the entity variable
 	getElse := &query.GetElseFunction{
-		Entity:  query.VariableTerm{Symbol: "?e"},
+		Entity:  query.VariableTerm{Symbol: datalog.NewSymbol("?e")},
 		Attr:    datalog.NewKeyword(":entity/name"),
 		Default: "",
 	}
 	syms := getElse.RequiredSymbols()
-	if len(syms) != 1 || syms[0] != "?e" {
+	if len(syms) != 1 || syms[0] != datalog.NewSymbol("?e") {
 		t.Errorf("expected [?e], got %v", syms)
 	}
 
 	missing := &query.MissingFunction{
-		Entity: query.VariableTerm{Symbol: "?person"},
+		Entity: query.VariableTerm{Symbol: datalog.NewSymbol("?person")},
 		Attr:   datalog.NewKeyword(":person/email"),
 	}
 	syms = missing.RequiredSymbols()
-	if len(syms) != 1 || syms[0] != "?person" {
+	if len(syms) != 1 || syms[0] != datalog.NewSymbol("?person") {
 		t.Errorf("expected [?person], got %v", syms)
 	}
 
 	getSome := &query.GetSomeFunction{
-		Entity: query.VariableTerm{Symbol: "?user"},
+		Entity: query.VariableTerm{Symbol: datalog.NewSymbol("?user")},
 		Attrs: []datalog.Keyword{
 			datalog.NewKeyword(":user/nickname"),
 			datalog.NewKeyword(":user/name"),
 		},
 	}
 	syms = getSome.RequiredSymbols()
-	if len(syms) != 1 || syms[0] != "?user" {
+	if len(syms) != 1 || syms[0] != datalog.NewSymbol("?user") {
 		t.Errorf("expected [?user], got %v", syms)
 	}
 }
@@ -336,7 +336,7 @@ func TestDatabaseFunctionRequiredSymbols(t *testing.T) {
 func TestDatabaseFunctionString(t *testing.T) {
 	// Test String() methods for debugging output
 	getElse := &query.GetElseFunction{
-		Entity:  query.VariableTerm{Symbol: "?e"},
+		Entity:  query.VariableTerm{Symbol: datalog.NewSymbol("?e")},
 		Attr:    datalog.NewKeyword(":entity/name"),
 		Default: "Unknown",
 	}
@@ -346,7 +346,7 @@ func TestDatabaseFunctionString(t *testing.T) {
 	}
 
 	missing := &query.MissingFunction{
-		Entity: query.VariableTerm{Symbol: "?e"},
+		Entity: query.VariableTerm{Symbol: datalog.NewSymbol("?e")},
 		Attr:   datalog.NewKeyword(":entity/email"),
 	}
 	str = missing.String()
@@ -355,7 +355,7 @@ func TestDatabaseFunctionString(t *testing.T) {
 	}
 
 	getSome := &query.GetSomeFunction{
-		Entity: query.VariableTerm{Symbol: "?e"},
+		Entity: query.VariableTerm{Symbol: datalog.NewSymbol("?e")},
 		Attrs: []datalog.Keyword{
 			datalog.NewKeyword(":a"),
 			datalog.NewKeyword(":b"),

--- a/datalog/parser/expression_test.go
+++ b/datalog/parser/expression_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -19,35 +20,35 @@ func TestParseExpressionPatterns(t *testing.T) {
 			input:    `[:find ?total :where [?item :price ?price] [?item :tax ?tax] [(+ ?price ?tax) ?total]]`,
 			wantFunc: "+",
 			wantArgs: 2,
-			wantBind: "?total",
+			wantBind: datalog.NewSymbol("?total"),
 		},
 		{
 			name:     "string concatenation",
 			input:    `[:find ?fullname :where [?person :first ?first] [?person :last ?last] [(str ?first " " ?last) ?fullname]]`,
 			wantFunc: "str",
 			wantArgs: 3,
-			wantBind: "?fullname",
+			wantBind: datalog.NewSymbol("?fullname"),
 		},
 		{
 			name:     "ground value",
 			input:    `[:find ?x ?answer :where [?x :age 42] [(ground 42) ?answer]]`,
 			wantFunc: "ground",
 			wantArgs: 1,
-			wantBind: "?answer",
+			wantBind: datalog.NewSymbol("?answer"),
 		},
 		{
 			name:     "identity binding",
 			input:    `[:find ?x ?y :where [?x :name "Alice"] [(identity ?x) ?y]]`,
 			wantFunc: "identity",
 			wantArgs: 1,
-			wantBind: "?y",
+			wantBind: datalog.NewSymbol("?y"),
 		},
 		{
 			name:     "complex arithmetic",
 			input:    `[:find ?result :where [?x :value ?v] [(* ?v 2) ?temp] [(+ ?temp 10) ?result]]`,
 			wantFunc: "+", // Testing the second expression
 			wantArgs: 2,
-			wantBind: "?result",
+			wantBind: datalog.NewSymbol("?result"),
 		},
 		// Comparison functions with binding
 		{
@@ -55,42 +56,42 @@ func TestParseExpressionPatterns(t *testing.T) {
 			input:    `[:find ?x ?flag :where [?x :count ?n] [(> ?n 0) ?flag]]`,
 			wantFunc: ">",
 			wantArgs: 2,
-			wantBind: "?flag",
+			wantBind: datalog.NewSymbol("?flag"),
 		},
 		{
 			name:     "equality with binding",
 			input:    `[:find ?x ?match :where [?x :status ?s] [(= ?s "active") ?match]]`,
 			wantFunc: "=",
 			wantArgs: 2,
-			wantBind: "?match",
+			wantBind: datalog.NewSymbol("?match"),
 		},
 		{
 			name:     "less than or equal with binding",
 			input:    `[:find ?x ?under :where [?x :price ?p] [(<= ?p 100) ?under]]`,
 			wantFunc: "<=",
 			wantArgs: 2,
-			wantBind: "?under",
+			wantBind: datalog.NewSymbol("?under"),
 		},
 		{
 			name:     "not equal with binding",
 			input:    `[:find ?x ?diff :where [?x :value ?v] [(!= ?v 0) ?diff]]`,
 			wantFunc: "!=",
 			wantArgs: 2,
-			wantBind: "?diff",
+			wantBind: datalog.NewSymbol("?diff"),
 		},
 		{
 			name:     "less than with binding",
 			input:    `[:find ?x ?small :where [?x :age ?a] [(< ?a 18) ?small]]`,
 			wantFunc: "<",
 			wantArgs: 2,
-			wantBind: "?small",
+			wantBind: datalog.NewSymbol("?small"),
 		},
 		{
 			name:     "greater than or equal with binding",
 			input:    `[:find ?x ?adult :where [?x :age ?a] [(>= ?a 18) ?adult]]`,
 			wantFunc: ">=",
 			wantArgs: 2,
-			wantBind: "?adult",
+			wantBind: datalog.NewSymbol("?adult"),
 		},
 	}
 
@@ -239,31 +240,31 @@ func TestParseTupleGround(t *testing.T) {
 			name:       "basic tuple ground",
 			input:      `[:find ?a ?b ?c :where [(ground [1 2 3]) [?a ?b ?c]]]`,
 			wantValues: []interface{}{int64(1), int64(2), int64(3)},
-			wantVars:   []query.Symbol{"?a", "?b", "?c"},
+			wantVars:   []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
 		},
 		{
 			name:       "tuple ground with zero values",
 			input:      `[:find ?x ?y ?z :where [(ground [0 0 0]) [?x ?y ?z]]]`,
 			wantValues: []interface{}{int64(0), int64(0), int64(0)},
-			wantVars:   []query.Symbol{"?x", "?y", "?z"},
+			wantVars:   []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
 		},
 		{
 			name:       "tuple ground with mixed types",
 			input:      `[:find ?s ?n :where [(ground ["hello" 42]) [?s ?n]]]`,
 			wantValues: []interface{}{"hello", int64(42)},
-			wantVars:   []query.Symbol{"?s", "?n"},
+			wantVars:   []query.Symbol{datalog.NewSymbol("?s"), datalog.NewSymbol("?n")},
 		},
 		{
 			name:       "tuple ground with keyword",
 			input:      `[:find ?status ?count :where [(ground [:none 0]) [?status ?count]]]`,
 			wantValues: nil, // Keyword parsing may differ
-			wantVars:   []query.Symbol{"?status", "?count"},
+			wantVars:   []query.Symbol{datalog.NewSymbol("?status"), datalog.NewSymbol("?count")},
 		},
 		{
 			name:       "single element tuple ground",
 			input:      `[:find ?x :where [(ground [42]) [?x]]]`,
 			wantValues: []interface{}{int64(42)},
-			wantVars:   []query.Symbol{"?x"},
+			wantVars:   []query.Symbol{datalog.NewSymbol("?x")},
 		},
 		{
 			name:      "tuple ground length mismatch",
@@ -384,7 +385,7 @@ func TestScalarGroundStillWorks(t *testing.T) {
 		t.Fatalf("Expected Symbol binding, got %T", expr.Binding)
 	}
 
-	if binding != "?x" {
+	if binding != datalog.NewSymbol("?x") {
 		t.Errorf("Binding = %v, want ?x", binding)
 	}
 }

--- a/datalog/parser/format_test.go
+++ b/datalog/parser/format_test.go
@@ -18,22 +18,22 @@ func TestFormatQueryEDN(t *testing.T) {
 			name: "simple query with variables",
 			query: &query.Query{
 				Find: []query.FindElement{
-					query.FindVariable{Symbol: "?name"},
-					query.FindVariable{Symbol: "?age"},
+					query.FindVariable{Symbol: datalog.NewSymbol("?name")},
+					query.FindVariable{Symbol: datalog.NewSymbol("?age")},
 				},
 				Where: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":user/name")},
-							query.Variable{Name: "?name"},
+							query.Variable{Name: datalog.NewSymbol("?name")},
 						},
 					},
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":user/age")},
-							query.Variable{Name: "?age"},
+							query.Variable{Name: datalog.NewSymbol("?age")},
 						},
 					},
 				},
@@ -46,12 +46,12 @@ func TestFormatQueryEDN(t *testing.T) {
 			name: "query with constants",
 			query: &query.Query{
 				Find: []query.FindElement{
-					query.FindVariable{Symbol: "?name"},
+					query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 				},
 				Where: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":user/name")},
 							query.Constant{Value: "Alice"},
 						},
@@ -65,27 +65,27 @@ func TestFormatQueryEDN(t *testing.T) {
 			name: "query with function pattern",
 			query: &query.Query{
 				Find: []query.FindElement{
-					query.FindVariable{Symbol: "?name"},
-					query.FindVariable{Symbol: "?age"},
+					query.FindVariable{Symbol: datalog.NewSymbol("?name")},
+					query.FindVariable{Symbol: datalog.NewSymbol("?age")},
 				},
 				Where: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":user/name")},
-							query.Variable{Name: "?name"},
+							query.Variable{Name: datalog.NewSymbol("?name")},
 						},
 					},
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":user/age")},
-							query.Variable{Name: "?age"},
+							query.Variable{Name: datalog.NewSymbol("?age")},
 						},
 					},
 					&query.Comparison{
 						Op:    query.OpLT,
-						Left:  query.VariableTerm{Symbol: "?age"},
+						Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?age")},
 						Right: query.ConstantTerm{Value: int64(30)},
 					},
 				},
@@ -99,14 +99,14 @@ func TestFormatQueryEDN(t *testing.T) {
 			name: "query with blanks",
 			query: &query.Query{
 				Find: []query.FindElement{
-					query.FindVariable{Symbol: "?name"},
+					query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 				},
 				Where: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":user/name")},
-							query.Variable{Name: "?name"},
+							query.Variable{Name: datalog.NewSymbol("?name")},
 							query.Blank{},
 						},
 					},
@@ -119,21 +119,21 @@ func TestFormatQueryEDN(t *testing.T) {
 			name: "query with entity reference",
 			query: &query.Query{
 				Find: []query.FindElement{
-					query.FindVariable{Symbol: "?name"},
+					query.FindVariable{Symbol: datalog.NewSymbol("?name")},
 				},
 				Where: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":user/friend")},
 							query.Constant{Value: datalog.NewIdentity("user:alice")},
 						},
 					},
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":user/name")},
-							query.Variable{Name: "?name"},
+							query.Variable{Name: datalog.NewSymbol("?name")},
 						},
 					},
 				},
@@ -146,12 +146,12 @@ func TestFormatQueryEDN(t *testing.T) {
 			name: "query with escaped strings",
 			query: &query.Query{
 				Find: []query.FindElement{
-					query.FindVariable{Symbol: "?msg"},
+					query.FindVariable{Symbol: datalog.NewSymbol("?msg")},
 				},
 				Where: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":message")},
 							query.Constant{Value: "Hello \"world\"\nNew line\t\tTab"},
 						},
@@ -165,26 +165,26 @@ func TestFormatQueryEDN(t *testing.T) {
 			name: "query with numeric types",
 			query: &query.Query{
 				Find: []query.FindElement{
-					query.FindVariable{Symbol: "?val"},
+					query.FindVariable{Symbol: datalog.NewSymbol("?val")},
 				},
 				Where: []query.Clause{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":int-val")},
 							query.Constant{Value: int64(42)},
 						},
 					},
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":float-val")},
 							query.Constant{Value: 3.14159},
 						},
 					},
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":bool-val")},
 							query.Constant{Value: true},
 						},

--- a/datalog/parser/function_parser.go
+++ b/datalog/parser/function_parser.go
@@ -290,13 +290,13 @@ func parseGetSome(args []query.PatternElement) (query.Function, error) {
 func validateDatabaseRef(arg query.PatternElement) error {
 	switch a := arg.(type) {
 	case query.Variable:
-		if a.Name == "$" {
+		if a.Name == datalog.SymDollar {
 			return nil
 		}
 		return fmt.Errorf("expected database reference ($), got variable %s", a.Name)
 	case query.Constant:
 		// $ is parsed as Constant{Value: Symbol("$")}
-		if sym, ok := a.Value.(query.Symbol); ok && sym == "$" {
+		if sym, ok := a.Value.(query.Symbol); ok && sym == datalog.SymDollar {
 			return nil
 		}
 		if str, ok := a.Value.(string); ok && str == "$" {

--- a/datalog/parser/in_clause_test.go
+++ b/datalog/parser/in_clause_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -41,7 +42,7 @@ func TestParseInputClause(t *testing.T) {
 				}
 				if scalar, ok := q.In[1].(query.ScalarInput); !ok {
 					t.Errorf("expected ScalarInput at position 1, got %T", q.In[1])
-				} else if scalar.Symbol != "?name" {
+				} else if scalar.Symbol != datalog.NewSymbol("?name") {
 					t.Errorf("expected ?name, got %s", scalar.Symbol)
 				}
 				return nil
@@ -58,7 +59,7 @@ func TestParseInputClause(t *testing.T) {
 				}
 				if coll, ok := q.In[1].(query.CollectionInput); !ok {
 					t.Errorf("expected CollectionInput at position 1, got %T", q.In[1])
-				} else if coll.Symbol != "?food" {
+				} else if coll.Symbol != datalog.NewSymbol("?food") {
 					t.Errorf("expected ?food, got %s", coll.Symbol)
 				}
 				return nil
@@ -80,7 +81,7 @@ func TestParseInputClause(t *testing.T) {
 					if len(tuple.Symbols) != 2 {
 						t.Errorf("expected 2 symbols in tuple, got %d", len(tuple.Symbols))
 					}
-					if tuple.Symbols[0] != "?name" || tuple.Symbols[1] != "?age" {
+					if tuple.Symbols[0] != datalog.NewSymbol("?name") || tuple.Symbols[1] != datalog.NewSymbol("?age") {
 						t.Errorf("expected [?name ?age], got %v", tuple.Symbols)
 					}
 				}
@@ -103,7 +104,7 @@ func TestParseInputClause(t *testing.T) {
 					if len(rel.Symbols) != 2 {
 						t.Errorf("expected 2 symbols in relation, got %d", len(rel.Symbols))
 					}
-					if rel.Symbols[0] != "?name" || rel.Symbols[1] != "?email" {
+					if rel.Symbols[0] != datalog.NewSymbol("?name") || rel.Symbols[1] != datalog.NewSymbol("?email") {
 						t.Errorf("expected [?name ?email], got %v", rel.Symbols)
 					}
 				}
@@ -127,7 +128,7 @@ func TestParseInputClause(t *testing.T) {
 				for i, expected := range expectedVars {
 					if scalar, ok := q.In[i+1].(query.ScalarInput); !ok {
 						t.Errorf("expected ScalarInput at position %d, got %T", i+1, q.In[i+1])
-					} else if scalar.Symbol != query.Symbol(expected) {
+					} else if scalar.Symbol != datalog.NewSymbol(expected) {
 						t.Errorf("expected %s at position %d, got %s", expected, i+1, scalar.Symbol)
 					}
 				}
@@ -313,10 +314,10 @@ func TestSubqueryWithInputClause(t *testing.T) {
 	if _, ok := subq.Query.In[0].(query.DatabaseInput); !ok {
 		t.Errorf("expected DatabaseInput at position 0")
 	}
-	if scalar, ok := subq.Query.In[1].(query.ScalarInput); !ok || scalar.Symbol != "?symbol" {
+	if scalar, ok := subq.Query.In[1].(query.ScalarInput); !ok || scalar.Symbol != datalog.NewSymbol("?symbol") {
 		t.Errorf("expected ScalarInput ?symbol at position 1")
 	}
-	if scalar, ok := subq.Query.In[2].(query.ScalarInput); !ok || scalar.Symbol != "?date" {
+	if scalar, ok := subq.Query.In[2].(query.ScalarInput); !ok || scalar.Symbol != datalog.NewSymbol("?date") {
 		t.Errorf("expected ScalarInput ?date at position 2")
 	}
 }
@@ -348,14 +349,14 @@ func TestNestedQueryInputParsing(t *testing.T) {
 	// Check first scalar input
 	if scalar, ok := q.In[1].(query.ScalarInput); !ok {
 		t.Errorf("Input 1: expected ScalarInput, got %T", q.In[1])
-	} else if scalar.Symbol != "?sym" {
+	} else if scalar.Symbol != datalog.NewSymbol("?sym") {
 		t.Errorf("Input 1: expected symbol ?sym, got %s", scalar.Symbol)
 	}
 
 	// Check second scalar input
 	if scalar, ok := q.In[2].(query.ScalarInput); !ok {
 		t.Errorf("Input 2: expected ScalarInput, got %T", q.In[2])
-	} else if scalar.Symbol != "?d" {
+	} else if scalar.Symbol != datalog.NewSymbol("?d") {
 		t.Errorf("Input 2: expected symbol ?d, got %s", scalar.Symbol)
 	}
 }

--- a/datalog/parser/not_or_test.go
+++ b/datalog/parser/not_or_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -85,7 +86,7 @@ func TestParseNotJoinClause(t *testing.T) {
 				if len(notJoinClause.JoinVars) != 1 {
 					t.Fatalf("expected 1 join var, got %d", len(notJoinClause.JoinVars))
 				}
-				if notJoinClause.JoinVars[0] != "?e" {
+				if notJoinClause.JoinVars[0] != datalog.NewSymbol("?e") {
 					t.Fatalf("expected join var ?e, got %s", notJoinClause.JoinVars[0])
 				}
 				if len(notJoinClause.Clauses) != 1 {
@@ -219,7 +220,7 @@ func TestParseOrJoinClause(t *testing.T) {
 				if len(orJoinClause.JoinVars) != 1 {
 					t.Fatalf("expected 1 join var, got %d", len(orJoinClause.JoinVars))
 				}
-				if orJoinClause.JoinVars[0] != "?e" {
+				if orJoinClause.JoinVars[0] != datalog.NewSymbol("?e") {
 					t.Fatalf("expected join var ?e, got %s", orJoinClause.JoinVars[0])
 				}
 				if len(orJoinClause.Branches) != 2 {

--- a/datalog/parser/order_by_test.go
+++ b/datalog/parser/order_by_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -23,7 +24,7 @@ func TestOrderByParsing(t *testing.T) {
 				if len(q.OrderBy) != 1 {
 					t.Errorf("expected 1 order-by clause, got %d", len(q.OrderBy))
 				}
-				if q.OrderBy[0].Variable != "?age" {
+				if q.OrderBy[0].Variable != datalog.NewSymbol("?age") {
 					t.Errorf("expected ?age, got %s", q.OrderBy[0].Variable)
 				}
 				if q.OrderBy[0].Direction != query.OrderAsc {
@@ -41,7 +42,7 @@ func TestOrderByParsing(t *testing.T) {
 				if len(q.OrderBy) != 1 {
 					t.Errorf("expected 1 order-by clause, got %d", len(q.OrderBy))
 				}
-				if q.OrderBy[0].Variable != "?score" {
+				if q.OrderBy[0].Variable != datalog.NewSymbol("?score") {
 					t.Errorf("expected ?score, got %s", q.OrderBy[0].Variable)
 				}
 				if q.OrderBy[0].Direction != query.OrderDesc {
@@ -60,10 +61,10 @@ func TestOrderByParsing(t *testing.T) {
 				if len(q.OrderBy) != 2 {
 					t.Errorf("expected 2 order-by clauses, got %d", len(q.OrderBy))
 				}
-				if q.OrderBy[0].Variable != "?dept" || q.OrderBy[0].Direction != query.OrderAsc {
+				if q.OrderBy[0].Variable != datalog.NewSymbol("?dept") || q.OrderBy[0].Direction != query.OrderAsc {
 					t.Errorf("first clause should be ?dept asc")
 				}
-				if q.OrderBy[1].Variable != "?salary" || q.OrderBy[1].Direction != query.OrderDesc {
+				if q.OrderBy[1].Variable != datalog.NewSymbol("?salary") || q.OrderBy[1].Direction != query.OrderDesc {
 					t.Errorf("second clause should be ?salary desc")
 				}
 			},

--- a/datalog/parser/parser.go
+++ b/datalog/parser/parser.go
@@ -141,7 +141,7 @@ func parseOrderByClause(node *edn.Node) (query.OrderByClause, error) {
 	switch node.Type {
 	case edn.NodeSymbol:
 		// Simple variable (defaults to ascending)
-		sym := query.Symbol(node.Value)
+		sym := datalog.NewSymbol(node.Value)
 		if !sym.IsVariable() {
 			return query.OrderByClause{}, fmt.Errorf("order-by must use variables, got %s", sym)
 		}
@@ -160,7 +160,7 @@ func parseOrderByClause(node *edn.Node) (query.OrderByClause, error) {
 			return query.OrderByClause{}, fmt.Errorf("order-by variable must be a symbol")
 		}
 
-		sym := query.Symbol(node.Nodes[0].Value)
+		sym := datalog.NewSymbol(node.Nodes[0].Value)
 		if !sym.IsVariable() {
 			return query.OrderByClause{}, fmt.Errorf("order-by must use variables, got %s", sym)
 		}
@@ -194,7 +194,7 @@ func parseFindElement(node *edn.Node) (query.FindElement, error) {
 	switch node.Type {
 	case edn.NodeSymbol:
 		// Simple variable
-		sym := query.Symbol(node.Value)
+		sym := datalog.NewSymbol(node.Value)
 		if !sym.IsVariable() {
 			return nil, fmt.Errorf("find clause must contain variables, got %s", sym)
 		}
@@ -226,7 +226,7 @@ func parseFindElement(node *edn.Node) (query.FindElement, error) {
 			return nil, fmt.Errorf("aggregate argument must be a symbol")
 		}
 
-		argSym := query.Symbol(node.Nodes[1].Value)
+		argSym := datalog.NewSymbol(node.Nodes[1].Value)
 
 		if !argSym.IsVariable() {
 			return nil, fmt.Errorf("aggregate argument must be a variable, got %s", argSym)
@@ -272,7 +272,7 @@ func parsePattern(node *edn.Node) (query.Clause, error) {
 		if len(node.Nodes) == 2 {
 			// Scalar binding: [(fn ...) ?x]
 			if node.Nodes[1].Type == edn.NodeSymbol {
-				sym := query.Symbol(node.Nodes[1].Value)
+				sym := datalog.NewSymbol(node.Nodes[1].Value)
 				if sym.IsVariable() {
 					return parseExpression(&node.Nodes[0], sym)
 				}
@@ -303,7 +303,7 @@ func parsePattern(node *edn.Node) (query.Clause, error) {
 	var source query.Symbol
 	if len(node.Nodes) >= 1 && node.Nodes[0].Type == edn.NodeSymbol {
 		if strings.HasPrefix(node.Nodes[0].Value, "$") {
-			source = query.Symbol(node.Nodes[0].Value)
+			source = datalog.NewSymbol(node.Nodes[0].Value)
 			sourceOffset = 1
 		}
 	}
@@ -514,7 +514,7 @@ func parseBindingForm(node *edn.Node) (query.BindingForm, error) {
 	switch node.Type {
 	case edn.NodeSymbol:
 		// Scalar binding: ?var (expects one row, one column)
-		sym := query.Symbol(node.Value)
+		sym := datalog.NewSymbol(node.Value)
 		if !sym.IsVariable() {
 			return nil, fmt.Errorf("scalar binding must be a variable, got %s", sym)
 		}
@@ -529,7 +529,7 @@ func parseBindingForm(node *edn.Node) (query.BindingForm, error) {
 		if len(node.Nodes) == 2 &&
 			node.Nodes[0].Type == edn.NodeSymbol &&
 			node.Nodes[1].Type == edn.NodeSymbol && node.Nodes[1].Value == "..." {
-			sym := query.Symbol(node.Nodes[0].Value)
+			sym := datalog.NewSymbol(node.Nodes[0].Value)
 			if !sym.IsVariable() {
 				return nil, fmt.Errorf("collection binding must be a variable, got %s", sym)
 			}
@@ -569,7 +569,7 @@ func parseTupleBinding(node *edn.Node) (query.TupleBinding, error) {
 		if elem.Type != edn.NodeSymbol {
 			return query.TupleBinding{}, fmt.Errorf("tuple binding element %d must be a symbol", i)
 		}
-		sym := query.Symbol(elem.Value)
+		sym := datalog.NewSymbol(elem.Value)
 		if !sym.IsVariable() {
 			return query.TupleBinding{}, fmt.Errorf("tuple binding element %d must be a variable, got %s", i, sym)
 		}
@@ -590,7 +590,7 @@ func parseRelationBinding(node *edn.Node) (query.RelationBinding, error) {
 		if elem.Type != edn.NodeSymbol {
 			return query.RelationBinding{}, fmt.Errorf("relation binding element %d must be a symbol", i)
 		}
-		sym := query.Symbol(elem.Value)
+		sym := datalog.NewSymbol(elem.Value)
 		if !sym.IsVariable() {
 			return query.RelationBinding{}, fmt.Errorf("relation binding element %d must be a variable, got %s", i, sym)
 		}
@@ -606,9 +606,9 @@ func parseInputSpec(node *edn.Node) (query.InputSpec, error) {
 	case edn.NodeSymbol:
 		// Either $name (database source) or ?var (scalar input)
 		if strings.HasPrefix(node.Value, "$") {
-			return query.DatabaseInput{Name: query.Symbol(node.Value)}, nil
+			return query.DatabaseInput{Name: datalog.NewSymbol(node.Value)}, nil
 		}
-		sym := query.Symbol(node.Value)
+		sym := datalog.NewSymbol(node.Value)
 		if !sym.IsVariable() {
 			return nil, fmt.Errorf("input must be $name or a variable, got %s", node.Value)
 		}
@@ -630,7 +630,7 @@ func parseInputSpec(node *edn.Node) (query.InputSpec, error) {
 				if elem.Type != edn.NodeSymbol {
 					return nil, fmt.Errorf("tuple input element %d must be a symbol", i)
 				}
-				sym := query.Symbol(elem.Value)
+				sym := datalog.NewSymbol(elem.Value)
 				if !sym.IsVariable() {
 					return nil, fmt.Errorf("tuple input element %d must be a variable, got %s", i, sym)
 				}
@@ -653,7 +653,7 @@ func parseInputSpec(node *edn.Node) (query.InputSpec, error) {
 			if node.Nodes[0].Type != edn.NodeSymbol {
 				return nil, fmt.Errorf("collection input must contain a variable")
 			}
-			sym := query.Symbol(node.Nodes[0].Value)
+			sym := datalog.NewSymbol(node.Nodes[0].Value)
 			if !sym.IsVariable() {
 				return nil, fmt.Errorf("collection input must contain a variable, got %s", sym)
 			}
@@ -671,16 +671,17 @@ func parseInputSpec(node *edn.Node) (query.InputSpec, error) {
 func parsePatternElement(node *edn.Node) (query.PatternElement, error) {
 	switch node.Type {
 	case edn.NodeSymbol:
-		sym := query.Symbol(node.Value)
+		sym := datalog.NewSymbol(node.Value)
 		if sym.IsVariable() {
 			return query.Variable{Name: sym}, nil
 		} else if node.Value == "_" {
 			return query.Blank{}, nil
 		} else if node.Value == "$" {
 			// Database marker - treat as a special constant
-			return query.Constant{Value: query.Symbol("$")}, nil
+			return query.Constant{Value: datalog.SymDollar}, nil
 		} else {
-			return nil, fmt.Errorf("invalid symbol in pattern: %s", node.Value)
+			// Bare symbols are Symbol values (function references, rule names, etc.)
+			return query.Constant{Value: datalog.NewSymbol(node.Value)}, nil
 		}
 
 	case edn.NodeKeyword:
@@ -735,6 +736,8 @@ func parsePatternElement(node *edn.Node) (query.PatternElement, error) {
 				values[i] = elem.Value == "true"
 			case edn.NodeKeyword:
 				values[i] = datalog.NewKeyword(elem.Value)
+			case edn.NodeSymbol:
+				values[i] = datalog.NewSymbol(elem.Value)
 			default:
 				return nil, fmt.Errorf("unsupported type in vector constant: %v", elem.Type)
 			}
@@ -926,7 +929,7 @@ func parseJoinVars(node *edn.Node) ([]query.Symbol, error) {
 		if elem.Type != edn.NodeSymbol {
 			return nil, fmt.Errorf("join variable %d must be a symbol, got %v", i, elem.Type)
 		}
-		sym := query.Symbol(elem.Value)
+		sym := datalog.NewSymbol(elem.Value)
 		if !sym.IsVariable() {
 			return nil, fmt.Errorf("join variable %d must start with ?, got %s", i, sym)
 		}
@@ -1181,11 +1184,11 @@ func formatQueryWithIndent(q *query.Query, indent string) string {
 			}
 			if clause.Direction == query.OrderDesc {
 				sb.WriteString("[")
-				sb.WriteString(string(clause.Variable))
+				sb.WriteString(clause.Variable.String())
 				sb.WriteString(" :desc]")
 			} else {
 				// For ascending (default), just write the variable
-				sb.WriteString(string(clause.Variable))
+				sb.WriteString(clause.Variable.String())
 			}
 		}
 		sb.WriteString("]")
@@ -1263,7 +1266,7 @@ func formatSubqueryPattern(sb *strings.Builder, p *query.SubqueryPattern, indent
 func formatPatternElement(sb *strings.Builder, elem query.PatternElement) {
 	switch e := elem.(type) {
 	case query.Variable:
-		sb.WriteString(string(e.Name))
+		sb.WriteString(e.Name.String())
 
 	case query.Blank:
 		sb.WriteString("_")

--- a/datalog/parser/parser_test.go
+++ b/datalog/parser/parser_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -32,11 +33,11 @@ func TestParseSimpleQuery(t *testing.T) {
 
 		switch i {
 		case 0:
-			if v.Symbol != "?e" {
+			if v.Symbol != datalog.NewSymbol("?e") {
 				t.Errorf("Find[0]: expected ?e, got %s", v.Symbol)
 			}
 		case 1:
-			if v.Symbol != "?name" {
+			if v.Symbol != datalog.NewSymbol("?name") {
 				t.Errorf("Find[1]: expected ?name, got %s", v.Symbol)
 			}
 		}
@@ -282,7 +283,7 @@ func TestExtractVariables(t *testing.T) {
 	}
 
 	vars := ExtractVariables(q.Where)
-	expected := []query.Symbol{"?e", "?name", "?age"}
+	expected := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age")}
 
 	if len(vars) != len(expected) {
 		t.Errorf("expected %d variables, got %d", len(expected), len(vars))
@@ -363,7 +364,7 @@ func TestParseSubqueryPatterns(t *testing.T) {
 					return fmt.Errorf("expected TupleBinding, got %T", subq.Binding)
 				}
 
-				if len(binding.Variables) != 1 || binding.Variables[0] != "?high" {
+				if len(binding.Variables) != 1 || binding.Variables[0] != datalog.NewSymbol("?high") {
 					return fmt.Errorf("expected [[?high]] binding, got %v", binding.Variables)
 				}
 
@@ -373,7 +374,7 @@ func TestParseSubqueryPatterns(t *testing.T) {
 				}
 
 				agg, ok := subq.Query.Find[0].(query.FindAggregate)
-				if !ok || agg.Function != "max" || agg.Arg != "?h" {
+				if !ok || agg.Function != "max" || agg.Arg != datalog.NewSymbol("?h") {
 					return fmt.Errorf("expected (max ?h) in nested query")
 				}
 
@@ -401,7 +402,7 @@ func TestParseSubqueryPatterns(t *testing.T) {
 					return fmt.Errorf("expected ScalarBinding, got %T", subq.Binding)
 				}
 
-				if binding.Variable != "?max-price" {
+				if binding.Variable != datalog.NewSymbol("?max-price") {
 					return fmt.Errorf("expected ?max-price binding, got %s", binding.Variable)
 				}
 
@@ -429,7 +430,7 @@ func TestParseSubqueryPatterns(t *testing.T) {
 					return fmt.Errorf("expected CollectionBinding, got %T", subq.Binding)
 				}
 
-				if binding.Variable != "?prices" {
+				if binding.Variable != datalog.NewSymbol("?prices") {
 					return fmt.Errorf("expected ?prices binding, got %s", binding.Variable)
 				}
 
@@ -462,7 +463,7 @@ func TestParseSubqueryPatterns(t *testing.T) {
 					return fmt.Errorf("expected 2 variables in binding, got %d", len(binding.Variables))
 				}
 
-				if binding.Variables[0] != "?price" || binding.Variables[1] != "?time" {
+				if binding.Variables[0] != datalog.NewSymbol("?price") || binding.Variables[1] != datalog.NewSymbol("?time") {
 					return fmt.Errorf("expected [[?price ?time] ...], got %v", binding.Variables)
 				}
 
@@ -494,13 +495,13 @@ func TestParseSubqueryPatterns(t *testing.T) {
 
 				// First input should be variable ?s
 				v1, ok := subq.Inputs[0].(query.Variable)
-				if !ok || v1.Name != "?s" {
+				if !ok || v1.Name != datalog.NewSymbol("?s") {
 					return fmt.Errorf("expected ?s as first input")
 				}
 
 				// Second input should be variable ?date
 				v2, ok := subq.Inputs[1].(query.Variable)
-				if !ok || v2.Name != "?date" {
+				if !ok || v2.Name != datalog.NewSymbol("?date") {
 					return fmt.Errorf("expected ?date as second input")
 				}
 
@@ -685,5 +686,50 @@ func TestParseScalarFindSpec(t *testing.T) {
 				t.Errorf("expected %d find elements, got %d", tt.findCount, len(q.Find))
 			}
 		})
+	}
+}
+
+func TestParseSymbolValue(t *testing.T) {
+	// Bare symbols in value position should parse as Symbol constants
+	input := `[:find ?e
+              :where [?e :fn/name my-function]]`
+
+	q, err := ParseQuery(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(q.Where) != 1 {
+		t.Fatalf("expected 1 where clause, got %d", len(q.Where))
+	}
+
+	pattern := q.Where[0].(*query.DataPattern)
+	elem := pattern.Elements[2]
+
+	if elem.IsVariable() {
+		t.Fatal("expected constant, got variable")
+	}
+	if elem.IsBlank() {
+		t.Fatal("expected constant, got blank")
+	}
+
+	c, ok := elem.(query.Constant)
+	if !ok {
+		t.Fatalf("expected Constant, got %T", elem)
+	}
+
+	sym, ok := c.Value.(datalog.Symbol)
+	if !ok {
+		t.Fatalf("expected Symbol value, got %T", c.Value)
+	}
+
+	if sym.String() != "my-function" {
+		t.Errorf("expected symbol value 'my-function', got %q", sym.String())
+	}
+
+	// Verify it's interned
+	expected := datalog.NewSymbol("my-function")
+	if sym != expected {
+		t.Error("parsed symbol should be pointer-equal to NewSymbol result (interning)")
 	}
 }

--- a/datalog/parser/pattern_test.go
+++ b/datalog/parser/pattern_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -16,25 +17,25 @@ func TestParseSourceQualifiedPattern(t *testing.T) {
 		{
 			name:       "unqualified 3-tuple",
 			query:      `[:find ?e :where [?e :attr ?v]]`,
-			wantSource: "",
+			wantSource: nil,
 			wantElems:  3,
 		},
 		{
 			name:       "source-qualified 3-tuple",
 			query:      `[:find ?e :in $users :where [$users ?e :user/name ?n]]`,
-			wantSource: "$users",
+			wantSource: datalog.NewSymbol("$users"),
 			wantElems:  3,
 		},
 		{
 			name:       "source-qualified 4-tuple",
 			query:      `[:find ?e :in $db :where [$db ?e :attr ?v ?tx]]`,
-			wantSource: "$db",
+			wantSource: datalog.NewSymbol("$db"),
 			wantElems:  4,
 		},
 		{
 			name:       "default source qualified",
 			query:      `[:find ?e :in $ :where [$ ?e :attr ?v]]`,
-			wantSource: "$",
+			wantSource: datalog.NewSymbol("$"),
 			wantElems:  3,
 		},
 	}

--- a/datalog/parser/predicate_parser.go
+++ b/datalog/parser/predicate_parser.go
@@ -221,12 +221,12 @@ func parseMissingAttrPredicate(args []query.PatternElement) (query.Predicate, er
 func validateDatabaseRefPredicate(arg query.PatternElement) error {
 	switch a := arg.(type) {
 	case query.Variable:
-		if a.Name == "$" {
+		if a.Name == datalog.SymDollar {
 			return nil
 		}
 		return fmt.Errorf("expected database reference ($), got variable %s", a.Name)
 	case query.Constant:
-		if sym, ok := a.Value.(query.Symbol); ok && sym == "$" {
+		if sym, ok := a.Value.(query.Symbol); ok && sym == datalog.SymDollar {
 			return nil
 		}
 		if str, ok := a.Value.(string); ok && str == "$" {

--- a/datalog/parser/pull_parser.go
+++ b/datalog/parser/pull_parser.go
@@ -22,7 +22,7 @@ func parseFindPull(node *edn.Node) (query.FindPull, error) {
 	if node.Nodes[1].Type != edn.NodeSymbol {
 		return query.FindPull{}, fmt.Errorf("pull first argument must be a variable, got %v", node.Nodes[1].Type)
 	}
-	varSym := query.Symbol(node.Nodes[1].Value)
+	varSym := datalog.NewSymbol(node.Nodes[1].Value)
 	if !varSym.IsVariable() {
 		return query.FindPull{}, fmt.Errorf("pull argument must be a variable (starting with ?), got %s", varSym)
 	}

--- a/datalog/parser/pull_parser_test.go
+++ b/datalog/parser/pull_parser_test.go
@@ -243,7 +243,7 @@ func TestParseFindPull_InQuery(t *testing.T) {
 		t.Fatalf("expected FindPull, got %T", q.Find[0])
 	}
 
-	if pull.Variable != "?e" {
+	if pull.Variable != datalog.NewSymbol("?e") {
 		t.Errorf("expected variable ?e, got %s", pull.Variable)
 	}
 
@@ -277,7 +277,7 @@ func TestParseFindPull_MixedWithVariables(t *testing.T) {
 		t.Fatalf("find[1]: expected FindPull, got %T", q.Find[1])
 	}
 
-	if pull.Variable != "?e" {
+	if pull.Variable != datalog.NewSymbol("?e") {
 		t.Errorf("expected variable ?e, got %s", pull.Variable)
 	}
 

--- a/datalog/planner/cache_benchmark_test.go
+++ b/datalog/planner/cache_benchmark_test.go
@@ -60,12 +60,12 @@ func BenchmarkPlannerCacheMissOverhead(b *testing.B) {
 		// Create a unique query each time to force cache miss
 		q := &query.Query{
 			Find: []query.FindElement{
-				query.FindVariable{Symbol: query.Symbol("?e")},
+				query.FindVariable{Symbol: datalog.NewSymbol("?e")},
 			},
 			Where: []query.Clause{
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: query.Symbol("?e")},
+						query.Variable{Name: datalog.NewSymbol("?e")},
 						query.Constant{Value: datalog.NewKeyword(":test/id")},
 						query.Constant{Value: int64(i)}, // Different value each time
 					},
@@ -84,59 +84,59 @@ func BenchmarkPlannerCacheMissOverhead(b *testing.B) {
 func createComplexQuery() *query.Query {
 	return &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: query.Symbol("?p")},
-			query.FindVariable{Symbol: query.Symbol("?name")},
-			query.FindVariable{Symbol: query.Symbol("?age")},
-			query.FindVariable{Symbol: query.Symbol("?city")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?p")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?name")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?age")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?city")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?p")},
+					query.Variable{Name: datalog.NewSymbol("?p")},
 					query.Constant{Value: datalog.NewKeyword(":person/name")},
-					query.Variable{Name: query.Symbol("?name")},
+					query.Variable{Name: datalog.NewSymbol("?name")},
 				},
 			},
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?p")},
+					query.Variable{Name: datalog.NewSymbol("?p")},
 					query.Constant{Value: datalog.NewKeyword(":person/age")},
-					query.Variable{Name: query.Symbol("?age")},
+					query.Variable{Name: datalog.NewSymbol("?age")},
 				},
 			},
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?p")},
+					query.Variable{Name: datalog.NewSymbol("?p")},
 					query.Constant{Value: datalog.NewKeyword(":person/address")},
-					query.Variable{Name: query.Symbol("?addr")},
+					query.Variable{Name: datalog.NewSymbol("?addr")},
 				},
 			},
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?addr")},
+					query.Variable{Name: datalog.NewSymbol("?addr")},
 					query.Constant{Value: datalog.NewKeyword(":address/city")},
-					query.Variable{Name: query.Symbol("?city")},
+					query.Variable{Name: datalog.NewSymbol("?city")},
 				},
 			},
 			// Add some predicates
 			&query.Comparison{
 				Op:    query.OpGT,
-				Left:  query.VariableTerm{Symbol: query.Symbol("?age")},
+				Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?age")},
 				Right: query.ConstantTerm{Value: int64(18)},
 			},
 			&query.Comparison{
 				Op:    query.OpNE,
-				Left:  query.VariableTerm{Symbol: query.Symbol("?city")},
+				Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?city")},
 				Right: query.ConstantTerm{Value: "Unknown"},
 			},
 			// Add an expression
 			&query.Expression{
 				Function: query.ArithmeticFunction{
 					Op:    query.OpAdd,
-					Left:  query.VariableTerm{Symbol: query.Symbol("?age")},
+					Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?age")},
 					Right: query.ConstantTerm{Value: int64(10)},
 				},
-				Binding: query.Symbol("?future_age"),
+				Binding: datalog.NewSymbol("?future_age"),
 			},
 		},
 	}

--- a/datalog/planner/cache_test.go
+++ b/datalog/planner/cache_test.go
@@ -15,12 +15,12 @@ func TestPlanCache(t *testing.T) {
 	// Create a sample query
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: query.Symbol("?e")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?e")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword(":person/name")},
 					query.Constant{Value: "Alice"},
 				},
@@ -34,7 +34,7 @@ func TestPlanCache(t *testing.T) {
 		Phases: []RealizedPhase{
 			{
 				Query:    q,
-				Provides: []query.Symbol{"?e"},
+				Provides: []query.Symbol{datalog.NewSymbol("?e")},
 			},
 		},
 	}
@@ -99,12 +99,12 @@ func TestPlanCacheEviction(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		queries[i] = &query.Query{
 			Find: []query.FindElement{
-				query.FindVariable{Symbol: query.Symbol("?e")},
+				query.FindVariable{Symbol: datalog.NewSymbol("?e")},
 			},
 			Where: []query.Clause{
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: query.Symbol("?e")},
+						query.Variable{Name: datalog.NewSymbol("?e")},
 						query.Constant{Value: datalog.NewKeyword(":person/id")},
 						query.Constant{Value: int64(i)},
 					},
@@ -117,7 +117,7 @@ func TestPlanCacheEviction(t *testing.T) {
 			Phases: []RealizedPhase{
 				{
 					Query:    queries[i],
-					Provides: []query.Symbol{"?e"},
+					Provides: []query.Symbol{datalog.NewSymbol("?e")},
 				},
 			},
 		}
@@ -159,12 +159,12 @@ func TestPlanCacheTTL(t *testing.T) {
 
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: query.Symbol("?e")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?e")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword(":person/name")},
 					query.Constant{Value: "Bob"},
 				},
@@ -177,7 +177,7 @@ func TestPlanCacheTTL(t *testing.T) {
 		Phases: []RealizedPhase{
 			{
 				Query:    q,
-				Provides: []query.Symbol{"?e"},
+				Provides: []query.Symbol{datalog.NewSymbol("?e")},
 			},
 		},
 	}
@@ -209,12 +209,12 @@ func TestPlannerWithCache(t *testing.T) {
 	// Create a query
 	q := &query.Query{
 		Find: []query.FindElement{
-			query.FindVariable{Symbol: query.Symbol("?e")},
+			query.FindVariable{Symbol: datalog.NewSymbol("?e")},
 		},
 		Where: []query.Clause{
 			&query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword(":person/name")},
 					query.Constant{Value: "Charlie"},
 				},

--- a/datalog/planner/clause_utils.go
+++ b/datalog/planner/clause_utils.go
@@ -73,7 +73,7 @@ func extractExpressionSymbols(e *query.Expression) ClauseSymbols {
 	var provides []query.Symbol
 	switch binding := e.Binding.(type) {
 	case query.Symbol:
-		if binding != "" {
+		if binding != nil {
 			provides = append(provides, binding)
 		}
 	case query.TupleBinding:

--- a/datalog/planner/clause_utils_test.go
+++ b/datalog/planner/clause_utils_test.go
@@ -20,21 +20,21 @@ func TestExtractOrClauseSymbols(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: datalog.NewKeyword(":test/attr")},
-								query.Variable{Name: "?x"},
+								query.Variable{Name: datalog.NewSymbol("?x")},
 							},
 						},
 					},
 					{
 						&query.Expression{
 							Function: &query.GroundFunction{Value: int64(0)},
-							Binding:  "?x",
+							Binding:  datalog.NewSymbol("?x"),
 						},
 					},
 				},
 			},
-			expectedProvides: []query.Symbol{"?x"},
+			expectedProvides: []query.Symbol{datalog.NewSymbol("?x")},
 		},
 		{
 			name: "Two patterns providing same variables",
@@ -43,24 +43,24 @@ func TestExtractOrClauseSymbols(t *testing.T) {
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: datalog.NewKeyword(":attr1")},
-								query.Variable{Name: "?x"},
+								query.Variable{Name: datalog.NewSymbol("?x")},
 							},
 						},
 					},
 					{
 						&query.DataPattern{
 							Elements: []query.PatternElement{
-								query.Variable{Name: "?e"},
+								query.Variable{Name: datalog.NewSymbol("?e")},
 								query.Constant{Value: datalog.NewKeyword(":attr2")},
-								query.Variable{Name: "?x"},
+								query.Variable{Name: datalog.NewSymbol("?x")},
 							},
 						},
 					},
 				},
 			},
-			expectedProvides: []query.Symbol{"?e", "?x"},
+			expectedProvides: []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?x")},
 		},
 		{
 			name: "Expression-only branches",
@@ -69,18 +69,18 @@ func TestExtractOrClauseSymbols(t *testing.T) {
 					{
 						&query.Expression{
 							Function: &query.GroundFunction{Value: "first"},
-							Binding:  query.Symbol("?x"),
+							Binding:  datalog.NewSymbol("?x"),
 						},
 					},
 					{
 						&query.Expression{
 							Function: &query.GroundFunction{Value: "second"},
-							Binding:  query.Symbol("?x"),
+							Binding:  datalog.NewSymbol("?x"),
 						},
 					},
 				},
 			},
-			expectedProvides: []query.Symbol{"?x"},
+			expectedProvides: []query.Symbol{datalog.NewSymbol("?x")},
 		},
 	}
 
@@ -123,31 +123,31 @@ func TestExtractSubqueryPatternSymbols(t *testing.T) {
 			pattern: &query.SubqueryPattern{
 				Query: &query.Query{
 					Find: []query.FindElement{
-						query.FindAggregate{Function: "count", Arg: "?t"},
+						query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?t")},
 					},
 				},
 				Inputs: []query.PatternElement{
 					query.Constant{Value: "db"},
-					query.Variable{Name: "?scenario"},
+					query.Variable{Name: datalog.NewSymbol("?scenario")},
 				},
-				Binding: query.TupleBinding{Variables: []query.Symbol{"?openingCount"}},
+				Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?openingCount")}},
 			},
-			expectedProvides: []query.Symbol{"?openingCount"},
-			expectedRequires: []query.Symbol{"?scenario"},
+			expectedProvides: []query.Symbol{datalog.NewSymbol("?openingCount")},
+			expectedRequires: []query.Symbol{datalog.NewSymbol("?scenario")},
 		},
 		{
 			name: "RelationBinding provides multiple variables",
 			pattern: &query.SubqueryPattern{
 				Query: &query.Query{
 					Find: []query.FindElement{
-						query.FindVariable{Symbol: "?a"},
-						query.FindVariable{Symbol: "?b"},
+						query.FindVariable{Symbol: datalog.NewSymbol("?a")},
+						query.FindVariable{Symbol: datalog.NewSymbol("?b")},
 					},
 				},
 				Inputs:  []query.PatternElement{},
-				Binding: query.RelationBinding{Variables: []query.Symbol{"?a", "?b"}},
+				Binding: query.RelationBinding{Variables: []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")}},
 			},
-			expectedProvides: []query.Symbol{"?a", "?b"},
+			expectedProvides: []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			expectedRequires: []query.Symbol{},
 		},
 		{
@@ -155,13 +155,13 @@ func TestExtractSubqueryPatternSymbols(t *testing.T) {
 			pattern: &query.SubqueryPattern{
 				Query: &query.Query{
 					Find: []query.FindElement{
-						query.FindVariable{Symbol: "?x"},
+						query.FindVariable{Symbol: datalog.NewSymbol("?x")},
 					},
 				},
 				Inputs:  []query.PatternElement{},
-				Binding: query.ScalarBinding{Variable: "?result"},
+				Binding: query.ScalarBinding{Variable: datalog.NewSymbol("?result")},
 			},
-			expectedProvides: []query.Symbol{"?result"},
+			expectedProvides: []query.Symbol{datalog.NewSymbol("?result")},
 			expectedRequires: []query.Symbol{},
 		},
 	}
@@ -208,18 +208,18 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 				{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":attr1")},
-							query.Variable{Name: "?x"},
+							query.Variable{Name: datalog.NewSymbol("?x")},
 						},
 					},
 				},
 				{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?f"},
+							query.Variable{Name: datalog.NewSymbol("?f")},
 							query.Constant{Value: datalog.NewKeyword(":attr2")},
-							query.Variable{Name: "?x"},
+							query.Variable{Name: datalog.NewSymbol("?x")},
 						},
 					},
 				},
@@ -232,7 +232,7 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 		if len(syms.Provides) != 1 {
 			t.Errorf("Expected 1 symbol (intersection), got %d: %v", len(syms.Provides), syms.Provides)
 		}
-		if len(syms.Provides) == 1 && syms.Provides[0] != "?x" {
+		if len(syms.Provides) == 1 && syms.Provides[0] != datalog.NewSymbol("?x") {
 			t.Errorf("Expected ?x, got %v", syms.Provides[0])
 		}
 	})
@@ -246,16 +246,16 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 				{
 					&query.DataPattern{
 						Elements: []query.PatternElement{
-							query.Variable{Name: "?e"},
+							query.Variable{Name: datalog.NewSymbol("?e")},
 							query.Constant{Value: datalog.NewKeyword(":test/attr")},
-							query.Variable{Name: "?x"},
+							query.Variable{Name: datalog.NewSymbol("?x")},
 						},
 					},
 				},
 				{
 					&query.Expression{
 						Function: &query.GroundFunction{Value: int64(0)},
-						Binding:  "?x",
+						Binding:  datalog.NewSymbol("?x"),
 					},
 				},
 			},
@@ -269,10 +269,10 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 			providedSet[sym] = true
 		}
 
-		if !providedSet["?x"] {
+		if !providedSet[datalog.NewSymbol("?x")] {
 			t.Errorf("Expected ?x to be provided, got: %v", syms.Provides)
 		}
-		if !providedSet["?e"] {
+		if !providedSet[datalog.NewSymbol("?e")] {
 			t.Errorf("Expected ?e to be provided (union semantics), got: %v", syms.Provides)
 		}
 	})
@@ -288,20 +288,20 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 					&query.SubqueryPattern{
 						Query: &query.Query{
 							Find: []query.FindElement{
-								query.FindAggregate{Function: "count", Arg: "?t"},
+								query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?t")},
 							},
 						},
 						Inputs: []query.PatternElement{
 							query.Constant{Value: "db"},
-							query.Variable{Name: "?scenario"},
+							query.Variable{Name: datalog.NewSymbol("?scenario")},
 						},
-						Binding: query.TupleBinding{Variables: []query.Symbol{"?openingCount"}},
+						Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?openingCount")}},
 					},
 				},
 				{
 					&query.Expression{
 						Function: &query.GroundFunction{Value: int64(0)},
-						Binding:  "?openingCount",
+						Binding:  datalog.NewSymbol("?openingCount"),
 					},
 				},
 			},
@@ -311,7 +311,7 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 
 		foundOpeningCount := false
 		for _, sym := range syms.Provides {
-			if sym == "?openingCount" {
+			if sym == datalog.NewSymbol("?openingCount") {
 				foundOpeningCount = true
 			}
 		}
@@ -335,20 +335,20 @@ func TestOrClauseRequiresCorrelatedInputs(t *testing.T) {
 					&query.SubqueryPattern{
 						Query: &query.Query{
 							Find: []query.FindElement{
-								query.FindAggregate{Function: "count", Arg: "?t"},
+								query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?t")},
 							},
 						},
 						Inputs: []query.PatternElement{
 							query.Constant{Value: "db"},
-							query.Variable{Name: "?scenario"}, // This is a correlated input
+							query.Variable{Name: datalog.NewSymbol("?scenario")}, // This is a correlated input
 						},
-						Binding: query.TupleBinding{Variables: []query.Symbol{"?count"}},
+						Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?count")}},
 					},
 				},
 				{
 					&query.Expression{
 						Function: &query.GroundFunction{Value: int64(0)},
-						Binding:  "?count",
+						Binding:  datalog.NewSymbol("?count"),
 					},
 				},
 			},
@@ -362,7 +362,7 @@ func TestOrClauseRequiresCorrelatedInputs(t *testing.T) {
 			requiresSet[sym] = true
 		}
 
-		if !requiresSet["?scenario"] {
+		if !requiresSet[datalog.NewSymbol("?scenario")] {
 			t.Errorf("OR clause with correlated subquery must require ?scenario, got Requires: %v", syms.Requires)
 		}
 
@@ -372,7 +372,7 @@ func TestOrClauseRequiresCorrelatedInputs(t *testing.T) {
 			providesSet[sym] = true
 		}
 
-		if !providesSet["?count"] {
+		if !providesSet[datalog.NewSymbol("?count")] {
 			t.Errorf("OR clause should provide ?count, got Provides: %v", syms.Provides)
 		}
 	})
@@ -383,13 +383,13 @@ func TestOrClauseRequiresCorrelatedInputs(t *testing.T) {
 				{
 					&query.Expression{
 						Function: &query.GroundFunction{Value: int64(0)},
-						Binding:  "?x",
+						Binding:  datalog.NewSymbol("?x"),
 					},
 				},
 				{
 					&query.Expression{
 						Function: &query.GroundFunction{Value: int64(1)},
-						Binding:  "?x",
+						Binding:  datalog.NewSymbol("?x"),
 					},
 				},
 			},
@@ -410,16 +410,16 @@ func TestOrClauseRequiresCorrelatedInputs(t *testing.T) {
 					&query.Expression{
 						Function: &query.ArithmeticFunction{
 							Op:    query.OpAdd,
-							Left:  query.VariableTerm{Symbol: "?input"},
+							Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?input")},
 							Right: query.ConstantTerm{Value: int64(1)},
 						},
-						Binding: "?output",
+						Binding: datalog.NewSymbol("?output"),
 					},
 				},
 				{
 					&query.Expression{
 						Function: &query.GroundFunction{Value: int64(0)},
-						Binding:  "?output",
+						Binding:  datalog.NewSymbol("?output"),
 					},
 				},
 			},
@@ -432,7 +432,7 @@ func TestOrClauseRequiresCorrelatedInputs(t *testing.T) {
 			requiresSet[sym] = true
 		}
 
-		if !requiresSet["?input"] {
+		if !requiresSet[datalog.NewSymbol("?input")] {
 			t.Errorf("OR clause should require ?input from arithmetic expression, got: %v", syms.Requires)
 		}
 	})
@@ -447,20 +447,20 @@ func TestOrWithSubqueryPatternAndFallback(t *testing.T) {
 				&query.SubqueryPattern{
 					Query: &query.Query{
 						Find: []query.FindElement{
-							query.FindAggregate{Function: "count", Arg: "?t"},
+							query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?t")},
 						},
 					},
 					Inputs: []query.PatternElement{
 						query.Constant{Value: "db"},
-						query.Variable{Name: "?scenario"},
+						query.Variable{Name: datalog.NewSymbol("?scenario")},
 					},
-					Binding: query.TupleBinding{Variables: []query.Symbol{"?openingCount"}},
+					Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?openingCount")}},
 				},
 			},
 			{
 				&query.Expression{
 					Function: &query.GroundFunction{Value: int64(0)},
-					Binding:  "?openingCount",
+					Binding:  datalog.NewSymbol("?openingCount"),
 				},
 			},
 		},
@@ -471,7 +471,7 @@ func TestOrWithSubqueryPatternAndFallback(t *testing.T) {
 	// Both branches provide ?openingCount, so the OR should provide it
 	foundOpeningCount := false
 	for _, sym := range syms.Provides {
-		if sym == "?openingCount" {
+		if sym == datalog.NewSymbol("?openingCount") {
 			foundOpeningCount = true
 		}
 	}
@@ -485,26 +485,26 @@ func TestOrJoinClauseRequiresCorrelatedInputs(t *testing.T) {
 	// Verify OR-JOIN also correctly propagates requirements from branches
 	t.Run("OR-JOIN with correlated subquery requires input variable", func(t *testing.T) {
 		orJoin := &query.OrJoinClause{
-			JoinVars: []query.Symbol{"?count"},
+			JoinVars: []query.Symbol{datalog.NewSymbol("?count")},
 			Branches: [][]query.Clause{
 				{
 					&query.SubqueryPattern{
 						Query: &query.Query{
 							Find: []query.FindElement{
-								query.FindAggregate{Function: "count", Arg: "?t"},
+								query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?t")},
 							},
 						},
 						Inputs: []query.PatternElement{
 							query.Constant{Value: "db"},
-							query.Variable{Name: "?entity"}, // Correlated input
+							query.Variable{Name: datalog.NewSymbol("?entity")}, // Correlated input
 						},
-						Binding: query.TupleBinding{Variables: []query.Symbol{"?count"}},
+						Binding: query.TupleBinding{Variables: []query.Symbol{datalog.NewSymbol("?count")}},
 					},
 				},
 				{
 					&query.Expression{
 						Function: &query.GroundFunction{Value: int64(0)},
-						Binding:  "?count",
+						Binding:  datalog.NewSymbol("?count"),
 					},
 				},
 			},
@@ -517,7 +517,7 @@ func TestOrJoinClauseRequiresCorrelatedInputs(t *testing.T) {
 			requiresSet[sym] = true
 		}
 
-		if !requiresSet["?entity"] {
+		if !requiresSet[datalog.NewSymbol("?entity")] {
 			t.Errorf("OR-JOIN with correlated subquery must require ?entity, got Requires: %v", syms.Requires)
 		}
 
@@ -527,7 +527,7 @@ func TestOrJoinClauseRequiresCorrelatedInputs(t *testing.T) {
 			providesSet[sym] = true
 		}
 
-		if !providesSet["?count"] {
+		if !providesSet[datalog.NewSymbol("?count")] {
 			t.Errorf("OR-JOIN should provide ?count (from JoinVars), got Provides: %v", syms.Provides)
 		}
 	})
@@ -540,7 +540,7 @@ func TestNotClauseRequiresAllInnerVariables(t *testing.T) {
 			Clauses: []query.Clause{
 				&query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: "?e"},
+						query.Variable{Name: datalog.NewSymbol("?e")},
 						query.Constant{Value: datalog.NewKeyword(":user/archived")},
 						query.Constant{Value: true},
 					},
@@ -555,7 +555,7 @@ func TestNotClauseRequiresAllInnerVariables(t *testing.T) {
 			requiresSet[sym] = true
 		}
 
-		if !requiresSet["?e"] {
+		if !requiresSet[datalog.NewSymbol("?e")] {
 			t.Errorf("NOT clause must require ?e from inner pattern, got Requires: %v", syms.Requires)
 		}
 
@@ -570,10 +570,10 @@ func TestNotClauseRequiresAllInnerVariables(t *testing.T) {
 				&query.Expression{
 					Function: &query.ArithmeticFunction{
 						Op:    query.OpAdd,
-						Left:  query.VariableTerm{Symbol: "?count"},
+						Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?count")},
 						Right: query.ConstantTerm{Value: int64(10)},
 					},
-					Binding: query.Symbol("?result"),
+					Binding: datalog.NewSymbol("?result"),
 				},
 			},
 		}
@@ -586,10 +586,10 @@ func TestNotClauseRequiresAllInnerVariables(t *testing.T) {
 		}
 
 		// Should require ?count (input to expression) and ?result (output of expression)
-		if !requiresSet["?count"] {
+		if !requiresSet[datalog.NewSymbol("?count")] {
 			t.Errorf("NOT clause must require ?count, got Requires: %v", syms.Requires)
 		}
-		if !requiresSet["?result"] {
+		if !requiresSet[datalog.NewSymbol("?result")] {
 			t.Errorf("NOT clause must require ?result, got Requires: %v", syms.Requires)
 		}
 	})
@@ -606,9 +606,9 @@ func TestExtractExpressionSymbols(t *testing.T) {
 			name: "Ground function provides binding",
 			expression: &query.Expression{
 				Function: &query.GroundFunction{Value: int64(0)},
-				Binding:  query.Symbol("?x"),
+				Binding:  datalog.NewSymbol("?x"),
 			},
-			expectedProvides: []query.Symbol{"?x"},
+			expectedProvides: []query.Symbol{datalog.NewSymbol("?x")},
 			expectedRequires: []query.Symbol{},
 		},
 		{
@@ -616,13 +616,13 @@ func TestExtractExpressionSymbols(t *testing.T) {
 			expression: &query.Expression{
 				Function: &query.ArithmeticFunction{
 					Op:    query.OpAdd,
-					Left:  query.VariableTerm{Symbol: "?a"},
-					Right: query.VariableTerm{Symbol: "?b"},
+					Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?a")},
+					Right: query.VariableTerm{Symbol: datalog.NewSymbol("?b")},
 				},
-				Binding: query.Symbol("?sum"),
+				Binding: datalog.NewSymbol("?sum"),
 			},
-			expectedProvides: []query.Symbol{"?sum"},
-			expectedRequires: []query.Symbol{"?a", "?b"},
+			expectedProvides: []query.Symbol{datalog.NewSymbol("?sum")},
+			expectedRequires: []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 		},
 	}
 

--- a/datalog/planner/explain_analysis.go
+++ b/datalog/planner/explain_analysis.go
@@ -23,7 +23,7 @@ func analyzeClausesForExplain(phase *RealizedPhase, clauses []query.Clause, avai
 			// Add expression output to available
 			switch binding := c.Binding.(type) {
 			case query.Symbol:
-				if binding != "" {
+				if binding != nil {
 					available[binding] = true
 				}
 			case query.TupleBinding:
@@ -232,7 +232,7 @@ func analyzeExprForExplain(expr *query.Expression, available map[query.Symbol]bo
 	var isEquality bool
 	switch b := expr.Binding.(type) {
 	case query.Symbol:
-		isEquality = b == ""
+		isEquality = b == nil
 	case query.TupleBinding:
 		isEquality = len(b.Variables) == 0
 	default:

--- a/datalog/planner/planner_clause_based.go
+++ b/datalog/planner/planner_clause_based.go
@@ -3,6 +3,7 @@ package planner
 import (
 	"fmt"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -191,12 +192,12 @@ func buildFindClause(provides []query.Symbol, originalFind []query.FindElement, 
 func buildInClause(available []query.Symbol) []query.InputSpec {
 	if len(available) == 0 {
 		// First phase with no inputs - just database
-		return []query.InputSpec{query.DatabaseInput{Name: query.Symbol("$")}}
+		return []query.InputSpec{query.DatabaseInput{Name: datalog.SymDollar}}
 	}
 
 	// Create relation input with all available symbols
 	inClause := []query.InputSpec{
-		query.DatabaseInput{Name: query.Symbol("$")},
+		query.DatabaseInput{Name: datalog.SymDollar},
 		query.RelationInput{Symbols: available},
 	}
 	return inClause

--- a/datalog/planner/semantic_rewriter.go
+++ b/datalog/planner/semantic_rewriter.go
@@ -262,7 +262,7 @@ func getVariableFromTerm(term query.Term) (query.Symbol, bool) {
 	if v, ok := term.(query.VariableTerm); ok {
 		return v.Symbol, true
 	}
-	return "", false
+	return nil, false
 }
 
 // getConstantInt extracts an integer constant from a term

--- a/datalog/planner/types.go
+++ b/datalog/planner/types.go
@@ -2,8 +2,10 @@ package planner
 
 import (
 	"fmt"
-	"github.com/wbrown/janus-datalog/datalog/query"
 	"strings"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
 // IndexType represents different index orderings (copied to avoid circular import)
@@ -56,7 +58,7 @@ func (p *Phase) combineTimeExtractions() {
 			// Check if this is a time extraction function
 			if tef, ok := exprPlan.Expression.Function.(*query.TimeExtractionFunction); ok {
 				// Time extraction only supports scalar binding
-				if outputSym, ok := exprPlan.Output.(query.Symbol); ok && outputSym != "" {
+				if outputSym, ok := exprPlan.Output.(query.Symbol); ok && outputSym != nil {
 					timeExtractionOutputs[outputSym] = tef.Field
 					// The input is typically the first argument
 					if len(exprPlan.Inputs) > 0 {
@@ -78,7 +80,7 @@ func (p *Phase) combineTimeExtractions() {
 			// Examples: [(= ?year ?year-open)], [(= ?month ?month-close)]
 			result = append(result, pred)
 
-		} else if (pred.Type == PredicateEquality || pred.Type == PredicateComparison) && pred.Variable != "" {
+		} else if (pred.Type == PredicateEquality || pred.Type == PredicateComparison) && pred.Variable != nil {
 			// Single variable with constant - check if it's a time extraction output
 			if timeField, found := timeExtractionOutputs[pred.Variable]; found {
 				// Create a time extraction predicate
@@ -180,7 +182,7 @@ func (pp *PatternPlan) toConstraint(pred PredicatePlan, phase Phase) *StorageCon
 	if pred.Type == PredicateTimeExtraction {
 		// Check if this pattern provides the time variable (pred.Variable contains the time var)
 		for i, elem := range dp.Elements {
-			if v, ok := elem.(query.Variable); ok && query.Symbol(v.Name) == pred.Variable {
+			if v, ok := elem.(query.Variable); ok && v.Name == pred.Variable {
 				// This pattern provides the time variable
 				if i == 2 { // Value position - the time is in the value
 					// Get the attribute
@@ -207,7 +209,7 @@ func (pp *PatternPlan) toConstraint(pred PredicatePlan, phase Phase) *StorageCon
 		// Check if this pattern has the variable in value position
 		if len(dp.Elements) > 2 {
 			if v, ok := dp.Elements[2].(query.Variable); ok {
-				if query.Symbol(v.Name) == pred.Variable {
+				if v.Name == pred.Variable {
 					// This pattern provides the variable in value position
 					// Get the attribute
 					if attrElem, ok := dp.Elements[1].(query.Constant); ok {
@@ -226,7 +228,7 @@ func (pp *PatternPlan) toConstraint(pred PredicatePlan, phase Phase) *StorageCon
 	// Check for equality predicates on the value position
 	if pred.Type == PredicateEquality && len(dp.Elements) > 2 && dp.Elements[2] != nil {
 		if v, ok := dp.Elements[2].(query.Variable); ok {
-			if query.Symbol(v.Name) == pred.Variable {
+			if v.Name == pred.Variable {
 				// Pattern's value variable has an equality constraint
 				if attrElem, ok := dp.Elements[1].(query.Constant); ok {
 					return &StorageConstraint{
@@ -603,7 +605,7 @@ func reconstructPredicatesFromConstraints(phase Phase) []query.Clause {
 
 	// Build a map of time extraction expression outputs
 	// For time extraction constraints, we need to know which variable represents the extraction
-	timeExtractionVars := make(map[string]map[string]query.Symbol) // timeField -> attribute -> output variable
+	timeExtractionVars := make(map[string]map[query.Symbol]query.Symbol) // timeField -> inputVar -> output variable
 	for _, expr := range phase.Expressions {
 		if expr.Expression != nil && expr.Output != "" {
 			if tef, ok := expr.Expression.Function.(*query.TimeExtractionFunction); ok {
@@ -613,9 +615,9 @@ func reconstructPredicatesFromConstraints(phase Phase) []query.Clause {
 				if outputSym, ok := expr.Output.(query.Symbol); ok && len(expr.Inputs) > 0 {
 					inputVar := expr.Inputs[0]
 					if timeExtractionVars[tef.Field] == nil {
-						timeExtractionVars[tef.Field] = make(map[string]query.Symbol)
+						timeExtractionVars[tef.Field] = make(map[query.Symbol]query.Symbol)
 					}
-					timeExtractionVars[tef.Field][string(inputVar)] = outputSym
+					timeExtractionVars[tef.Field][inputVar] = outputSym
 				}
 			}
 		}
@@ -640,7 +642,7 @@ func reconstructPredicatesFromConstraints(phase Phase) []query.Clause {
 				if dp, ok := pattern.Pattern.(*query.DataPattern); ok && len(dp.Elements) >= 3 {
 					if v, ok := dp.Elements[2].(query.Variable); ok {
 						predicates = append(predicates, &query.Comparison{
-							Left:  query.VariableTerm{Symbol: query.Symbol(v.Name)},
+							Left:  query.VariableTerm{Symbol: v.Name},
 							Right: query.ConstantTerm{Value: constraint.Value},
 							Op:    query.OpEQ,
 						})
@@ -652,7 +654,7 @@ func reconstructPredicatesFromConstraints(phase Phase) []query.Clause {
 				if dp, ok := pattern.Pattern.(*query.DataPattern); ok && len(dp.Elements) >= 3 {
 					if v, ok := dp.Elements[2].(query.Variable); ok {
 						predicates = append(predicates, &query.Comparison{
-							Left:  query.VariableTerm{Symbol: query.Symbol(v.Name)},
+							Left:  query.VariableTerm{Symbol: v.Name},
 							Right: query.ConstantTerm{Value: constraint.Value},
 							Op:    constraint.Operator,
 						})
@@ -668,7 +670,7 @@ func reconstructPredicatesFromConstraints(phase Phase) []query.Clause {
 						// v is the time variable from the pattern (e.g., ?t)
 						// Look up the corresponding extraction output variable (e.g., ?d)
 						if fieldMap, found := timeExtractionVars[constraint.TimeField]; found {
-							if outputVar, found := fieldMap[string(v.Name)]; found {
+							if outputVar, found := fieldMap[v.Name]; found {
 								// Found it! Create predicate: [(op ?d value)]
 								predicates = append(predicates, &query.Comparison{
 									Left:  query.VariableTerm{Symbol: outputVar},
@@ -787,7 +789,7 @@ func realizePhase(phase Phase, isLastPhase bool, prevKeep []query.Symbol) Realiz
 	// First phase has no :in, subsequent phases receive previous Keep
 	var in []query.InputSpec
 	if len(prevKeep) > 0 {
-		in = append(in, query.DatabaseInput{Name: query.Symbol("$")})
+		in = append(in, query.DatabaseInput{Name: datalog.SymDollar})
 		in = append(in, query.RelationInput{Symbols: prevKeep})
 	}
 

--- a/datalog/qb/input.go
+++ b/datalog/qb/input.go
@@ -1,6 +1,7 @@
 package qb
 
 import (
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -24,7 +25,7 @@ type dbInput struct{}
 var DB InputSpec = dbInput{}
 
 func (d dbInput) toInputSpec() query.InputSpec {
-	return query.DatabaseInput{Name: query.Symbol("$")}
+	return query.DatabaseInput{Name: datalog.SymDollar}
 }
 
 // scalarInput represents a scalar input parameter (?x).

--- a/datalog/qb/qb_test.go
+++ b/datalog/qb/qb_test.go
@@ -22,7 +22,7 @@ func TestNewVar(t *testing.T) {
 
 	// Symbol should be ?v1
 	sym1 := v1.Symbol()
-	if sym1 != "?v1" {
+	if sym1 != datalog.NewSymbol("?v1") {
 		t.Errorf("Symbol should be ?v1, got %s", sym1)
 	}
 }
@@ -1478,7 +1478,7 @@ func TestQueryForBasic(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected FindVariable, got %T", built.Find[0])
 	}
-	if fv0.Symbol != "?name" {
+	if fv0.Symbol != datalog.NewSymbol("?name") {
 		t.Errorf("Expected ?name, got %s", fv0.Symbol)
 	}
 
@@ -1486,7 +1486,7 @@ func TestQueryForBasic(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected FindVariable, got %T", built.Find[1])
 	}
-	if fv1.Symbol != "?age" {
+	if fv1.Symbol != datalog.NewSymbol("?age") {
 		t.Errorf("Expected ?age, got %s", fv1.Symbol)
 	}
 }
@@ -1520,7 +1520,7 @@ func TestQueryForVvsFind(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected FindVariable, got %T", built.Find[0])
 	}
-	if fv.Symbol != "?name" {
+	if fv.Symbol != datalog.NewSymbol("?name") {
 		t.Errorf("Expected ?name, got %s", fv.Symbol)
 	}
 }
@@ -1590,7 +1590,7 @@ func TestQueryForFindOrder(t *testing.T) {
 		if !ok {
 			t.Fatalf("Expected FindVariable at %d, got %T", i, built.Find[i])
 		}
-		if string(fv.Symbol) != exp {
+		if fv.Symbol.String() != exp {
 			t.Errorf("Find[%d]: expected %s, got %s", i, exp, fv.Symbol)
 		}
 	}
@@ -1611,10 +1611,10 @@ func TestQueryForIgnoresAggregateTag(t *testing.T) {
 	dept := q.V(&f.Dept)
 	salary := q.V(&f.Salary)
 
-	if dept.Symbol() != "?dept" {
+	if dept.Symbol() != datalog.NewSymbol("?dept") {
 		t.Errorf("Expected ?dept, got %s", dept.Symbol())
 	}
-	if salary.Symbol() != "?salary" {
+	if salary.Symbol() != datalog.NewSymbol("?salary") {
 		t.Errorf("Expected ?salary, got %s", salary.Symbol())
 	}
 

--- a/datalog/qb/source.go
+++ b/datalog/qb/source.go
@@ -1,6 +1,7 @@
 package qb
 
 import (
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -31,7 +32,7 @@ type sourceInput struct {
 //	        qb.PatFrom(perms, e, qb.Kw(":perm/role"), role),
 //	    ).MustBuild()
 func Source(name string) *sourceInput {
-	return &sourceInput{sym: query.Symbol(name)}
+	return &sourceInput{sym: datalog.NewSymbol(name)}
 }
 
 // Symbol returns the underlying query.Symbol for this source.

--- a/datalog/qb/source_test.go
+++ b/datalog/qb/source_test.go
@@ -3,12 +3,13 @@ package qb
 import (
 	"testing"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
 func TestSource(t *testing.T) {
 	users := Source("$users")
-	if users.Symbol() != query.Symbol("$users") {
+	if users.Symbol() != datalog.NewSymbol("$users") {
 		t.Errorf("expected Symbol $users, got %s", users.Symbol())
 	}
 
@@ -17,7 +18,7 @@ func TestSource(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected DatabaseInput, got %T", spec)
 	}
-	if db.Name != query.Symbol("$users") {
+	if db.Name != datalog.NewSymbol("$users") {
 		t.Errorf("expected Name $users, got %s", db.Name)
 	}
 }
@@ -40,7 +41,7 @@ func TestSourceInQuery(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected DatabaseInput, got %T", q.In[0])
 	}
-	if db.Name != query.Symbol("$users") {
+	if db.Name != datalog.NewSymbol("$users") {
 		t.Errorf("expected Name $users, got %s", db.Name)
 	}
 }
@@ -57,7 +58,7 @@ func TestPatFrom(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *query.DataPattern, got %T", clause)
 	}
-	if pat.Source != query.Symbol("$users") {
+	if pat.Source != datalog.NewSymbol("$users") {
 		t.Errorf("expected Source $users, got %s", pat.Source)
 	}
 	if len(pat.Elements) != 3 {
@@ -89,7 +90,7 @@ func TestPatFromInQuery(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected DatabaseInput for first input, got %T", q.In[0])
 	}
-	if db1.Name != query.Symbol("$users") {
+	if db1.Name != datalog.NewSymbol("$users") {
 		t.Errorf("expected $users, got %s", db1.Name)
 	}
 
@@ -97,7 +98,7 @@ func TestPatFromInQuery(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected DatabaseInput for second input, got %T", q.In[1])
 	}
-	if db2.Name != query.Symbol("$perms") {
+	if db2.Name != datalog.NewSymbol("$perms") {
 		t.Errorf("expected $perms, got %s", db2.Name)
 	}
 
@@ -109,7 +110,7 @@ func TestPatFromInQuery(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *query.DataPattern for first clause, got %T", q.Where[0])
 	}
-	if pat1.Source != query.Symbol("$users") {
+	if pat1.Source != datalog.NewSymbol("$users") {
 		t.Errorf("expected $users source, got %s", pat1.Source)
 	}
 
@@ -117,7 +118,7 @@ func TestPatFromInQuery(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *query.DataPattern for second clause, got %T", q.Where[1])
 	}
-	if pat2.Source != query.Symbol("$perms") {
+	if pat2.Source != datalog.NewSymbol("$perms") {
 		t.Errorf("expected $perms source, got %s", pat2.Source)
 	}
 }
@@ -132,8 +133,8 @@ func TestPatWithoutSource(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *query.DataPattern, got %T", clause)
 	}
-	if pat.Source != "" {
-		t.Errorf("expected empty Source for plain Pat, got %s", pat.Source)
+	if pat.Source != nil {
+		t.Errorf("expected nil Source for plain Pat, got %s", pat.Source)
 	}
 }
 
@@ -161,7 +162,7 @@ func TestSourceWithDBAndNamedSources(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected DatabaseInput for DB, got %T", q.In[0])
 	}
-	if db1.Name != query.Symbol("$") {
+	if db1.Name != datalog.NewSymbol("$") {
 		t.Errorf("expected $, got %s", db1.Name)
 	}
 
@@ -170,7 +171,7 @@ func TestSourceWithDBAndNamedSources(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected DatabaseInput for $cache, got %T", q.In[1])
 	}
-	if db2.Name != query.Symbol("$cache") {
+	if db2.Name != datalog.NewSymbol("$cache") {
 		t.Errorf("expected $cache, got %s", db2.Name)
 	}
 
@@ -179,8 +180,8 @@ func TestSourceWithDBAndNamedSources(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *query.DataPattern, got %T", q.Where[0])
 	}
-	if pat1.Source != "" {
-		t.Errorf("expected empty source for default pattern, got %s", pat1.Source)
+	if pat1.Source != nil {
+		t.Errorf("expected nil source for default pattern, got %s", pat1.Source)
 	}
 
 	// Second where clause has $cache source
@@ -188,7 +189,7 @@ func TestSourceWithDBAndNamedSources(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *query.DataPattern, got %T", q.Where[1])
 	}
-	if pat2.Source != query.Symbol("$cache") {
+	if pat2.Source != datalog.NewSymbol("$cache") {
 		t.Errorf("expected $cache source, got %s", pat2.Source)
 	}
 }
@@ -223,7 +224,7 @@ func TestSubqueryWithNamedSource(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected Constant for source input, got %T", sq.Inputs[0])
 	}
-	if firstInput.Value != query.Symbol("$users") {
+	if firstInput.Value != datalog.NewSymbol("$users") {
 		t.Errorf("expected $users source input, got %v", firstInput.Value)
 	}
 }

--- a/datalog/qb/var.go
+++ b/datalog/qb/var.go
@@ -16,6 +16,7 @@ package qb
 import (
 	"sync/atomic"
 
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -50,7 +51,7 @@ func NewVar(name string) *Var {
 	}
 	return &Var{
 		id:   id,
-		name: query.Symbol(name),
+		name: datalog.NewSymbol(name),
 	}
 }
 
@@ -62,7 +63,7 @@ func (v *Var) Symbol() query.Symbol {
 
 // String returns the variable name for debugging.
 func (v *Var) String() string {
-	return string(v.name)
+	return v.name.String()
 }
 
 // toPatternElement converts Var to a query.PatternElement

--- a/datalog/query/and_function_test.go
+++ b/datalog/query/and_function_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestAndFunction(t *testing.T) {
@@ -16,20 +17,20 @@ func TestAndFunction(t *testing.T) {
 	}{
 		{
 			name:     "All true",
-			terms:    []Symbol{"?a", "?b", "?c"},
-			bindings: map[Symbol]interface{}{"?a": true, "?b": true, "?c": true},
+			terms:    []Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?a"): true, datalog.NewSymbol("?b"): true, datalog.NewSymbol("?c"): true},
 			expected: true,
 		},
 		{
 			name:     "One false",
-			terms:    []Symbol{"?a", "?b", "?c"},
-			bindings: map[Symbol]interface{}{"?a": true, "?b": false, "?c": true},
+			terms:    []Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?a"): true, datalog.NewSymbol("?b"): false, datalog.NewSymbol("?c"): true},
 			expected: false,
 		},
 		{
 			name:     "All false",
-			terms:    []Symbol{"?a", "?b"},
-			bindings: map[Symbol]interface{}{"?a": false, "?b": false},
+			terms:    []Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?a"): false, datalog.NewSymbol("?b"): false},
 			expected: false,
 		},
 		{
@@ -40,26 +41,26 @@ func TestAndFunction(t *testing.T) {
 		},
 		{
 			name:     "Single true",
-			terms:    []Symbol{"?a"},
-			bindings: map[Symbol]interface{}{"?a": true},
+			terms:    []Symbol{datalog.NewSymbol("?a")},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?a"): true},
 			expected: true,
 		},
 		{
 			name:     "Single false",
-			terms:    []Symbol{"?a"},
-			bindings: map[Symbol]interface{}{"?a": false},
+			terms:    []Symbol{datalog.NewSymbol("?a")},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?a"): false},
 			expected: false,
 		},
 		{
 			name:     "Non-boolean value",
-			terms:    []Symbol{"?a", "?b"},
-			bindings: map[Symbol]interface{}{"?a": true, "?b": 42},
+			terms:    []Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?a"): true, datalog.NewSymbol("?b"): 42},
 			expected: false, // Non-boolean treated as false
 		},
 		{
 			name:     "Missing binding",
-			terms:    []Symbol{"?a", "?b"},
-			bindings: map[Symbol]interface{}{"?a": true},
+			terms:    []Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?a"): true},
 			hasError: true,
 		},
 	}
@@ -88,12 +89,12 @@ func TestAndFunctionString(t *testing.T) {
 	}{
 		{
 			name:     "Multiple terms",
-			terms:    []Symbol{"?a", "?b", "?c"},
+			terms:    []Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
 			expected: "(and ?a ?b ?c)",
 		},
 		{
 			name:     "Single term",
-			terms:    []Symbol{"?filter"},
+			terms:    []Symbol{datalog.NewSymbol("?filter")},
 			expected: "?filter",
 		},
 		{
@@ -113,17 +114,17 @@ func TestAndFunctionString(t *testing.T) {
 
 func TestAndFunctionRequiredSymbols(t *testing.T) {
 	andFunc := AndFunction{
-		Terms: []Symbol{"?a", "?b", "?c"},
+		Terms: []Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
 	}
 
 	symbols := andFunc.RequiredSymbols()
 	assert.Equal(t, 3, len(symbols))
-	assert.Contains(t, symbols, Symbol("?a"))
-	assert.Contains(t, symbols, Symbol("?b"))
-	assert.Contains(t, symbols, Symbol("?c"))
+	assert.Contains(t, symbols, datalog.NewSymbol("?a"))
+	assert.Contains(t, symbols, datalog.NewSymbol("?b"))
+	assert.Contains(t, symbols, datalog.NewSymbol("?c"))
 }
 
 func TestAndFunctionReturnType(t *testing.T) {
-	andFunc := AndFunction{Terms: []Symbol{"?a"}}
+	andFunc := AndFunction{Terms: []Symbol{datalog.NewSymbol("?a")}}
 	assert.Equal(t, "boolean", andFunc.ReturnType())
 }

--- a/datalog/query/clause.go
+++ b/datalog/query/clause.go
@@ -80,7 +80,7 @@ func (n *NotJoinClause) String() string {
 		if i > 0 {
 			result += " "
 		}
-		result += string(v)
+		result += v.String()
 	}
 	result += "]"
 	for _, c := range n.Clauses {
@@ -151,7 +151,7 @@ func (o *OrJoinClause) String() string {
 		if i > 0 {
 			result += " "
 		}
-		result += string(v)
+		result += v.String()
 	}
 	result += "]"
 	for _, branch := range o.Branches {

--- a/datalog/query/function.go
+++ b/datalog/query/function.go
@@ -403,12 +403,12 @@ func (a AndFunction) String() string {
 		return "(and)"
 	}
 	if len(a.Terms) == 1 {
-		return string(a.Terms[0])
+		return a.Terms[0].String()
 	}
 
 	result := "(and"
 	for _, term := range a.Terms {
-		result += " " + string(term)
+		result += " " + term.String()
 	}
 	result += ")"
 	return result

--- a/datalog/query/function_test.go
+++ b/datalog/query/function_test.go
@@ -3,6 +3,8 @@ package query
 import (
 	"testing"
 	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestArithmeticFunction(t *testing.T) {
@@ -16,30 +18,30 @@ func TestArithmeticFunction(t *testing.T) {
 			name: "Addition int",
 			fn: ArithmeticFunction{
 				Op:    OpAdd,
-				Left:  VariableTerm{Symbol: "?x"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
 				Right: ConstantTerm{Value: int64(10)},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(5)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(5)},
 			expected: int64(15),
 		},
 		{
 			name: "Subtraction float",
 			fn: ArithmeticFunction{
 				Op:    OpSubtract,
-				Left:  VariableTerm{Symbol: "?x"},
-				Right: VariableTerm{Symbol: "?y"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
+				Right: VariableTerm{Symbol: datalog.NewSymbol("?y")},
 			},
-			bindings: map[Symbol]interface{}{"?x": 10.5, "?y": 3.5},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): 10.5, datalog.NewSymbol("?y"): 3.5},
 			expected: 7.0,
 		},
 		{
 			name: "Multiplication mixed",
 			fn: ArithmeticFunction{
 				Op:    OpMultiply,
-				Left:  VariableTerm{Symbol: "?x"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
 				Right: ConstantTerm{Value: 2.5},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(4)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(4)},
 			expected: 10.0,
 		},
 		{
@@ -47,9 +49,9 @@ func TestArithmeticFunction(t *testing.T) {
 			fn: ArithmeticFunction{
 				Op:    OpDivide,
 				Left:  ConstantTerm{Value: int64(10)},
-				Right: VariableTerm{Symbol: "?x"},
+				Right: VariableTerm{Symbol: datalog.NewSymbol("?x")},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(2)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(2)},
 			expected: 5.0,
 		},
 	}
@@ -72,13 +74,13 @@ func TestStringConcatFunction(t *testing.T) {
 	fn := StringConcatFunction{
 		Terms: []Term{
 			ConstantTerm{Value: "Hello "},
-			VariableTerm{Symbol: "?name"},
+			VariableTerm{Symbol: datalog.NewSymbol("?name")},
 			ConstantTerm{Value: "!"},
 		},
 	}
 
 	bindings := map[Symbol]interface{}{
-		"?name": "World",
+		datalog.NewSymbol("?name"): "World",
 	}
 
 	result, err := fn.Eval(bindings)
@@ -111,11 +113,11 @@ func TestTimeExtractionFunction(t *testing.T) {
 		t.Run(tt.field, func(t *testing.T) {
 			fn := TimeExtractionFunction{
 				Field:    tt.field,
-				TimeTerm: VariableTerm{Symbol: "?t"},
+				TimeTerm: VariableTerm{Symbol: datalog.NewSymbol("?t")},
 			}
 
 			bindings := map[Symbol]interface{}{
-				"?t": testTime,
+				datalog.NewSymbol("?t"): testTime,
 			}
 
 			result, err := fn.Eval(bindings)
@@ -140,27 +142,27 @@ func TestAggregates(t *testing.T) {
 	}{
 		{
 			name:     "Count",
-			agg:      CountAggregate{Var: "?x"},
+			agg:      CountAggregate{Var: datalog.NewSymbol("?x")},
 			expected: int64(4),
 		},
 		{
 			name:     "Sum",
-			agg:      SumAggregate{Var: "?x"},
+			agg:      SumAggregate{Var: datalog.NewSymbol("?x")},
 			expected: int64(100),
 		},
 		{
 			name:     "Avg",
-			agg:      AvgAggregate{Var: "?x"},
+			agg:      AvgAggregate{Var: datalog.NewSymbol("?x")},
 			expected: 25.0,
 		},
 		{
 			name:     "Min",
-			agg:      MinAggregate{Var: "?x"},
+			agg:      MinAggregate{Var: datalog.NewSymbol("?x")},
 			expected: int64(10),
 		},
 		{
 			name:     "Max",
-			agg:      MaxAggregate{Var: "?x"},
+			agg:      MaxAggregate{Var: datalog.NewSymbol("?x")},
 			expected: int64(40),
 		},
 	}

--- a/datalog/query/pattern_utils_test.go
+++ b/datalog/query/pattern_utils_test.go
@@ -40,16 +40,16 @@ func TestPatternExtractor_Variables(t *testing.T) {
 	// Pattern with all variables: [?e ?a ?v]
 	pattern := &DataPattern{
 		Elements: []PatternElement{
-			Variable{Name: "?e"},
-			Variable{Name: "?a"},
-			Variable{Name: "?v"},
+			Variable{Name: datalog.NewSymbol("?e")},
+			Variable{Name: datalog.NewSymbol("?a")},
+			Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
 	alice := datalog.NewIdentity("user:alice")
 	nameAttr := datalog.NewKeyword(":user/name")
 
-	columns := []Symbol{"?e", "?a", "?v"}
+	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice, nameAttr, "Alice"}
 
 	extractor := NewPatternExtractor(pattern, columns)
@@ -75,14 +75,14 @@ func TestPatternExtractor_MixedConstantsAndVariables(t *testing.T) {
 
 	pattern := &DataPattern{
 		Elements: []PatternElement{
-			Variable{Name: "?e"},
+			Variable{Name: datalog.NewSymbol("?e")},
 			Constant{Value: nameAttr},
-			Variable{Name: "?v"},
+			Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
 	alice := datalog.NewIdentity("user:alice")
-	columns := []Symbol{"?e", "?v"}
+	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice, "Alice"}
 
 	extractor := NewPatternExtractor(pattern, columns)
@@ -107,11 +107,11 @@ func TestPatternExtractor_Blanks(t *testing.T) {
 		Elements: []PatternElement{
 			Blank{},
 			Constant{Value: nameAttr},
-			Variable{Name: "?v"},
+			Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
-	columns := []Symbol{"?v"}
+	columns := []Symbol{datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{"Alice"}
 
 	extractor := NewPatternExtractor(pattern, columns)
@@ -132,14 +132,14 @@ func TestPatternExtractor_VariableNotInBinding(t *testing.T) {
 	// Pattern: [?e ?a ?v] but binding only has ?e
 	pattern := &DataPattern{
 		Elements: []PatternElement{
-			Variable{Name: "?e"},
-			Variable{Name: "?a"},
-			Variable{Name: "?v"},
+			Variable{Name: datalog.NewSymbol("?e")},
+			Variable{Name: datalog.NewSymbol("?a")},
+			Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
 	alice := datalog.NewIdentity("user:alice")
-	columns := []Symbol{"?e"}
+	columns := []Symbol{datalog.NewSymbol("?e")}
 	bindingTuple := Tuple{alice}
 
 	extractor := NewPatternExtractor(pattern, columns)
@@ -160,17 +160,17 @@ func TestPatternExtractor_WithTransaction(t *testing.T) {
 	// Pattern with 4 elements: [?e ?a ?v ?t]
 	pattern := &DataPattern{
 		Elements: []PatternElement{
-			Variable{Name: "?e"},
-			Variable{Name: "?a"},
-			Variable{Name: "?v"},
-			Variable{Name: "?t"},
+			Variable{Name: datalog.NewSymbol("?e")},
+			Variable{Name: datalog.NewSymbol("?a")},
+			Variable{Name: datalog.NewSymbol("?v")},
+			Variable{Name: datalog.NewSymbol("?t")},
 		},
 	}
 
 	alice := datalog.NewIdentity("user:alice")
 	nameAttr := datalog.NewKeyword(":user/name")
 
-	columns := []Symbol{"?e", "?a", "?v", "?t"}
+	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v"), datalog.NewSymbol("?t")}
 	bindingTuple := Tuple{alice, nameAttr, "Alice", uint64(123)}
 
 	extractor := NewPatternExtractor(pattern, columns)
@@ -197,13 +197,13 @@ func TestPatternExtractor_IndividualExtractors(t *testing.T) {
 
 	pattern := &DataPattern{
 		Elements: []PatternElement{
-			Variable{Name: "?e"},
+			Variable{Name: datalog.NewSymbol("?e")},
 			Constant{Value: nameAttr},
-			Variable{Name: "?v"},
+			Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
-	columns := []Symbol{"?e", "?v"}
+	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice, "Alice"}
 
 	extractor := NewPatternExtractor(pattern, columns)
@@ -230,17 +230,17 @@ func TestPatternExtractor_IndividualExtractors(t *testing.T) {
 }
 
 func TestBuildColumnIndexMap(t *testing.T) {
-	columns := []Symbol{"?e", "?a", "?v"}
+	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
 	colMap := BuildColumnIndexMap(columns)
 
-	if colMap["?e"] != 0 {
-		t.Errorf("Expected ?e at index 0, got %d", colMap["?e"])
+	if colMap[datalog.NewSymbol("?e")] != 0 {
+		t.Errorf("Expected ?e at index 0, got %d", colMap[datalog.NewSymbol("?e")])
 	}
-	if colMap["?a"] != 1 {
-		t.Errorf("Expected ?a at index 1, got %d", colMap["?a"])
+	if colMap[datalog.NewSymbol("?a")] != 1 {
+		t.Errorf("Expected ?a at index 1, got %d", colMap[datalog.NewSymbol("?a")])
 	}
-	if colMap["?v"] != 2 {
-		t.Errorf("Expected ?v at index 2, got %d", colMap["?v"])
+	if colMap[datalog.NewSymbol("?v")] != 2 {
+		t.Errorf("Expected ?v at index 2, got %d", colMap[datalog.NewSymbol("?v")])
 	}
 }
 
@@ -251,13 +251,13 @@ func TestExtractPatternValues_ConvenienceFunction(t *testing.T) {
 
 	pattern := &DataPattern{
 		Elements: []PatternElement{
-			Variable{Name: "?e"},
+			Variable{Name: datalog.NewSymbol("?e")},
 			Constant{Value: nameAttr},
-			Variable{Name: "?v"},
+			Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
-	columns := []Symbol{"?e", "?v"}
+	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice, "Alice"}
 
 	e, a, v, tx := ExtractPatternValues(pattern, columns, bindingTuple)
@@ -280,14 +280,14 @@ func TestPatternExtractor_OutOfBoundsTuple(t *testing.T) {
 	// Pattern expects more columns than the binding tuple has
 	pattern := &DataPattern{
 		Elements: []PatternElement{
-			Variable{Name: "?e"},
-			Variable{Name: "?a"},
-			Variable{Name: "?v"},
+			Variable{Name: datalog.NewSymbol("?e")},
+			Variable{Name: datalog.NewSymbol("?a")},
+			Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
 	alice := datalog.NewIdentity("user:alice")
-	columns := []Symbol{"?e", "?a", "?v"}
+	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice} // Only has 1 value instead of 3
 
 	extractor := NewPatternExtractor(pattern, columns)
@@ -334,14 +334,14 @@ func TestPatternExtractor_ColumnsInDifferentOrder(t *testing.T) {
 
 	pattern := &DataPattern{
 		Elements: []PatternElement{
-			Variable{Name: "?e"},
-			Variable{Name: "?a"},
-			Variable{Name: "?v"},
+			Variable{Name: datalog.NewSymbol("?e")},
+			Variable{Name: datalog.NewSymbol("?a")},
+			Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
 	// Columns in different order: ?v, ?e, ?a
-	columns := []Symbol{"?v", "?e", "?a"}
+	columns := []Symbol{datalog.NewSymbol("?v"), datalog.NewSymbol("?e"), datalog.NewSymbol("?a")}
 	bindingTuple := Tuple{"Alice", alice, nameAttr}
 
 	extractor := NewPatternExtractor(pattern, columns)

--- a/datalog/query/predicate.go
+++ b/datalog/query/predicate.go
@@ -63,7 +63,7 @@ func (v VariableTerm) RequiredSymbols() []Symbol {
 }
 
 func (v VariableTerm) String() string {
-	return string(v.Symbol)
+	return v.Symbol.String()
 }
 
 // ConstantTerm represents a literal value like 5 or "hello"
@@ -159,14 +159,14 @@ func (c *Comparison) extractLeftVar() Symbol {
 	if v, ok := c.Left.(VariableTerm); ok {
 		return v.Symbol
 	}
-	return ""
+	return nil
 }
 
 func (c *Comparison) extractRightVar() Symbol {
 	if v, ok := c.Right.(VariableTerm); ok {
 		return v.Symbol
 	}
-	return ""
+	return nil
 }
 
 func (c *Comparison) extractLeftValue() interface{} {
@@ -318,7 +318,7 @@ func (g GroundPredicate) Eval(bindings map[Symbol]interface{}) (bool, error) {
 func (g GroundPredicate) String() string {
 	s := "[(ground"
 	for _, v := range g.Variables {
-		s += " " + string(v)
+		s += " " + v.String()
 	}
 	s += ")]"
 	return s
@@ -354,7 +354,7 @@ func (m MissingPredicate) Eval(bindings map[Symbol]interface{}) (bool, error) {
 func (m MissingPredicate) String() string {
 	s := "[(missing"
 	for _, v := range m.Variables {
-		s += " " + string(v)
+		s += " " + v.String()
 	}
 	s += ")]"
 	return s

--- a/datalog/query/predicate_extended_test.go
+++ b/datalog/query/predicate_extended_test.go
@@ -16,28 +16,28 @@ func TestGroundPredicate(t *testing.T) {
 		{
 			name: "All variables bound",
 			pred: &GroundPredicate{
-				Variables: []Symbol{"?x", "?y"},
+				Variables: []Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			},
 			bindings: map[Symbol]interface{}{
-				"?x": int64(5),
-				"?y": "hello",
+				datalog.NewSymbol("?x"): int64(5),
+				datalog.NewSymbol("?y"): "hello",
 			},
 			expected: true,
 		},
 		{
 			name: "Some variables missing",
 			pred: &GroundPredicate{
-				Variables: []Symbol{"?x", "?y"},
+				Variables: []Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			},
 			bindings: map[Symbol]interface{}{
-				"?x": int64(5),
+				datalog.NewSymbol("?x"): int64(5),
 			},
 			expected: false,
 		},
 		{
 			name: "Empty bindings",
 			pred: &GroundPredicate{
-				Variables: []Symbol{"?x"},
+				Variables: []Symbol{datalog.NewSymbol("?x")},
 			},
 			bindings: map[Symbol]interface{}{},
 			expected: false,
@@ -67,41 +67,41 @@ func TestMissingPredicate(t *testing.T) {
 		{
 			name: "Variable is missing",
 			pred: &MissingPredicate{
-				Variables: []Symbol{"?z"},
+				Variables: []Symbol{datalog.NewSymbol("?z")},
 			},
 			bindings: map[Symbol]interface{}{
-				"?x": int64(5),
-				"?y": "hello",
+				datalog.NewSymbol("?x"): int64(5),
+				datalog.NewSymbol("?y"): "hello",
 			},
 			expected: true,
 		},
 		{
 			name: "Variable is present",
 			pred: &MissingPredicate{
-				Variables: []Symbol{"?x"},
+				Variables: []Symbol{datalog.NewSymbol("?x")},
 			},
 			bindings: map[Symbol]interface{}{
-				"?x": int64(5),
+				datalog.NewSymbol("?x"): int64(5),
 			},
 			expected: false,
 		},
 		{
 			name: "Multiple variables all missing",
 			pred: &MissingPredicate{
-				Variables: []Symbol{"?a", "?b"},
+				Variables: []Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			},
 			bindings: map[Symbol]interface{}{
-				"?x": int64(5),
+				datalog.NewSymbol("?x"): int64(5),
 			},
 			expected: true,
 		},
 		{
 			name: "One variable present",
 			pred: &MissingPredicate{
-				Variables: []Symbol{"?a", "?x"},
+				Variables: []Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?x")},
 			},
 			bindings: map[Symbol]interface{}{
-				"?x": int64(5),
+				datalog.NewSymbol("?x"): int64(5),
 			},
 			expected: false,
 		},
@@ -132,13 +132,13 @@ func TestNotEqualPredicate(t *testing.T) {
 			pred: &NotEqualPredicate{
 				Comparison: Comparison{
 					Op:    OpEQ,
-					Left:  VariableTerm{Symbol: "?x"},
-					Right: VariableTerm{Symbol: "?y"},
+					Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
+					Right: VariableTerm{Symbol: datalog.NewSymbol("?y")},
 				},
 			},
 			bindings: map[Symbol]interface{}{
-				"?x": int64(5),
-				"?y": int64(10),
+				datalog.NewSymbol("?x"): int64(5),
+				datalog.NewSymbol("?y"): int64(10),
 			},
 			expected: true,
 		},
@@ -147,13 +147,13 @@ func TestNotEqualPredicate(t *testing.T) {
 			pred: &NotEqualPredicate{
 				Comparison: Comparison{
 					Op:    OpEQ,
-					Left:  VariableTerm{Symbol: "?x"},
-					Right: VariableTerm{Symbol: "?y"},
+					Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
+					Right: VariableTerm{Symbol: datalog.NewSymbol("?y")},
 				},
 			},
 			bindings: map[Symbol]interface{}{
-				"?x": int64(5),
-				"?y": int64(5),
+				datalog.NewSymbol("?x"): int64(5),
+				datalog.NewSymbol("?y"): int64(5),
 			},
 			expected: false,
 		},
@@ -162,12 +162,12 @@ func TestNotEqualPredicate(t *testing.T) {
 			pred: &NotEqualPredicate{
 				Comparison: Comparison{
 					Op:    OpEQ,
-					Left:  VariableTerm{Symbol: "?x"},
+					Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
 					Right: ConstantTerm{Value: int64(10)},
 				},
 			},
 			bindings: map[Symbol]interface{}{
-				"?x": int64(5),
+				datalog.NewSymbol("?x"): int64(5),
 			},
 			expected: true,
 		},
@@ -176,12 +176,12 @@ func TestNotEqualPredicate(t *testing.T) {
 			pred: &NotEqualPredicate{
 				Comparison: Comparison{
 					Op:    OpEQ,
-					Left:  VariableTerm{Symbol: "?attr"},
+					Left:  VariableTerm{Symbol: datalog.NewSymbol("?attr")},
 					Right: ConstantTerm{Value: datalog.NewKeyword(":symbol/ticker")},
 				},
 			},
 			bindings: map[Symbol]interface{}{
-				"?attr": datalog.NewKeyword(":symbol/name"),
+				datalog.NewSymbol("?attr"): datalog.NewKeyword(":symbol/name"),
 			},
 			expected: true,
 		},
@@ -190,12 +190,12 @@ func TestNotEqualPredicate(t *testing.T) {
 			pred: &NotEqualPredicate{
 				Comparison: Comparison{
 					Op:    OpEQ,
-					Left:  VariableTerm{Symbol: "?attr"},
+					Left:  VariableTerm{Symbol: datalog.NewSymbol("?attr")},
 					Right: ConstantTerm{Value: datalog.NewKeyword(":symbol/ticker")},
 				},
 			},
 			bindings: map[Symbol]interface{}{
-				"?attr": datalog.NewKeyword(":symbol/ticker"),
+				datalog.NewSymbol("?attr"): datalog.NewKeyword(":symbol/ticker"),
 			},
 			expected: false,
 		},

--- a/datalog/query/predicate_test.go
+++ b/datalog/query/predicate_test.go
@@ -3,6 +3,8 @@ package query
 import (
 	"testing"
 	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestComparison(t *testing.T) {
@@ -16,50 +18,50 @@ func TestComparison(t *testing.T) {
 			name: "Variable equals constant",
 			pred: &Comparison{
 				Op:    OpEQ,
-				Left:  VariableTerm{Symbol: "?x"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
 				Right: ConstantTerm{Value: int64(5)},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(5)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(5)},
 			expected: true,
 		},
 		{
 			name: "Variable not equals constant",
 			pred: &Comparison{
 				Op:    OpEQ,
-				Left:  VariableTerm{Symbol: "?x"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
 				Right: ConstantTerm{Value: int64(5)},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(10)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(10)},
 			expected: false,
 		},
 		{
 			name: "Variable less than constant",
 			pred: &Comparison{
 				Op:    OpLT,
-				Left:  VariableTerm{Symbol: "?x"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
 				Right: ConstantTerm{Value: int64(10)},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(5)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(5)},
 			expected: true,
 		},
 		{
 			name: "Variable equals variable",
 			pred: &Comparison{
 				Op:    OpEQ,
-				Left:  VariableTerm{Symbol: "?x"},
-				Right: VariableTerm{Symbol: "?y"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
+				Right: VariableTerm{Symbol: datalog.NewSymbol("?y")},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(5), "?y": int64(5)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(5), datalog.NewSymbol("?y"): int64(5)},
 			expected: true,
 		},
 		{
 			name: "Variable not equals variable",
 			pred: &Comparison{
 				Op:    OpEQ,
-				Left:  VariableTerm{Symbol: "?x"},
-				Right: VariableTerm{Symbol: "?y"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
+				Right: VariableTerm{Symbol: datalog.NewSymbol("?y")},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(5), "?y": int64(10)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(5), datalog.NewSymbol("?y"): int64(10)},
 			expected: false,
 		},
 		{
@@ -67,39 +69,39 @@ func TestComparison(t *testing.T) {
 			pred: &Comparison{
 				Op:    OpLT,
 				Left:  ConstantTerm{Value: int64(5)},
-				Right: VariableTerm{Symbol: "?x"},
+				Right: VariableTerm{Symbol: datalog.NewSymbol("?x")},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(10)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(10)},
 			expected: true,
 		},
 		{
 			name: "String comparison",
 			pred: &Comparison{
 				Op:    OpLT,
-				Left:  VariableTerm{Symbol: "?s"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?s")},
 				Right: ConstantTerm{Value: "zebra"},
 			},
-			bindings: map[Symbol]interface{}{"?s": "apple"},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?s"): "apple"},
 			expected: true,
 		},
 		{
 			name: "Time comparison",
 			pred: &Comparison{
 				Op:    OpGT,
-				Left:  VariableTerm{Symbol: "?t"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?t")},
 				Right: ConstantTerm{Value: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
-			bindings: map[Symbol]interface{}{"?t": time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?t"): time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			expected: true,
 		},
 		{
 			name: "Mixed numeric types",
 			pred: &Comparison{
 				Op:    OpEQ,
-				Left:  VariableTerm{Symbol: "?x"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
 				Right: ConstantTerm{Value: float64(5.0)},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(5)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(5)},
 			expected: true,
 		},
 	}
@@ -130,11 +132,11 @@ func TestChainedComparison(t *testing.T) {
 				Op: OpLT,
 				Terms: []Term{
 					ConstantTerm{Value: int64(0)},
-					VariableTerm{Symbol: "?x"},
+					VariableTerm{Symbol: datalog.NewSymbol("?x")},
 					ConstantTerm{Value: int64(10)},
 				},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(5)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(5)},
 			expected: true,
 		},
 		{
@@ -143,11 +145,11 @@ func TestChainedComparison(t *testing.T) {
 				Op: OpLT,
 				Terms: []Term{
 					ConstantTerm{Value: int64(0)},
-					VariableTerm{Symbol: "?x"},
+					VariableTerm{Symbol: datalog.NewSymbol("?x")},
 					ConstantTerm{Value: int64(10)},
 				},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(15)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(15)},
 			expected: false,
 		},
 		{
@@ -155,12 +157,12 @@ func TestChainedComparison(t *testing.T) {
 			pred: &ChainedComparison{
 				Op: OpLT,
 				Terms: []Term{
-					VariableTerm{Symbol: "?x"},
-					VariableTerm{Symbol: "?y"},
-					VariableTerm{Symbol: "?z"},
+					VariableTerm{Symbol: datalog.NewSymbol("?x")},
+					VariableTerm{Symbol: datalog.NewSymbol("?y")},
+					VariableTerm{Symbol: datalog.NewSymbol("?z")},
 				},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(1), "?y": int64(5), "?z": int64(10)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(1), datalog.NewSymbol("?y"): int64(5), datalog.NewSymbol("?z"): int64(10)},
 			expected: true,
 		},
 		{
@@ -168,12 +170,12 @@ func TestChainedComparison(t *testing.T) {
 			pred: &ChainedComparison{
 				Op: OpLT,
 				Terms: []Term{
-					VariableTerm{Symbol: "?x"},
-					VariableTerm{Symbol: "?y"},
-					VariableTerm{Symbol: "?z"},
+					VariableTerm{Symbol: datalog.NewSymbol("?x")},
+					VariableTerm{Symbol: datalog.NewSymbol("?y")},
+					VariableTerm{Symbol: datalog.NewSymbol("?z")},
 				},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(1), "?y": int64(10), "?z": int64(5)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(1), datalog.NewSymbol("?y"): int64(10), datalog.NewSymbol("?z"): int64(5)},
 			expected: false,
 		},
 		{
@@ -181,12 +183,12 @@ func TestChainedComparison(t *testing.T) {
 			pred: &ChainedComparison{
 				Op: OpEQ,
 				Terms: []Term{
-					VariableTerm{Symbol: "?x"},
-					VariableTerm{Symbol: "?y"},
-					VariableTerm{Symbol: "?z"},
+					VariableTerm{Symbol: datalog.NewSymbol("?x")},
+					VariableTerm{Symbol: datalog.NewSymbol("?y")},
+					VariableTerm{Symbol: datalog.NewSymbol("?z")},
 				},
 			},
-			bindings: map[Symbol]interface{}{"?x": int64(5), "?y": int64(5), "?z": int64(5)},
+			bindings: map[Symbol]interface{}{datalog.NewSymbol("?x"): int64(5), datalog.NewSymbol("?y"): int64(5), datalog.NewSymbol("?z"): int64(5)},
 			expected: true,
 		},
 	}
@@ -214,19 +216,19 @@ func TestRequiredSymbols(t *testing.T) {
 			name: "Variable comparison",
 			pred: &Comparison{
 				Op:    OpEQ,
-				Left:  VariableTerm{Symbol: "?x"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
 				Right: ConstantTerm{Value: int64(5)},
 			},
-			expected: []Symbol{"?x"},
+			expected: []Symbol{datalog.NewSymbol("?x")},
 		},
 		{
 			name: "Two variables",
 			pred: &Comparison{
 				Op:    OpEQ,
-				Left:  VariableTerm{Symbol: "?x"},
-				Right: VariableTerm{Symbol: "?y"},
+				Left:  VariableTerm{Symbol: datalog.NewSymbol("?x")},
+				Right: VariableTerm{Symbol: datalog.NewSymbol("?y")},
 			},
-			expected: []Symbol{"?x", "?y"},
+			expected: []Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		},
 		{
 			name: "Chained comparison",
@@ -234,12 +236,12 @@ func TestRequiredSymbols(t *testing.T) {
 				Op: OpLT,
 				Terms: []Term{
 					ConstantTerm{Value: int64(0)},
-					VariableTerm{Symbol: "?x"},
-					VariableTerm{Symbol: "?y"},
+					VariableTerm{Symbol: datalog.NewSymbol("?x")},
+					VariableTerm{Symbol: datalog.NewSymbol("?y")},
 					ConstantTerm{Value: int64(100)},
 				},
 			},
-			expected: []Symbol{"?x", "?y"},
+			expected: []Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		},
 	}
 

--- a/datalog/query/types.go
+++ b/datalog/query/types.go
@@ -11,18 +11,9 @@ import (
 // It's used throughout the executor and storage layers for query results
 type Tuple []interface{}
 
-// Symbol represents a variable in a query (e.g., ?x, ?name)
-type Symbol string
-
-// IsVariable returns true if this is a variable symbol (starts with ?)
-func (s Symbol) IsVariable() bool {
-	return len(s) > 0 && s[0] == '?'
-}
-
-// String returns the string representation
-func (s Symbol) String() string {
-	return string(s)
-}
+// Symbol is an interned pointer type for query variables, source names, etc.
+// Alias for datalog.Symbol — construction via datalog.NewSymbol("?x").
+type Symbol = datalog.Symbol
 
 // PatternElement represents an element in a pattern
 // It can be a concrete value, a variable, or a blank
@@ -86,7 +77,7 @@ type Pattern interface {
 // For multi-source queries, Source identifies which data source to query
 // (e.g., Symbol("$users")). Empty Source means the default source ($).
 type DataPattern struct {
-	Source   Symbol           // Source identifier (e.g., "$users"); empty for default
+	Source   Symbol // Source identifier (e.g., "$users"); empty for default
 	Elements []PatternElement
 }
 
@@ -166,8 +157,8 @@ func (r RelationBinding) String() string {
 // String returns a string representation of the data pattern
 func (p DataPattern) String() string {
 	result := "["
-	if p.Source != "" {
-		result += string(p.Source) + " "
+	if p.Source != nil {
+		result += p.Source.String() + " "
 	}
 	for i, elem := range p.Elements {
 		if i > 0 {
@@ -353,7 +344,7 @@ type DatabaseInput struct {
 }
 
 func (d DatabaseInput) isInputSpec()   {}
-func (d DatabaseInput) String() string { return string(d.Name) }
+func (d DatabaseInput) String() string { return d.Name.String() }
 
 // ScalarInput represents a single value input (?x)
 type ScalarInput struct {
@@ -435,7 +426,7 @@ type FindAggregate struct {
 
 // IsConditional returns true if this is a conditional aggregate (has a predicate)
 func (f FindAggregate) IsConditional() bool {
-	return f.Predicate != ""
+	return f.Predicate != nil
 }
 
 func (f FindAggregate) String() string {
@@ -594,7 +585,7 @@ const (
 // String returns the string representation of an OrderByClause
 func (o OrderByClause) String() string {
 	if o.Direction == "" || o.Direction == OrderAsc {
-		return string(o.Variable)
+		return o.Variable.String()
 	}
 	return fmt.Sprintf("[%s :%s]", o.Variable, o.Direction)
 }

--- a/datalog/query/types_test.go
+++ b/datalog/query/types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wbrown/janus-datalog/datalog"
 )
 
 func TestDataPatternString(t *testing.T) {
@@ -16,9 +17,9 @@ func TestDataPatternString(t *testing.T) {
 			name: "unqualified",
 			pattern: DataPattern{
 				Elements: []PatternElement{
-					Variable{Name: "?e"},
+					Variable{Name: datalog.NewSymbol("?e")},
 					Constant{Value: ":attr"},
-					Variable{Name: "?v"},
+					Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			want: "[?e :attr ?v]",
@@ -26,11 +27,11 @@ func TestDataPatternString(t *testing.T) {
 		{
 			name: "source-qualified",
 			pattern: DataPattern{
-				Source: Symbol("$users"),
+				Source: datalog.NewSymbol("$users"),
 				Elements: []PatternElement{
-					Variable{Name: "?e"},
+					Variable{Name: datalog.NewSymbol("?e")},
 					Constant{Value: ":attr"},
-					Variable{Name: "?v"},
+					Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			want: "[$users ?e :attr ?v]",
@@ -38,11 +39,11 @@ func TestDataPatternString(t *testing.T) {
 		{
 			name: "empty source same as unqualified",
 			pattern: DataPattern{
-				Source: "",
+				Source: nil,
 				Elements: []PatternElement{
-					Variable{Name: "?e"},
+					Variable{Name: datalog.NewSymbol("?e")},
 					Constant{Value: ":a"},
-					Variable{Name: "?v"},
+					Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			want: "[?e :a ?v]",
@@ -61,9 +62,9 @@ func TestDatabaseInputString(t *testing.T) {
 		input DatabaseInput
 		want  string
 	}{
-		{"default", DatabaseInput{Name: Symbol("$")}, "$"},
-		{"named", DatabaseInput{Name: Symbol("$users")}, "$users"},
-		{"named with underscore", DatabaseInput{Name: Symbol("$foo_bar")}, "$foo_bar"},
+		{"default", DatabaseInput{Name: datalog.NewSymbol("$")}, "$"},
+		{"named", DatabaseInput{Name: datalog.NewSymbol("$users")}, "$users"},
+		{"named with underscore", DatabaseInput{Name: datalog.NewSymbol("$foo_bar")}, "$foo_bar"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/datalog/storage/aevt_bug_test.go
+++ b/datalog/storage/aevt_bug_test.go
@@ -97,7 +97,7 @@ func TestAEVTIndexBugDirect(t *testing.T) {
 
 	// Bind 3 entities as a RelationInput (this is what triggers the bug)
 	inputRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e"},
+		[]query.Symbol{datalog.NewSymbol("?e")},
 		[]executor.Tuple{{entities[0]}, {entities[5]}, {entities[9]}},
 	)
 

--- a/datalog/storage/aevt_matcher_bug_test.go
+++ b/datalog/storage/aevt_matcher_bug_test.go
@@ -62,15 +62,15 @@ func TestAEVTMatcherBug(t *testing.T) {
 	// This is the problematic pattern when ?e is bound
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":person/age")},
-			query.Variable{Name: "?age"},
+			query.Variable{Name: datalog.NewSymbol("?age")},
 		},
 	}
 
 	// Create binding relation with 3 entities
 	bindingRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e"},
+		[]query.Symbol{datalog.NewSymbol("?e")},
 		[]executor.Tuple{
 			{entities[0]},
 			{entities[5]},

--- a/datalog/storage/avet_reuse_benchmark_test.go
+++ b/datalog/storage/avet_reuse_benchmark_test.go
@@ -57,9 +57,9 @@ func BenchmarkAVETReuse(b *testing.B) {
 	// Pattern: [?b :price/symbol ?s] with multiple symbols bound
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?b"},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-			query.Variable{Name: "?s"},
+			query.Variable{Name: datalog.NewSymbol("?s")},
 		},
 	}
 
@@ -70,7 +70,7 @@ func BenchmarkAVETReuse(b *testing.B) {
 		symbolTuples = append(symbolTuples, executor.Tuple{symbolEntity})
 	}
 	symbolRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?s"},
+		[]query.Symbol{datalog.NewSymbol("?s")},
 		symbolTuples,
 	)
 
@@ -144,9 +144,9 @@ func BenchmarkAVETNoReuse(b *testing.B) {
 	// Pattern: [?b :price/symbol ?s] with multiple symbols bound
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?b"},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-			query.Variable{Name: "?s"},
+			query.Variable{Name: datalog.NewSymbol("?s")},
 		},
 	}
 
@@ -157,7 +157,7 @@ func BenchmarkAVETNoReuse(b *testing.B) {
 		symbolTuples = append(symbolTuples, executor.Tuple{symbolEntity})
 	}
 	symbolRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?s"},
+		[]query.Symbol{datalog.NewSymbol("?s")},
 		symbolTuples,
 	)
 

--- a/datalog/storage/badger_store_test.go
+++ b/datalog/storage/badger_store_test.go
@@ -488,6 +488,7 @@ func TestKeyOnlyScanningAllTypes(t *testing.T) {
 		{E: entity, A: datalog.NewKeyword(":test/bytes"), V: []byte("binary data"), Tx: 6},
 		{E: entity, A: datalog.NewKeyword(":test/ref"), V: refEntity, Tx: 7},
 		{E: entity, A: datalog.NewKeyword(":test/keyword"), V: datalog.NewKeyword(":status/active"), Tx: 8},
+		{E: entity, A: datalog.NewKeyword(":test/symbol"), V: datalog.NewSymbol("my-function"), Tx: 9},
 	}
 
 	// Assert all datoms
@@ -599,6 +600,10 @@ func TestKeyOnlyScanningAllTypes(t *testing.T) {
 					case datalog.Keyword:
 						if kv, ok := kd.V.(datalog.Keyword); !ok || rv != kv {
 							t.Errorf("Keyword value mismatch: regular=%v, key-only=%v", rv, kd.V)
+						}
+					case datalog.Symbol:
+						if kv, ok := kd.V.(datalog.Symbol); !ok || rv != kv {
+							t.Errorf("Symbol value mismatch: regular=%v, key-only=%v", rv, kd.V)
 						}
 					}
 				}

--- a/datalog/storage/batch_iterator_simple_test.go
+++ b/datalog/storage/batch_iterator_simple_test.go
@@ -35,9 +35,9 @@ func TestBatchIteratorSimple(t *testing.T) {
 	// Pattern: [?e :test/value ?v]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?e")},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: attr},
-			query.Variable{Name: query.Symbol("?v")},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 
@@ -63,7 +63,7 @@ func TestBatchIteratorSimple(t *testing.T) {
 		{e1},
 		{e3},
 	}
-	bindingRel := executor.NewMaterializedRelation([]query.Symbol{"?e"}, bindingTuples)
+	bindingRel := executor.NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, bindingTuples)
 
 	t.Logf("\nBinding relation:")
 	for _, tuple := range bindingTuples {

--- a/datalog/storage/batch_scan_benchmark_test.go
+++ b/datalog/storage/batch_scan_benchmark_test.go
@@ -51,7 +51,7 @@ func BenchmarkBatchScanning(b *testing.B) {
 	// Patterns
 	symbolPattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: priceSymbol},
 			query.Constant{Value: symbolEntity},
 		},
@@ -59,9 +59,9 @@ func BenchmarkBatchScanning(b *testing.B) {
 
 	timePattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: priceTime},
-			query.Variable{Name: query.Symbol("?t")},
+			query.Variable{Name: datalog.NewSymbol("?t")},
 		},
 	}
 
@@ -180,17 +180,17 @@ func BenchmarkBatchScanScaling(b *testing.B) {
 
 		pattern1 := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: query.Symbol("?e")},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: datalog.NewKeyword(":test/attr")},
-				query.Variable{Name: query.Symbol("?a")},
+				query.Variable{Name: datalog.NewSymbol("?a")},
 			},
 		}
 
 		pattern2 := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: query.Symbol("?e")},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: datalog.NewKeyword(":test/value")},
-				query.Variable{Name: query.Symbol("?v")},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 

--- a/datalog/storage/batch_scan_debug_test.go
+++ b/datalog/storage/batch_scan_debug_test.go
@@ -37,9 +37,9 @@ func TestBatchScanDebug(t *testing.T) {
 	// Pattern: [?e :price/time ?t]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?e")},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: priceTime},
-			query.Variable{Name: query.Symbol("?t")},
+			query.Variable{Name: datalog.NewSymbol("?t")},
 		},
 	}
 
@@ -78,7 +78,7 @@ func TestBatchScanDebug(t *testing.T) {
 			tuples = append(tuples, executor.Tuple{tuple[0]})
 		}
 
-		bindingRel := executor.NewMaterializedRelation([]query.Symbol{"?e"}, tuples)
+		bindingRel := executor.NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, tuples)
 		t.Logf("Binding relation has %d tuples", bindingRel.Size())
 
 		// Now match with constraint

--- a/datalog/storage/batch_scan_performance_test.go
+++ b/datalog/storage/batch_scan_performance_test.go
@@ -63,9 +63,9 @@ func TestBatchScanPerformance(t *testing.T) {
 	// Pattern: [?bar :price/time ?time]
 	timePattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("bar")},
+			query.Variable{Name: datalog.NewSymbol("bar")},
 			query.Constant{Value: datalog.NewKeyword(":price/time")},
-			query.Variable{Name: query.Symbol("time")},
+			query.Variable{Name: datalog.NewSymbol("time")},
 		},
 	}
 
@@ -75,7 +75,7 @@ func TestBatchScanPerformance(t *testing.T) {
 		tuples[i] = executor.Tuple{bar}
 	}
 	bindingRel := executor.NewMaterializedRelation(
-		[]query.Symbol{query.Symbol("bar")},
+		[]query.Symbol{datalog.NewSymbol("bar")},
 		tuples,
 	)
 

--- a/datalog/storage/batch_scan_trace_test.go
+++ b/datalog/storage/batch_scan_trace_test.go
@@ -44,7 +44,7 @@ func TestBatchScanTrace(t *testing.T) {
 	// First pattern: get all bars for symbol
 	symbolPattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: priceSymbol},
 			query.Constant{Value: symbolEntity},
 		},
@@ -53,9 +53,9 @@ func TestBatchScanTrace(t *testing.T) {
 	// Second pattern: get times
 	timePattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: priceTime},
-			query.Variable{Name: query.Symbol("?t")},
+			query.Variable{Name: datalog.NewSymbol("?t")},
 		},
 	}
 

--- a/datalog/storage/choose_index_values_test.go
+++ b/datalog/storage/choose_index_values_test.go
@@ -147,15 +147,15 @@ func TestChooseIndexForValuesAVET(t *testing.T) {
 	t.Run("Match with binding relation returns correct count", func(t *testing.T) {
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: datalog.NewKeyword(":task/scenario")},
-				query.Variable{Name: "?scenario"},
+				query.Variable{Name: datalog.NewSymbol("?scenario")},
 			},
 		}
 
 		opts := getDefaultExecutorOptions()
 		inputRel := executor.NewMaterializedRelationWithOptions(
-			[]query.Symbol{"?scenario"},
+			[]query.Symbol{datalog.NewSymbol("?scenario")},
 			[]executor.Tuple{{scenario2}},
 			opts,
 		)

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -403,8 +403,8 @@ func buildSourceMap(
 	for sym, src := range provided {
 		sources[sym] = src
 	}
-	if _, ok := sources[query.Symbol("$")]; !ok {
-		sources[query.Symbol("$")] = dbMatcher
+	if _, ok := sources[datalog.SymDollar]; !ok {
+		sources[datalog.SymDollar] = dbMatcher
 	}
 	return sources
 }
@@ -1378,10 +1378,10 @@ func (t *Transaction) validateUniqueness() error {
 		// Create a pattern [?e :attr value _] to find entities with this value
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: query.Symbol("?e")}, // Entity variable
-				query.Constant{Value: d.A},               // Bound attribute
-				query.Constant{Value: d.V},               // Bound value
-				query.Blank{},                            // Transaction wildcard
+				query.Variable{Name: datalog.NewSymbol("?e")}, // Entity variable
+				query.Constant{Value: d.A},                    // Bound attribute
+				query.Constant{Value: d.V},                    // Bound value
+				query.Blank{},                                 // Transaction wildcard
 			},
 		}
 
@@ -1394,7 +1394,7 @@ func (t *Transaction) validateUniqueness() error {
 		columns := results.Columns()
 		eIndex := -1
 		for i, col := range columns {
-			if col == query.Symbol("?e") {
+			if col == datalog.NewSymbol("?e") {
 				eIndex = i
 				break
 			}

--- a/datalog/storage/database_schema_test.go
+++ b/datalog/storage/database_schema_test.go
@@ -132,7 +132,7 @@ func TestSchemaUniquenessValue(t *testing.T) {
 	matcher := NewBadgerMatcher(db.Store())
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?e")},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: email},
 			query.Constant{Value: "alice@example.com"},
 			query.Blank{},

--- a/datalog/storage/datasource_test.go
+++ b/datalog/storage/datasource_test.go
@@ -45,9 +45,9 @@ func TestDatabaseMatch(t *testing.T) {
 	// Use Database.Match directly (PatternMatcher interface)
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":user/name")},
-			query.Variable{Name: "?name"},
+			query.Variable{Name: datalog.NewSymbol("?name")},
 		},
 	}
 
@@ -100,8 +100,8 @@ func TestDatabaseMatchWithConstantEntity(t *testing.T) {
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
 			query.Constant{Value: alice},
-			query.Variable{Name: "?a"},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?a")},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 

--- a/datalog/storage/datom_decoder.go
+++ b/datalog/storage/datom_decoder.go
@@ -156,7 +156,8 @@ func (i *HistoryKeyOnlyIterator) Next() bool {
 		return false
 	}
 
-	key := i.it.Item().Key()
+	// Must copy since BadgerDB reuses the key buffer
+	key := i.it.Item().KeyCopy(nil)
 	i.currentDatom, i.currentOp, i.currentError = DatomFromHistoryKey(i.index, key, i.encoder)
 
 	if i.currentError != nil {
@@ -194,8 +195,8 @@ func (i *KeyOnlyIterator) Next() bool {
 		return false
 	}
 
-	// Decode datom from key
-	key := i.it.Item().Key()
+	// Decode datom from key - must copy since BadgerDB reuses the key buffer
+	key := i.it.Item().KeyCopy(nil)
 
 	i.currentDatom, i.currentError = DatomFromKey(i.index, key, i.encoder)
 

--- a/datalog/storage/iterator_clean_bench_test.go
+++ b/datalog/storage/iterator_clean_bench_test.go
@@ -45,9 +45,9 @@ func BenchmarkIteratorReuseClean(b *testing.B) {
 	// Setup pattern and binding
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?b"},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-			query.Variable{Name: "?s"},
+			query.Variable{Name: datalog.NewSymbol("?s")},
 		},
 	}
 
@@ -71,7 +71,7 @@ func BenchmarkIteratorReuseClean(b *testing.B) {
 				tuples = append(tuples, executor.Tuple{symbolEntity})
 			}
 			bindingRel := executor.NewMaterializedRelation(
-				[]query.Symbol{"?s"},
+				[]query.Symbol{datalog.NewSymbol("?s")},
 				tuples,
 			)
 

--- a/datalog/storage/iterator_reuse_performance_test.go
+++ b/datalog/storage/iterator_reuse_performance_test.go
@@ -45,9 +45,9 @@ func TestIteratorReusePerformance(t *testing.T) {
 	// Pattern: [?b :price/symbol ?s] with ?s bound to multiple symbols
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?b"},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-			query.Variable{Name: "?s"},
+			query.Variable{Name: datalog.NewSymbol("?s")},
 		},
 	}
 
@@ -63,7 +63,7 @@ func TestIteratorReusePerformance(t *testing.T) {
 				tuples = append(tuples, executor.Tuple{symbolEntity})
 			}
 			bindingRel := executor.NewMaterializedRelation(
-				[]query.Symbol{"?s"},
+				[]query.Symbol{datalog.NewSymbol("?s")},
 				tuples,
 			)
 

--- a/datalog/storage/iterator_reuse_profile_test.go
+++ b/datalog/storage/iterator_reuse_profile_test.go
@@ -47,9 +47,9 @@ func BenchmarkIteratorReuse(b *testing.B) {
 	// Pattern: [?b :price/symbol ?s] with ?s bound to 5 symbols
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?b"},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-			query.Variable{Name: "?s"},
+			query.Variable{Name: datalog.NewSymbol("?s")},
 		},
 	}
 
@@ -60,7 +60,7 @@ func BenchmarkIteratorReuse(b *testing.B) {
 		tuples = append(tuples, executor.Tuple{symbolEntity})
 	}
 	bindingRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?s"},
+		[]query.Symbol{datalog.NewSymbol("?s")},
 		tuples,
 	)
 
@@ -129,7 +129,7 @@ func BenchmarkNoIteratorReuse(b *testing.B) {
 			symbolEntity := datalog.NewIdentity(fmt.Sprintf("symbol:%s", symbols[j]))
 			pattern := &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?b"},
+					query.Variable{Name: datalog.NewSymbol("?b")},
 					query.Constant{Value: datalog.NewKeyword(":price/symbol")},
 					query.Constant{Value: symbolEntity}, // Constant instead of variable
 				},

--- a/datalog/storage/iterator_reuse_regression_test.go
+++ b/datalog/storage/iterator_reuse_regression_test.go
@@ -50,9 +50,9 @@ func TestIteratorReuseRegression(t *testing.T) {
 	testMatcher := NewBadgerMatcherWithOptions(db.store, opts)
 	testPattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":price/minute-of-day")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 	testResult, err := testMatcher.Match(testPattern, nil)
@@ -64,9 +64,9 @@ func TestIteratorReuseRegression(t *testing.T) {
 	// Check what's stored for :price/symbol
 	symbolPattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
 	symbolResult, err := testMatcher.Match(symbolPattern, nil)
@@ -95,7 +95,7 @@ func TestIteratorReuseRegression(t *testing.T) {
 	// Check specifically for minute 570
 	test570Pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":price/minute-of-day")},
 			query.Constant{Value: int64(570)},
 		},
@@ -110,7 +110,7 @@ func TestIteratorReuseRegression(t *testing.T) {
 	for _, testVal := range []int64{570, 571, 959, 960} {
 		testPattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: datalog.NewKeyword(":price/minute-of-day")},
 				query.Constant{Value: testVal},
 			},
@@ -135,7 +135,7 @@ func TestIteratorReuseRegression(t *testing.T) {
 		// Note: This pattern doesn't use the binding, so we expect just 1 iterator open
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?bar"},
+				query.Variable{Name: datalog.NewSymbol("?bar")},
 				query.Constant{Value: datalog.NewKeyword(":price/minute-of-day")},
 				query.Constant{Value: int64(570)}, // 9:30 AM
 			},
@@ -148,7 +148,7 @@ func TestIteratorReuseRegression(t *testing.T) {
 			tuples = append(tuples, executor.Tuple{e})
 		}
 		symbolRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?s"},
+			[]query.Symbol{datalog.NewSymbol("?s")},
 			tuples,
 		)
 
@@ -213,7 +213,7 @@ func TestIteratorReuseRegression(t *testing.T) {
 
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?bar"},
+				query.Variable{Name: datalog.NewSymbol("?bar")},
 				query.Constant{Value: datalog.NewKeyword(":price/minute-of-day")},
 				query.Constant{Value: int64(570)},
 			},
@@ -225,7 +225,7 @@ func TestIteratorReuseRegression(t *testing.T) {
 			tuples = append(tuples, executor.Tuple{e})
 		}
 		symbolRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?s"},
+			[]query.Symbol{datalog.NewSymbol("?s")},
 			tuples,
 		)
 
@@ -275,7 +275,7 @@ func TestIteratorReuseRegression(t *testing.T) {
 			Elements: []query.PatternElement{
 				query.Constant{Value: datalog.NewIdentity("bar:AAPL:0:0")}, // Try a specific bar
 				query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 		regularMatcher := NewBadgerMatcherWithOptions(db.store, opts)
@@ -305,7 +305,7 @@ func TestIteratorReuseRegression(t *testing.T) {
 		// Now try the direct query
 		checkPattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?b"},
+				query.Variable{Name: datalog.NewSymbol("?b")},
 				query.Constant{Value: datalog.NewKeyword(":price/symbol")},
 				query.Constant{Value: datalog.NewIdentity("symbol:AAPL")},
 			},
@@ -319,14 +319,14 @@ func TestIteratorReuseRegression(t *testing.T) {
 		// Now test with binding
 		testPattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?b"},
+				query.Variable{Name: datalog.NewSymbol("?b")},
 				query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-				query.Variable{Name: "?s"}, // This will be bound
+				query.Variable{Name: datalog.NewSymbol("?s")}, // This will be bound
 			},
 		}
 		testSymbol := datalog.NewIdentity("symbol:AAPL")
 		testRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?s"},
+			[]query.Symbol{datalog.NewSymbol("?s")},
 			[]executor.Tuple{{testSymbol}},
 		)
 		testResult, err := regularMatcher.Match(testPattern, executor.Relations{testRel})
@@ -353,9 +353,9 @@ func TestIteratorReuseRegression(t *testing.T) {
 		// find all bars for a specific date
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?b"},
+				query.Variable{Name: datalog.NewSymbol("?b")},
 				query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-				query.Variable{Name: "?s"}, // This will be bound
+				query.Variable{Name: datalog.NewSymbol("?s")}, // This will be bound
 			},
 		}
 
@@ -366,7 +366,7 @@ func TestIteratorReuseRegression(t *testing.T) {
 			symbolTuples = append(symbolTuples, executor.Tuple{symbolEntity})
 		}
 		symbolRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?s"},
+			[]query.Symbol{datalog.NewSymbol("?s")},
 			symbolTuples,
 		)
 

--- a/datalog/storage/join_strategy_threshold_bench_test.go
+++ b/datalog/storage/join_strategy_threshold_bench_test.go
@@ -62,16 +62,16 @@ func BenchmarkJoinStrategyThreshold(b *testing.B) {
 		}
 
 		bindingRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?e"},
+			[]query.Symbol{datalog.NewSymbol("?e")},
 			bindingTuples,
 		)
 
 		// Create pattern: [?e :person/age ?age]
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: datalog.NewKeyword(":person/age")},
-				query.Variable{Name: "?age"},
+				query.Variable{Name: datalog.NewSymbol("?age")},
 			},
 		}
 

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -85,7 +85,7 @@ func (m *BadgerMatcher) getTupleBuilder(pattern *query.DataPattern, columns []qu
 
 	key := pattern.String()
 	for _, col := range columns {
-		key += "|" + string(col)
+		key += "|" + col.String()
 	}
 
 	if val, ok := m.builderCache.Load(key); ok {

--- a/datalog/storage/matcher_concurrency_test.go
+++ b/datalog/storage/matcher_concurrency_test.go
@@ -19,12 +19,12 @@ func TestTupleBuilderCacheConcurrency(t *testing.T) {
 	// Create test pattern and columns
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":test/attr")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
-	columns := []query.Symbol{"?e", "?v"}
+	columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 	// Spawn 1000 goroutines accessing cache concurrently
 	// This should trigger the concurrent map access bug if not fixed
@@ -67,12 +67,12 @@ func TestTupleBuilderCacheSharing(t *testing.T) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":test/attr")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
-	columns := []query.Symbol{"?e", "?v"}
+	columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 	// Get builder from base matcher
 	builder1 := baseMatcher.getTupleBuilder(pattern, columns)

--- a/datalog/storage/matcher_multi_position_debug_test.go
+++ b/datalog/storage/matcher_multi_position_debug_test.go
@@ -33,16 +33,16 @@ func TestMultiPositionDebug(t *testing.T) {
 	// Create pattern: [?e :attr/code ?code]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":attr/code")},
-			query.Variable{Name: "?code"},
+			query.Variable{Name: datalog.NewSymbol("?code")},
 		},
 	}
 	t.Logf("Pattern: %s", pattern.String())
 
 	// Create binding relation: entity1 with code="A"
 	bindingRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e", "?code"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 		[]executor.Tuple{
 			{entity1, "A"},
 		},

--- a/datalog/storage/matcher_multi_position_test.go
+++ b/datalog/storage/matcher_multi_position_test.go
@@ -42,9 +42,9 @@ func TestMultiPositionBindingCorrectness(t *testing.T) {
 	// Create pattern: [?e :attr/code ?code]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":attr/code")},
-			query.Variable{Name: "?code"},
+			query.Variable{Name: datalog.NewSymbol("?code")},
 		},
 	}
 
@@ -59,7 +59,7 @@ func TestMultiPositionBindingCorrectness(t *testing.T) {
 		{entities[8], "A"}, // Has code="B" in DB, should NOT match
 	}
 	bindingRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e", "?code"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 		bindingTuples,
 	)
 
@@ -135,15 +135,15 @@ func TestMultiPositionAllCombinations(t *testing.T) {
 		// Pattern: [?e :attr/name ?name] with ?e and ?name bound
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
 				query.Constant{Value: datalog.NewKeyword(":attr/name")},
-				query.Variable{Name: "?name"},
+				query.Variable{Name: datalog.NewSymbol("?name")},
 			},
 		}
 
 		// Bindings: entity1 with name="Alice", entity2 with name="Alice" (wrong!)
 		bindingRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?e", "?name"},
+			[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?name")},
 			[]executor.Tuple{
 				{entity1, "Alice"}, // Matches
 				{entity2, "Alice"}, // entity2 has name="Bob", should NOT match
@@ -162,15 +162,15 @@ func TestMultiPositionAllCombinations(t *testing.T) {
 		// This tests attribute binding (less common but possible)
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
-				query.Variable{Name: "?a"},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
+				query.Variable{Name: datalog.NewSymbol("?a")},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
 		// Bindings: entity1 with :attr/name, entity1 with :attr/age
 		bindingRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?e", "?a"},
+			[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a")},
 			[]executor.Tuple{
 				{entity1, datalog.NewKeyword(":attr/name")},
 				{entity1, datalog.NewKeyword(":attr/age")},
@@ -189,15 +189,15 @@ func TestMultiPositionAllCombinations(t *testing.T) {
 		// Find all entities with :attr/name="Alice"
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?e"},
-				query.Variable{Name: "?a"},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?e")},
+				query.Variable{Name: datalog.NewSymbol("?a")},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
 		// Bindings: :attr/name with value "Alice"
 		bindingRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?a", "?v"},
+			[]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?v")},
 			[]executor.Tuple{
 				{datalog.NewKeyword(":attr/name"), "Alice"},
 			},
@@ -242,9 +242,9 @@ func TestMultiPositionAsymmetricCardinality(t *testing.T) {
 	// Pattern: [?e :entity/code ?code]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":entity/code")},
-			query.Variable{Name: "?code"},
+			query.Variable{Name: datalog.NewSymbol("?code")},
 		},
 	}
 
@@ -255,7 +255,7 @@ func TestMultiPositionAsymmetricCardinality(t *testing.T) {
 		bindingTuples[i] = executor.Tuple{entities[i], "rare"}
 	}
 	bindingRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e", "?code"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 		bindingTuples,
 	)
 
@@ -285,16 +285,16 @@ func TestMultiPositionNoMatches(t *testing.T) {
 	// Pattern: [?e :attr/code ?code]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":attr/code")},
-			query.Variable{Name: "?code"},
+			query.Variable{Name: datalog.NewSymbol("?code")},
 		},
 	}
 
 	// Bindings with values that don't match
 	nonExistentEntity := datalog.NewIdentity("entity:nonexistent")
 	bindingRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e", "?code"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 		[]executor.Tuple{
 			{nonExistentEntity, "missing"},
 			{entity1, "missing"}, // entity1 exists but has code="exists", not "missing"
@@ -326,15 +326,15 @@ func TestMultiPositionSingleBinding(t *testing.T) {
 	// Pattern: [?e :attr/code ?code]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":attr/code")},
-			query.Variable{Name: "?code"},
+			query.Variable{Name: datalog.NewSymbol("?code")},
 		},
 	}
 
 	// Single binding tuple
 	bindingRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e", "?code"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 		[]executor.Tuple{
 			{entity1, "A"},
 		},
@@ -371,9 +371,9 @@ func TestMultiPositionResultOrdering(t *testing.T) {
 	// Pattern: [?e :attr/code ?code]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":attr/code")},
-			query.Variable{Name: "?code"},
+			query.Variable{Name: datalog.NewSymbol("?code")},
 		},
 	}
 
@@ -385,7 +385,7 @@ func TestMultiPositionResultOrdering(t *testing.T) {
 		bindingTuples1[i] = executor.Tuple{entities[i], "same"}
 	}
 	bindingRel1 := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e", "?code"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 		bindingTuples1,
 	)
 
@@ -399,7 +399,7 @@ func TestMultiPositionResultOrdering(t *testing.T) {
 		bindingTuples2[i] = executor.Tuple{entities[4-i], "same"}
 	}
 	bindingRel2 := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e", "?code"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 		bindingTuples2,
 	)
 
@@ -444,9 +444,9 @@ func TestMultiPositionPerformance(t *testing.T) {
 	// Pattern: [?e :entity/code ?code]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":entity/code")},
-			query.Variable{Name: "?code"},
+			query.Variable{Name: datalog.NewSymbol("?code")},
 		},
 	}
 
@@ -457,7 +457,7 @@ func TestMultiPositionPerformance(t *testing.T) {
 		bindingTuples[i] = executor.Tuple{entities[i], "target"}
 	}
 	bindingRel := executor.NewMaterializedRelation(
-		[]query.Symbol{"?e", "?code"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 		bindingTuples,
 	)
 
@@ -476,7 +476,7 @@ func TestMultiPositionPerformance(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		// Need fresh binding relation each time since iterator is consumed
 		bindingRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?e", "?code"},
+			[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 			bindingTuples,
 		)
 
@@ -532,9 +532,9 @@ func BenchmarkMultiPositionBinding(b *testing.B) {
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":entity/code")},
-			query.Variable{Name: "?code"},
+			query.Variable{Name: datalog.NewSymbol("?code")},
 		},
 	}
 
@@ -548,7 +548,7 @@ func BenchmarkMultiPositionBinding(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		bindingRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?e", "?code"},
+			[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 			bindingTuples,
 		)
 		result, _ := matcher.Match(pattern, executor.Relations{bindingRel})
@@ -621,9 +621,9 @@ func TestMultiPositionWithStreamingBinding(t *testing.T) {
 	// Create pattern: [?e :attr/code ?code]
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":attr/code")},
-			query.Variable{Name: "?code"},
+			query.Variable{Name: datalog.NewSymbol("?code")},
 		},
 	}
 
@@ -638,7 +638,7 @@ func TestMultiPositionWithStreamingBinding(t *testing.T) {
 	// This simulates what happens when binding comes from a previous pattern match
 	tupleIter := &sliceTupleIterator{tuples: bindingTuples, idx: -1}
 	streamingBindingRel := executor.NewStreamingRelation(
-		[]query.Symbol{"?e", "?code"},
+		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?code")},
 		tupleIter,
 	)
 

--- a/datalog/storage/matcher_strategy.go
+++ b/datalog/storage/matcher_strategy.go
@@ -223,7 +223,7 @@ func chooseBestMultiPositionStrategy(
 			}
 		}
 
-		if varName == "" {
+		if varName == nil {
 			continue
 		}
 

--- a/datalog/storage/merge_join_test.go
+++ b/datalog/storage/merge_join_test.go
@@ -103,14 +103,14 @@ func TestJoinStrategySelection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create mock binding relation with specified size
-			bindingRel := createMockRelation(tt.bindingSize, []query.Symbol{"?e"})
+			bindingRel := createMockRelation(tt.bindingSize, []query.Symbol{datalog.NewSymbol("?e")})
 
 			// Create pattern - attribute is bound to control cardinality estimate
 			pattern := &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword(":test/attr")},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			}
 
@@ -221,20 +221,20 @@ func TestMergeJoinCorrectness(t *testing.T) {
 				tuples[i] = executor.Tuple{e}
 			}
 			bindingRel := executor.NewMaterializedRelationNoDedupe(
-				[]query.Symbol{"?e"},
+				[]query.Symbol{datalog.NewSymbol("?e")},
 				tuples,
 			)
 
 			// Create pattern: [?e :test/value ?v]
 			pattern := &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword(":test/value")},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			}
 
-			columns := []query.Symbol{"?e", "?v"}
+			columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 			// Call merge join directly
 			result, err := matcher.matchWithMergeJoin(
@@ -330,18 +330,18 @@ func TestMergeJoinVsHashJoin(t *testing.T) {
 				tuples[i] = executor.Tuple{entities[i]}
 			}
 			bindingRel := executor.NewMaterializedRelationNoDedupe(
-				[]query.Symbol{"?e"},
+				[]query.Symbol{datalog.NewSymbol("?e")},
 				tuples,
 			)
 
 			pattern := &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?e"},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword(":test/value")},
-					query.Variable{Name: "?v"},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			}
-			columns := []query.Symbol{"?e", "?v"}
+			columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 			// Call hash join
 			hashResult, err := matcher.matchWithHashJoin(
@@ -443,18 +443,18 @@ func TestMergeJoinPerformance(t *testing.T) {
 		tuples[i] = executor.Tuple{entities[i]}
 	}
 	bindingRel := executor.NewMaterializedRelationNoDedupe(
-		[]query.Symbol{"?e"},
+		[]query.Symbol{datalog.NewSymbol("?e")},
 		tuples,
 	)
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":test/value")},
-			query.Variable{Name: "?v"},
+			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
-	columns := []query.Symbol{"?e", "?v"}
+	columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 	start := time.Now()
 	result, err := matcher.matchWithMergeJoin(

--- a/datalog/storage/multi_source_integration_test.go
+++ b/datalog/storage/multi_source_integration_test.go
@@ -44,7 +44,7 @@ func TestMultiSource_MemorySourceWithDatabase(t *testing.T) {
 		         [$cache ?c :cache/user-id ?uid]
 		         [$cache ?c :cache/score ?score]]`,
 		WithSources(map[query.Symbol]executor.PatternMatcher{
-			query.Symbol("$cache"): cache,
+			datalog.NewSymbol("$cache"): cache,
 		}),
 	)
 	if err != nil {
@@ -84,7 +84,7 @@ func TestMultiSource_MemorySourceOnly(t *testing.T) {
 		  :in $items
 		  :where [$items ?e :item/name ?name]]`,
 		WithSources(map[query.Symbol]executor.PatternMatcher{
-			query.Symbol("$items"): items,
+			datalog.NewSymbol("$items"): items,
 		}),
 	)
 	if err != nil {
@@ -137,7 +137,7 @@ func TestMultiSource_SliceSourceWithQueryBuilder(t *testing.T) {
 
 	results, err := db.ExecuteQueryWithInputs(q,
 		WithSources(map[query.Symbol]executor.PatternMatcher{
-			query.Symbol("$rules"): ruleSource,
+			datalog.NewSymbol("$rules"): ruleSource,
 		}),
 	)
 	if err != nil {
@@ -185,7 +185,7 @@ func TestMultiSource_SliceSourceDependencyQuery(t *testing.T) {
 		  :where [$rules ?r :rule/key ?key]
 		         [$rules ?r :rule/depends-on ?dep]]`,
 		WithSources(map[query.Symbol]executor.PatternMatcher{
-			query.Symbol("$rules"): ruleSource,
+			datalog.NewSymbol("$rules"): ruleSource,
 		}),
 		"region-lore",
 	)
@@ -276,8 +276,8 @@ func TestMultiSource_CrossDatabaseJoin(t *testing.T) {
 		         [$perms ?p :perm/user-id ?uid]
 		         [$perms ?p :perm/role ?role]]`,
 		WithSources(map[query.Symbol]executor.PatternMatcher{
-			query.Symbol("$users"): usersDB,
-			query.Symbol("$perms"): permsDB,
+			datalog.NewSymbol("$users"): usersDB,
+			datalog.NewSymbol("$perms"): permsDB,
 		}),
 	)
 	if err != nil {

--- a/datalog/storage/perf_diagnostic_test.go
+++ b/datalog/storage/perf_diagnostic_test.go
@@ -81,12 +81,12 @@ func BenchmarkHashJoinIteration(b *testing.B) {
 	matcher := db.Matcher().(*BadgerMatcher)
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: "?e"},
+			query.Variable{Name: datalog.NewSymbol("?e")},
 			query.Constant{Value: datalog.NewKeyword(":task/scenario")},
-			query.Variable{Name: "?scenario"},
+			query.Variable{Name: datalog.NewSymbol("?scenario")},
 		},
 	}
-	inputCols := []query.Symbol{"?scenario"}
+	inputCols := []query.Symbol{datalog.NewSymbol("?scenario")}
 	inputTuples := []executor.Tuple{{scenario1}}
 	inputRel := executor.NewMaterializedRelationWithOptions(inputCols, inputTuples, getDefaultExecutorOptions())
 

--- a/datalog/storage/prebuilt_bench_test.go
+++ b/datalog/storage/prebuilt_bench_test.go
@@ -39,9 +39,9 @@ func BenchmarkPrebuiltDatabase_PatternMatching(b *testing.B) {
 			name: "UnboundAttribute_PriceTime",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?bar"},
+					query.Variable{Name: datalog.NewSymbol("?bar")},
 					query.Constant{Value: datalog.NewKeyword("price/time")},
-					query.Variable{Name: "?time"},
+					query.Variable{Name: datalog.NewSymbol("?time")},
 				},
 			},
 		},
@@ -49,9 +49,9 @@ func BenchmarkPrebuiltDatabase_PatternMatching(b *testing.B) {
 			name: "UnboundAttribute_PriceOpen",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?bar"},
+					query.Variable{Name: datalog.NewSymbol("?bar")},
 					query.Constant{Value: datalog.NewKeyword("price/open")},
-					query.Variable{Name: "?open"},
+					query.Variable{Name: datalog.NewSymbol("?open")},
 				},
 			},
 		},
@@ -60,8 +60,8 @@ func BenchmarkPrebuiltDatabase_PatternMatching(b *testing.B) {
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
 					query.Constant{Value: datalog.NewIdentity("bar500")},
-					query.Variable{Name: "?attr"},
-					query.Variable{Name: "?value"},
+					query.Variable{Name: datalog.NewSymbol("?attr")},
+					query.Variable{Name: datalog.NewSymbol("?value")},
 				},
 			},
 		},
@@ -69,7 +69,7 @@ func BenchmarkPrebuiltDatabase_PatternMatching(b *testing.B) {
 			name: "BoundSymbol_SpecificStock",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?bar"},
+					query.Variable{Name: datalog.NewSymbol("?bar")},
 					query.Constant{Value: datalog.NewKeyword("price/symbol")},
 					query.Constant{Value: datalog.NewIdentity("TICK0005")},
 				},
@@ -79,9 +79,9 @@ func BenchmarkPrebuiltDatabase_PatternMatching(b *testing.B) {
 			name: "LargeBindingSet_260Entities",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?bar"},
+					query.Variable{Name: datalog.NewSymbol("?bar")},
 					query.Constant{Value: datalog.NewKeyword("price/open")},
-					query.Variable{Name: "?open"},
+					query.Variable{Name: datalog.NewSymbol("?open")},
 				},
 			},
 			setup: func() executor.Relations {
@@ -92,7 +92,7 @@ func BenchmarkPrebuiltDatabase_PatternMatching(b *testing.B) {
 				}
 				return executor.Relations{
 					executor.NewMaterializedRelation(
-						[]query.Symbol{"?bar"},
+						[]query.Symbol{datalog.NewSymbol("?bar")},
 						tuples,
 					),
 				}
@@ -154,7 +154,7 @@ func BenchmarkPrebuiltDatabase_FullQuery(b *testing.B) {
 		// Pattern: [?bar :price/symbol ?symbol]
 		symbolPattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?bar"},
+				query.Variable{Name: datalog.NewSymbol("?bar")},
 				query.Constant{Value: datalog.NewKeyword("price/symbol")},
 				query.Constant{Value: datalog.NewIdentity("TICK0001")},
 			},
@@ -181,7 +181,7 @@ func BenchmarkPrebuiltDatabase_FullQuery(b *testing.B) {
 					Elements: []query.PatternElement{
 						query.Constant{Value: barEntity},
 						query.Constant{Value: datalog.NewKeyword("price/open")},
-						query.Variable{Name: "?open"},
+						query.Variable{Name: datalog.NewSymbol("?open")},
 					},
 				}
 				openResult, _ := matcher.Match(openPattern, nil)

--- a/datalog/storage/predicate_pushdown_benchmark_test.go
+++ b/datalog/storage/predicate_pushdown_benchmark_test.go
@@ -68,7 +68,7 @@ func BenchmarkPredicatePushdown(b *testing.B) {
 	// Patterns for testing
 	symbolPattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
 			query.Constant{Value: symbolEntity},
 		},
@@ -76,9 +76,9 @@ func BenchmarkPredicatePushdown(b *testing.B) {
 
 	timePattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/time")},
-			query.Variable{Name: query.Symbol("?t")},
+			query.Variable{Name: datalog.NewSymbol("?t")},
 		},
 	}
 
@@ -107,7 +107,7 @@ func BenchmarkPredicatePushdown(b *testing.B) {
 				tuple := it.Tuple()
 				// Find the time value
 				for i, col := range timeRel.Columns() {
-					if col == "?t" {
+					if col == datalog.NewSymbol("?t") {
 						if t, ok := tuple[i].(time.Time); ok {
 							if t.Day() == 5 {
 								count++
@@ -190,7 +190,7 @@ func BenchmarkPredicatePushdown(b *testing.B) {
 				for it.Next() {
 					tuple := it.Tuple()
 					for i, col := range timeRel.Columns() {
-						if col == "?t" {
+						if col == datalog.NewSymbol("?t") {
 							if t, ok := tuple[i].(time.Time); ok {
 								if t.Day() == 5 {
 									count++
@@ -273,7 +273,7 @@ func BenchmarkPredicatePushdownAllocs(b *testing.B) {
 
 	symbolPattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
 			query.Constant{Value: symbolEntity},
 		},
@@ -281,9 +281,9 @@ func BenchmarkPredicatePushdownAllocs(b *testing.B) {
 
 	timePattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/time")},
-			query.Variable{Name: query.Symbol("?t")},
+			query.Variable{Name: datalog.NewSymbol("?t")},
 		},
 	}
 
@@ -301,7 +301,7 @@ func BenchmarkPredicatePushdownAllocs(b *testing.B) {
 			for it.Next() {
 				tuple := it.Tuple()
 				for i, col := range timeRel.Columns() {
-					if col == "?t" {
+					if col == datalog.NewSymbol("?t") {
 						if t, ok := tuple[i].(time.Time); ok {
 							_ = t.Day() == 5
 						}

--- a/datalog/storage/predicate_pushdown_debug_test.go
+++ b/datalog/storage/predicate_pushdown_debug_test.go
@@ -51,7 +51,7 @@ func TestPredicatePushdownDebug(t *testing.T) {
 	// Test patterns
 	symbolPattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: priceSymbol},
 			query.Constant{Value: symbolEntity},
 		},
@@ -59,9 +59,9 @@ func TestPredicatePushdownDebug(t *testing.T) {
 
 	timePattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: priceTime},
-			query.Variable{Name: query.Symbol("?t")},
+			query.Variable{Name: datalog.NewSymbol("?t")},
 		},
 	}
 

--- a/datalog/storage/predicate_pushdown_integration_test.go
+++ b/datalog/storage/predicate_pushdown_integration_test.go
@@ -93,7 +93,7 @@ func TestPredicatePushdownIntegration(t *testing.T) {
 	// Create a pattern that would fetch all bars for the symbol
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
 			query.Constant{Value: symbolEntity},
 		},
@@ -129,9 +129,9 @@ func TestPredicatePushdownIntegration(t *testing.T) {
 		// Create a second pattern for time
 		timePattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: query.Symbol("?b")},
+				query.Variable{Name: datalog.NewSymbol("?b")},
 				query.Constant{Value: datalog.NewKeyword(":price/time")},
-				query.Variable{Name: query.Symbol("?t")},
+				query.Variable{Name: datalog.NewSymbol("?t")},
 			},
 		}
 
@@ -181,9 +181,9 @@ func TestPredicatePushdownIntegration(t *testing.T) {
 				{Pattern: pattern},
 				{Pattern: &query.DataPattern{
 					Elements: []query.PatternElement{
-						query.Variable{Name: query.Symbol("?b")},
+						query.Variable{Name: datalog.NewSymbol("?b")},
 						query.Constant{Value: datalog.NewKeyword(":price/time")},
-						query.Variable{Name: query.Symbol("?t")},
+						query.Variable{Name: datalog.NewSymbol("?t")},
 					},
 				}},
 			},
@@ -192,13 +192,13 @@ func TestPredicatePushdownIntegration(t *testing.T) {
 					Predicate: &query.FunctionPredicate{
 						Fn: "day",
 						Args: []query.PatternElement{
-							query.Variable{Name: query.Symbol("?t")},
+							query.Variable{Name: datalog.NewSymbol("?t")},
 							query.Constant{Value: int64(20)},
 						},
 					},
 				},
 			},
-			Provides: []query.Symbol{"?b", "?t"},
+			Provides: []query.Symbol{datalog.NewSymbol("?b"), datalog.NewSymbol("?t")},
 		}
 
 		// Use the predicate classifier

--- a/datalog/storage/predicate_pushdown_trace_test.go
+++ b/datalog/storage/predicate_pushdown_trace_test.go
@@ -41,7 +41,7 @@ func TestPredicatePushdownTrace(t *testing.T) {
 	// Patterns
 	symbolPattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/symbol")},
 			query.Constant{Value: symbolEntity},
 		},
@@ -49,9 +49,9 @@ func TestPredicatePushdownTrace(t *testing.T) {
 
 	timePattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?b")},
+			query.Variable{Name: datalog.NewSymbol("?b")},
 			query.Constant{Value: datalog.NewKeyword(":price/time")},
-			query.Variable{Name: query.Symbol("?t")},
+			query.Variable{Name: datalog.NewSymbol("?t")},
 		},
 	}
 

--- a/datalog/storage/production_query_test.go
+++ b/datalog/storage/production_query_test.go
@@ -52,7 +52,7 @@ func TestProductionQueryPattern(t *testing.T) {
 
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?bar"},
+				query.Variable{Name: datalog.NewSymbol("?bar")},
 				query.Constant{Value: datalog.NewKeyword(":price/minute-of-day")},
 				query.Constant{Value: int64(570)}, // 9:30 AM
 			},
@@ -94,15 +94,15 @@ func TestProductionQueryPattern(t *testing.T) {
 
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?b"},
+				query.Variable{Name: datalog.NewSymbol("?b")},
 				query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-				query.Variable{Name: "?s"},
+				query.Variable{Name: datalog.NewSymbol("?s")},
 			},
 		}
 
 		// Bind to the symbol
 		symbolRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?s"},
+			[]query.Symbol{datalog.NewSymbol("?s")},
 			[]executor.Tuple{{symbolEntity}},
 		)
 
@@ -149,14 +149,14 @@ func TestProductionQueryPattern(t *testing.T) {
 
 			pattern := &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: "?b"},
+					query.Variable{Name: datalog.NewSymbol("?b")},
 					query.Constant{Value: datalog.NewKeyword(":price/symbol")},
-					query.Variable{Name: "?s"},
+					query.Variable{Name: datalog.NewSymbol("?s")},
 				},
 			}
 
 			symbolRel := executor.NewMaterializedRelation(
-				[]query.Symbol{"?s"},
+				[]query.Symbol{datalog.NewSymbol("?s")},
 				[]executor.Tuple{{symbolEntity}},
 			)
 
@@ -193,9 +193,9 @@ func TestProductionQueryPattern(t *testing.T) {
 		// Pattern with minute-of-day that will be bound
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
-				query.Variable{Name: "?bar"},
+				query.Variable{Name: datalog.NewSymbol("?bar")},
 				query.Constant{Value: datalog.NewKeyword(":price/minute-of-day")},
-				query.Variable{Name: "?mod"},
+				query.Variable{Name: datalog.NewSymbol("?mod")},
 			},
 		}
 
@@ -206,7 +206,7 @@ func TestProductionQueryPattern(t *testing.T) {
 			tuples = append(tuples, executor.Tuple{min})
 		}
 		minuteRel := executor.NewMaterializedRelation(
-			[]query.Symbol{"?mod"},
+			[]query.Symbol{datalog.NewSymbol("?mod")},
 			tuples,
 		)
 

--- a/datalog/storage/pull_integration_test.go
+++ b/datalog/storage/pull_integration_test.go
@@ -242,8 +242,8 @@ func TestPullWildcardPatternMatching(t *testing.T) {
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
 				query.Constant{Value: alice},
-				query.Variable{Name: "?a"},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?a")},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
@@ -278,8 +278,8 @@ func TestPullWildcardPatternMatching(t *testing.T) {
 		pattern := &query.DataPattern{
 			Elements: []query.PatternElement{
 				query.Constant{Value: alice},
-				query.Variable{Name: "?a"},
-				query.Variable{Name: "?v"},
+				query.Variable{Name: datalog.NewSymbol("?a")},
+				query.Variable{Name: datalog.NewSymbol("?v")},
 			},
 		}
 
@@ -299,9 +299,9 @@ func TestPullWildcardPatternMatching(t *testing.T) {
 		aIdx := -1
 		vIdx := -1
 		for i, col := range cols {
-			if col == "?a" {
+			if col == datalog.NewSymbol("?a") {
 				aIdx = i
-			} else if col == "?v" {
+			} else if col == datalog.NewSymbol("?v") {
 				vIdx = i
 			}
 		}

--- a/datalog/storage/tuple_builder_bench_test.go
+++ b/datalog/storage/tuple_builder_bench_test.go
@@ -19,18 +19,18 @@ func BenchmarkTupleBuilding(b *testing.B) {
 	// Create a pattern with all variables
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
-			query.Variable{Name: query.Symbol("?e")},
-			query.Variable{Name: query.Symbol("?a")},
-			query.Variable{Name: query.Symbol("?v")},
-			query.Variable{Name: query.Symbol("?t")},
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Variable{Name: datalog.NewSymbol("?a")},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Variable{Name: datalog.NewSymbol("?t")},
 		},
 	}
 
 	columns := []query.Symbol{
-		query.Symbol("?e"),
-		query.Symbol("?a"),
-		query.Symbol("?v"),
-		query.Symbol("?t"),
+		datalog.NewSymbol("?e"),
+		datalog.NewSymbol("?a"),
+		datalog.NewSymbol("?v"),
+		datalog.NewSymbol("?t"),
 	}
 
 	b.Run("DatomToTuple", func(b *testing.B) {
@@ -112,46 +112,46 @@ func BenchmarkTupleBuildingScenarios(b *testing.B) {
 			name: "2_vars",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?e")},
 					query.Constant{Value: datalog.NewKeyword(":test/attr")},
-					query.Variable{Name: query.Symbol("?v")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			columns: []query.Symbol{
-				query.Symbol("?e"),
-				query.Symbol("?v"),
+				datalog.NewSymbol("?e"),
+				datalog.NewSymbol("?v"),
 			},
 		},
 		{
 			name: "3_vars",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?e")},
-					query.Variable{Name: query.Symbol("?a")},
-					query.Variable{Name: query.Symbol("?v")},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
 			columns: []query.Symbol{
-				query.Symbol("?e"),
-				query.Symbol("?a"),
-				query.Symbol("?v"),
+				datalog.NewSymbol("?e"),
+				datalog.NewSymbol("?a"),
+				datalog.NewSymbol("?v"),
 			},
 		},
 		{
 			name: "4_vars",
 			pattern: &query.DataPattern{
 				Elements: []query.PatternElement{
-					query.Variable{Name: query.Symbol("?e")},
-					query.Variable{Name: query.Symbol("?a")},
-					query.Variable{Name: query.Symbol("?v")},
-					query.Variable{Name: query.Symbol("?t")},
+					query.Variable{Name: datalog.NewSymbol("?e")},
+					query.Variable{Name: datalog.NewSymbol("?a")},
+					query.Variable{Name: datalog.NewSymbol("?v")},
+					query.Variable{Name: datalog.NewSymbol("?t")},
 				},
 			},
 			columns: []query.Symbol{
-				query.Symbol("?e"),
-				query.Symbol("?a"),
-				query.Symbol("?v"),
-				query.Symbol("?t"),
+				datalog.NewSymbol("?e"),
+				datalog.NewSymbol("?a"),
+				datalog.NewSymbol("?v"),
+				datalog.NewSymbol("?t"),
 			},
 		},
 	}

--- a/datalog/storage/types.go
+++ b/datalog/storage/types.go
@@ -238,6 +238,8 @@ func toStorageValue(v interface{}) datalog.Value {
 		return datalog.Float(val)
 	case bool:
 		return datalog.Bool(val)
+	case datalog.Symbol:
+		return datalog.SymbolValue(val)
 	default:
 		// Fall back to string representation
 		return datalog.String(fmt.Sprintf("%v", v))

--- a/datalog/symbol_test.go
+++ b/datalog/symbol_test.go
@@ -1,0 +1,213 @@
+package datalog
+
+import "testing"
+
+func TestNewSymbol_Interning(t *testing.T) {
+	// Same string must return same pointer
+	s1 := NewSymbol("?x")
+	s2 := NewSymbol("?x")
+	if s1 != s2 {
+		t.Errorf("NewSymbol(%q) returned different pointers: %p vs %p", "?x", s1, s2)
+	}
+
+	// Different strings must return different pointers
+	s3 := NewSymbol("?y")
+	if s1 == s3 {
+		t.Errorf("NewSymbol(%q) and NewSymbol(%q) returned same pointer", "?x", "?y")
+	}
+}
+
+func TestSymbol_String(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{"?x", "?x"},
+		{"?name", "?name"},
+		{"$users", "$users"},
+		{"$", "$"},
+		{"foo", "foo"},
+	}
+
+	for _, tt := range tests {
+		s := NewSymbol(tt.input)
+		if got := s.String(); got != tt.expect {
+			t.Errorf("NewSymbol(%q).String() = %q, want %q", tt.input, got, tt.expect)
+		}
+	}
+}
+
+func TestSymbol_String_Nil(t *testing.T) {
+	var s Symbol
+	if got := s.String(); got != "" {
+		t.Errorf("nil Symbol.String() = %q, want %q", got, "")
+	}
+}
+
+func TestSymbol_IsVariable(t *testing.T) {
+	tests := []struct {
+		input string
+		isVar bool
+	}{
+		{"?x", true},
+		{"?name", true},
+		{"?", true},
+		{"$users", false},
+		{"$", false},
+		{"foo", false},
+	}
+
+	for _, tt := range tests {
+		s := NewSymbol(tt.input)
+		if got := s.IsVariable(); got != tt.isVar {
+			t.Errorf("NewSymbol(%q).IsVariable() = %v, want %v", tt.input, got, tt.isVar)
+		}
+	}
+}
+
+func TestSymbol_IsVariable_Nil(t *testing.T) {
+	var s Symbol
+	if s.IsVariable() {
+		t.Error("nil Symbol.IsVariable() should be false")
+	}
+}
+
+func TestSymbol_IsSource(t *testing.T) {
+	tests := []struct {
+		input    string
+		isSource bool
+	}{
+		{"$users", true},
+		{"$perms", true},
+		{"$", true},
+		{"?x", false},
+		{"foo", false},
+	}
+
+	for _, tt := range tests {
+		s := NewSymbol(tt.input)
+		if got := s.IsSource(); got != tt.isSource {
+			t.Errorf("NewSymbol(%q).IsSource() = %v, want %v", tt.input, got, tt.isSource)
+		}
+	}
+}
+
+func TestSymbol_IsSource_Nil(t *testing.T) {
+	var s Symbol
+	if s.IsSource() {
+		t.Error("nil Symbol.IsSource() should be false")
+	}
+}
+
+func TestSymbol_Compare(t *testing.T) {
+	a := NewSymbol("?a")
+	b := NewSymbol("?b")
+	a2 := NewSymbol("?a")
+
+	// Same pointer (interned)
+	if cmp := a.Compare(a2); cmp != 0 {
+		t.Errorf("?a.Compare(?a) = %d, want 0", cmp)
+	}
+
+	// Different values
+	if cmp := a.Compare(b); cmp >= 0 {
+		t.Errorf("?a.Compare(?b) = %d, want < 0", cmp)
+	}
+	if cmp := b.Compare(a); cmp <= 0 {
+		t.Errorf("?b.Compare(?a) = %d, want > 0", cmp)
+	}
+}
+
+func TestSymbol_Compare_Nil(t *testing.T) {
+	s := NewSymbol("?x")
+	var nilSym Symbol
+
+	if cmp := nilSym.Compare(nilSym); cmp != 0 {
+		t.Errorf("nil.Compare(nil) = %d, want 0", cmp)
+	}
+	if cmp := nilSym.Compare(s); cmp >= 0 {
+		t.Errorf("nil.Compare(?x) = %d, want < 0", cmp)
+	}
+	if cmp := s.Compare(nilSym); cmp <= 0 {
+		t.Errorf("?x.Compare(nil) = %d, want > 0", cmp)
+	}
+}
+
+func TestSymbol_Equal(t *testing.T) {
+	a := NewSymbol("?a")
+	b := NewSymbol("?b")
+	a2 := NewSymbol("?a")
+
+	if !a.Equal(a2) {
+		t.Error("?a.Equal(?a) should be true (interned)")
+	}
+	if a.Equal(b) {
+		t.Error("?a.Equal(?b) should be false")
+	}
+}
+
+func TestSymbol_Equal_Nil(t *testing.T) {
+	s := NewSymbol("?x")
+	var nilSym Symbol
+
+	if !nilSym.Equal(nilSym) {
+		t.Error("nil.Equal(nil) should be true")
+	}
+	if nilSym.Equal(s) {
+		t.Error("nil.Equal(?x) should be false")
+	}
+	if s.Equal(nilSym) {
+		t.Error("?x.Equal(nil) should be false")
+	}
+}
+
+func TestSymbol_PointerEquality(t *testing.T) {
+	// Interning guarantees == works for same-string symbols
+	s1 := NewSymbol("$cache")
+	s2 := NewSymbol("$cache")
+	s3 := NewSymbol("$other")
+
+	if s1 != s2 {
+		t.Error("same-string symbols should be pointer-equal")
+	}
+	if s1 == s3 {
+		t.Error("different-string symbols should not be pointer-equal")
+	}
+}
+
+func TestSymbol_MapKey(t *testing.T) {
+	// Pointer-interned symbols work as map keys
+	m := map[Symbol]string{}
+	s1 := NewSymbol("?e")
+	s2 := NewSymbol("?e")
+
+	m[s1] = "entity"
+	if m[s2] != "entity" {
+		t.Error("interned symbol should work as map key")
+	}
+}
+
+func TestNewSymbol_EmptyStringPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("NewSymbol(\"\") should panic")
+		}
+	}()
+	NewSymbol("")
+}
+
+func TestClearInterns_Symbol(t *testing.T) {
+	s1 := NewSymbol("?cleartest")
+	ClearInterns()
+	s2 := NewSymbol("?cleartest")
+
+	// After clearing, same string gets a new pointer
+	if s1 == s2 {
+		t.Error("after ClearInterns, new symbol should be a different pointer")
+	}
+	// But values are still equal
+	if s1.String() != s2.String() {
+		t.Errorf("values should match: %q vs %q", s1.String(), s2.String())
+	}
+}

--- a/datalog/types.go
+++ b/datalog/types.go
@@ -177,6 +177,87 @@ func (k Keyword) Matches(pattern Keyword) bool {
 	return true
 }
 
+// symbol is the unexported base type for query symbols.
+// Symbols represent names that resolve to something: variables (?x),
+// data sources ($users), function references, etc.
+// Unlike keywords, symbols are not persisted to storage — they exist only
+// in query ASTs and execution contexts.
+type symbol struct {
+	value string // The symbol string (e.g., "?x", "$users")
+}
+
+// Symbol is the exported pointer type, always interned.
+type Symbol = *symbol
+
+// NewSymbol creates an interned symbol.
+// Panics on empty string — use nil for absent symbols.
+func NewSymbol(s string) Symbol {
+	if s == "" {
+		panic("NewSymbol: empty string is not a valid symbol (use nil for absent)")
+	}
+	return internSymbol(s)
+}
+
+// String returns the symbol string
+func (s *symbol) String() string {
+	if s == nil {
+		return ""
+	}
+	return s.value
+}
+
+// IsVariable returns true if this symbol represents a query variable (starts with ?)
+func (s *symbol) IsVariable() bool {
+	return s != nil && len(s.value) > 0 && s.value[0] == '?'
+}
+
+// IsSource returns true if this symbol represents a data source (starts with $)
+func (s *symbol) IsSource() bool {
+	return s != nil && len(s.value) > 0 && s.value[0] == '$'
+}
+
+// Compare compares two symbols using pointer equality first.
+// Since all Symbols are interned, pointer equality implies value equality.
+// Panics if two different pointers have the same string (indicates interning bug).
+func (s *symbol) Compare(other Symbol) int {
+	if s == nil && other == nil {
+		return 0
+	}
+	if s == nil {
+		return -1
+	}
+	if other == nil {
+		return 1
+	}
+	// Pointer equality for interned symbols
+	if s == other {
+		return 0
+	}
+	// Different pointers - compare strings for ordering
+	cmp := strings.Compare(s.value, other.value)
+	if cmp == 0 {
+		panic(fmt.Sprintf("BUG: two Symbol pointers with same value %q in Compare - interning failed", s.value))
+	}
+	return cmp
+}
+
+// Equal checks if two symbols are equal using pointer comparison.
+// Since all Symbols are interned, pointer equality implies value equality.
+// Panics if two different pointers have the same string (indicates interning bug).
+func (s *symbol) Equal(other Symbol) bool {
+	if s == other {
+		return true
+	}
+	if s == nil || other == nil {
+		return false
+	}
+	// Different pointers - if they have the same value, interning is broken
+	if s.value == other.value {
+		panic(fmt.Sprintf("BUG: two Symbol pointers with same value %q in Equal - interning failed", s.value))
+	}
+	return false
+}
+
 // String returns a string representation of the Datom
 func (d Datom) String() string {
 	return fmt.Sprintf("[%s %s %v %d]", d.E, d.A, d.V, d.Tx)

--- a/datalog/value.go
+++ b/datalog/value.go
@@ -18,6 +18,7 @@ type Value interface{}
 // - []byte
 // - Identity (for references to other entities)
 // - Keyword (when used as a value, e.g., storing :status/active)
+// - Symbol (when used as a value, e.g., storing function references or rule names)
 
 // Reference is an alias for Identity when used as a value
 // This makes it clear when we're storing an entity reference
@@ -32,3 +33,4 @@ func Time(t time.Time) Value       { return t }
 func Bytes(b []byte) Value         { return b }
 func Ref(id Identity) Value        { return Reference(id) }
 func KeywordValue(k Keyword) Value { return k }
+func SymbolValue(s Symbol) Value   { return s }

--- a/datalog/value_encoding.go
+++ b/datalog/value_encoding.go
@@ -19,6 +19,7 @@ const (
 	TypeBytes
 	TypeReference
 	TypeKeyword
+	TypeSymbol
 )
 
 // Type returns the type of a value
@@ -29,6 +30,8 @@ func Type(v Value) ValueType {
 		return TypeReference
 	case *Keyword:
 		return TypeKeyword
+	case *Symbol:
+		return TypeSymbol
 	case *uint64:
 		return TypeInt
 	case string:
@@ -47,6 +50,8 @@ func Type(v Value) ValueType {
 		return TypeReference
 	case Keyword:
 		return TypeKeyword
+	case Symbol:
+		return TypeSymbol
 	default:
 		panic(fmt.Sprintf("unknown value type: %T", val))
 	}
@@ -59,6 +64,8 @@ func ValueBytes(v Value) []byte {
 	case Identity:
 		return ptr.Bytes()
 	case Keyword:
+		return []byte(ptr.String())
+	case Symbol:
 		return []byte(ptr.String())
 	case *uint64:
 		buf := make([]byte, 8)
@@ -92,6 +99,8 @@ func ValueBytes(v Value) []byte {
 	case Identity:
 		return val.Bytes()
 	case Keyword:
+		return []byte(val.String())
+	case Symbol:
 		return []byte(val.String())
 	default:
 		panic(fmt.Sprintf("cannot encode value type: %T", v))
@@ -136,6 +145,8 @@ func ValueFromBytes(vType ValueType, data []byte) (Value, error) {
 		return NewIdentityFromHash(hash), nil
 	case TypeKeyword:
 		return NewKeyword(string(data)), nil
+	case TypeSymbol:
+		return NewSymbol(string(data)), nil
 	default:
 		return nil, fmt.Errorf("unknown value type: %v", vType)
 	}

--- a/datalog/value_encoding_test.go
+++ b/datalog/value_encoding_test.go
@@ -1,0 +1,68 @@
+package datalog
+
+import (
+	"testing"
+)
+
+func TestSymbolValueEncoding_RoundTrip(t *testing.T) {
+	tests := []string{
+		"my-function",
+		"concat",
+		"rule-name",
+		"$source",
+		"?var",
+	}
+
+	for _, name := range tests {
+		sym := NewSymbol(name)
+
+		// Check type
+		vt := Type(sym)
+		if vt != TypeSymbol {
+			t.Errorf("Type(NewSymbol(%q)) = %d, want TypeSymbol (%d)", name, vt, TypeSymbol)
+		}
+
+		// Encode
+		data := ValueBytes(sym)
+		if string(data) != name {
+			t.Errorf("ValueBytes(NewSymbol(%q)) = %q, want %q", name, string(data), name)
+		}
+
+		// Decode
+		val, err := ValueFromBytes(TypeSymbol, data)
+		if err != nil {
+			t.Fatalf("ValueFromBytes(TypeSymbol, %q): %v", name, err)
+		}
+
+		got, ok := val.(Symbol)
+		if !ok {
+			t.Fatalf("ValueFromBytes(TypeSymbol, %q) returned %T, want Symbol", name, val)
+		}
+
+		// Interning: round-tripped symbol should be pointer-equal to original
+		if got != sym {
+			t.Errorf("round-tripped symbol %q not pointer-equal to original", name)
+		}
+	}
+}
+
+func TestSymbolValueType_Distinct(t *testing.T) {
+	// Symbol, Keyword, and String should have distinct type tags
+	sym := NewSymbol("foo")
+	kw := NewKeyword(":foo")
+	str := "foo"
+
+	symType := Type(sym)
+	kwType := Type(kw)
+	strType := Type(str)
+
+	if symType == kwType {
+		t.Errorf("Symbol and Keyword have same type tag: %d", symType)
+	}
+	if symType == strType {
+		t.Errorf("Symbol and String have same type tag: %d", symType)
+	}
+	if symType != TypeSymbol {
+		t.Errorf("Symbol type = %d, want %d (TypeSymbol)", symType, TypeSymbol)
+	}
+}

--- a/tests/badger_profile_test.go
+++ b/tests/badger_profile_test.go
@@ -82,7 +82,7 @@ func TestBadgerParallelProfile(t *testing.T) {
 			}
 		}
 	}
-	inputRel := executor.NewMaterializedRelation([]query.Symbol{"?n", "?y", "?m"}, inputTuples)
+	inputRel := executor.NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y"), datalog.NewSymbol("?m")}, inputTuples)
 
 	// Profile parallel execution
 	f, err := os.Create("badger_parallel.prof")

--- a/tests/parallel_badgerdb_test.go
+++ b/tests/parallel_badgerdb_test.go
@@ -79,7 +79,7 @@ func TestParallelSubqueryWithBadgerDB(t *testing.T) {
 			}
 		}
 	}
-	inputRel := executor.NewMaterializedRelation([]query.Symbol{"?n", "?y", "?m"}, inputTuples)
+	inputRel := executor.NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y"), datalog.NewSymbol("?m")}, inputTuples)
 
 	t.Run("sequential with BadgerDB", func(t *testing.T) {
 		seqExec := executor.NewExecutor(matcher)

--- a/tests/parameterized_cartesian_product_test.go
+++ b/tests/parameterized_cartesian_product_test.go
@@ -147,7 +147,7 @@ func TestParameterizedQueryCartesianProduct(t *testing.T) {
 
 		// Create input relation for ?symbol
 		symbolInput := executor.NewMaterializedRelation(
-			[]query.Symbol{"?symbol"},
+			[]query.Symbol{datalog.NewSymbol("?symbol")},
 			[]executor.Tuple{{"AAPL"}},
 		)
 

--- a/tests/string_predicate_with_parameters_test.go
+++ b/tests/string_predicate_with_parameters_test.go
@@ -77,7 +77,7 @@ func TestStringPredicateWithParameter(t *testing.T) {
 
 		// Create input relation for ?symbol
 		symbolInput := executor.NewMaterializedRelation(
-			[]query.Symbol{"?symbol"},
+			[]query.Symbol{datalog.NewSymbol("?symbol")},
 			[]executor.Tuple{{"CRWV"}},
 		)
 
@@ -121,11 +121,11 @@ func TestStringPredicateWithParameter(t *testing.T) {
 		// Create input relations for ?symbol and ?month
 		inputs := []executor.Relation{
 			executor.NewMaterializedRelation(
-				[]query.Symbol{"?symbol"},
+				[]query.Symbol{datalog.NewSymbol("?symbol")},
 				[]executor.Tuple{{"CRWV"}},
 			),
 			executor.NewMaterializedRelation(
-				[]query.Symbol{"?month"},
+				[]query.Symbol{datalog.NewSymbol("?month")},
 				[]executor.Tuple{{"2025-11"}},
 			),
 		}
@@ -170,11 +170,11 @@ func TestStringPredicateWithParameter(t *testing.T) {
 		// Create input relations for ?symbol and ?month
 		inputs := []executor.Relation{
 			executor.NewMaterializedRelation(
-				[]query.Symbol{"?symbol"},
+				[]query.Symbol{datalog.NewSymbol("?symbol")},
 				[]executor.Tuple{{"CRWV"}},
 			),
 			executor.NewMaterializedRelation(
-				[]query.Symbol{"?month"},
+				[]query.Symbol{datalog.NewSymbol("?month")},
 				[]executor.Tuple{{"2025-12"}},
 			),
 		}


### PR DESCRIPTION
### Summary

This PR makes three related changes:
1. Converts `Symbol` from a simple string alias to an interned pointer type, matching the existing patterns for `Identity` and `Keyword`
2. Adds `Symbol` as a first-class storage value type (`TypeSymbol = 8`)
3. Fixes a latent buffer reuse bug in the BadgerDB key-only iterator

### Motivation

The query system uses `Symbol` extensively for variable bindings and pattern matching. The previous `type Symbol string` definition meant every symbol comparison required a full string comparison, and symbols couldn't participate in the same fast pointer-equality patterns used by `Identity` and `Keyword`.

Adding `Symbol` as a storage value type enables storing symbolic constants directly in the database, which is useful for enum-like attributes and categorical data.

### Changes

#### Phase 1: Interned Symbol Type

Changed `Symbol` from `type Symbol string` to an interned pointer type (`Symbol = *symbol`), matching the `Identity` and `Keyword` patterns. This includes:

- Global interning cache with `NewSymbol()` constructor ensuring pointer equality for identical symbols
- `Compare()`, `Equal()`, `String()`, and `Bytes()` methods
- Updates across 149 files to use the new type consistently
- String comparisons replaced with pointer equality where applicable

#### Phase 2: Symbol as Storage Value Type

Extended the value encoding system to support `Symbol` as a persistable type:

- Added `TypeSymbol` (8) to the `ValueType` enum in `value_encoding.go`
- Threaded `Symbol` through `Type()`, `ValueBytes()`, and `ValueFromBytes()`
- Added double-pointer case (`*Symbol`) matching the `Identity`/`Keyword` pattern for constraint binding
- Extended `compare.go` with `Symbol` comparison and equality operations
- Added fast-paths in the executor for `Symbol` constraint evaluation
- Added `Symbol` pass-through in storage type normalization
- Query parser now recognizes bare symbols in value positions as `Symbol` constants

New tests cover round-trip encoding, cross-type comparison semantics, and parser integration.

#### Phase 3: BadgerDB Key-Only Iterator Fix

Fixed a buffer reuse bug in `KeyOnlyIterator.Next()` and `HistoryKeyOnlyIterator.Next()`:

```go
// Before (incorrect)
key := item.Key()

// After (correct)
key := item.KeyCopy(nil)
```

**Root cause:** BadgerDB reuses the underlying key buffer across iterator advances. Most value types copy data during deserialization, but `TypeBytes` returns the slice directly without copying. When iterating, subsequent advances would overwrite the buffer, corrupting previously-returned keys.

This bug was latent in the codebase but became observable when the 9th test datom was added, which happened to trigger the buffer reuse in a detectable way.

### Testing

- Existing test suite passes
- Added round-trip encoding tests for `Symbol` values
- Added comparison tests covering `Symbol` ordering and cross-type behavior
- Added parser tests for bare symbol recognition in value positions
- Iterator fix validated by the test that originally exposed it