### PR TITLE
Add database export/import to EDN format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,11 @@ Before making ANY of these decisions, ASK:
 - "It's simpler/easier this way" (when deviating from a plan or established pattern)
 - Making a choice between multiple valid approaches without consulting
 
+**Bugs do not authorize design changes:**
+- Discovering a bug does not authorize you to change the agreed design. Report it and ask.
+- If something we agreed on doesn't work, STOP and ask. Do not substitute alternatives.
+- If you're about to do something different from what was discussed/agreed, ASK FIRST. No exceptions.
+
 **The user's job**: Set direction, make architectural choices, review designs
 **Your job**: Implement, follow patterns, propose options (not make choices)
 
@@ -294,6 +299,7 @@ The storage layer connects the query engine to BadgerDB:
 25. **NOT/OR clauses** - Full support for `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with Datomic-compatible semantics; OR supports fallback expressions for default values
 26. **QueryInto API** - Typed query results via `QueryInto()` and `QueryOneInto()` with struct tag mapping for variables and aggregates
 27. **Multi-source queries** - Named sources (`$name`), `SourceRouter`, cross-source joins, `MemoryPatternMatcher`, `SliceSource[T]`, query builder `Source()`/`PatFrom()`
+28. **Database export/import** - EDN format export/import for backup and migration; CLI flags `-export` and `-import`; preserves all value types and transaction IDs
 
 ### 📋 TODO (Priority Order)
 

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -24,6 +24,7 @@ Janus-datalog implements a substantial subset of Datomic's Datalog query languag
 
 **Storage:**
 - ✅ BadgerDB persistent storage with EAVT model and 5 indices
+- ✅ Export/Import to EDN format for backup and migration
 
 **Not Implemented:**
 - ❌ Rules (recursive queries)
@@ -276,6 +277,7 @@ Every datom includes a transaction ID for temporal queries.
 - **Multiple indices**: EAVT, AEVT, AVET, VAET, TAEV
 - **BadgerDB backend** for persistence
 - **L85 encoding** for sortable, efficient keys
+- **Export/Import** to EDN format for backup and migration (see [docs/reference/EXPORT_IMPORT.md](docs/reference/EXPORT_IMPORT.md))
 
 ### 11. Type System
 

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -20,6 +20,7 @@
 Configuration and optimization guides in `docs/reference/`:
 - **[SCHEMA.md](docs/reference/SCHEMA.md)** - Schema support: types, cardinality, uniqueness, Pull API integration
 - **[PLANNER_OPTIONS.md](docs/reference/PLANNER_OPTIONS.md)** - Complete planner options reference with performance guidance
+- **[EXPORT_IMPORT.md](docs/reference/EXPORT_IMPORT.md)** - Database export/import to EDN format for backup and migration
 
 ## Current Work in Progress
 

--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -23,6 +23,8 @@ func main() {
 	var verbose bool
 	var queryStr string
 	var enableDecorrelation bool
+	var exportPath string
+	var importPath string
 
 	flag.StringVar(&dbPath, "db", "", "database path")
 	flag.BoolVar(&interactive, "i", false, "interactive mode")
@@ -30,6 +32,8 @@ func main() {
 	flag.BoolVar(&verbose, "verbose", false, "verbose mode (show query annotations)")
 	flag.StringVar(&queryStr, "query", "", "run a single query and exit")
 	flag.BoolVar(&enableDecorrelation, "decorrelate", true, "enable subquery decorrelation optimization (default: true)")
+	flag.StringVar(&exportPath, "export", "", "export database to EDN file")
+	flag.StringVar(&importPath, "import", "", "import database from EDN file")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options] [database_path]\n\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "A Datalog query engine with persistent storage.\n\n")
@@ -44,6 +48,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  %s -verbose           # Verbose mode with query annotations\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -verbose -i        # Interactive mode with annotations\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -query '[:find ?x :where [?x :person/name _]]'  # Run single query\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -db mydata.db -export data.edn  # Export database to EDN file\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -db newdata.db -import data.edn # Import EDN file into database\n", os.Args[0])
 	}
 	flag.Parse()
 
@@ -57,9 +63,26 @@ func main() {
 		dbPath = flag.Arg(0)
 	}
 
+	// Check for conflicting flags
+	if exportPath != "" && importPath != "" {
+		log.Fatalf("Cannot specify both -export and -import")
+	}
+
 	// Default to datalog.db if no path specified
 	if dbPath == "" {
 		dbPath = "datalog.db"
+	}
+
+	// Handle export mode
+	if exportPath != "" {
+		runExport(dbPath, exportPath)
+		return
+	}
+
+	// Handle import mode
+	if importPath != "" {
+		runImport(dbPath, importPath)
+		return
 	}
 
 	// Check if database exists
@@ -365,6 +388,64 @@ func isDatabaseEmpty(db *storage.Database) bool {
 	}
 
 	return result.Size() == 0
+}
+
+// runExport exports the database to an EDN file
+func runExport(dbPath, exportPath string) {
+	// Check if database exists
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		log.Fatalf("Database does not exist: %s", dbPath)
+	}
+
+	// Open database
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		log.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create export file
+	f, err := os.Create(exportPath)
+	if err != nil {
+		log.Fatalf("Failed to create export file: %v", err)
+	}
+	defer f.Close()
+
+	// Export database
+	if err := db.Export(f); err != nil {
+		log.Fatalf("Failed to export database: %v", err)
+	}
+
+	fmt.Printf("Exported database to %s\n", exportPath)
+}
+
+// runImport imports an EDN file into the database
+func runImport(dbPath, importPath string) {
+	// Check if import file exists
+	if _, err := os.Stat(importPath); os.IsNotExist(err) {
+		log.Fatalf("Import file does not exist: %s", importPath)
+	}
+
+	// Open/create database
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		log.Fatalf("Failed to open/create database: %v", err)
+	}
+	defer db.Close()
+
+	// Open import file
+	f, err := os.Open(importPath)
+	if err != nil {
+		log.Fatalf("Failed to open import file: %v", err)
+	}
+	defer f.Close()
+
+	// Import into database
+	if err := db.Import(f); err != nil {
+		log.Fatalf("Failed to import: %v", err)
+	}
+
+	fmt.Printf("Imported %s into database %s\n", importPath, dbPath)
 }
 
 // runSingleQuery executes a single query and exits

--- a/cmd/datalog/main_test.go
+++ b/cmd/datalog/main_test.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// Note: We use db.ExecuteQuery() directly instead of NewExecutor() + Execute()
+// because Database provides a simpler API that handles parsing internally.
+
+// buildCLI builds the CLI binary for testing
+func buildCLI(t *testing.T) string {
+	t.Helper()
+	binPath := filepath.Join(t.TempDir(), "datalog-test")
+	cmd := exec.Command("go", "build", "-o", binPath, ".")
+	cmd.Dir = filepath.Dir(os.Args[0])
+	// Get the actual source directory
+	if wd, err := os.Getwd(); err == nil {
+		cmd.Dir = wd
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to build CLI: %v\n%s", err, out)
+	}
+	return binPath
+}
+
+// createTestDatabase creates a database with test data
+func createTestDatabase(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+
+	tx := db.NewTransaction()
+	alice := datalog.NewIdentity("alice")
+	tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":person/age"), int64(30))
+
+	bob := datalog.NewIdentity("bob")
+	tx.Add(bob, datalog.NewKeyword(":person/name"), "Bob")
+	tx.Add(bob, datalog.NewKeyword(":person/age"), int64(25))
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	db.Close()
+
+	return dbPath
+}
+
+func TestCLI_ExportFlag(t *testing.T) {
+	binPath := buildCLI(t)
+	dbPath := createTestDatabase(t)
+	exportPath := filepath.Join(t.TempDir(), "export.edn")
+
+	cmd := exec.Command(binPath, "-db", dbPath, "-export", exportPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Export failed: %v\n%s", err, out)
+	}
+
+	// Verify output message
+	if !strings.Contains(string(out), "Exported database to") {
+		t.Errorf("Expected export success message, got: %s", out)
+	}
+
+	// Verify file exists and has content
+	content, err := os.ReadFile(exportPath)
+	if err != nil {
+		t.Fatalf("Failed to read export file: %v", err)
+	}
+
+	if len(content) == 0 {
+		t.Error("Export file is empty")
+	}
+
+	// Verify it contains valid EDN vectors
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "[#identity") {
+			t.Errorf("Line %d doesn't start with [#identity: %s", i+1, line)
+		}
+		if !strings.HasSuffix(line, "]") {
+			t.Errorf("Line %d doesn't end with ]: %s", i+1, line)
+		}
+	}
+}
+
+func TestCLI_ImportFlag(t *testing.T) {
+	binPath := buildCLI(t)
+
+	// Create a source database with test data
+	sourceDir := t.TempDir()
+	sourceDBPath := filepath.Join(sourceDir, "source.db")
+	sourceDB, err := storage.NewDatabase(sourceDBPath)
+	if err != nil {
+		t.Fatalf("Failed to create source database: %v", err)
+	}
+
+	tx := sourceDB.NewTransaction()
+	entity := datalog.NewIdentity("test-entity")
+	tx.Add(entity, datalog.NewKeyword(":test/value"), "hello")
+	tx.Add(entity, datalog.NewKeyword(":test/count"), int64(42))
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Export the source database to EDN
+	ednPath := filepath.Join(t.TempDir(), "import.edn")
+	ednFile, err := os.Create(ednPath)
+	if err != nil {
+		t.Fatalf("Failed to create EDN file: %v", err)
+	}
+	if err := sourceDB.Export(ednFile); err != nil {
+		t.Fatalf("Failed to export source database: %v", err)
+	}
+	ednFile.Close()
+	sourceDB.Close()
+
+	// Import into new database using CLI
+	dbPath := filepath.Join(t.TempDir(), "imported.db")
+	cmd := exec.Command(binPath, "-db", dbPath, "-import", ednPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Import failed: %v\n%s", err, out)
+	}
+
+	// Verify output message
+	if !strings.Contains(string(out), "Imported") {
+		t.Errorf("Expected import success message, got: %s", out)
+	}
+
+	// Verify database was created and has data
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		t.Error("Database was not created")
+	}
+
+	// Open and verify data
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open imported database: %v", err)
+	}
+	defer db.Close()
+
+	// Query to verify data exists
+	result, err := db.ExecuteQuery(`[:find ?v :where [_ :test/value ?v]]`)
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(result))
+	}
+}
+
+func TestCLI_ExportImportRoundTrip(t *testing.T) {
+	binPath := buildCLI(t)
+	db1Path := createTestDatabase(t)
+	exportPath := filepath.Join(t.TempDir(), "roundtrip.edn")
+	db2Path := filepath.Join(t.TempDir(), "roundtrip.db")
+
+	// Export db1
+	cmd := exec.Command(binPath, "-db", db1Path, "-export", exportPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Export failed: %v\n%s", err, out)
+	}
+
+	// Import to db2
+	cmd = exec.Command(binPath, "-db", db2Path, "-import", exportPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Import failed: %v\n%s", err, out)
+	}
+
+	// Query both databases and compare
+	db1, err := storage.NewDatabase(db1Path)
+	if err != nil {
+		t.Fatalf("Failed to open db1: %v", err)
+	}
+	defer db1.Close()
+
+	db2, err := storage.NewDatabase(db2Path)
+	if err != nil {
+		t.Fatalf("Failed to open db2: %v", err)
+	}
+	defer db2.Close()
+
+	// Query names from both
+	result1, err := db1.ExecuteQuery(`[:find ?name :where [_ :person/name ?name]]`)
+	if err != nil {
+		t.Fatalf("Query db1 failed: %v", err)
+	}
+
+	result2, err := db2.ExecuteQuery(`[:find ?name :where [_ :person/name ?name]]`)
+	if err != nil {
+		t.Fatalf("Query db2 failed: %v", err)
+	}
+
+	if len(result1) != len(result2) {
+		t.Errorf("Result sizes differ: db1=%d, db2=%d", len(result1), len(result2))
+	}
+}
+
+func TestCLI_ExportNonexistentDB(t *testing.T) {
+	binPath := buildCLI(t)
+	exportPath := filepath.Join(t.TempDir(), "export.edn")
+
+	cmd := exec.Command(binPath, "-db", "/nonexistent/path/db", "-export", exportPath)
+	out, err := cmd.CombinedOutput()
+
+	// Should fail
+	if err == nil {
+		t.Error("Expected error for nonexistent database")
+	}
+
+	// Should mention database doesn't exist
+	if !strings.Contains(string(out), "does not exist") {
+		t.Errorf("Expected 'does not exist' error, got: %s", out)
+	}
+}
+
+func TestCLI_ImportMalformedFile(t *testing.T) {
+	binPath := buildCLI(t)
+
+	// Create a valid database and export one line
+	sourceDir := t.TempDir()
+	sourceDBPath := filepath.Join(sourceDir, "source.db")
+	sourceDB, err := storage.NewDatabase(sourceDBPath)
+	if err != nil {
+		t.Fatalf("Failed to create source database: %v", err)
+	}
+
+	tx := sourceDB.NewTransaction()
+	entity := datalog.NewIdentity("test-entity")
+	tx.Add(entity, datalog.NewKeyword(":test/ok"), int64(1))
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Export to get valid EDN line
+	var validEDN strings.Builder
+	if err := sourceDB.Export(&validEDN); err != nil {
+		t.Fatalf("Failed to export: %v", err)
+	}
+	sourceDB.Close()
+
+	// Get just the first non-txInstant line (our actual data)
+	lines := strings.Split(strings.TrimSpace(validEDN.String()), "\n")
+	var validLine string
+	for _, line := range lines {
+		if strings.Contains(line, ":test/ok") {
+			validLine = line
+			break
+		}
+	}
+	if validLine == "" {
+		t.Fatal("Could not find valid test line in export")
+	}
+
+	// Create malformed EDN file with valid line, then garbage, then valid line
+	ednPath := filepath.Join(t.TempDir(), "malformed.edn")
+	ednContent := validLine + "\nnot valid edn at all\n" + validLine + "\n"
+	if err := os.WriteFile(ednPath, []byte(ednContent), 0644); err != nil {
+		t.Fatalf("Failed to write EDN file: %v", err)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "malformed.db")
+	cmd := exec.Command(binPath, "-db", dbPath, "-import", ednPath)
+	out, err := cmd.CombinedOutput()
+
+	// Should fail
+	if err == nil {
+		t.Error("Expected error for malformed file")
+	}
+
+	// Should mention line number
+	if !strings.Contains(string(out), "line 2") {
+		t.Errorf("Expected error to mention line 2, got: %s", out)
+	}
+}
+
+func TestCLI_BothFlagsError(t *testing.T) {
+	binPath := buildCLI(t)
+
+	cmd := exec.Command(binPath, "-db", "test.db", "-export", "out.edn", "-import", "in.edn")
+	out, err := cmd.CombinedOutput()
+
+	// Should fail
+	if err == nil {
+		t.Error("Expected error when both flags specified")
+	}
+
+	// Should mention cannot use both
+	if !strings.Contains(string(out), "Cannot specify both") {
+		t.Errorf("Expected 'Cannot specify both' error, got: %s", out)
+	}
+}
+
+func TestCLI_ImportNonexistentFile(t *testing.T) {
+	binPath := buildCLI(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	cmd := exec.Command(binPath, "-db", dbPath, "-import", "/nonexistent/file.edn")
+	out, err := cmd.CombinedOutput()
+
+	// Should fail
+	if err == nil {
+		t.Error("Expected error for nonexistent import file")
+	}
+
+	// Should mention file doesn't exist
+	if !strings.Contains(string(out), "does not exist") {
+		t.Errorf("Expected 'does not exist' error, got: %s", out)
+	}
+}

--- a/datalog/codec/l85.go
+++ b/datalog/codec/l85.go
@@ -59,22 +59,30 @@ func EncodeL85(src []byte) string {
 	// Handle remainder bytes
 	remainder := len(src) % 4
 	if remainder > 0 {
-		// Pad with zeros
-		padded := [4]byte{}
-		copy(padded[:], src[len(src)-remainder:])
-
-		v := uint32(padded[0])<<24 | uint32(padded[1])<<16 |
-			uint32(padded[2])<<8 | uint32(padded[3])
-
-		// Convert to base85
-		chars := [5]byte{}
-		for j := 4; j >= 0; j-- {
-			chars[j] = L85Alphabet[v%85]
-			v /= 85
+		// Treat remainder bytes as a small integer (big-endian)
+		// 1 byte  -> value 0-255      -> 2 chars (85^2 = 7225 > 256)
+		// 2 bytes -> value 0-65535    -> 3 chars (85^3 = 614125 > 65536)
+		// 3 bytes -> value 0-16777215 -> 4 chars (85^4 = 52200625 > 16777216)
+		offset := len(src) - remainder
+		var v uint32
+		switch remainder {
+		case 1:
+			v = uint32(src[offset])
+		case 2:
+			v = uint32(src[offset])<<8 | uint32(src[offset+1])
+		case 3:
+			v = uint32(src[offset])<<16 | uint32(src[offset+1])<<8 | uint32(src[offset+2])
 		}
 
-		// Append only remainder+1 characters (matching C implementation)
-		result = append(result, chars[:remainder+1]...)
+		// Convert to base85 (remainder+1 chars needed)
+		switch remainder {
+		case 1:
+			result = append(result, L85Alphabet[v/85], L85Alphabet[v%85])
+		case 2:
+			result = append(result, L85Alphabet[v/7225], L85Alphabet[(v/85)%85], L85Alphabet[v%85])
+		case 3:
+			result = append(result, L85Alphabet[v/614125], L85Alphabet[(v/7225)%85], L85Alphabet[(v/85)%85], L85Alphabet[v%85])
+		}
 	}
 
 	return string(result)
@@ -119,31 +127,24 @@ func DecodeL85(src string) ([]byte, error) {
 	if remainder > 0 {
 		// The number of bytes encoded is remainder-1
 		// (2 chars = 1 byte, 3 chars = 2 bytes, 4 chars = 3 bytes)
-		numBytes := remainder - 1
-		if numBytes <= 0 {
+		if remainder == 1 {
 			return nil, errors.New("invalid L85 encoding: incomplete group")
 		}
 
-		// Pad to 5 chars with first alphabet char
-		padded := src[len(src)-remainder:]
-		for len(padded) < 5 {
-			padded += string(L85Alphabet[0])
+		// Convert remainder chars directly to integer (no padding)
+		offset := len(src) - remainder
+		var v uint32
+		switch remainder {
+		case 2:
+			v = uint32(l85Decode[src[offset]]-1)*85 + uint32(l85Decode[src[offset+1]]-1)
+			result = append(result, byte(v))
+		case 3:
+			v = uint32(l85Decode[src[offset]]-1)*7225 + uint32(l85Decode[src[offset+1]]-1)*85 + uint32(l85Decode[src[offset+2]]-1)
+			result = append(result, byte(v>>8), byte(v))
+		case 4:
+			v = uint32(l85Decode[src[offset]]-1)*614125 + uint32(l85Decode[src[offset+1]]-1)*7225 + uint32(l85Decode[src[offset+2]]-1)*85 + uint32(l85Decode[src[offset+3]]-1)
+			result = append(result, byte(v>>16), byte(v>>8), byte(v))
 		}
-
-		// Convert to uint32
-		v := uint32(0)
-		for j := 0; j < 5; j++ {
-			v = v*85 + uint32(l85Decode[padded[j]]-1)
-		}
-
-		// Extract only the needed bytes
-		bytes := [4]byte{
-			byte(v >> 24),
-			byte(v >> 16),
-			byte(v >> 8),
-			byte(v),
-		}
-		result = append(result, bytes[:numBytes]...)
 	}
 
 	return result, nil

--- a/datalog/codec/l85_verify_test.go
+++ b/datalog/codec/l85_verify_test.go
@@ -127,6 +127,42 @@ func TestL85VerifyAlphabet(t *testing.T) {
 	}
 }
 
+// TestL85NonAlignedLengths tests encoding/decoding of byte slices that are
+// not multiples of 4 bytes. This is a regression test for a bug where
+// non-aligned lengths would corrupt the last byte during round-trip.
+//
+// Bug example: [1,2,3,4,5] encodes to "!ASD/$Y" but decodes to [1,2,3,4,4]
+func TestL85NonAlignedLengths(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{"1 byte", []byte{0x05}},
+		{"2 bytes", []byte{0x01, 0x02}},
+		{"3 bytes", []byte{0x01, 0x02, 0x03}},
+		{"5 bytes", []byte{0x01, 0x02, 0x03, 0x04, 0x05}},
+		{"6 bytes", []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}},
+		{"7 bytes", []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}},
+		{"9 bytes", []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := EncodeL85(tt.input)
+			decoded, err := DecodeL85(encoded)
+			if err != nil {
+				t.Fatalf("Decode error: %v", err)
+			}
+			if !bytes.Equal(decoded, tt.input) {
+				t.Errorf("Round trip failed for %d bytes", len(tt.input))
+				t.Logf("Input:   %v", tt.input)
+				t.Logf("Encoded: %s (len=%d)", encoded, len(encoded))
+				t.Logf("Decoded: %v", decoded)
+			}
+		})
+	}
+}
+
 func TestL85VerifySpecificBytes(t *testing.T) {
 	// Test specific byte patterns
 	tests := []struct {

--- a/datalog/storage/export.go
+++ b/datalog/storage/export.go
@@ -1,0 +1,446 @@
+package storage
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/codec"
+	"github.com/wbrown/janus-datalog/datalog/edn"
+)
+
+// Export writes all datoms in the database to EDN format.
+// Each line contains a single EDN vector: [#identity "L85" :attribute value tx-id]
+//
+// The format preserves all type information for round-trip fidelity:
+//   - Entities: #identity "L85hash" (always L85 encoded, 25 chars)
+//   - Attributes: keyword (e.g., :person/name)
+//   - Values: EDN representation with type tags where needed
+//   - Transaction IDs: integers
+//
+// Example output:
+//
+//	[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/name "Alice" 1]
+//	[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/age 30 1]
+//	[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/created #inst "2025-01-15T10:30:00Z" 1]
+//
+// The output is suitable for Import() to restore the database.
+func (d *Database) Export(w io.Writer) error {
+	// Scan all datoms from EAVT index only
+	// Keys are prefixed with index type byte, so we scan from EAVT prefix to AEVT prefix
+	start := []byte{byte(EAVT)}
+	end := []byte{byte(AEVT)} // AEVT is the next index after EAVT
+	iter, err := d.store.Scan(EAVT, start, end)
+	if err != nil {
+		return fmt.Errorf("failed to scan database: %w", err)
+	}
+	defer iter.Close()
+
+	bw := bufio.NewWriter(w)
+
+	for iter.Next() {
+		datom, err := iter.Datom()
+		if err != nil {
+			return fmt.Errorf("failed to read datom: %w", err)
+		}
+
+		// Format as EDN vector
+		line := FormatDatomEDN(datom)
+		if _, err := bw.WriteString(line); err != nil {
+			return fmt.Errorf("failed to write datom: %w", err)
+		}
+		if _, err := bw.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write newline: %w", err)
+		}
+	}
+
+	if err := bw.Flush(); err != nil {
+		return fmt.Errorf("failed to flush writer: %w", err)
+	}
+
+	return nil
+}
+
+// Import reads datoms from EDN format and loads them into the database.
+// Each line should contain a single EDN vector: [#identity "L85" :attribute value tx-id]
+//
+// The transaction IDs from the file are preserved, allowing exact restoration
+// of the database state. Empty lines and lines starting with ; are ignored.
+//
+// Import uses batched transactions for efficiency (5000 datoms per batch).
+func (d *Database) Import(r io.Reader) error {
+	scanner := bufio.NewScanner(r)
+	// Increase buffer size for long lines
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	const batchSize = 5000
+	datoms := make([]datalog.Datom, 0, batchSize)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, ";") {
+			continue
+		}
+
+		datom, err := ParseDatomEDN(line)
+		if err != nil {
+			return fmt.Errorf("line %d: %w", lineNum, err)
+		}
+
+		datoms = append(datoms, *datom)
+
+		// Batch commit
+		if len(datoms) >= batchSize {
+			if err := d.store.Assert(datoms); err != nil {
+				return fmt.Errorf("failed to assert batch at line %d: %w", lineNum, err)
+			}
+			datoms = datoms[:0]
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	// Commit remaining datoms
+	if len(datoms) > 0 {
+		if err := d.store.Assert(datoms); err != nil {
+			return fmt.Errorf("failed to assert final batch: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// FormatDatomEDN formats a single datom as an EDN vector string.
+// The format is: [#identity "L85" :attribute value tx-id]
+func FormatDatomEDN(d *datalog.Datom) string {
+	var sb strings.Builder
+	sb.WriteString("[")
+	sb.WriteString(FormatIdentityEDN(d.E))
+	sb.WriteString(" ")
+	sb.WriteString(d.A.String())
+	sb.WriteString(" ")
+	sb.WriteString(FormatValueEDN(d.V))
+	sb.WriteString(" ")
+	sb.WriteString(strconv.FormatUint(d.Tx, 10))
+	sb.WriteString("]")
+	return sb.String()
+}
+
+// FormatIdentityEDN formats an entity Identity as EDN.
+// Always uses L85 encoding for consistency.
+func FormatIdentityEDN(id datalog.Identity) string {
+	if id == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("#identity %s", formatStringEDN(id.L85()))
+}
+
+// FormatValueEDN formats a value as EDN with proper type representation.
+func FormatValueEDN(v interface{}) string {
+	if v == nil {
+		return "nil"
+	}
+
+	switch val := v.(type) {
+	case string:
+		return formatStringEDN(val)
+
+	case int64:
+		return strconv.FormatInt(val, 10)
+
+	case int:
+		return strconv.Itoa(val)
+
+	case float64:
+		// Use %g for compact representation, but ensure it has a decimal point
+		s := strconv.FormatFloat(val, 'g', -1, 64)
+		if !strings.Contains(s, ".") && !strings.Contains(s, "e") && !strings.Contains(s, "E") {
+			s += ".0"
+		}
+		return s
+
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+
+	case time.Time:
+		// EDN instant format - always UTC
+		return fmt.Sprintf("#inst %s", formatStringEDN(val.UTC().Format(time.RFC3339Nano)))
+
+	case []byte:
+		// L85 encoded bytes
+		if len(val) == 0 {
+			return `#bytes ""`
+		}
+		return fmt.Sprintf("#bytes %s", formatStringEDN(codec.EncodeL85(val)))
+
+	case datalog.Identity:
+		// Entity reference - use #identity tag
+		return FormatIdentityEDN(val)
+
+	case datalog.Keyword:
+		return val.String()
+
+	case datalog.Symbol:
+		return val.String()
+
+	default:
+		// Fallback to string representation
+		return formatStringEDN(fmt.Sprintf("%v", val))
+	}
+}
+
+// formatStringEDN formats a string with proper EDN escaping.
+func formatStringEDN(s string) string {
+	var sb strings.Builder
+	sb.WriteString("\"")
+	for _, r := range s {
+		switch r {
+		case '"':
+			sb.WriteString("\\\"")
+		case '\\':
+			sb.WriteString("\\\\")
+		case '\n':
+			sb.WriteString("\\n")
+		case '\r':
+			sb.WriteString("\\r")
+		case '\t':
+			sb.WriteString("\\t")
+		default:
+			sb.WriteRune(r)
+		}
+	}
+	sb.WriteString("\"")
+	return sb.String()
+}
+
+// ParseDatomEDN parses a single EDN vector into a Datom.
+// Expected format: [#identity "L85" :attribute value tx-id]
+func ParseDatomEDN(s string) (*datalog.Datom, error) {
+	// Parse as EDN
+	node, err := edn.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid EDN: %w", err)
+	}
+
+	if node.Type != edn.NodeVector {
+		return nil, fmt.Errorf("expected vector, got %s", nodeTypeName(node.Type))
+	}
+
+	if len(node.Nodes) != 4 {
+		return nil, fmt.Errorf("expected 4 elements [e a v tx], got %d", len(node.Nodes))
+	}
+
+	// Parse entity
+	entity, err := ParseIdentityNode(&node.Nodes[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid entity: %w", err)
+	}
+
+	// Parse attribute
+	attr, err := parseKeywordNode(&node.Nodes[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid attribute: %w", err)
+	}
+
+	// Parse value
+	value, err := ParseValueNode(&node.Nodes[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid value: %w", err)
+	}
+
+	// Parse transaction ID
+	txID, err := parseIntNode(&node.Nodes[3])
+	if err != nil {
+		return nil, fmt.Errorf("invalid tx: %w", err)
+	}
+
+	return &datalog.Datom{
+		E:  entity,
+		A:  attr,
+		V:  value,
+		Tx: uint64(txID),
+	}, nil
+}
+
+// ParseIdentityNode parses an identity from an EDN node.
+// Expects #identity "L85string" format.
+func ParseIdentityNode(node *edn.Node) (datalog.Identity, error) {
+	switch node.Type {
+	case edn.NodeTagged:
+		if node.Tag != "identity" {
+			return nil, fmt.Errorf("expected #identity tag, got #%s", node.Tag)
+		}
+		if node.Tagged == nil || node.Tagged.Type != edn.NodeString {
+			return nil, fmt.Errorf("#identity requires string value")
+		}
+		// Decode L85 to get the hash
+		l85Str := node.Tagged.Value
+		hash, err := codec.DecodeFixed20(l85Str)
+		if err != nil {
+			return nil, fmt.Errorf("invalid L85 in #identity: %w", err)
+		}
+		return datalog.NewIdentityFromHash(hash), nil
+
+	case edn.NodeSymbol:
+		if node.Value == "nil" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("expected #identity tag, got symbol %s", node.Value)
+
+	default:
+		return nil, fmt.Errorf("expected #identity tag, got %s", nodeTypeName(node.Type))
+	}
+}
+
+// ParseValueNode parses a value from an EDN node.
+func ParseValueNode(node *edn.Node) (interface{}, error) {
+	switch node.Type {
+	case edn.NodeString:
+		return node.Value, nil
+
+	case edn.NodeInt:
+		return strconv.ParseInt(node.Value, 10, 64)
+
+	case edn.NodeFloat:
+		return strconv.ParseFloat(node.Value, 64)
+
+	case edn.NodeBool:
+		return node.Value == "true", nil
+
+	case edn.NodeNil:
+		return nil, nil
+
+	case edn.NodeKeyword:
+		return datalog.NewKeyword(node.Value), nil
+
+	case edn.NodeSymbol:
+		if node.Value == "nil" {
+			return nil, nil
+		}
+		return datalog.NewSymbol(node.Value), nil
+
+	case edn.NodeTagged:
+		return parseTaggedValue(node)
+
+	default:
+		return nil, fmt.Errorf("unsupported value type: %s", nodeTypeName(node.Type))
+	}
+}
+
+// parseTaggedValue parses a tagged literal value.
+func parseTaggedValue(node *edn.Node) (interface{}, error) {
+	if node.Tagged == nil {
+		return nil, fmt.Errorf("tagged literal missing value")
+	}
+
+	tag := node.Tag
+	valueNode := node.Tagged
+
+	switch tag {
+	case "inst":
+		// Parse instant
+		if valueNode.Type != edn.NodeString {
+			return nil, fmt.Errorf("#inst requires string value")
+		}
+		t, err := time.Parse(time.RFC3339Nano, valueNode.Value)
+		if err != nil {
+			// Try without nanoseconds
+			t, err = time.Parse(time.RFC3339, valueNode.Value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid instant: %w", err)
+			}
+		}
+		return t.UTC(), nil
+
+	case "bytes":
+		// Parse L85 encoded bytes
+		if valueNode.Type != edn.NodeString {
+			return nil, fmt.Errorf("#bytes requires string value")
+		}
+		if valueNode.Value == "" {
+			return []byte{}, nil
+		}
+		decoded, err := codec.DecodeL85(valueNode.Value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid L85 in #bytes: %w", err)
+		}
+		return decoded, nil
+
+	case "identity":
+		// Parse entity reference
+		if valueNode.Type != edn.NodeString {
+			return nil, fmt.Errorf("#identity requires string value")
+		}
+		hash, err := codec.DecodeFixed20(valueNode.Value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid L85 in #identity: %w", err)
+		}
+		return datalog.NewIdentityFromHash(hash), nil
+
+	default:
+		return nil, fmt.Errorf("unknown tag: #%s", tag)
+	}
+}
+
+// parseKeywordNode parses a keyword from an EDN node.
+func parseKeywordNode(node *edn.Node) (datalog.Keyword, error) {
+	if node.Type != edn.NodeKeyword {
+		return nil, fmt.Errorf("expected keyword, got %s", nodeTypeName(node.Type))
+	}
+	return datalog.NewKeyword(node.Value), nil
+}
+
+// parseIntNode parses an integer from an EDN node.
+func parseIntNode(node *edn.Node) (int64, error) {
+	if node.Type != edn.NodeInt {
+		return 0, fmt.Errorf("expected int, got %s", nodeTypeName(node.Type))
+	}
+	return strconv.ParseInt(node.Value, 10, 64)
+}
+
+// nodeTypeName returns a human-readable name for an EDN node type.
+func nodeTypeName(t edn.NodeType) string {
+	switch t {
+	case edn.NodeNil:
+		return "nil"
+	case edn.NodeBool:
+		return "bool"
+	case edn.NodeInt:
+		return "int"
+	case edn.NodeFloat:
+		return "float"
+	case edn.NodeString:
+		return "string"
+	case edn.NodeChar:
+		return "char"
+	case edn.NodeSymbol:
+		return "symbol"
+	case edn.NodeKeyword:
+		return "keyword"
+	case edn.NodeList:
+		return "list"
+	case edn.NodeVector:
+		return "vector"
+	case edn.NodeMap:
+		return "map"
+	case edn.NodeSet:
+		return "set"
+	case edn.NodeTagged:
+		return "tagged"
+	default:
+		return fmt.Sprintf("unknown(%d)", t)
+	}
+}

--- a/datalog/storage/export_test.go
+++ b/datalog/storage/export_test.go
@@ -1,0 +1,808 @@
+package storage
+
+import (
+	"bytes"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/codec"
+	"github.com/wbrown/janus-datalog/datalog/edn"
+)
+
+// Helper to create a temp BadgerDB database
+func createTempDatabase(t *testing.T) *Database {
+	dir := t.TempDir()
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// Helper to create keywords
+func kw(s string) datalog.Keyword {
+	return datalog.NewKeyword(s)
+}
+
+// =============================================================================
+// Unit Tests: Value EDN Formatting
+// =============================================================================
+
+func TestFormatValueEDN_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"simple", "hello", `"hello"`},
+		{"empty", "", `""`},
+		{"with quotes", `say "hello"`, `"say \"hello\""`},
+		{"with newline", "line1\nline2", `"line1\nline2"`},
+		{"with tab", "col1\tcol2", `"col1\tcol2"`},
+		{"with backslash", `path\to\file`, `"path\\to\\file"`},
+		{"unicode", "日本語", `"日本語"`},
+		{"mixed escapes", "a\"b\\c\nd", `"a\"b\\c\nd"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatValueEDN(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatValueEDN_Int(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int64
+		expected string
+	}{
+		{"zero", 0, "0"},
+		{"positive", 42, "42"},
+		{"negative", -42, "-42"},
+		{"max", math.MaxInt64, "9223372036854775807"},
+		{"min", math.MinInt64, "-9223372036854775808"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatValueEDN(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatValueEDN_Float(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected string
+	}{
+		{"zero", 0.0, "0.0"},
+		{"pi", 3.14159, "3.14159"},
+		{"negative", -2.718, "-2.718"},
+		{"integer float", 42.0, "42.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatValueEDN(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+
+	// Scientific notation - just verify it's parseable
+	t.Run("scientific", func(t *testing.T) {
+		result := FormatValueEDN(1e10)
+		assert.True(t, strings.Contains(result, "e") || strings.Contains(result, "E") || result == "10000000000.0")
+	})
+}
+
+func TestFormatValueEDN_Bool(t *testing.T) {
+	assert.Equal(t, "true", FormatValueEDN(true))
+	assert.Equal(t, "false", FormatValueEDN(false))
+}
+
+func TestFormatValueEDN_Time(t *testing.T) {
+	// UTC time
+	utc := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	result := FormatValueEDN(utc)
+	assert.Equal(t, `#inst "2025-01-15T10:30:00Z"`, result)
+
+	// With nanoseconds
+	withNanos := time.Date(2025, 1, 15, 10, 30, 0, 123456789, time.UTC)
+	result = FormatValueEDN(withNanos)
+	assert.Equal(t, `#inst "2025-01-15T10:30:00.123456789Z"`, result)
+
+	// Non-UTC should be converted
+	loc, _ := time.LoadLocation("America/New_York")
+	nonUTC := time.Date(2025, 1, 15, 10, 30, 0, 0, loc)
+	result = FormatValueEDN(nonUTC)
+	assert.Contains(t, result, "#inst")
+	assert.Contains(t, result, "Z") // Should be UTC
+}
+
+func TestFormatValueEDN_Bytes(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []byte
+		expectedChars int // expected L85 character count
+	}{
+		{"empty", []byte{}, 0},
+		{"1 byte", []byte{0x42}, 2},
+		{"2 bytes", []byte{0x42, 0x43}, 3},
+		{"3 bytes", []byte{0x42, 0x43, 0x44}, 4},
+		{"4 bytes", []byte{0x42, 0x43, 0x44, 0x45}, 5},
+		{"5 bytes", []byte{0x42, 0x43, 0x44, 0x45, 0x46}, 7},
+		{"7 bytes", []byte{0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48}, 9},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatValueEDN(tt.input)
+			assert.True(t, strings.HasPrefix(result, `#bytes "`))
+			assert.True(t, strings.HasSuffix(result, `"`))
+
+			// Extract the L85 string
+			l85 := result[8 : len(result)-1]
+			assert.Equal(t, tt.expectedChars, len(l85))
+
+			// Verify round-trip
+			if len(l85) > 0 {
+				decoded, err := codec.DecodeL85(l85)
+				require.NoError(t, err)
+				assert.Equal(t, tt.input, decoded)
+			}
+		})
+	}
+}
+
+func TestFormatValueEDN_Identity(t *testing.T) {
+	id := datalog.NewIdentity("test-entity")
+	result := FormatValueEDN(id)
+	assert.True(t, strings.HasPrefix(result, `#identity "`))
+	assert.True(t, strings.HasSuffix(result, `"`))
+
+	// L85 hash should be 25 chars
+	l85 := result[11 : len(result)-1]
+	assert.Equal(t, 25, len(l85))
+}
+
+func TestFormatValueEDN_Keyword(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    datalog.Keyword
+		expected string
+	}{
+		{"qualified", kw(":person/name"), ":person/name"},
+		{"simple", kw(":status"), ":status"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatValueEDN(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatValueEDN_Symbol(t *testing.T) {
+	sym := datalog.NewSymbol("my-symbol")
+	result := FormatValueEDN(sym)
+	assert.Equal(t, "my-symbol", result)
+}
+
+func TestFormatValueEDN_Nil(t *testing.T) {
+	assert.Equal(t, "nil", FormatValueEDN(nil))
+}
+
+func TestFormatIdentityEDN(t *testing.T) {
+	t.Run("valid identity", func(t *testing.T) {
+		id := datalog.NewIdentity("test")
+		result := FormatIdentityEDN(id)
+		assert.True(t, strings.HasPrefix(result, `#identity "`))
+		// L85 is 25 chars for 20 bytes
+		l85 := result[11 : len(result)-1]
+		assert.Equal(t, 25, len(l85))
+	})
+
+	t.Run("nil identity", func(t *testing.T) {
+		result := FormatIdentityEDN(nil)
+		assert.Equal(t, "nil", result)
+	})
+}
+
+// =============================================================================
+// Unit Tests: Value EDN Parsing
+// =============================================================================
+
+func TestParseValueNode_String(t *testing.T) {
+	tests := []string{"hello", "", `with "quotes"`, "with\nnewline", "日本語"}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			formatted := FormatValueEDN(input)
+			// Parse just the string value
+			node, err := parseEDNValue(formatted)
+			require.NoError(t, err)
+			result, err := ParseValueNode(node)
+			require.NoError(t, err)
+			assert.Equal(t, input, result)
+		})
+	}
+}
+
+func TestParseValueNode_Int(t *testing.T) {
+	tests := []int64{0, 42, -42, math.MaxInt64, math.MinInt64}
+
+	for _, input := range tests {
+		t.Run("", func(t *testing.T) {
+			formatted := FormatValueEDN(input)
+			node, err := parseEDNValue(formatted)
+			require.NoError(t, err)
+			result, err := ParseValueNode(node)
+			require.NoError(t, err)
+			assert.Equal(t, input, result)
+		})
+	}
+}
+
+func TestParseValueNode_Float(t *testing.T) {
+	tests := []float64{0.0, 3.14159, -2.718}
+
+	for _, input := range tests {
+		t.Run("", func(t *testing.T) {
+			formatted := FormatValueEDN(input)
+			node, err := parseEDNValue(formatted)
+			require.NoError(t, err)
+			result, err := ParseValueNode(node)
+			require.NoError(t, err)
+			assert.InDelta(t, input, result.(float64), 0.0001)
+		})
+	}
+}
+
+func TestParseValueNode_Bool(t *testing.T) {
+	for _, input := range []bool{true, false} {
+		t.Run("", func(t *testing.T) {
+			formatted := FormatValueEDN(input)
+			node, err := parseEDNValue(formatted)
+			require.NoError(t, err)
+			result, err := ParseValueNode(node)
+			require.NoError(t, err)
+			assert.Equal(t, input, result)
+		})
+	}
+}
+
+func TestParseValueNode_Time(t *testing.T) {
+	t.Run("without nanoseconds", func(t *testing.T) {
+		input := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+		formatted := FormatValueEDN(input)
+		node, err := parseEDNValue(formatted)
+		require.NoError(t, err)
+		result, err := ParseValueNode(node)
+		require.NoError(t, err)
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("with nanoseconds", func(t *testing.T) {
+		input := time.Date(2025, 1, 15, 10, 30, 0, 123456789, time.UTC)
+		formatted := FormatValueEDN(input)
+		node, err := parseEDNValue(formatted)
+		require.NoError(t, err)
+		result, err := ParseValueNode(node)
+		require.NoError(t, err)
+		assert.Equal(t, input, result)
+	})
+}
+
+func TestParseValueNode_Bytes(t *testing.T) {
+	tests := [][]byte{
+		{},
+		{0x42},
+		{0x42, 0x43},
+		{0x42, 0x43, 0x44},
+		{0x42, 0x43, 0x44, 0x45},
+		{0x42, 0x43, 0x44, 0x45, 0x46},
+		{0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48},
+	}
+
+	for _, input := range tests {
+		t.Run("", func(t *testing.T) {
+			formatted := FormatValueEDN(input)
+			node, err := parseEDNValue(formatted)
+			require.NoError(t, err)
+			result, err := ParseValueNode(node)
+			require.NoError(t, err)
+			assert.Equal(t, input, result)
+		})
+	}
+}
+
+func TestParseValueNode_Identity(t *testing.T) {
+	input := datalog.NewIdentity("test-entity")
+	formatted := FormatValueEDN(input)
+	node, err := parseEDNValue(formatted)
+	require.NoError(t, err)
+	result, err := ParseValueNode(node)
+	require.NoError(t, err)
+
+	resultID := result.(datalog.Identity)
+	assert.Equal(t, input.Hash(), resultID.Hash())
+}
+
+func TestParseValueNode_Keyword(t *testing.T) {
+	input := kw(":person/name")
+	formatted := FormatValueEDN(input)
+	node, err := parseEDNValue(formatted)
+	require.NoError(t, err)
+	result, err := ParseValueNode(node)
+	require.NoError(t, err)
+	assert.Equal(t, input, result)
+}
+
+func TestParseValueNode_Errors(t *testing.T) {
+	t.Run("unknown tag", func(t *testing.T) {
+		node, err := parseEDNValue(`#unknown "value"`)
+		require.NoError(t, err)
+		_, err = ParseValueNode(node)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown tag")
+	})
+
+	t.Run("invalid L85 in bytes", func(t *testing.T) {
+		// Use a space character which is NOT in the L85 alphabet
+		node, err := parseEDNValue(`#bytes "invalid with space"`)
+		require.NoError(t, err)
+		_, err = ParseValueNode(node)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid timestamp", func(t *testing.T) {
+		node, err := parseEDNValue(`#inst "not-a-date"`)
+		require.NoError(t, err)
+		_, err = ParseValueNode(node)
+		assert.Error(t, err)
+	})
+}
+
+// =============================================================================
+// Unit Tests: Datom EDN Round-Trip
+// =============================================================================
+
+func TestFormatDatomEDN(t *testing.T) {
+	id := datalog.NewIdentity("entity1")
+	datom := &datalog.Datom{
+		E:  id,
+		A:  kw(":person/name"),
+		V:  "Alice",
+		Tx: 12345,
+	}
+
+	result := FormatDatomEDN(datom)
+	assert.True(t, strings.HasPrefix(result, "[#identity "))
+	assert.Contains(t, result, ":person/name")
+	assert.Contains(t, result, `"Alice"`)
+	assert.Contains(t, result, "12345]")
+}
+
+func TestParseDatomEDN(t *testing.T) {
+	id := datalog.NewIdentity("entity1")
+	original := &datalog.Datom{
+		E:  id,
+		A:  kw(":person/name"),
+		V:  "Alice",
+		Tx: 12345,
+	}
+
+	formatted := FormatDatomEDN(original)
+	parsed, err := ParseDatomEDN(formatted)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.E.Hash(), parsed.E.Hash())
+	assert.Equal(t, original.A, parsed.A)
+	assert.Equal(t, original.V, parsed.V)
+	assert.Equal(t, original.Tx, parsed.Tx)
+}
+
+func TestDatomEDN_RoundTrip(t *testing.T) {
+	id1 := datalog.NewIdentity("entity1")
+	id2 := datalog.NewIdentity("entity2")
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+
+	testCases := []struct {
+		name  string
+		datom datalog.Datom
+	}{
+		{"string", datalog.Datom{E: id1, A: kw(":test/string"), V: "hello", Tx: 1}},
+		{"int", datalog.Datom{E: id1, A: kw(":test/int"), V: int64(42), Tx: 1}},
+		{"float", datalog.Datom{E: id1, A: kw(":test/float"), V: 3.14, Tx: 1}},
+		{"bool-true", datalog.Datom{E: id1, A: kw(":test/bool"), V: true, Tx: 1}},
+		{"bool-false", datalog.Datom{E: id1, A: kw(":test/bool"), V: false, Tx: 1}},
+		{"time", datalog.Datom{E: id1, A: kw(":test/time"), V: now, Tx: 1}},
+		{"bytes", datalog.Datom{E: id1, A: kw(":test/bytes"), V: []byte{1, 2, 3, 4, 5}, Tx: 1}},
+		{"ref", datalog.Datom{E: id1, A: kw(":test/ref"), V: id2, Tx: 1}},
+		{"keyword", datalog.Datom{E: id1, A: kw(":test/kw"), V: kw(":status/active"), Tx: 1}},
+		{"symbol", datalog.Datom{E: id1, A: kw(":test/sym"), V: datalog.NewSymbol("my-symbol"), Tx: 1}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			formatted := FormatDatomEDN(&tc.datom)
+			parsed, err := ParseDatomEDN(formatted)
+			require.NoError(t, err, "failed to parse: %s", formatted)
+
+			assert.Equal(t, tc.datom.E.Hash(), parsed.E.Hash(), "entity mismatch")
+			assert.Equal(t, tc.datom.A, parsed.A, "attribute mismatch")
+			assert.Equal(t, tc.datom.Tx, parsed.Tx, "tx mismatch")
+
+			// Value comparison depends on type
+			switch expected := tc.datom.V.(type) {
+			case time.Time:
+				actual := parsed.V.(time.Time)
+				assert.True(t, expected.Equal(actual), "time mismatch: %v vs %v", expected, actual)
+			case []byte:
+				actual := parsed.V.([]byte)
+				assert.Equal(t, expected, actual, "bytes mismatch")
+			case datalog.Identity:
+				actual := parsed.V.(datalog.Identity)
+				assert.Equal(t, expected.Hash(), actual.Hash(), "identity ref mismatch")
+			default:
+				assert.Equal(t, tc.datom.V, parsed.V, "value mismatch")
+			}
+		})
+	}
+}
+
+func TestParseDatomEDN_Errors(t *testing.T) {
+	// Use a valid L85 identity for tests that need to get past identity parsing
+	validID := datalog.NewIdentity("test").L85()
+
+	tests := []struct {
+		name  string
+		input string
+		error string
+	}{
+		{"not vector", `"just a string"`, "expected vector"},
+		{"too few elements", `[#identity "` + validID + `" :attr "val"]`, "expected 4 elements"},
+		{"too many elements", `[#identity "` + validID + `" :attr "val" 1 extra]`, "expected 4 elements"},
+		{"invalid attribute", `[#identity "` + validID + `" "not-keyword" "val" 1]`, "invalid attribute"},
+		{"invalid tx", `[#identity "` + validID + `" :attr "val" "not-int"]`, "invalid tx"},
+		{"invalid identity L85", `[#identity "abc" :attr "val" 1]`, "invalid L85"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseDatomEDN(tt.input)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.error)
+		})
+	}
+}
+
+// =============================================================================
+// Integration Tests: Database Export/Import
+// =============================================================================
+
+func TestExport_EmptyDatabase(t *testing.T) {
+	db := createTempDatabase(t)
+
+	var buf bytes.Buffer
+	err := db.Export(&buf)
+	require.NoError(t, err)
+
+	assert.Empty(t, buf.String())
+}
+
+func TestExport_SingleDatom(t *testing.T) {
+	db := createTempDatabase(t)
+
+	// Add a datom
+	tx := db.NewTransaction()
+	id := datalog.NewIdentity("entity1")
+	require.NoError(t, tx.Add(id, kw(":person/name"), "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = db.Export(&buf)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	// Expect 2 lines: user datom + :db/txInstant transaction metadata
+	assert.Equal(t, 2, len(lines))
+
+	// Verify our datom is present
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, ":person/name") && strings.Contains(line, `"Alice"`) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected to find :person/name datom")
+}
+
+func TestExport_MultipleDatoms(t *testing.T) {
+	db := createTempDatabase(t)
+
+	// Add multiple datoms with various types
+	tx := db.NewTransaction()
+	id := datalog.NewIdentity("entity1")
+	require.NoError(t, tx.Add(id, kw(":test/string"), "hello"))
+	require.NoError(t, tx.Add(id, kw(":test/int"), int64(42)))
+	require.NoError(t, tx.Add(id, kw(":test/float"), 3.14))
+	require.NoError(t, tx.Add(id, kw(":test/bool"), true))
+	require.NoError(t, tx.Add(id, kw(":test/time"), time.Now().UTC()))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = db.Export(&buf)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	// Expect 6 lines: 5 user datoms + 1 :db/txInstant
+	assert.Equal(t, 6, len(lines))
+
+	// Verify each line is parseable
+	for _, line := range lines {
+		_, err := ParseDatomEDN(line)
+		require.NoError(t, err, "failed to parse: %s", line)
+	}
+}
+
+func TestImport_EmptyFile(t *testing.T) {
+	db := createTempDatabase(t)
+
+	err := db.Import(strings.NewReader(""))
+	require.NoError(t, err)
+
+	// Verify database is empty
+	var buf bytes.Buffer
+	err = db.Export(&buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestImport_WithComments(t *testing.T) {
+	db := createTempDatabase(t)
+
+	id := datalog.NewIdentity("test")
+	l85 := id.L85()
+
+	input := `; This is a comment
+[#identity "` + l85 + `" :test/val 42 1]
+
+; Another comment
+[#identity "` + l85 + `" :test/name "Alice" 1]
+`
+
+	err := db.Import(strings.NewReader(input))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = db.Export(&buf)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	// We imported 2 datoms, but the database already had a tx, so we may have
+	// additional :db/txInstant datoms. Just verify our datoms are present.
+	assert.GreaterOrEqual(t, len(lines), 2)
+
+	// Verify our datoms are present
+	foundVal := false
+	foundName := false
+	for _, line := range lines {
+		if strings.Contains(line, ":test/val") {
+			foundVal = true
+		}
+		if strings.Contains(line, ":test/name") {
+			foundName = true
+		}
+	}
+	assert.True(t, foundVal, "expected :test/val datom")
+	assert.True(t, foundName, "expected :test/name datom")
+}
+
+func TestImport_BatchBoundary(t *testing.T) {
+	db := createTempDatabase(t)
+
+	// Generate exactly 5001 datoms (triggers second batch)
+	var sb strings.Builder
+	id := datalog.NewIdentity("entity")
+	l85 := id.L85()
+
+	for i := 0; i < 5001; i++ {
+		sb.WriteString(`[#identity "` + l85 + `" :test/idx ` + string(rune('0'+i%10)) + ` 1]`)
+		sb.WriteString("\n")
+	}
+
+	err := db.Import(strings.NewReader(sb.String()))
+	require.NoError(t, err)
+}
+
+func TestImport_LargeFile(t *testing.T) {
+	db := createTempDatabase(t)
+
+	// Generate 10000 datoms
+	var sb strings.Builder
+	for i := 0; i < 10000; i++ {
+		id := datalog.NewIdentity("entity-" + string(rune(i)))
+		l85 := id.L85()
+		sb.WriteString(`[#identity "` + l85 + `" :test/idx `)
+		sb.WriteString(string(rune('0' + i%10)))
+		sb.WriteString(` 1]`)
+		sb.WriteString("\n")
+	}
+
+	err := db.Import(strings.NewReader(sb.String()))
+	require.NoError(t, err)
+}
+
+func TestImport_Errors(t *testing.T) {
+	validID := datalog.NewIdentity("test").L85()
+
+	t.Run("malformed EDN", func(t *testing.T) {
+		db := createTempDatabase(t)
+		input := `[#identity "` + validID + `" :test/val 1 1]
+[#identity "` + validID + `" :test/val 2 1]
+not valid EDN
+[#identity "` + validID + `" :test/val 3 1]
+`
+		err := db.Import(strings.NewReader(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "line 3")
+	})
+
+	t.Run("wrong element count", func(t *testing.T) {
+		db := createTempDatabase(t)
+		input := `[#identity "` + validID + `" :test/val]`
+		err := db.Import(strings.NewReader(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected 4 elements")
+	})
+
+	t.Run("invalid L85 identity", func(t *testing.T) {
+		db := createTempDatabase(t)
+		input := `[#identity "abc" :test/val 42 1]`
+		err := db.Import(strings.NewReader(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid L85")
+	})
+}
+
+func TestDatabaseRoundTrip(t *testing.T) {
+	db1 := createTempDatabase(t)
+
+	// Add diverse data
+	tx := db1.NewTransaction()
+	id1 := datalog.NewIdentity("person1")
+	id2 := datalog.NewIdentity("person2")
+	now := time.Now().UTC().Truncate(time.Nanosecond)
+
+	require.NoError(t, tx.Add(id1, kw(":person/name"), "Alice"))
+	require.NoError(t, tx.Add(id1, kw(":person/age"), int64(30)))
+	require.NoError(t, tx.Add(id1, kw(":person/score"), 95.5))
+	require.NoError(t, tx.Add(id1, kw(":person/active"), true))
+	require.NoError(t, tx.Add(id1, kw(":person/created"), now))
+	require.NoError(t, tx.Add(id1, kw(":person/data"), []byte{1, 2, 3}))
+	require.NoError(t, tx.Add(id1, kw(":person/friend"), id2))
+	require.NoError(t, tx.Add(id2, kw(":person/name"), "Bob"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Export
+	var buf bytes.Buffer
+	err = db1.Export(&buf)
+	require.NoError(t, err)
+
+	// Import into fresh database
+	db2 := createTempDatabase(t)
+	err = db2.Import(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+
+	// Export db2
+	var buf2 bytes.Buffer
+	err = db2.Export(&buf2)
+	require.NoError(t, err)
+
+	// Compare exports
+	lines1 := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	lines2 := strings.Split(strings.TrimSpace(buf2.String()), "\n")
+	assert.Equal(t, len(lines1), len(lines2))
+}
+
+func TestDatabaseRoundTrip_Deterministic(t *testing.T) {
+	db1 := createTempDatabase(t)
+
+	// Add data
+	tx := db1.NewTransaction()
+	id := datalog.NewIdentity("entity1")
+	require.NoError(t, tx.Add(id, kw(":test/a"), "value-a"))
+	require.NoError(t, tx.Add(id, kw(":test/b"), "value-b"))
+	require.NoError(t, tx.Add(id, kw(":test/c"), "value-c"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Export → file1
+	var buf1 bytes.Buffer
+	err = db1.Export(&buf1)
+	require.NoError(t, err)
+
+	// Import → db2
+	db2 := createTempDatabase(t)
+	err = db2.Import(strings.NewReader(buf1.String()))
+	require.NoError(t, err)
+
+	// Export db2 → file2
+	var buf2 bytes.Buffer
+	err = db2.Export(&buf2)
+	require.NoError(t, err)
+
+	// Compare byte-for-byte
+	assert.Equal(t, buf1.String(), buf2.String())
+}
+
+func TestExportImport_PreservesTxIDs(t *testing.T) {
+	db1 := createTempDatabase(t)
+
+	// Create datoms with specific tx IDs by doing multiple commits
+	id := datalog.NewIdentity("entity1")
+
+	tx1 := db1.NewTransaction()
+	require.NoError(t, tx1.Add(id, kw(":test/a"), "value-a"))
+	txID1, err := tx1.Commit()
+	require.NoError(t, err)
+
+	tx2 := db1.NewTransaction()
+	require.NoError(t, tx2.Add(id, kw(":test/b"), "value-b"))
+	txID2, err := tx2.Commit()
+	require.NoError(t, err)
+
+	// Export
+	var buf bytes.Buffer
+	err = db1.Export(&buf)
+	require.NoError(t, err)
+
+	// Import into fresh database
+	db2 := createTempDatabase(t)
+	err = db2.Import(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+
+	// Export and verify tx IDs are preserved
+	var buf2 bytes.Buffer
+	err = db2.Export(&buf2)
+	require.NoError(t, err)
+
+	// Parse and check tx IDs
+	lines := strings.Split(strings.TrimSpace(buf2.String()), "\n")
+	var foundTx1, foundTx2 bool
+	for _, line := range lines {
+		datom, err := ParseDatomEDN(line)
+		require.NoError(t, err)
+		if datom.Tx == txID1 {
+			foundTx1 = true
+		}
+		if datom.Tx == txID2 {
+			foundTx2 = true
+		}
+	}
+	assert.True(t, foundTx1, "txID1 not preserved")
+	assert.True(t, foundTx2, "txID2 not preserved")
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+// parseEDNValue parses a single EDN value and returns the node
+func parseEDNValue(s string) (*edn.Node, error) {
+	return edn.Parse(s)
+}

--- a/docs/reference/EXPORT_IMPORT.md
+++ b/docs/reference/EXPORT_IMPORT.md
@@ -1,0 +1,221 @@
+# Database Export/Import
+
+This document describes the database export and import functionality for backing up, migrating, and sharing Janus Datalog databases.
+
+## Overview
+
+Janus Datalog supports exporting the entire database to a human-readable EDN (Extensible Data Notation) format and importing it back. This enables:
+
+- **Backup and restore** - Create portable backups of your database
+- **Migration** - Move data between systems or database versions
+- **Debugging** - Inspect database contents in a readable format
+- **Data sharing** - Share datasets in a standard format
+
+## EDN Format
+
+Each line in the export file is a complete EDN vector representing a single datom:
+
+```edn
+[#identity "L85hash25chars" :attribute value tx-id]
+```
+
+### Example Output
+
+```edn
+[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/name "Alice" 1]
+[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/age 30 1]
+[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/email "alice@example.com" 1]
+[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/created #inst "2025-01-15T10:30:00Z" 1]
+[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/avatar #bytes "L85encodeddata" 1]
+[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/friend #identity "1$&2Ku;N<k)8Q"7t1CwE5l".-"" 2]
+```
+
+### Value Type Mappings
+
+| Go Type | EDN Format | Example |
+|---------|------------|---------|
+| `string` | quoted string | `"Alice"` |
+| `int64` | integer | `12345` |
+| `float64` | float | `3.14` |
+| `bool` | boolean | `true` / `false` |
+| `time.Time` | instant tag | `#inst "2025-01-15T10:30:00Z"` |
+| `[]byte` | bytes tag (L85) | `#bytes "L85encoded"` |
+| `Identity` | identity tag | `#identity "L85hash"` |
+| `Keyword` | keyword | `:namespace/name` |
+| `Symbol` | symbol | `my-symbol` |
+
+### Reader Tags
+
+- `#identity "L85string"` - Entity identity (always 25-character L85 encoding of SHA1 hash)
+- `#inst "RFC3339"` - Timestamp in RFC3339 format, always UTC
+- `#bytes "L85encoded"` - Byte array in L85 encoding (self-describing length)
+
+## CLI Usage
+
+### Export
+
+Export a database to an EDN file:
+
+```bash
+datalog -db mydata.db -export backup.edn
+```
+
+### Import
+
+Import an EDN file into a database (creates the database if it doesn't exist):
+
+```bash
+datalog -db newdata.db -import backup.edn
+```
+
+### Round-Trip Verification
+
+```bash
+# Export original
+datalog -db original.db -export data.edn
+
+# Import to new database
+datalog -db copy.db -import data.edn
+
+# Export copy and compare (should be identical)
+datalog -db copy.db -export data2.edn
+diff data.edn data2.edn
+```
+
+## Go API Usage
+
+### Export
+
+```go
+import (
+    "os"
+    "github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// Open database
+db, err := storage.NewDatabase("mydata.db")
+if err != nil {
+    log.Fatal(err)
+}
+defer db.Close()
+
+// Export to file
+f, err := os.Create("backup.edn")
+if err != nil {
+    log.Fatal(err)
+}
+defer f.Close()
+
+if err := db.Export(f); err != nil {
+    log.Fatal(err)
+}
+```
+
+### Import
+
+```go
+// Open/create database
+db, err := storage.NewDatabase("newdata.db")
+if err != nil {
+    log.Fatal(err)
+}
+defer db.Close()
+
+// Import from file
+f, err := os.Open("backup.edn")
+if err != nil {
+    log.Fatal(err)
+}
+defer f.Close()
+
+if err := db.Import(f); err != nil {
+    log.Fatal(err)
+}
+```
+
+### Export to Buffer (for testing or in-memory use)
+
+```go
+var buf bytes.Buffer
+if err := db.Export(&buf); err != nil {
+    log.Fatal(err)
+}
+
+// Use buf.String() or buf.Bytes()
+```
+
+## Format Details
+
+### Entity Identities
+
+Entity identities are always exported as L85-encoded SHA1 hashes (20 bytes = 25 characters). This ensures:
+
+- **Consistency** - Same entity always produces same output
+- **Portability** - No dependency on internal database IDs
+- **Sortability** - L85 encoding preserves lexicographic order
+
+### Transaction IDs
+
+Transaction IDs are preserved during export/import, allowing exact restoration of database state including the transaction history structure.
+
+### Comments and Blank Lines
+
+During import:
+- Lines starting with `;` are treated as comments and ignored
+- Blank lines are ignored
+- This allows annotating export files for documentation
+
+Example with comments:
+```edn
+; Person records
+[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/name "Alice" 1]
+[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/age 30 1]
+
+; Friendship relations
+[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/friend #identity "1$&2Ku;N<k)8Q"7t1CwE5l".-"" 2]
+```
+
+## Performance
+
+### Export
+
+- Streams directly from EAVT index
+- Uses buffered I/O for efficiency
+- Memory usage is constant regardless of database size
+
+### Import
+
+- Batched transactions (5000 datoms per batch)
+- Uses 1MB line buffer for long values
+- Efficient for large imports
+
+## Error Handling
+
+### Import Errors
+
+Import errors include the line number for easy debugging:
+
+```
+line 42: invalid EDN: unexpected character
+line 100: invalid entity: invalid L85 in #identity: expected 25 characters, got 20
+```
+
+### Validation
+
+The import process validates:
+- EDN syntax correctness
+- Vector format (exactly 4 elements: entity, attribute, value, tx)
+- Entity identity format (valid L85, 25 characters)
+- Attribute format (must be a keyword)
+- Transaction ID format (must be an integer)
+
+## Limitations
+
+- **No incremental export** - Always exports the entire database
+- **No schema export** - Schema definitions are not included (schema is optional and additive)
+- **No compression** - Output is plain text (use external compression if needed)
+
+## Related Documentation
+
+- [L85 Encoding](../../CLAUDE.md#l85-encoding-details) - Details on the L85 encoding used for identities and bytes
+- [Storage Design](../../CLAUDE.md#storage-design) - Overview of the EAVT storage model


### PR DESCRIPTION
Implements database export and import functionality for backup, migration, and data sharing:

- Add Export/Import API to storage.Database (export.go)
- Add -export and -import CLI flags to cmd/datalog
- Support all 9 value types: string, int64, float64, bool, time.Time, []byte, Identity, Keyword, Symbol
- Use L85 encoding for identities (#identity tag) and bytes (#bytes tag)
- Preserve transaction IDs for exact database restoration
- Batch imports (5000 datoms) for efficiency

Also fixes L85 codec bug for non-aligned byte lengths where round-trip would corrupt the last byte (e.g., [1,2,3,4,5] decoded to [1,2,3,4,4]).

Includes comprehensive tests and reference documentation.