### PR TITLE
Fix PullInto and Pull expression CRDT resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,7 +452,8 @@ baseMatcher := storage.NewBadgerMatcher(db.Store())
 matcher := executor.WrapMatcher(baseMatcher, handler)
 
 // Use matcher normally - annotations are transparent
-executor := executor.NewExecutor(matcher)
+// Second parameter is EntityResolver (db) for CRDT resolution in Pull operations
+executor := executor.NewExecutor(matcher, db)
 ```
 
 **Key Design Principles**:

--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -376,7 +376,7 @@ func isDatabaseEmpty(db *storage.Database) bool {
 	// Try a simple query to see if there's any data
 	query := `[:find ?e :where [?e _ _]]`
 
-	exec := executor.NewExecutor(db.Matcher())
+	exec := db.NewExecutor()
 	q, err := parser.ParseQuery(query)
 	if err != nil {
 		return true // Assume empty on error

--- a/datalog/executor/batched_agg_correctness_test.go
+++ b/datalog/executor/batched_agg_correctness_test.go
@@ -39,7 +39,7 @@ func TestBatchedAggregationCorrectness(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Query with RelationInput (uses batched path)
 	queryStr := `

--- a/datalog/executor/benchmark_test.go
+++ b/datalog/executor/benchmark_test.go
@@ -104,7 +104,7 @@ func BenchmarkFullQuery(b *testing.B) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query with expression and aggregation
 	queryStr := `[:find ?age (avg ?score)

--- a/datalog/executor/componentized_subquery_bench_test.go
+++ b/datalog/executor/componentized_subquery_bench_test.go
@@ -141,7 +141,7 @@ func BenchmarkSubqueryExecution(b *testing.B) {
 	// Benchmark Legacy Path (UseComponentizedSubquery: false)
 	b.Run("Legacy", func(b *testing.B) {
 		matcher := NewMemoryPatternMatcher(datoms)
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			UseComponentizedSubquery: false,
 			EnableParallelSubqueries: false,
 		})
@@ -162,7 +162,7 @@ func BenchmarkSubqueryExecution(b *testing.B) {
 	// Benchmark Componentized Path - Sequential (UseComponentizedSubquery: true, no parallel)
 	b.Run("Componentized_Sequential", func(b *testing.B) {
 		matcher := NewMemoryPatternMatcher(datoms)
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			UseComponentizedSubquery: true,
 			EnableParallelSubqueries: false,
 		})
@@ -183,7 +183,7 @@ func BenchmarkSubqueryExecution(b *testing.B) {
 	// Benchmark Componentized Path - Parallel (UseComponentizedSubquery: true, with parallel)
 	b.Run("Componentized_Parallel", func(b *testing.B) {
 		matcher := NewMemoryPatternMatcher(datoms)
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			UseComponentizedSubquery:  true,
 			EnableParallelSubqueries:  true,
 			MaxSubqueryWorkers:        4,
@@ -292,7 +292,7 @@ func BenchmarkSubqueryExecutionLarge(b *testing.B) {
 	// Benchmark Legacy Path
 	b.Run("Legacy_Large", func(b *testing.B) {
 		matcher := NewMemoryPatternMatcher(datoms)
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			UseComponentizedSubquery: false,
 		})
 
@@ -313,7 +313,7 @@ func BenchmarkSubqueryExecutionLarge(b *testing.B) {
 	// Benchmark Componentized Path
 	b.Run("Componentized_Large", func(b *testing.B) {
 		matcher := NewMemoryPatternMatcher(datoms)
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			UseComponentizedSubquery: true,
 			EnableParallelSubqueries: true,
 			MaxSubqueryWorkers:       4,

--- a/datalog/executor/cse_large_scale_test.go
+++ b/datalog/executor/cse_large_scale_test.go
@@ -195,7 +195,7 @@ func TestCSELargeScale(t *testing.T) {
 
 	// Test 1: Sequential WITHOUT CSE
 	t.Log("\n=== Test 1: Sequential WITHOUT CSE ===")
-	exec1 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec1 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: false,
 		EnableCSE:                   false,
@@ -221,7 +221,7 @@ func TestCSELargeScale(t *testing.T) {
 
 	// Test 2: Sequential WITH CSE
 	t.Log("\n=== Test 2: Sequential WITH CSE ===")
-	exec2 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec2 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: false,
 		EnableCSE:                   true,
@@ -247,7 +247,7 @@ func TestCSELargeScale(t *testing.T) {
 
 	// Test 3: Parallel WITHOUT CSE
 	t.Log("\n=== Test 3: Parallel WITHOUT CSE ===")
-	exec3 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec3 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableCSE:                   false,
@@ -273,7 +273,7 @@ func TestCSELargeScale(t *testing.T) {
 
 	// Test 4: Parallel WITH CSE
 	t.Log("\n=== Test 4: Parallel WITH CSE ===")
-	exec4 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec4 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableCSE:                   true,

--- a/datalog/executor/cse_parallel_comparison_test.go
+++ b/datalog/executor/cse_parallel_comparison_test.go
@@ -200,7 +200,7 @@ func TestCSEWithAndWithoutParallel(t *testing.T) {
 
 	// Test 1: Sequential execution WITHOUT CSE
 	t.Log("\n=== Test 1: Sequential, No CSE ===")
-	exec1 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec1 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: false, // Sequential
 		EnableCSE:                   false,
@@ -226,7 +226,7 @@ func TestCSEWithAndWithoutParallel(t *testing.T) {
 
 	// Test 2: Sequential execution WITH CSE
 	t.Log("\n=== Test 2: Sequential, With CSE ===")
-	exec2 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec2 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: false, // Sequential
 		EnableCSE:                   true,
@@ -252,7 +252,7 @@ func TestCSEWithAndWithoutParallel(t *testing.T) {
 
 	// Test 3: Parallel execution WITHOUT CSE
 	t.Log("\n=== Test 3: Parallel, No CSE ===")
-	exec3 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec3 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true, // Parallel
 		EnableCSE:                   false,
@@ -278,7 +278,7 @@ func TestCSEWithAndWithoutParallel(t *testing.T) {
 
 	// Test 4: Parallel execution WITH CSE
 	t.Log("\n=== Test 4: Parallel, With CSE ===")
-	exec4 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec4 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true, // Parallel
 		EnableCSE:                   true,

--- a/datalog/executor/cse_performance_test.go
+++ b/datalog/executor/cse_performance_test.go
@@ -197,7 +197,7 @@ func TestCSEPerformanceImpact(t *testing.T) {
 	}
 
 	// Test 1: Decorrelation WITHOUT CSE (2 filter groups)
-	execWithoutCSE := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execWithoutCSE := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableCSE:                   false, // CSE disabled
@@ -230,7 +230,7 @@ func TestCSEPerformanceImpact(t *testing.T) {
 	}
 
 	// Test 2: Decorrelation WITH CSE (1 filter group)
-	execWithCSE := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execWithCSE := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableCSE:                   true, // CSE enabled

--- a/datalog/executor/cse_test.go
+++ b/datalog/executor/cse_test.go
@@ -60,7 +60,7 @@ func TestCSEOpportunity(t *testing.T) {
 	}
 
 	// Execute with CSE enabled
-	exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableCSE:                   true,
@@ -267,7 +267,7 @@ func TestOHLCCSEOpportunity(t *testing.T) {
 		t.Fatalf("Parse error: %v", err)
 	}
 
-	exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableCSE:                   true,

--- a/datalog/executor/decorr_perf_test.go
+++ b/datalog/executor/decorr_perf_test.go
@@ -51,7 +51,7 @@ func TestDecorrelationActuallyWorks(t *testing.T) {
 	}
 
 	// Test WITHOUT decorrelation
-	execNoDecor := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execNoDecor := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: false,
 		EnableFineGrainedPhases:     true,
 		MaxPhases:                   10,
@@ -65,7 +65,7 @@ func TestDecorrelationActuallyWorks(t *testing.T) {
 	}
 
 	// Test WITH decorrelation (parallel by default)
-	execWithDecor := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execWithDecor := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableFineGrainedPhases:     true,
@@ -143,7 +143,7 @@ func TestDecorrelationAnnotations(t *testing.T) {
 	}
 
 	// Execute WITH decorrelation and capture annotations
-	execWithDecor := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execWithDecor := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableFineGrainedPhases:     true,

--- a/datalog/executor/decorrelation_column_order_test.go
+++ b/datalog/executor/decorrelation_column_order_test.go
@@ -103,7 +103,7 @@ func TestParallelDecorrelationColumnOrder(t *testing.T) {
 	// Test with PARALLEL decorrelation
 	t.Run("ParallelDecorrelation", func(t *testing.T) {
 		matcher := NewMemoryPatternMatcher(datoms)
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: true, // PARALLEL
 		})
@@ -178,7 +178,7 @@ func TestParallelDecorrelationColumnOrder(t *testing.T) {
 	// Test with SEQUENTIAL decorrelation (should work)
 	t.Run("SequentialDecorrelation", func(t *testing.T) {
 		matcher := NewMemoryPatternMatcher(datoms)
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: false, // SEQUENTIAL
 		})

--- a/datalog/executor/decorrelation_end_to_end_test.go
+++ b/datalog/executor/decorrelation_end_to_end_test.go
@@ -75,7 +75,7 @@ func TestDecorrelationEndToEnd(t *testing.T) {
 	}
 
 	// Create executor with decorrelation enabled
-	executor := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	executor := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableDynamicReordering:     true,
 		EnablePredicatePushdown:     true,

--- a/datalog/executor/decorrelation_integration_test.go
+++ b/datalog/executor/decorrelation_integration_test.go
@@ -165,7 +165,7 @@ func TestHourlyOHLCDecorrelation(t *testing.T) {
 	}
 
 	// Execute with decorrelation DISABLED first to verify test data
-	execNoDecor := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execNoDecor := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: false,
 		EnableFineGrainedPhases:     true,
 		MaxPhases:                   10,
@@ -185,7 +185,7 @@ func TestHourlyOHLCDecorrelation(t *testing.T) {
 	}
 
 	// Execute with decorrelation ENABLED (with parallel execution)
-	execWithDecor := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execWithDecor := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableFineGrainedPhases:     true,

--- a/datalog/executor/decorrelation_ohlc_column_order_test.go
+++ b/datalog/executor/decorrelation_ohlc_column_order_test.go
@@ -154,7 +154,7 @@ func TestOHLCColumnOrderBug(t *testing.T) {
 
 	t.Run("ParallelDecorrelation", func(t *testing.T) {
 		matcher := NewMemoryPatternMatcher(datoms)
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: true,
 		})
@@ -238,7 +238,7 @@ func TestOHLCColumnOrderBug(t *testing.T) {
 
 	t.Run("SequentialDecorrelation", func(t *testing.T) {
 		matcher := NewMemoryPatternMatcher(datoms)
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: false,
 		})

--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -11,6 +11,7 @@ import (
 // Executor is the main query execution engine
 type Executor struct {
 	matcher                  PatternMatcher
+	entityResolver           EntityResolver
 	planner                  planner.QueryPlanner
 	options                  ExecutorOptions
 	enableParallelSubqueries bool
@@ -18,7 +19,7 @@ type Executor struct {
 }
 
 // NewExecutor creates a new query executor with default options
-func NewExecutor(matcher PatternMatcher) *Executor {
+func NewExecutor(matcher PatternMatcher, resolver EntityResolver) *Executor {
 	defaultOpts := planner.PlannerOptions{
 		EnableDynamicReordering:     true,
 		EnablePredicatePushdown:     true,
@@ -37,11 +38,11 @@ func NewExecutor(matcher PatternMatcher) *Executor {
 		EnableStreamingAggregation:  true,
 		EnableDebugLogging:          false,
 	}
-	return NewExecutorWithOptions(matcher, defaultOpts)
+	return NewExecutorWithOptions(matcher, resolver, defaultOpts)
 }
 
 // NewExecutorWithOptions creates a new query executor with custom planner options
-func NewExecutorWithOptions(matcher PatternMatcher, opts planner.PlannerOptions) *Executor {
+func NewExecutorWithOptions(matcher PatternMatcher, resolver EntityResolver, opts planner.PlannerOptions) *Executor {
 	// Convert to executor options
 	execOpts := convertToExecutorOptions(opts)
 
@@ -55,6 +56,7 @@ func NewExecutorWithOptions(matcher PatternMatcher, opts planner.PlannerOptions)
 
 	return &Executor{
 		matcher:                  matcher,
+		entityResolver:           resolver,
 		planner:                  queryPlanner,
 		options:                  execOpts,
 		enableParallelSubqueries: opts.EnableParallelSubqueries,
@@ -117,6 +119,7 @@ func (e *Executor) ExecuteWithRelations(ctx Context, q *query.Query, inputRelati
 	// Create a temporary executor with the wrapped matcher
 	executor := &Executor{
 		matcher:                  matcher,
+		entityResolver:           e.entityResolver,
 		planner:                  e.planner,
 		options:                  e.options,
 		enableParallelSubqueries: e.enableParallelSubqueries,
@@ -201,7 +204,7 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 	if collector := ctx.Collector(); collector != nil {
 		opts.Collector = collector
 	}
-	queryExecutor := newQueryExecutor(e.matcher, opts)
+	queryExecutor := newQueryExecutor(e.matcher, e.entityResolver, opts)
 
 	var currentGroups []Relation
 
@@ -595,7 +598,7 @@ func (e *Executor) executeRealizedNonIterating(
 	relationInput query.RelationInput,
 ) (Relation, error) {
 	// Create QueryExecutor
-	queryExecutor := newQueryExecutor(e.matcher, e.options)
+	queryExecutor := newQueryExecutor(e.matcher, e.entityResolver, e.options)
 
 	var currentGroups []Relation
 

--- a/datalog/executor/executor_aggregate_test.go
+++ b/datalog/executor/executor_aggregate_test.go
@@ -18,7 +18,7 @@ func TestAggregateSum(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	queryStr := `[:find (sum ?total)
 	              :where [?o :order/total ?total]]`
@@ -45,7 +45,7 @@ func TestAggregateCount(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	queryStr := `[:find (count ?user)
 	              :where [?user :user/name ?name]]`
@@ -72,7 +72,7 @@ func TestAggregateAvg(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	queryStr := `[:find (avg ?value)
 	              :where [?s :score/value ?value]]`
@@ -103,7 +103,7 @@ func TestAggregateMinMax(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	queryStr := `[:find (min ?time) (max ?time)
 	              :where [?e :event/time ?time]]`
@@ -138,7 +138,7 @@ func TestAggregateGroupBy(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	queryStr := `[:find ?dept (sum ?amount)
 	              :where [?s :sale/dept ?dept]
@@ -179,7 +179,7 @@ func TestAggregateMixedWithNonAggregated(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Find category and average price
 	queryStr := `[:find ?category (avg ?price) (count ?p)

--- a/datalog/executor/executor_sorting_test.go
+++ b/datalog/executor/executor_sorting_test.go
@@ -49,7 +49,7 @@ func TestQueryWithOrderBy(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	tests := []struct {
 		name     string
@@ -181,7 +181,7 @@ func TestSortingEdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			matcher := NewMemoryPatternMatcher(tt.datoms)
-			executor := NewExecutor(matcher)
+			executor := NewExecutor(matcher, nil)
 
 			// Parse query
 			q, err := parser.ParseQuery(tt.query)
@@ -225,7 +225,7 @@ func TestSortingWithNulls(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Note: get-else is not implemented, so we test with a simpler query
 	// This is more about ensuring no panic than specific null handling

--- a/datalog/executor/executor_subquery_complete_test.go
+++ b/datalog/executor/executor_subquery_complete_test.go
@@ -66,7 +66,7 @@ func TestSubqueryComplete(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	t.Run("SingleInputSubquery", func(t *testing.T) {
 		// Find max high price for each symbol

--- a/datalog/executor/executor_subquery_comprehensive_test.go
+++ b/datalog/executor/executor_subquery_comprehensive_test.go
@@ -22,7 +22,7 @@ func TestSubqueryWithNoResults(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Subquery should return no results for max price
 	queryStr := `[:find ?symbol ?max-price
@@ -76,7 +76,7 @@ func TestSubqueryWithRelationBinding(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Subquery returns all prices for a symbol (relation binding)
 	queryStr := `[:find ?symbol ?time ?price
@@ -141,7 +141,7 @@ func TestSubqueryWithMultipleOuterRows(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Find average salary per department using subquery
 	queryStr := `[:find ?dept-name ?avg-salary
@@ -224,7 +224,7 @@ func TestSubqueryWithTwoInputs(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Find sales for specific category and date using subquery with two inputs
 	targetDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -292,7 +292,7 @@ func TestSubqueryWithNoInput(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Find products cheaper than max configured price
 	// NOTE: Changed order - subquery must come before its result is used
@@ -355,7 +355,7 @@ func TestSubqueryInFilter(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Find employees earning more than average
 	queryStr := `[:find ?name ?salary
@@ -443,7 +443,7 @@ func TestSubqueryErrorHandling(t *testing.T) {
 				},
 			}
 
-			exec := NewExecutor(matcher)
+			exec := NewExecutor(matcher, nil)
 			q, err := parser.ParseQuery(tt.queryStr)
 			if err != nil {
 				t.Fatalf("Failed to parse query: %v", err)
@@ -472,7 +472,7 @@ func TestSubqueryWithEmptyOuterQuery(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	queryStr := `[:find ?symbol ?max-price
 	             :where 
@@ -530,7 +530,7 @@ func TestSubqueryPerformance(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Count products per category using subquery
 	queryStr := `[:find ?cat-name ?count

--- a/datalog/executor/executor_subquery_datomic_test.go
+++ b/datalog/executor/executor_subquery_datomic_test.go
@@ -28,7 +28,7 @@ func TestSubqueryDatomicCompatible(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	t.Run("ExplicitDatabasePassing", func(t *testing.T) {
 		// Datomic-style query with explicit $ passing

--- a/datalog/executor/executor_subquery_test.go
+++ b/datalog/executor/executor_subquery_test.go
@@ -33,7 +33,7 @@ func TestSimpleSubquery(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Query with subquery to find max price for each symbol
 	queryStr := `[:find ?symbol ?max-price
@@ -169,7 +169,7 @@ func TestSubqueryWithMultipleInputs(t *testing.T) {
 		return result, nil
 	})
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Query with subquery that takes multiple inputs
 	// Note: Simplified to test basic functionality first

--- a/datalog/executor/executor_test.go
+++ b/datalog/executor/executor_test.go
@@ -24,7 +24,7 @@ func TestExecutorBasicQuery(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find all names
 	q := &query.Query{
@@ -88,7 +88,7 @@ func TestExecutorJoinQuery(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find friends of friends
 	// [?p1 :user/friend ?p2]
@@ -168,7 +168,7 @@ func TestExecutorWithFilter(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find people younger than 30
 	q := &query.Query{
@@ -242,7 +242,7 @@ func TestExecutorMultipleFilters(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find people aged 25-30 with salary > 50000
 	q := &query.Query{
@@ -326,7 +326,7 @@ func TestExecutorEmptyResult(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query for non-existent attribute
 	q := &query.Query{

--- a/datalog/executor/hash_join_presize_bench_test.go
+++ b/datalog/executor/hash_join_presize_bench_test.go
@@ -112,7 +112,7 @@ func BenchmarkOHLCWithPreSizing(b *testing.B) {
 
 	datoms := createOHLCData(0, 260) // 260 hours
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	queryStr := `
 	[:find ?day ?hour ?open ?high ?low ?close

--- a/datalog/executor/indexed_memory_matcher.go
+++ b/datalog/executor/indexed_memory_matcher.go
@@ -390,3 +390,4 @@ func (m *IndexedMemoryMatcher) getCandidates(strategy matchStrategy) []int {
 		return positions
 	}
 }
+

--- a/datalog/executor/interfaces.go
+++ b/datalog/executor/interfaces.go
@@ -34,3 +34,16 @@ type EntityLookupMatcher interface {
 	// Returns (value, true) if the attribute exists, (nil, false) otherwise.
 	LookupAttribute(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool)
 }
+
+// EntityResolver provides CRDT-aware entity resolution.
+// This is used by wildcard pulls to get all attributes for an entity with
+// proper CRDT resolution (LWW for cardinality-one, add-wins for many, RGA for vector).
+// Implemented by Database, not by matchers.
+type EntityResolver interface {
+	// ResolveAllAttributes returns all CRDT-resolved attributes for an entity.
+	// The returned map uses Keyword keys and properly resolved values:
+	// - CardinalityOne: single value (LWW)
+	// - CardinalityMany: []interface{} (add-wins set, order undefined)
+	// - CardinalityVector: []interface{} (RGA ordered list)
+	ResolveAllAttributes(entity datalog.Identity) (map[datalog.Keyword]interface{}, error)
+}

--- a/datalog/executor/not_or_test.go
+++ b/datalog/executor/not_or_test.go
@@ -26,7 +26,7 @@ func TestNotClause(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find non-archived users
 	// [:find ?name :where [?e :user/name ?name] (not [?e :user/archived true])]
@@ -95,7 +95,7 @@ func TestNotClauseNoMatches(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find non-archived users (no one is archived)
 	q := &query.Query{
@@ -151,7 +151,7 @@ func TestNotClauseAllMatch(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find non-archived users (everyone is archived)
 	q := &query.Query{
@@ -211,7 +211,7 @@ func TestNotJoinClause(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find users that are neither archived nor deleted
 	// [:find ?name :where [?e :user/name ?name] (not-join [?e] [?e :user/archived true] [?e :user/deleted true])]
@@ -287,7 +287,7 @@ func TestOrClause(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find users with status "active" OR "pending"
 	// [:find ?name :where [?e :user/name ?name] (or [?e :user/status "active"] [?e :user/status "pending"])]
@@ -371,7 +371,7 @@ func TestOrJoinClause(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: Find users that are active users OR enabled admins
 	// [:find ?name :where [?e :user/name ?name] (or-join [?e] [?e :user/status "active"] [?e :admin/status "enabled"])]
@@ -444,7 +444,7 @@ func TestOrJoinClause(t *testing.T) {
 func TestOrFallbackWithGroundExpressionDirectQueryExecutor(t *testing.T) {
 	// Directly test the query executor to isolate the issue
 	matcher := NewMemoryPatternMatcher(nil)
-	queryExecutor := NewExecutor(matcher)
+	queryExecutor := NewExecutor(matcher, nil)
 
 	// Build the OR clause query directly
 	orClause := &query.OrClause{
@@ -490,7 +490,7 @@ func TestOrFallbackWithGroundExpression(t *testing.T) {
 	// Test OR with ground expression as fallback
 	// When pattern matches nothing, ground should provide default value
 	matcher := NewMemoryPatternMatcher(nil) // Empty database
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: (or [?e :nonexistent ?x] [(ground 0) ?x])
 	// Since no data exists, should fall back to ground(0)
@@ -549,7 +549,7 @@ func TestOrFallbackFirstBranchMatches(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: (or [?e :user/name ?x] [(ground "fallback") ?x])
 	// First branch should match, so we should get "Alice", not "fallback"
@@ -602,7 +602,7 @@ func TestOrFallbackMultipleBranches(t *testing.T) {
 	// Test OR with multiple fallback branches
 	// (or [nonexistent1] [nonexistent2] [(ground "default")])
 	matcher := NewMemoryPatternMatcher(nil) // Empty database
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	nonexistent1 := datalog.NewKeyword(":nonexistent1")
 	nonexistent2 := datalog.NewKeyword(":nonexistent2")
@@ -671,7 +671,7 @@ func TestOrFallbackWithArithmeticExpression(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: (or [?e :nonexistent ?x] [(+ 1 1) ?x])
 	// Pattern won't match, so should get 2 from arithmetic
@@ -741,7 +741,7 @@ func TestOrFallbackPatternOnlyUnionSemantics(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Pattern-only OR should return BOTH Alice and Bob (union semantics)
 	q := &query.Query{
@@ -796,7 +796,7 @@ func TestOrFallbackPatternWithStreamingRelation(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query: (or [?e :user/name ?x] [(ground "fallback") ?x])
 	// Pattern should match, returning "Alice"
@@ -855,7 +855,7 @@ func TestOrFallbackWithSubqueryPattern(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	queryExecutor := NewExecutor(matcher)
+	queryExecutor := NewExecutor(matcher, nil)
 
 	// Build the OR clause with SubqueryPattern and ground fallback
 	// (or [(q [:find (count ?t) :where [?t :task/status :status/complete]] $) [[?count]]]
@@ -946,7 +946,7 @@ func TestOrFallbackWithSubqueryPatternAndVariableInput(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	queryExecutor := NewExecutor(matcher)
+	queryExecutor := NewExecutor(matcher, nil)
 
 	// Create annotation handler to debug OR fallback behavior
 	var events []annotations.Event
@@ -1085,7 +1085,7 @@ func TestOrFallbackWithPatternAndTupleGround(t *testing.T) {
 		events = append(events, event)
 	}
 	ctx := NewContext(handler)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Query:
 	// [:find ?scenario ?name ?taskCount
@@ -1206,7 +1206,7 @@ func TestOrFallbackWithPatternAndScalarGround(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Same as TestOrFallbackWithPatternAndTupleGround but with SCALAR ground
 	orClause := &query.OrClause{
@@ -1296,7 +1296,7 @@ func TestOrFallbackWithPatternAndScalarGround(t *testing.T) {
 func TestOrFallbackWithSubqueryPatternEmpty(t *testing.T) {
 	// Test OR with SubqueryPattern that returns empty, falling back to ground
 	matcher := NewMemoryPatternMatcher(nil) // Empty database
-	queryExecutor := NewExecutor(matcher)
+	queryExecutor := NewExecutor(matcher, nil)
 
 	statusAttr := datalog.NewKeyword(":task/status")
 	completeStatus := datalog.NewKeyword(":status/complete")

--- a/datalog/executor/ohlc_chain_profile_test.go
+++ b/datalog/executor/ohlc_chain_profile_test.go
@@ -28,7 +28,7 @@ func BenchmarkOHLCFullChain(b *testing.B) {
 			// Create test data
 			datoms := createOHLCData(bm.numDays, bm.numHours)
 			matcher := NewMemoryPatternMatcher(datoms)
-			exec := NewExecutor(matcher)
+			exec := NewExecutor(matcher, nil)
 
 			// Build the query
 			var queryStr string
@@ -268,7 +268,7 @@ func BenchmarkTimeExtractionFunctions(b *testing.B) {
 	// Create test data
 	datoms := createOHLCData(0, 260)
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Query with multiple time extractions
 	queryStr := `

--- a/datalog/executor/ohlc_subquery_performance_test.go
+++ b/datalog/executor/ohlc_subquery_performance_test.go
@@ -86,7 +86,7 @@ func TestOHLCSubqueryPerformance(t *testing.T) {
 
 	// Create memory matcher with our test data
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Test 1: Single subquery (just get the open price for each day)
 	t.Run("SingleSubquery", func(t *testing.T) {
@@ -247,7 +247,7 @@ func BenchmarkOHLCSubqueries(b *testing.B) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Benchmark single subquery
 	b.Run("SingleAggregation", func(b *testing.B) {
@@ -381,7 +381,7 @@ func BenchmarkRelationInputParallel(b *testing.B) {
 	inputRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y"), datalog.NewSymbol("?m")}, inputTuples)
 
 	b.Run("Sequential", func(b *testing.B) {
-		seqExec := NewExecutor(matcher)
+		seqExec := NewExecutor(matcher, nil)
 		seqExec.DisableParallelSubqueries()
 
 		b.ResetTimer()
@@ -394,7 +394,7 @@ func BenchmarkRelationInputParallel(b *testing.B) {
 	})
 
 	b.Run("Parallel-2Workers", func(b *testing.B) {
-		parExec := NewExecutor(matcher)
+		parExec := NewExecutor(matcher, nil)
 		parExec.EnableParallelSubqueries(2)
 
 		b.ResetTimer()
@@ -407,7 +407,7 @@ func BenchmarkRelationInputParallel(b *testing.B) {
 	})
 
 	b.Run("Parallel-4Workers", func(b *testing.B) {
-		parExec := NewExecutor(matcher)
+		parExec := NewExecutor(matcher, nil)
 		parExec.EnableParallelSubqueries(4)
 
 		b.ResetTimer()
@@ -420,7 +420,7 @@ func BenchmarkRelationInputParallel(b *testing.B) {
 	})
 
 	b.Run("Parallel-8Workers", func(b *testing.B) {
-		parExec := NewExecutor(matcher)
+		parExec := NewExecutor(matcher, nil)
 		parExec.EnableParallelSubqueries(8)
 
 		b.ResetTimer()
@@ -433,7 +433,7 @@ func BenchmarkRelationInputParallel(b *testing.B) {
 	})
 
 	b.Run("Parallel-16Workers", func(b *testing.B) {
-		parExec := NewExecutor(matcher)
+		parExec := NewExecutor(matcher, nil)
 		parExec.EnableParallelSubqueries(16)
 
 		b.ResetTimer()
@@ -446,7 +446,7 @@ func BenchmarkRelationInputParallel(b *testing.B) {
 	})
 
 	b.Run("Parallel-32Workers", func(b *testing.B) {
-		parExec := NewExecutor(matcher)
+		parExec := NewExecutor(matcher, nil)
 		parExec.EnableParallelSubqueries(32)
 
 		b.ResetTimer()

--- a/datalog/executor/parallel_decorr_bench_test.go
+++ b/datalog/executor/parallel_decorr_bench_test.go
@@ -49,7 +49,7 @@ func BenchmarkParallelDecorrelation(b *testing.B) {
 	}
 
 	// Run benchmark - current implementation uses parallel execution
-	exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableFineGrainedPhases:     true,
 		MaxPhases:                   10,
@@ -210,7 +210,7 @@ func BenchmarkParallelOHLCDecorrelation(b *testing.B) {
 		b.Fatalf("Failed to parse query: %v", err)
 	}
 
-	exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableFineGrainedPhases:     true,
 		MaxPhases:                   10,

--- a/datalog/executor/parallel_subquery_test.go
+++ b/datalog/executor/parallel_subquery_test.go
@@ -134,7 +134,7 @@ func TestExecuteSubqueryStructure(t *testing.T) {
 
 	// Verify configuration defaults
 	// NOTE: EnableParallelSubqueries is now in ExecutorOptions, test default via executor creation
-	exec := NewExecutor(nil)
+	exec := NewExecutor(nil, nil)
 	if !exec.enableParallelSubqueries {
 		t.Error("enableParallelSubqueries should be true by default")
 	}

--- a/datalog/executor/parallel_vs_sequential_test.go
+++ b/datalog/executor/parallel_vs_sequential_test.go
@@ -152,7 +152,7 @@ func TestParallelVsSequentialDecorrelation(t *testing.T) {
 
 	// Test 1: Sequential decorrelation
 	t.Run("Sequential", func(t *testing.T) {
-		execSeq := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		execSeq := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: false, // Sequential
 			EnableFineGrainedPhases:     true,
@@ -177,7 +177,7 @@ func TestParallelVsSequentialDecorrelation(t *testing.T) {
 
 	// Test 2: Parallel decorrelation
 	t.Run("Parallel", func(t *testing.T) {
-		execPar := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		execPar := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: true, // Parallel
 			EnableFineGrainedPhases:     true,
@@ -201,14 +201,14 @@ func TestParallelVsSequentialDecorrelation(t *testing.T) {
 
 	// Test 3: Verify results are identical
 	t.Run("ResultsMatch", func(t *testing.T) {
-		execSeq := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		execSeq := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: false,
 			EnableFineGrainedPhases:     true,
 			MaxPhases:                   10,
 		})
 
-		execPar := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		execPar := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: true,
 			EnableFineGrainedPhases:     true,

--- a/datalog/executor/performance_test.go
+++ b/datalog/executor/performance_test.go
@@ -26,7 +26,7 @@ func TestPerformanceRegression(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	executor := NewExecutor(matcher)
+	executor := NewExecutor(matcher, nil)
 
 	// Test queries
 	queries := []string{

--- a/datalog/executor/predicate_pushdown_test.go
+++ b/datalog/executor/predicate_pushdown_test.go
@@ -347,7 +347,7 @@ func TestExecutorWithCustomPlannerOptions(t *testing.T) {
 	matcher := &mockMatcher{}
 
 	t.Run("DefaultExecutor", func(t *testing.T) {
-		exec := NewExecutor(matcher)
+		exec := NewExecutor(matcher, nil)
 		if exec == nil {
 			t.Fatal("Expected executor, got nil")
 		}
@@ -358,7 +358,7 @@ func TestExecutorWithCustomPlannerOptions(t *testing.T) {
 	})
 
 	t.Run("CustomOptions", func(t *testing.T) {
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnablePredicatePushdown: false,
 			EnableFineGrainedPhases: true,
 			MaxPhases:               5,

--- a/datalog/executor/pull.go
+++ b/datalog/executor/pull.go
@@ -10,23 +10,26 @@ import (
 
 // PullExecutor executes pull patterns against the database
 type PullExecutor struct {
-	matcher PatternMatcher
-	ctx     PullContext
+	matcher        PatternMatcher
+	ctx            PullContext
+	entityResolver EntityResolver
 }
 
 // NewPullExecutor creates a new pull executor
-func NewPullExecutor(matcher PatternMatcher) *PullExecutor {
+func NewPullExecutor(matcher PatternMatcher, resolver EntityResolver) *PullExecutor {
 	return &PullExecutor{
-		matcher: matcher,
-		ctx:     &BasePullContext{},
+		matcher:        matcher,
+		entityResolver: resolver,
+		ctx:            &BasePullContext{},
 	}
 }
 
 // NewPullExecutorWithHandler creates a new pull executor with annotation support
-func NewPullExecutorWithHandler(matcher PatternMatcher, handler annotations.Handler) *PullExecutor {
+func NewPullExecutorWithHandler(matcher PatternMatcher, resolver EntityResolver, handler annotations.Handler) *PullExecutor {
 	return &PullExecutor{
-		matcher: matcher,
-		ctx:     NewPullContext(handler),
+		matcher:        matcher,
+		entityResolver: resolver,
+		ctx:            NewPullContext(handler),
 	}
 }
 
@@ -96,23 +99,34 @@ func (pe *PullExecutor) processSpec(entity datalog.Identity, spec query.PullAttr
 		// Missing attributes are omitted (not included as nil)
 
 	case *query.PullWildcard:
-		// Get all attributes for entity
-		datoms, err := pe.getAllAttributes(entity)
-		if err != nil {
-			return fmt.Errorf("wildcard pull failed: %w", err)
-		}
-		for _, datom := range datoms {
-			key := query.KeyName(datom.A)
-			if existing, ok := result[key]; ok {
-				// Attribute already seen - accumulate into slice (cardinality-many)
-				switch v := existing.(type) {
-				case []interface{}:
-					result[key] = append(v, datom.V)
-				default:
-					result[key] = []interface{}{v, datom.V}
+		// Use EntityResolver for CRDT-resolved values if available
+		if pe.entityResolver != nil {
+			resolved, err := pe.entityResolver.ResolveAllAttributes(entity)
+			if err != nil {
+				return fmt.Errorf("wildcard pull failed: %w", err)
+			}
+			for kw, val := range resolved {
+				result[query.KeyName(kw)] = val
+			}
+		} else {
+			// Fallback to raw datoms when no EntityResolver
+			datoms, err := pe.getAllAttributes(entity)
+			if err != nil {
+				return fmt.Errorf("wildcard pull failed: %w", err)
+			}
+			for _, datom := range datoms {
+				key := query.KeyName(datom.A)
+				if existing, ok := result[key]; ok {
+					// Attribute already seen - accumulate into slice (cardinality-many)
+					switch v := existing.(type) {
+					case []interface{}:
+						result[key] = append(v, datom.V)
+					default:
+						result[key] = []interface{}{v, datom.V}
+					}
+				} else {
+					result[key] = datom.V
 				}
-			} else {
-				result[key] = datom.V
 			}
 		}
 
@@ -388,24 +402,13 @@ func (pe *PullExecutor) processResolvedSpec(entity datalog.Identity, spec query.
 		}
 
 	case *query.ResolvedPullWildcard:
-		// Get all attributes for entity (same as unresolved)
-		datoms, err := pe.getAllAttributes(entity)
+		// Use EntityResolver for CRDT-resolved values
+		resolved, err := pe.entityResolver.ResolveAllAttributes(entity)
 		if err != nil {
 			return fmt.Errorf("wildcard pull failed: %w", err)
 		}
-		for _, datom := range datoms {
-			key := query.KeyName(datom.A)
-			if existing, ok := result[key]; ok {
-				// Attribute already seen - accumulate into slice (cardinality-many)
-				switch v := existing.(type) {
-				case []interface{}:
-					result[key] = append(v, datom.V)
-				default:
-					result[key] = []interface{}{v, datom.V}
-				}
-			} else {
-				result[key] = datom.V
-			}
+		for kw, val := range resolved {
+			result[query.KeyName(kw)] = val
 		}
 
 	case *query.ResolvedPullMapSpec:

--- a/datalog/executor/pull_benchmark_test.go
+++ b/datalog/executor/pull_benchmark_test.go
@@ -19,8 +19,8 @@ func BenchmarkPull_SingleAttribute(b *testing.B) {
 		{E: alice, A: nameAttr, V: "Alice", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 	pattern, _ := parser.ParsePullPattern(`[:user/name]`)
 
 	b.ResetTimer()
@@ -41,8 +41,8 @@ func BenchmarkPull_MultipleAttributes(b *testing.B) {
 		{E: alice, A: datalog.NewKeyword(":user/country"), V: "USA", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 	pattern, _ := parser.ParsePullPattern(`[:user/name :user/age :user/email :user/city :user/country]`)
 
 	b.ResetTimer()
@@ -63,8 +63,8 @@ func BenchmarkPull_Wildcard(b *testing.B) {
 		{E: alice, A: datalog.NewKeyword(":user/country"), V: "USA", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 	pattern, _ := parser.ParsePullPattern(`[*]`)
 
 	b.ResetTimer()
@@ -85,8 +85,8 @@ func BenchmarkPull_NestedReference(b *testing.B) {
 		{E: region, A: datalog.NewKeyword(":region/name"), V: "US West", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 	pattern, _ := parser.ParsePullPattern(`[:user/name {:user/region [:region/code :region/name]}]`)
 
 	b.ResetTimer()
@@ -109,8 +109,8 @@ func BenchmarkPull_DeepNesting(b *testing.B) {
 		{E: entity, A: datalog.NewKeyword(":entity/region"), V: region, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 	pattern, _ := parser.ParsePullPattern(`[:entity/code {:entity/region [:region/code {:region/nation [:nation/name]}]}]`)
 
 	b.ResetTimer()
@@ -134,8 +134,8 @@ func BenchmarkPullMany(b *testing.B) {
 		)
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 	pattern, _ := parser.ParsePullPattern(`[:user/name :user/age]`)
 
 	b.ResetTimer()
@@ -160,7 +160,7 @@ func BenchmarkPull_VsManualQuery(b *testing.B) {
 	matcher := NewMemoryPatternMatcher(datoms)
 
 	b.Run("Pull", func(b *testing.B) {
-		puller := NewPullExecutor(matcher)
+		puller := NewPullExecutor(matcher, nil)
 		pattern, _ := parser.ParsePullPattern(`[:user/name :user/age :user/email]`)
 
 		b.ResetTimer()
@@ -219,7 +219,7 @@ func BenchmarkPull_ScalingWithAttributes(b *testing.B) {
 		}
 
 		matcher := NewMemoryPatternMatcher(datoms)
-		puller := NewPullExecutor(matcher)
+		puller := NewPullExecutor(matcher, nil)
 		pattern, _ := parser.ParsePullPattern(fmt.Sprintf("[%s]", patternAttrs))
 
 		b.Run(fmt.Sprintf("Attrs_%d", numAttrs), func(b *testing.B) {

--- a/datalog/executor/pull_test.go
+++ b/datalog/executor/pull_test.go
@@ -22,8 +22,8 @@ func TestPullExecutor_SimpleAttributes(t *testing.T) {
 		{E: alice, A: emailAttr, V: "alice@example.com", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse pull pattern
 	pattern, err := parser.ParsePullPattern(`[:user/name :user/age]`)
@@ -68,8 +68,8 @@ func TestPullExecutor_Wildcard(t *testing.T) {
 		{E: alice, A: emailAttr, V: "alice@example.com", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse wildcard pattern
 	pattern, err := parser.ParsePullPattern(`[*]`)
@@ -118,8 +118,8 @@ func TestPullExecutor_Wildcard_CardinalityMany(t *testing.T) {
 		{E: alice, A: tagAttr, V: "reviewer", Tx: datalog.ElementID{Lamport: 3, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse wildcard pattern
 	pattern, err := parser.ParsePullPattern(`[*]`)
@@ -188,8 +188,8 @@ func TestPullExecutor_NestedReference(t *testing.T) {
 		{E: entity, A: entityRegionAttr, V: region, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}}, // Reference to region
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse nested pattern
 	pattern, err := parser.ParsePullPattern(`[:entity/code :entity/name {:entity/region [:region/code :region/name]}]`)
@@ -244,8 +244,8 @@ func TestPullExecutor_CycleDetection(t *testing.T) {
 		{E: entity2, A: nextAttr, V: entity1, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}}, // Circular reference back to entity1
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse pattern that would recurse infinitely without cycle detection
 	pattern, err := parser.ParsePullPattern(`[:entity/name {:entity/next [:entity/name {:entity/next [:entity/name]}]}]`)
@@ -300,8 +300,8 @@ func TestPullExecutor_MissingAttribute(t *testing.T) {
 		// No age attribute
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse pattern requesting missing attribute
 	pattern, err := parser.ParsePullPattern(`[:user/name :user/age]`)
@@ -336,8 +336,8 @@ func TestPullExecutor_DefaultValue(t *testing.T) {
 		// No status attribute
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse pattern with default value
 	pattern, err := parser.ParsePullPattern(`[:user/name (default :user/status "inactive")]`)
@@ -366,8 +366,8 @@ func TestPullExecutor_NonExistentEntity(t *testing.T) {
 	// Create empty datoms
 	datoms := []datalog.Datom{}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse pattern
 	pattern, err := parser.ParsePullPattern(`[:user/name :user/age]`)
@@ -399,8 +399,8 @@ func TestPullExecutor_PullMany(t *testing.T) {
 		{E: bob, A: nameAttr, V: "Bob", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse pattern
 	pattern, err := parser.ParsePullPattern(`[:user/name]`)
@@ -446,8 +446,8 @@ func TestPullExecutor_DeeplyNested(t *testing.T) {
 		{E: entity, A: entityRegionAttr, V: region, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Parse 3-level nested pattern
 	pattern, err := parser.ParsePullPattern(`[:entity/code {:entity/region [:region/code {:region/nation [:nation/name]}]}]`)
@@ -508,8 +508,8 @@ func TestPullExecutor_AnnotationsEmitted(t *testing.T) {
 		{E: alice, A: ageAttr, V: int64(30), Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Capture events
 	var events []annotations.Event
@@ -572,8 +572,8 @@ func TestPullExecutor_NoEventsWhenHandlerNil(t *testing.T) {
 		{E: alice, A: nameAttr, V: "Alice", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 	// Don't set handler - should use BasePullContext (no-op)
 
 	pattern, err := parser.ParsePullPattern(`[:user/name]`)
@@ -607,8 +607,8 @@ func TestPullExecutor_CycleDetectedEvent(t *testing.T) {
 		{E: entity2, A: nextAttr, V: entity1, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}}, // Circular reference
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Capture events
 	var events []annotations.Event
@@ -657,8 +657,8 @@ func TestPullExecutor_NestedRefsEmitDepthEvents(t *testing.T) {
 		{E: entity, A: entityRegionAttr, V: region, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	matcher := NewMemoryPatternMatcher(datoms)
-	puller := NewPullExecutor(matcher)
+	matcher := NewIndexedMemoryMatcher(datoms)
+	puller := NewPullExecutor(matcher, nil)
 
 	// Capture events
 	var events []annotations.Event

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -29,6 +29,7 @@ type QueryExecutor interface {
 // DefaultQueryExecutor implements QueryExecutor using the PatternMatcher interface
 type DefaultQueryExecutor struct {
 	matcher          PatternMatcher
+	entityResolver   EntityResolver
 	options          ExecutorOptions
 	constantBindings map[query.Symbol]interface{} // Scalar inputs resolved as constants (not relation columns)
 }
@@ -40,10 +41,11 @@ type DefaultQueryExecutor struct {
 // of this function in tests is for unit testing internal executor methods like
 // executePattern or executeExpression. End-to-end and integration tests must use
 // the public API to ensure the planner is exercised.
-func newQueryExecutor(matcher PatternMatcher, options ExecutorOptions) *DefaultQueryExecutor {
+func newQueryExecutor(matcher PatternMatcher, resolver EntityResolver, options ExecutorOptions) *DefaultQueryExecutor {
 	return &DefaultQueryExecutor{
-		matcher: matcher,
-		options: options,
+		matcher:        matcher,
+		entityResolver: resolver,
+		options:        options,
 	}
 }
 
@@ -1055,7 +1057,7 @@ func (e *DefaultQueryExecutor) executePulls(rel Relation, find []query.FindEleme
 	}
 
 	// Create pull executor
-	puller := NewPullExecutor(e.matcher)
+	puller := NewPullExecutor(e.matcher, e.entityResolver)
 
 	// Process tuples and execute pulls
 	var resultTuples []Tuple

--- a/datalog/executor/query_executor_test.go
+++ b/datalog/executor/query_executor_test.go
@@ -139,7 +139,7 @@ func TestExecutePattern(t *testing.T) {
 		},
 	}
 
-	executor := newQueryExecutor(matcher, ExecutorOptions{})
+	executor := newQueryExecutor(matcher, nil, ExecutorOptions{})
 	ctx := NewContext(nil)
 
 	pattern := &query.DataPattern{
@@ -163,7 +163,7 @@ func TestExecutePattern(t *testing.T) {
 // TestExecuteExpression tests expression evaluation
 func TestExecuteExpression(t *testing.T) {
 	t.Run("single relation expression", func(t *testing.T) {
-		executor := newQueryExecutor(&MockMatcher{}, ExecutorOptions{})
+		executor := newQueryExecutor(&MockMatcher{}, nil, ExecutorOptions{})
 		ctx := NewContext(nil)
 
 		// Create a relation with ?x
@@ -204,7 +204,7 @@ func TestExecuteExpression(t *testing.T) {
 	})
 
 	t.Run("multi-relation expression (Cartesian product)", func(t *testing.T) {
-		executor := newQueryExecutor(&MockMatcher{}, ExecutorOptions{})
+		executor := newQueryExecutor(&MockMatcher{}, nil, ExecutorOptions{})
 		ctx := NewContext(nil)
 
 		// Two disjoint relations
@@ -247,7 +247,7 @@ func TestExecuteExpression(t *testing.T) {
 // TestExecutePredicate tests predicate filtering
 func TestExecutePredicate(t *testing.T) {
 	t.Run("single relation predicate", func(t *testing.T) {
-		executor := newQueryExecutor(&MockMatcher{}, ExecutorOptions{})
+		executor := newQueryExecutor(&MockMatcher{}, nil, ExecutorOptions{})
 		ctx := NewContext(nil)
 
 		// Create relation with ?x
@@ -296,7 +296,7 @@ func TestExecuteAggregates(t *testing.T) {
 		},
 	}
 
-	executor := newQueryExecutor(matcher, ExecutorOptions{})
+	executor := newQueryExecutor(matcher, nil, ExecutorOptions{})
 	ctx := NewContext(nil)
 
 	t.Run("grouped aggregation", func(t *testing.T) {
@@ -387,7 +387,7 @@ func TestEndToEndQueries(t *testing.T) {
 		},
 	}
 
-	executor := newQueryExecutor(matcher, ExecutorOptions{})
+	executor := newQueryExecutor(matcher, nil, ExecutorOptions{})
 	ctx := NewContext(nil)
 
 	t.Run("pattern + predicate query", func(t *testing.T) {
@@ -433,7 +433,7 @@ func TestEndToEndQueries(t *testing.T) {
 // TestExecuteTupleGround tests tuple ground expression execution
 func TestExecuteTupleGround(t *testing.T) {
 	t.Run("standalone tuple ground", func(t *testing.T) {
-		executor := newQueryExecutor(&MockMatcher{}, ExecutorOptions{})
+		executor := newQueryExecutor(&MockMatcher{}, nil, ExecutorOptions{})
 		ctx := NewContext(nil)
 
 		// Expression: [(ground [1 2 3]) [?a ?b ?c]]
@@ -486,7 +486,7 @@ func TestExecuteTupleGround(t *testing.T) {
 	})
 
 	t.Run("tuple ground with existing relation", func(t *testing.T) {
-		executor := newQueryExecutor(&MockMatcher{}, ExecutorOptions{})
+		executor := newQueryExecutor(&MockMatcher{}, nil, ExecutorOptions{})
 		ctx := NewContext(nil)
 
 		// Create a relation with ?x
@@ -526,7 +526,7 @@ func TestExecuteTupleGround(t *testing.T) {
 	})
 
 	t.Run("tuple ground mismatch error", func(t *testing.T) {
-		executor := newQueryExecutor(&MockMatcher{}, ExecutorOptions{})
+		executor := newQueryExecutor(&MockMatcher{}, nil, ExecutorOptions{})
 		ctx := NewContext(nil)
 
 		// Expression with mismatched values and bindings

--- a/datalog/executor/queryexecutor_correlated_subquery_test.go
+++ b/datalog/executor/queryexecutor_correlated_subquery_test.go
@@ -47,7 +47,7 @@ func TestQueryExecutorCorrelatedSubquery(t *testing.T) {
 
 	matcher := NewIndexedMemoryMatcher(datoms)
 	opts := planner.PlannerOptions{}
-	exec := NewExecutorWithOptions(matcher, opts)
+	exec := NewExecutorWithOptions(matcher, nil, opts)
 	result, err := exec.Execute(q)
 
 	if err != nil {

--- a/datalog/executor/queryexecutor_multiple_correlated_subqueries_test.go
+++ b/datalog/executor/queryexecutor_multiple_correlated_subqueries_test.go
@@ -138,7 +138,7 @@ func TestQueryExecutorMultipleCorrelatedSubqueries(t *testing.T) {
 	t.Run("QueryExecutor", func(t *testing.T) {
 		matcher := NewIndexedMemoryMatcher(datoms)
 		opts := planner.PlannerOptions{}
-		exec := NewExecutorWithOptions(matcher, opts)
+		exec := NewExecutorWithOptions(matcher, nil, opts)
 		result, err := exec.Execute(q)
 
 		if err != nil {

--- a/datalog/executor/queryexecutor_subquery_projection_test.go
+++ b/datalog/executor/queryexecutor_subquery_projection_test.go
@@ -49,7 +49,7 @@ func TestQueryExecutorSubqueryProjection(t *testing.T) {
 
 	matcher := NewIndexedMemoryMatcher(datoms)
 	opts := planner.PlannerOptions{}
-	exec := NewExecutorWithOptions(matcher, opts)
+	exec := NewExecutorWithOptions(matcher, nil, opts)
 	result, err := exec.Execute(q)
 	assert.NoError(t, err, "QueryExecutor should preserve subquery result column names")
 
@@ -154,7 +154,7 @@ func TestQueryExecutorMultipleSubqueryProjections(t *testing.T) {
 	t.Run("QueryExecutor", func(t *testing.T) {
 		matcher := NewIndexedMemoryMatcher(datoms) // Fresh matcher per subtest
 		opts := planner.PlannerOptions{}
-		exec := NewExecutorWithOptions(matcher, opts)
+		exec := NewExecutorWithOptions(matcher, nil, opts)
 		result, err := exec.Execute(q)
 
 		// BUG: This should succeed but fails with:

--- a/datalog/executor/relation_input_test.go
+++ b/datalog/executor/relation_input_test.go
@@ -35,7 +35,7 @@ func TestRelationInputIteration(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 	ctx := NewContext(nil)
 
 	t.Run("direct query with RelationInput", func(t *testing.T) {
@@ -158,7 +158,7 @@ func TestRelationInputIterationParallel(t *testing.T) {
 	}
 
 	matcher := NewMemoryPatternMatcher(datoms)
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 	exec.EnableParallelSubqueries(4) // Use 4 workers for testing
 	ctx := NewContext(nil)
 
@@ -254,7 +254,7 @@ func TestRelationInputIterationParallel(t *testing.T) {
 		)
 
 		// Execute sequentially
-		seqExec := NewExecutor(matcher)
+		seqExec := NewExecutor(matcher, nil)
 		seqExec.DisableParallelSubqueries()
 		seqResult, err := seqExec.ExecuteWithRelations(ctx, parsed, []Relation{inputRel})
 		if err != nil {
@@ -262,7 +262,7 @@ func TestRelationInputIterationParallel(t *testing.T) {
 		}
 
 		// Execute in parallel
-		parExec := NewExecutor(matcher)
+		parExec := NewExecutor(matcher, nil)
 		parExec.EnableParallelSubqueries(4)
 		parResult, err := parExec.ExecuteWithRelations(ctx, parsed, []Relation{inputRel})
 		if err != nil {
@@ -337,7 +337,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 	ctx := NewContext(nil)
 
 	t.Run("empty input relation", func(t *testing.T) {
-		exec := NewExecutor(matcher)
+		exec := NewExecutor(matcher, nil)
 		exec.EnableParallelSubqueries(4)
 
 		q := `[:find ?n ?y (max ?age)
@@ -365,7 +365,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 	})
 
 	t.Run("single tuple", func(t *testing.T) {
-		exec := NewExecutor(matcher)
+		exec := NewExecutor(matcher, nil)
 		exec.EnableParallelSubqueries(4)
 
 		q := `[:find ?n ?y (max ?age)
@@ -396,7 +396,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 	})
 
 	t.Run("no matching results", func(t *testing.T) {
-		exec := NewExecutor(matcher)
+		exec := NewExecutor(matcher, nil)
 		exec.EnableParallelSubqueries(4)
 
 		q := `[:find ?n ?y (max ?age)
@@ -430,7 +430,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 	})
 
 	t.Run("mixed matching and non-matching", func(t *testing.T) {
-		exec := NewExecutor(matcher)
+		exec := NewExecutor(matcher, nil)
 		exec.EnableParallelSubqueries(4)
 
 		q := `[:find ?n ?y (max ?age)
@@ -466,7 +466,7 @@ func TestRelationInputParallelEdgeCases(t *testing.T) {
 	})
 
 	t.Run("high worker count with small input", func(t *testing.T) {
-		exec := NewExecutor(matcher)
+		exec := NewExecutor(matcher, nil)
 		exec.EnableParallelSubqueries(100) // Way more workers than tuples
 
 		q := `[:find ?n ?y (max ?age)
@@ -530,7 +530,7 @@ func TestRelationInputParallelStress(t *testing.T) {
 	ctx := NewContext(nil)
 
 	t.Run("stress test with many iterations", func(t *testing.T) {
-		exec := NewExecutor(matcher)
+		exec := NewExecutor(matcher, nil)
 		exec.EnableParallelSubqueries(16) // High worker count
 
 		q := `[:find ?n ?y ?m (max ?age)
@@ -613,7 +613,7 @@ func TestRelationInputParallelStress(t *testing.T) {
 		errCh := make(chan error, 10)
 		for i := 0; i < 10; i++ {
 			go func() {
-				exec := NewExecutor(matcher)
+				exec := NewExecutor(matcher, nil)
 				exec.EnableParallelSubqueries(8)
 				_, err := exec.ExecuteWithRelations(ctx, parsed, []Relation{inputRel})
 				errCh <- err

--- a/datalog/executor/semantic_rewriting_bench_test.go
+++ b/datalog/executor/semantic_rewriting_bench_test.go
@@ -59,7 +59,7 @@ func BenchmarkSemanticRewritingYearFilter(b *testing.B) {
 
 	// Benchmark WITHOUT semantic rewriting
 	b.Run("WithoutRewriting", func(b *testing.B) {
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSemanticRewriting: false,
 			EnableFineGrainedPhases: true,
 			MaxPhases:               10,
@@ -79,7 +79,7 @@ func BenchmarkSemanticRewritingYearFilter(b *testing.B) {
 
 	// Benchmark WITH semantic rewriting
 	b.Run("WithRewriting", func(b *testing.B) {
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSemanticRewriting: true,
 			EnableFineGrainedPhases: true,
 			MaxPhases:               10,
@@ -154,7 +154,7 @@ func BenchmarkSemanticRewritingMultiComponent(b *testing.B) {
 
 	// Benchmark WITHOUT semantic rewriting
 	b.Run("WithoutRewriting", func(b *testing.B) {
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSemanticRewriting: false,
 			EnableFineGrainedPhases: true,
 			MaxPhases:               10,
@@ -174,7 +174,7 @@ func BenchmarkSemanticRewritingMultiComponent(b *testing.B) {
 
 	// Benchmark WITH semantic rewriting
 	b.Run("WithRewriting", func(b *testing.B) {
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSemanticRewriting: true,
 			EnableFineGrainedPhases: true,
 			MaxPhases:               10,
@@ -271,7 +271,7 @@ func BenchmarkSemanticRewritingOHLCScale(b *testing.B) {
 
 	// Benchmark WITHOUT semantic rewriting
 	b.Run("WithoutRewriting", func(b *testing.B) {
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSemanticRewriting: false,
 			EnableFineGrainedPhases: true,
 			MaxPhases:               10,
@@ -292,7 +292,7 @@ func BenchmarkSemanticRewritingOHLCScale(b *testing.B) {
 
 	// Benchmark WITH semantic rewriting
 	b.Run("WithRewriting", func(b *testing.B) {
-		exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 			EnableSemanticRewriting: true,
 			EnableFineGrainedPhases: true,
 			MaxPhases:               10,

--- a/datalog/executor/semantic_rewriting_ohlc_test.go
+++ b/datalog/executor/semantic_rewriting_ohlc_test.go
@@ -179,7 +179,7 @@ func TestSemanticRewritingOHLCScale(t *testing.T) {
 
 	// Test 1: Decorrelation WITHOUT Semantic Rewriting
 	t.Log("\n=== Config 1: Decorrelation WITHOUT Semantic Rewriting ===")
-	exec1 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec1 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableSemanticRewriting:     false,
@@ -197,7 +197,7 @@ func TestSemanticRewritingOHLCScale(t *testing.T) {
 
 	// Test 2: Decorrelation WITH Semantic Rewriting
 	t.Log("\n=== Config 2: Decorrelation WITH Semantic Rewriting ===")
-	exec2 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec2 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: true,
 		EnableSemanticRewriting:     true,
@@ -215,7 +215,7 @@ func TestSemanticRewritingOHLCScale(t *testing.T) {
 
 	// Test 3: NO Decorrelation, NO Semantic Rewriting (baseline)
 	t.Log("\n=== Config 3: NO Decorrelation, NO Semantic Rewriting (Baseline) ===")
-	exec3 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec3 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: false,
 		EnableParallelDecorrelation: false,
 		EnableSemanticRewriting:     false,
@@ -233,7 +233,7 @@ func TestSemanticRewritingOHLCScale(t *testing.T) {
 
 	// Test 4: NO Decorrelation, WITH Semantic Rewriting
 	t.Log("\n=== Config 4: NO Decorrelation, WITH Semantic Rewriting ===")
-	exec4 := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec4 := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: false,
 		EnableParallelDecorrelation: false,
 		EnableSemanticRewriting:     true,

--- a/datalog/executor/semantic_rewriting_test.go
+++ b/datalog/executor/semantic_rewriting_test.go
@@ -61,7 +61,7 @@ func TestSemanticRewritingTimePredicates(t *testing.T) {
 	}
 
 	// Execute WITH semantic rewriting
-	execWithRewriting := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execWithRewriting := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSemanticRewriting: true,
 		EnableFineGrainedPhases: true,
 		MaxPhases:               10,
@@ -73,7 +73,7 @@ func TestSemanticRewritingTimePredicates(t *testing.T) {
 	}
 
 	// Execute WITHOUT semantic rewriting for comparison
-	execWithoutRewriting := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execWithoutRewriting := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSemanticRewriting: false,
 		EnableFineGrainedPhases: true,
 		MaxPhases:               10,
@@ -165,7 +165,7 @@ func TestSemanticRewritingMultipleTimeComponents(t *testing.T) {
 	}
 
 	// Execute WITH semantic rewriting
-	execWithRewriting := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execWithRewriting := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSemanticRewriting: true,
 		EnableFineGrainedPhases: true,
 		MaxPhases:               10,
@@ -245,7 +245,7 @@ func TestSemanticRewritingDisabled(t *testing.T) {
 	}
 
 	// Execute WITHOUT semantic rewriting - should still work via expressions
-	exec := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSemanticRewriting: false,
 		EnableFineGrainedPhases: true,
 		MaxPhases:               10,

--- a/datalog/executor/subquery_find_clause_bug_test.go
+++ b/datalog/executor/subquery_find_clause_bug_test.go
@@ -35,7 +35,7 @@ func TestSubqueryFindClauseBug(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Query with TWO subqueries that share the same input parameter
 	// This triggers decorrelation optimization which incorrectly modifies the find clause
@@ -144,7 +144,7 @@ func TestSubqueryFindClauseBugWithAnnotations(t *testing.T) {
 
 	// Wrap matcher with annotation support
 	annotatedMatcher := WrapMatcher(matcher, handler)
-	exec := NewExecutor(annotatedMatcher)
+	exec := NewExecutor(annotatedMatcher, nil)
 
 	// Query with TWO subqueries that share the same input parameter
 	queryStr := `[:find ?symbol ?max-price ?min-price
@@ -234,7 +234,7 @@ func TestSubqueryMultiValueFindClauseBug(t *testing.T) {
 		},
 	}
 
-	exec := NewExecutor(matcher)
+	exec := NewExecutor(matcher, nil)
 
 	// Query with TWO multi-value binding subqueries that have intermediate variables
 	// Both subqueries share the same inputs (?sym, ?d) which triggers decorrelation

--- a/datalog/executor/subquery_union_bench_test.go
+++ b/datalog/executor/subquery_union_bench_test.go
@@ -52,7 +52,7 @@ func BenchmarkSubqueryUnionComparison(b *testing.B) {
 			EnableStreamingJoins:      true,
 			EnableParallelSubqueries:  false, // Sequential for cleaner comparison
 		}
-		exec := NewExecutorWithOptions(matcher, opts)
+		exec := NewExecutorWithOptions(matcher, nil, opts)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -76,7 +76,7 @@ func BenchmarkSubqueryUnionComparison(b *testing.B) {
 			EnableStreamingJoins:      true,
 			EnableParallelSubqueries:  false, // Sequential for cleaner comparison
 		}
-		exec := NewExecutorWithOptions(matcher, opts)
+		exec := NewExecutorWithOptions(matcher, nil, opts)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/datalog/executor/time_range_integration_test.go
+++ b/datalog/executor/time_range_integration_test.go
@@ -60,7 +60,7 @@ func TestTimeRangeMetadataFlow(t *testing.T) {
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: false, // Disable for deterministic testing
 	}
-	exec := NewExecutorWithOptions(matcher, plannerOpts)
+	exec := NewExecutorWithOptions(matcher, nil, plannerOpts)
 
 	// Query: Hourly OHLC for hours 9 and 10 only (not 11)
 	queryStr := `[:find ?hour (max ?h) (min ?l)
@@ -85,7 +85,7 @@ func TestTimeRangeMetadataFlow(t *testing.T) {
 	}
 
 	// Execute without decorrelation (baseline)
-	execNoDecorr := NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	execNoDecorr := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
 		EnableSubqueryDecorrelation: false,
 	})
 
@@ -168,7 +168,7 @@ func TestTimeRangeOptimizationCorrectness(t *testing.T) {
 		EnableSubqueryDecorrelation: true,
 		EnableParallelDecorrelation: false,
 	}
-	exec := NewExecutorWithOptions(matcher, plannerOpts)
+	exec := NewExecutorWithOptions(matcher, nil, plannerOpts)
 
 	// Query with decorrelated subquery (like OHLC pattern)
 	queryStr := `[:find ?hour ?high ?low

--- a/datalog/executor/wrapper_relation_copy_test.go
+++ b/datalog/executor/wrapper_relation_copy_test.go
@@ -426,7 +426,7 @@ func TestOrFallbackIteratorCopiesFromUnsafeOuter(t *testing.T) {
 	}
 
 	matcher := NewIndexedMemoryMatcher(datoms)
-	queryExec := newQueryExecutor(matcher, ExecutorOptions{})
+	queryExec := newQueryExecutor(matcher, nil, ExecutorOptions{})
 	ctx := NewContext(nil)
 
 	// Create an unsafe outer relation with [?e, ?name]
@@ -595,7 +595,7 @@ func TestOrFallbackIteratorMultipleBranchResultsIntegration(t *testing.T) {
 	}
 
 	matcher := NewIndexedMemoryMatcher(datoms)
-	queryExec := newQueryExecutor(matcher, ExecutorOptions{})
+	queryExec := newQueryExecutor(matcher, nil, ExecutorOptions{})
 	ctx := NewContext(func(e annotations.Event) {
 		t.Logf("[ANNOTATION] %s: %v", e.Name, e.Data)
 	})
@@ -687,7 +687,7 @@ func TestOrFallbackIteratorWithFallbackBranch(t *testing.T) {
 	}
 
 	matcher := NewIndexedMemoryMatcher(datoms)
-	queryExec := newQueryExecutor(matcher, ExecutorOptions{})
+	queryExec := newQueryExecutor(matcher, nil, ExecutorOptions{})
 	ctx := NewContext(nil)
 
 	// Create an unsafe outer relation with 3 items

--- a/datalog/reflect/writer.go
+++ b/datalog/reflect/writer.go
@@ -2,7 +2,8 @@ package reflect
 
 import (
 	"crypto/rand"
-	"encoding/hex"
+	"crypto/sha1"
+	"encoding/binary"
 	"fmt"
 	"reflect"
 	"time"
@@ -12,13 +13,19 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
-// generateUniqueID creates a unique entity ID using timestamp + random bytes
+// generateUniqueID creates a unique entity ID using timestamp + random bytes.
+// Returns an Identity that displays as L85 hash (not the raw timestamp string).
 func generateUniqueID() datalog.Identity {
-	// 8 random bytes gives us 64 bits of entropy
-	var randomBytes [8]byte
-	rand.Read(randomBytes[:])
-	randomHex := hex.EncodeToString(randomBytes[:])
-	return datalog.NewIdentity(fmt.Sprintf("e%d-%s", time.Now().UnixNano(), randomHex))
+	// Build unique bytes: 8 bytes timestamp + 8 bytes random
+	var buf [16]byte
+	binary.BigEndian.PutUint64(buf[:8], uint64(time.Now().UnixNano()))
+	rand.Read(buf[8:])
+
+	// Hash to get a proper 20-byte identity
+	hash := sha1.Sum(buf[:])
+
+	// Use NewIdentityFromHash so String() returns L85 (not the raw input)
+	return datalog.NewIdentityFromHash(hash)
 }
 
 // TransactionAdder is the interface required for adding datoms

--- a/datalog/storage/aevt_bug_test.go
+++ b/datalog/storage/aevt_bug_test.go
@@ -102,7 +102,7 @@ func TestAEVTIndexBugDirect(t *testing.T) {
 	)
 
 	// Execute query without parallel execution (to capture all annotations)
-	exec := executor.NewExecutor(matcher)
+	exec := executor.NewExecutor(matcher, db)
 	exec.DisableParallelSubqueries() // Disable parallel to get all events in our handler
 	result, err := exec.ExecuteWithRelations(ctx, parsed, []executor.Relation{inputRel})
 	if err != nil {

--- a/datalog/storage/cache.go
+++ b/datalog/storage/cache.go
@@ -74,6 +74,11 @@ type Cache struct {
 	// When querying [?e :name "Bob"], we can check if ANY :name has changed
 	// without checking every individual (E, :name) pair
 	attrVersions sync.Map // map[Attribute]datalog.ElementID
+
+	// Per-entity attribute tracking - tracks which attributes we've cached per entity
+	// This is NOT source of truth - just tracks what's in cache for difference-based
+	// decisions on whether to do individual lookups vs full entity scan
+	entityAttrs sync.Map // map[Entity]*sync.Map (inner: map[Attribute]struct{})
 }
 
 // NewCache creates a new cache instance
@@ -109,6 +114,8 @@ func (c *Cache) GetOrResolve(key CacheKey, resolver CacheResolver) *CacheEntry {
 		c.entries.Store(key, entry)
 		// Update maxVersions to reflect what we just resolved
 		c.UpdateMaxVersion(key, entry.version)
+		// Track that we've cached this attribute for this entity
+		c.TrackEntityAttr(key.E, key.A)
 	}
 	return entry
 }
@@ -191,6 +198,33 @@ func (c *Cache) Clear() {
 	c.entries = sync.Map{}
 	c.maxVersions = sync.Map{}
 	c.attrVersions = sync.Map{}
+	c.entityAttrs = sync.Map{}
+}
+
+// TrackEntityAttr records that we have cached an (E, A) entry
+// Called when storing cache entries to track what's cached per entity
+func (c *Cache) TrackEntityAttr(e Entity, a Attribute) {
+	// Get or create the attribute set for this entity
+	val, _ := c.entityAttrs.LoadOrStore(e, &sync.Map{})
+	set := val.(*sync.Map)
+	set.Store(a, struct{}{})
+}
+
+// GetCachedAttrs returns the set of attributes we've cached for an entity
+// Returns nil if no attributes are cached for this entity
+func (c *Cache) GetCachedAttrs(e Entity) map[Attribute]bool {
+	val, ok := c.entityAttrs.Load(e)
+	if !ok {
+		return nil
+	}
+	set := val.(*sync.Map)
+
+	result := make(map[Attribute]bool)
+	set.Range(func(key, _ any) bool {
+		result[key.(Attribute)] = true
+		return true
+	})
+	return result
 }
 
 // rebuild resolves the current value for (E, A) based on cardinality

--- a/datalog/storage/crdt_bug_verify_test.go
+++ b/datalog/storage/crdt_bug_verify_test.go
@@ -1,0 +1,64 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// TaskEntity matches the exact bug scenario from PULLINTO_CRDT_RESOLUTION.md
+type TaskEntity struct {
+	ID     datalog.Identity `datalog:"-,id"`
+	Status datalog.Keyword  `datalog:"task/status"`
+}
+
+// TestBugVerification_PullInto_CardinalityOne reproduces the exact bug from the doc:
+// "Error: field Status (attr task/status): expected Keyword, got []interface {}"
+func TestBugVerification_PullInto_CardinalityOne(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create schema with CardinalityOne (exactly as in bug doc)
+	s, err := schema.NewBuilder().
+		Attribute(":task/status").Type(schema.TypeKeyword).One().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Create entity
+	taskID := datalog.NewIdentity("task-1")
+
+	// Write status TWICE - this is the bug scenario
+	// First: pending
+	tx1 := db.NewTransaction()
+	err = tx1.Set(taskID, datalog.NewKeyword(":task/status"), datalog.NewKeyword(":status/pending"))
+	require.NoError(t, err)
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	// Second: complete
+	tx2 := db.NewTransaction()
+	err = tx2.Set(taskID, datalog.NewKeyword(":task/status"), datalog.NewKeyword(":status/complete"))
+	require.NoError(t, err)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Clear cache to force storage resolution
+	db.Cache().Clear()
+
+	// THE ACTUAL BUG: PullInto fails with "expected Keyword, got []interface{}"
+	var task TaskEntity
+	err = db.PullInto(taskID, &task)
+
+	// If bug exists, this fails with: "field Status (attr task/status): expected Keyword, got []interface {}"
+	require.NoError(t, err, "PullInto should not fail - if it does, the bug still exists")
+
+	// Verify we got the LWW-resolved value (latest wins)
+	assert.Equal(t, datalog.NewKeyword(":status/complete"), task.Status,
+		"should return LWW-resolved status")
+}

--- a/datalog/storage/crdt_resolve.go
+++ b/datalog/storage/crdt_resolve.go
@@ -1,0 +1,201 @@
+package storage
+
+import (
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// CRDT resolution functions that operate on pre-fetched datoms.
+// These are pure functions that can be used by both:
+// 1. Cache rebuild path (GetOrResolve → rebuild → storage scan → resolve)
+// 2. Entity scan path (EAVT scan → group by attribute → resolve each)
+//
+// This factoring avoids redundant storage scans when processing multiple
+// attributes for the same entity.
+
+// ResolveLWWFromDatoms resolves cardinality-one using Last-Writer-Wins semantics.
+// Input: datoms for a single (E, A) pair, any order.
+// Output: current value (highest ElementID wins), max ElementID seen.
+//
+// Returns (nil, zero ElementID) if no datoms provided.
+func ResolveLWWFromDatoms(datoms []datalog.Datom) (any, datalog.ElementID) {
+	if len(datoms) == 0 {
+		return nil, datalog.ElementID{}
+	}
+
+	var maxID datalog.ElementID
+	var currentValue any
+
+	for _, d := range datoms {
+		if d.Tx.Compare(maxID) > 0 {
+			maxID = d.Tx
+			currentValue = d.V
+		}
+	}
+
+	return currentValue, maxID
+}
+
+// ResolveAddWinsFromDatoms resolves cardinality-many using add-wins CRDT semantics.
+// Input: datoms for a single (E, A) pair, any order. Datoms include Op field.
+// Output: set of current members, max ElementID seen.
+//
+// Add-wins semantics:
+// - For each unique value, track highest add tx and highest remove tx
+// - If add has higher Lamport: in set
+// - If remove has higher Lamport: not in set
+// - Same Lamport (concurrent): add wins
+func ResolveAddWinsFromDatoms(datoms []datalog.Datom) (map[any]bool, datalog.ElementID) {
+	if len(datoms) == 0 {
+		return make(map[any]bool), datalog.ElementID{}
+	}
+
+	var maxID datalog.ElementID
+
+	// Track state per value
+	type valueState struct {
+		highestAddTx    datalog.ElementID
+		highestRemoveTx datalog.ElementID
+		hasAdd          bool
+		hasRemove       bool
+		value           any
+	}
+	valueStates := make(map[string]*valueState)
+
+	for _, d := range datoms {
+		// Track global max
+		if d.Tx.Compare(maxID) > 0 {
+			maxID = d.Tx
+		}
+
+		// Build key for this value (type + bytes)
+		vType := byte(datalog.Type(d.V))
+		vBytes := datalog.ValueBytes(d.V)
+		valueKey := string(append([]byte{vType}, vBytes...))
+
+		state, exists := valueStates[valueKey]
+		if !exists {
+			state = &valueState{value: d.V}
+			valueStates[valueKey] = state
+		}
+
+		// Track highest tx per operation type
+		if d.Op == datalog.OpCRDTAdd {
+			if !state.hasAdd || d.Tx.Compare(state.highestAddTx) > 0 {
+				state.highestAddTx = d.Tx
+				state.hasAdd = true
+			}
+		} else if d.Op == datalog.OpCRDTRemove {
+			if !state.hasRemove || d.Tx.Compare(state.highestRemoveTx) > 0 {
+				state.highestRemoveTx = d.Tx
+				state.hasRemove = true
+			}
+		}
+	}
+
+	// Resolve membership
+	result := make(map[any]bool)
+	for _, state := range valueStates {
+		inSet := false
+		if state.hasAdd && !state.hasRemove {
+			inSet = true
+		} else if state.hasAdd && state.hasRemove {
+			if state.highestAddTx.Lamport > state.highestRemoveTx.Lamport {
+				inSet = true
+			} else if state.highestAddTx.Lamport == state.highestRemoveTx.Lamport {
+				// Concurrent: add wins
+				inSet = true
+			}
+		}
+		if inSet {
+			result[state.value] = true
+		}
+	}
+
+	return result, maxID
+}
+
+// ResolveRGAFromDatoms resolves cardinality-vector using RGA reconstruction.
+// Input: datoms for a single (E, A) pair, any order. Datoms must include Op and AfterRef.
+// Output: ordered values, position index (element IDs), max ElementID seen.
+//
+// RGA semantics:
+// - OpRGAInsert: element inserted after AfterRef position
+// - OpRGATombstone: element deleted (AfterRef is the deleted element's ID)
+// - Final order determined by tree reconstruction
+func ResolveRGAFromDatoms(datoms []datalog.Datom) ([]any, []datalog.ElementID, datalog.ElementID) {
+	if len(datoms) == 0 {
+		return nil, nil, datalog.ElementID{}
+	}
+
+	// Build RGAElement map with deduplication
+	elemByID := make(map[datalog.ElementID]RGAElement)
+
+	for _, d := range datoms {
+		if d.Op != datalog.OpRGAInsert && d.Op != datalog.OpRGATombstone {
+			continue
+		}
+
+		if d.Op == datalog.OpRGAInsert {
+			rgaElem := RGAElement{
+				ID:       d.Tx,
+				Value:    d.V,
+				AfterRef: d.AfterRef,
+			}
+
+			existing, exists := elemByID[rgaElem.ID]
+			if !exists {
+				elemByID[rgaElem.ID] = rgaElem
+			} else if existing.Tombstone == nil {
+				elemByID[rgaElem.ID] = rgaElem
+			}
+
+		} else if d.Op == datalog.OpRGATombstone {
+			targetID := d.AfterRef
+			tombstoneID := d.Tx
+
+			existing, exists := elemByID[targetID]
+			if !exists {
+				elemByID[targetID] = RGAElement{
+					ID:        targetID,
+					Value:     d.V,
+					AfterRef:  datalog.ElementID{},
+					Tombstone: &tombstoneID,
+				}
+			} else {
+				if existing.Tombstone == nil || existing.Tombstone.Less(tombstoneID) {
+					existing.Tombstone = &tombstoneID
+					if existing.Value == nil {
+						existing.Value = d.V
+					}
+					elemByID[targetID] = existing
+				}
+			}
+		}
+	}
+
+	// Convert to slice
+	elements := make([]RGAElement, 0, len(elemByID))
+	for _, elem := range elemByID {
+		elements = append(elements, elem)
+	}
+
+	if len(elements) == 0 {
+		return nil, nil, datalog.ElementID{}
+	}
+
+	// Reconstruct with IDs
+	withIDs := ReconstructRGAWithIDs(elements)
+
+	// Extract values and positions
+	values := make([]any, len(withIDs))
+	positions := make([]datalog.ElementID, len(withIDs))
+	for i, ewp := range withIDs {
+		values[i] = ewp.Element.Value
+		positions[i] = ewp.Element.ID
+	}
+
+	// Find max ElementID
+	maxID := FindMaxElementID(elements)
+
+	return values, positions, maxID
+}

--- a/datalog/storage/crdt_resolve_test.go
+++ b/datalog/storage/crdt_resolve_test.go
@@ -1,0 +1,267 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// Helper to create ElementID with specific Lamport clock
+func elemID(lamport uint64, replica uint64) datalog.ElementID {
+	return datalog.ElementID{Lamport: lamport, ReplicaID: replica}
+}
+
+// Helper to create a datom for testing
+func testDatom(tx datalog.ElementID, value any, op datalog.CRDTOp) datalog.Datom {
+	return datalog.Datom{
+		Tx: tx,
+		V:  value,
+		Op: op,
+	}
+}
+
+// Helper to create RGA datom with AfterRef
+func rgaDatom(tx datalog.ElementID, value any, op datalog.CRDTOp, afterRef datalog.ElementID) datalog.Datom {
+	return datalog.Datom{
+		Tx:       tx,
+		V:        value,
+		Op:       op,
+		AfterRef: afterRef,
+	}
+}
+
+// =============================================================================
+// LWW Resolution Tests
+// =============================================================================
+
+func TestResolveLWWFromDatoms_Empty(t *testing.T) {
+	val, maxID := ResolveLWWFromDatoms(nil)
+	assert.Nil(t, val)
+	assert.Equal(t, datalog.ElementID{}, maxID)
+}
+
+func TestResolveLWWFromDatoms_Single(t *testing.T) {
+	datoms := []datalog.Datom{
+		testDatom(elemID(100, 1), "Alice", datalog.OpNone),
+	}
+
+	val, maxID := ResolveLWWFromDatoms(datoms)
+	assert.Equal(t, "Alice", val)
+	assert.Equal(t, elemID(100, 1), maxID)
+}
+
+func TestResolveLWWFromDatoms_HighestWins(t *testing.T) {
+	datoms := []datalog.Datom{
+		testDatom(elemID(100, 1), "Alice", datalog.OpNone),
+		testDatom(elemID(200, 1), "Bob", datalog.OpNone),
+		testDatom(elemID(150, 1), "Charlie", datalog.OpNone),
+	}
+
+	val, maxID := ResolveLWWFromDatoms(datoms)
+	assert.Equal(t, "Bob", val) // Highest Lamport wins
+	assert.Equal(t, elemID(200, 1), maxID)
+}
+
+func TestResolveLWWFromDatoms_SameLamportDifferentReplica(t *testing.T) {
+	// When Lamport is same, higher ReplicaID wins (ElementID.Compare behavior)
+	datoms := []datalog.Datom{
+		testDatom(elemID(100, 1), "Alice", datalog.OpNone),
+		testDatom(elemID(100, 2), "Bob", datalog.OpNone),
+	}
+
+	val, maxID := ResolveLWWFromDatoms(datoms)
+	assert.Equal(t, "Bob", val) // Higher ReplicaID wins
+	assert.Equal(t, elemID(100, 2), maxID)
+}
+
+// =============================================================================
+// Add-Wins Set Resolution Tests
+// =============================================================================
+
+func TestResolveAddWinsFromDatoms_Empty(t *testing.T) {
+	members, maxID := ResolveAddWinsFromDatoms(nil)
+	assert.Empty(t, members)
+	assert.Equal(t, datalog.ElementID{}, maxID)
+}
+
+func TestResolveAddWinsFromDatoms_OnlyAdds(t *testing.T) {
+	datoms := []datalog.Datom{
+		testDatom(elemID(100, 1), "tag1", datalog.OpCRDTAdd),
+		testDatom(elemID(101, 1), "tag2", datalog.OpCRDTAdd),
+	}
+
+	members, maxID := ResolveAddWinsFromDatoms(datoms)
+	assert.True(t, members["tag1"])
+	assert.True(t, members["tag2"])
+	assert.Equal(t, 2, len(members))
+	assert.Equal(t, elemID(101, 1), maxID)
+}
+
+func TestResolveAddWinsFromDatoms_AddThenRemove_RemoveWins(t *testing.T) {
+	// Remove has higher Lamport -> not in set
+	datoms := []datalog.Datom{
+		testDatom(elemID(100, 1), "tag1", datalog.OpCRDTAdd),
+		testDatom(elemID(200, 1), "tag1", datalog.OpCRDTRemove),
+	}
+
+	members, _ := ResolveAddWinsFromDatoms(datoms)
+	assert.False(t, members["tag1"])
+	assert.Equal(t, 0, len(members))
+}
+
+func TestResolveAddWinsFromDatoms_RemoveThenAdd_AddWins(t *testing.T) {
+	// Add has higher Lamport -> in set
+	datoms := []datalog.Datom{
+		testDatom(elemID(100, 1), "tag1", datalog.OpCRDTRemove),
+		testDatom(elemID(200, 1), "tag1", datalog.OpCRDTAdd),
+	}
+
+	members, _ := ResolveAddWinsFromDatoms(datoms)
+	assert.True(t, members["tag1"])
+}
+
+func TestResolveAddWinsFromDatoms_Concurrent_AddWins(t *testing.T) {
+	// Same Lamport (concurrent) -> add wins regardless of ReplicaID
+	datoms := []datalog.Datom{
+		testDatom(elemID(100, 1), "tag1", datalog.OpCRDTAdd),
+		testDatom(elemID(100, 2), "tag1", datalog.OpCRDTRemove), // Same Lamport, higher replica
+	}
+
+	members, _ := ResolveAddWinsFromDatoms(datoms)
+	assert.True(t, members["tag1"]) // Add wins at same Lamport
+}
+
+func TestResolveAddWinsFromDatoms_MultipleValues(t *testing.T) {
+	datoms := []datalog.Datom{
+		// tag1: added then removed (remove wins)
+		testDatom(elemID(100, 1), "tag1", datalog.OpCRDTAdd),
+		testDatom(elemID(200, 1), "tag1", datalog.OpCRDTRemove),
+		// tag2: only added (in set)
+		testDatom(elemID(150, 1), "tag2", datalog.OpCRDTAdd),
+		// tag3: removed then re-added (add wins)
+		testDatom(elemID(100, 1), "tag3", datalog.OpCRDTAdd),
+		testDatom(elemID(200, 1), "tag3", datalog.OpCRDTRemove),
+		testDatom(elemID(300, 1), "tag3", datalog.OpCRDTAdd),
+	}
+
+	members, maxID := ResolveAddWinsFromDatoms(datoms)
+	assert.False(t, members["tag1"]) // Removed
+	assert.True(t, members["tag2"])  // Only added
+	assert.True(t, members["tag3"])  // Re-added
+	assert.Equal(t, 2, len(members))
+	assert.Equal(t, elemID(300, 1), maxID)
+}
+
+func TestResolveAddWinsFromDatoms_OnlyRemoves(t *testing.T) {
+	// Remove without prior add -> not in set
+	datoms := []datalog.Datom{
+		testDatom(elemID(100, 1), "tag1", datalog.OpCRDTRemove),
+	}
+
+	members, _ := ResolveAddWinsFromDatoms(datoms)
+	assert.Empty(t, members)
+}
+
+// =============================================================================
+// RGA Vector Resolution Tests
+// =============================================================================
+
+func TestResolveRGAFromDatoms_Empty(t *testing.T) {
+	values, positions, maxID := ResolveRGAFromDatoms(nil)
+	assert.Nil(t, values)
+	assert.Nil(t, positions)
+	assert.Equal(t, datalog.ElementID{}, maxID)
+}
+
+func TestResolveRGAFromDatoms_SingleInsert(t *testing.T) {
+	id1 := elemID(100, 1)
+	datoms := []datalog.Datom{
+		rgaDatom(id1, "first", datalog.OpRGAInsert, datalog.ElementID{}), // After root
+	}
+
+	values, positions, maxID := ResolveRGAFromDatoms(datoms)
+	assert.Equal(t, []any{"first"}, values)
+	assert.Equal(t, []datalog.ElementID{id1}, positions)
+	assert.Equal(t, id1, maxID)
+}
+
+func TestResolveRGAFromDatoms_OrderedInserts(t *testing.T) {
+	id1 := elemID(100, 1)
+	id2 := elemID(200, 1)
+	id3 := elemID(300, 1)
+
+	datoms := []datalog.Datom{
+		rgaDatom(id1, "first", datalog.OpRGAInsert, datalog.ElementID{}), // After root
+		rgaDatom(id2, "second", datalog.OpRGAInsert, id1),                // After first
+		rgaDatom(id3, "third", datalog.OpRGAInsert, id2),                 // After second
+	}
+
+	values, positions, maxID := ResolveRGAFromDatoms(datoms)
+	assert.Equal(t, []any{"first", "second", "third"}, values)
+	assert.Equal(t, []datalog.ElementID{id1, id2, id3}, positions)
+	assert.Equal(t, id3, maxID)
+}
+
+func TestResolveRGAFromDatoms_InsertInMiddle(t *testing.T) {
+	id1 := elemID(100, 1)
+	id2 := elemID(200, 1)
+	id3 := elemID(300, 1)
+
+	datoms := []datalog.Datom{
+		rgaDatom(id1, "first", datalog.OpRGAInsert, datalog.ElementID{}),
+		rgaDatom(id2, "third", datalog.OpRGAInsert, id1),  // After first
+		rgaDatom(id3, "second", datalog.OpRGAInsert, id1), // Also after first
+	}
+
+	values, _, _ := ResolveRGAFromDatoms(datoms)
+	// RGA: when two elements have same AfterRef, lower ElementID comes first
+	// So id2 (200, "third") comes before id3 (300, "second")
+	assert.Equal(t, []any{"first", "third", "second"}, values)
+}
+
+func TestResolveRGAFromDatoms_WithTombstone(t *testing.T) {
+	id1 := elemID(100, 1)
+	id2 := elemID(200, 1)
+	id3 := elemID(300, 1)
+	tombstoneID := elemID(400, 1)
+
+	datoms := []datalog.Datom{
+		rgaDatom(id1, "first", datalog.OpRGAInsert, datalog.ElementID{}),
+		rgaDatom(id2, "second", datalog.OpRGAInsert, id1),
+		rgaDatom(id3, "third", datalog.OpRGAInsert, id2),
+		rgaDatom(tombstoneID, "second", datalog.OpRGATombstone, id2), // Delete "second"
+	}
+
+	values, positions, _ := ResolveRGAFromDatoms(datoms)
+	assert.Equal(t, []any{"first", "third"}, values)
+	assert.Equal(t, []datalog.ElementID{id1, id3}, positions)
+}
+
+func TestResolveRGAFromDatoms_OutOfOrderInput(t *testing.T) {
+	// Datoms arrive in arbitrary order - resolution should still work
+	id1 := elemID(100, 1)
+	id2 := elemID(200, 1)
+	id3 := elemID(300, 1)
+
+	datoms := []datalog.Datom{
+		rgaDatom(id3, "third", datalog.OpRGAInsert, id2),                 // Third insert, but first in input
+		rgaDatom(id1, "first", datalog.OpRGAInsert, datalog.ElementID{}), // First insert
+		rgaDatom(id2, "second", datalog.OpRGAInsert, id1),                // Second insert
+	}
+
+	values, _, _ := ResolveRGAFromDatoms(datoms)
+	assert.Equal(t, []any{"first", "second", "third"}, values)
+}
+
+func TestResolveRGAFromDatoms_IgnoresNonRGAOps(t *testing.T) {
+	id1 := elemID(100, 1)
+	datoms := []datalog.Datom{
+		rgaDatom(id1, "first", datalog.OpRGAInsert, datalog.ElementID{}),
+		testDatom(elemID(200, 1), "ignored", datalog.OpNone),     // Not RGA op
+		testDatom(elemID(300, 1), "ignored", datalog.OpCRDTAdd),    // Not RGA op
+	}
+
+	values, _, _ := ResolveRGAFromDatoms(datoms)
+	assert.Equal(t, []any{"first"}, values)
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -460,7 +460,7 @@ func DefaultPlannerOptions() planner.PlannerOptions {
 func (d *Database) NewExecutor() *executor.Executor {
 	opts := DefaultPlannerOptions()
 	opts.Cache = d.planCache // Use database's cache
-	return executor.NewExecutorWithOptions(d.Matcher(), opts)
+	return executor.NewExecutorWithOptions(d.Matcher(), d, opts)
 }
 
 // NewExecutorWithOptions creates a new query executor with custom options and the database's plan cache
@@ -481,7 +481,7 @@ func (d *Database) NewExecutorWithOptions(opts planner.PlannerOptions) *executor
 		IndexNestedLoopThreshold:        opts.IndexNestedLoopThreshold,
 	}
 	matcher := NewBadgerMatcherWithOptions(d.store, execOpts)
-	return executor.NewExecutorWithOptions(matcher, opts)
+	return executor.NewExecutorWithOptions(matcher, d, opts)
 }
 
 // Store returns the underlying store for direct access (debugging/testing)
@@ -663,7 +663,7 @@ func (d *Database) ExecuteQueryWithInputs(queryInput interface{}, inputs ...inte
 	// Execute with the SourceRouter as the PatternMatcher
 	planOpts := DefaultPlannerOptions()
 	planOpts.Cache = d.planCache
-	exec := executor.NewExecutorWithOptions(router, planOpts)
+	exec := executor.NewExecutorWithOptions(router, d, planOpts)
 	result, err := exec.ExecuteWithRelations(executor.NewContext(d.annotationHandler), q, inputRelations)
 	if err != nil {
 		return nil, fmt.Errorf("query execution failed: %w", err)
@@ -703,7 +703,7 @@ func (d *Database) ExecuteQueryRelation(queryInput interface{}, inputs ...interf
 	// Execute with the SourceRouter as the PatternMatcher
 	planOpts := DefaultPlannerOptions()
 	planOpts.Cache = d.planCache
-	exec := executor.NewExecutorWithOptions(router, planOpts)
+	exec := executor.NewExecutorWithOptions(router, d, planOpts)
 	result, err := exec.ExecuteWithRelations(executor.NewContext(d.annotationHandler), q, inputRelations)
 	if err != nil {
 		return nil, fmt.Errorf("query execution failed: %w", err)
@@ -2314,7 +2314,7 @@ func (d *Database) Pull(entityID datalog.Identity, patternStr string) (map[strin
 
 	// Create pull executor with database matcher
 	matcher := d.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, d)
 
 	// Execute pull
 	return puller.Pull(entityID, pattern)
@@ -2340,10 +2340,193 @@ func (d *Database) PullMany(entityIDs []datalog.Identity, patternStr string) ([]
 
 	// Create pull executor with database matcher
 	matcher := d.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, d)
 
 	// Execute pull for all entities
 	return puller.PullMany(entityIDs, pattern)
+}
+
+// ResolveEntityAttributes resolves CRDT values for the requested attributes of an entity.
+// This is the core resolution method that properly applies CRDT semantics:
+// - CardinalityOne: LWW (Last-Writer-Wins)
+// - CardinalityMany: Add-wins set
+// - CardinalityVector: RGA ordered list
+//
+// The method uses difference-based logic:
+// - Checks which attributes are already cached for this entity
+// - If few missing: individual GetOrResolve calls
+// - If many missing: full EAVT scan then resolve
+//
+// Returns a map of keyword -> resolved value. Missing attributes are not included.
+func (d *Database) ResolveEntityAttributes(entity datalog.Identity, attrs []datalog.Keyword) (map[datalog.Keyword]interface{}, error) {
+	if len(attrs) == 0 {
+		return make(map[datalog.Keyword]interface{}), nil
+	}
+
+	eBytes := Entity(entity.Hash())
+	matcher := d.Matcher().(*BadgerMatcher)
+	result := make(map[datalog.Keyword]interface{})
+
+	// Get what's already cached for this entity
+	cachedAttrs := d.cache.GetCachedAttrs(eBytes)
+
+	// Partition needed attrs into cached vs missing
+	var missing []datalog.Keyword
+	for _, kw := range attrs {
+		var aBytes Attribute
+		copy(aBytes[:], kw.String())
+
+		if cachedAttrs != nil && cachedAttrs[aBytes] {
+			// Already cached - GetOrResolve will do freshness check
+			key := CacheKey{E: eBytes, A: aBytes}
+			if entry := d.cache.GetOrResolve(key, matcher); entry != nil {
+				if val := entryToValue(entry); val != nil {
+					result[kw] = val
+				}
+			}
+		} else {
+			missing = append(missing, kw)
+		}
+	}
+
+	if len(missing) == 0 {
+		return result, nil // All from cache
+	}
+
+	// For now, use individual GetOrResolve for missing attrs
+	// TODO: Add threshold-based scan optimization
+	for _, kw := range missing {
+		var aBytes Attribute
+		copy(aBytes[:], kw.String())
+		key := CacheKey{E: eBytes, A: aBytes}
+		if entry := d.cache.GetOrResolve(key, matcher); entry != nil {
+			if val := entryToValue(entry); val != nil {
+				result[kw] = val
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// entryToValue converts a CacheEntry to its appropriate value representation
+func entryToValue(entry *CacheEntry) interface{} {
+	switch entry.Cardinality() {
+	case schema.CardinalityOne:
+		return entry.OneValue()
+	case schema.CardinalityMany:
+		// Convert set to slice for API consistency
+		set := entry.ManySet()
+		if len(set) == 0 {
+			return nil
+		}
+		values := make([]interface{}, 0, len(set))
+		for v := range set {
+			values = append(values, v)
+		}
+		return values
+	case schema.CardinalityVector:
+		return entry.VectorList()
+	default:
+		return entry.OneValue()
+	}
+}
+
+// ResolveAllAttributes retrieves all CRDT-resolved attributes for an entity.
+// This is used by wildcard pulls to get all attributes with proper CRDT resolution.
+//
+// It scans EAVT for all datoms with the given entity, discovers unique attributes,
+// and resolves each using the cache (LWW for one, add-wins for many, RGA for vector).
+//
+// Returns a map of keyword -> resolved value. The value type depends on cardinality:
+// - CardinalityOne: single value (LWW)
+// - CardinalityMany: []interface{} (add-wins set)
+// - CardinalityVector: []interface{} (RGA ordered list)
+func (d *Database) ResolveAllAttributes(entity datalog.Identity) (map[datalog.Keyword]interface{}, error) {
+	if d.cache == nil {
+		return nil, fmt.Errorf("ResolveAllAttributes requires cache")
+	}
+
+	// If schema exists, delegate to ResolveEntityAttributes with all schema attrs.
+	// This uses difference-based logic: check cache first, scan only if needed.
+	if d.schema != nil {
+		if s, ok := d.schema.(*schema.Schema); ok && s.HasSchema() {
+			attrs := s.Attributes()
+			keywords := make([]datalog.Keyword, len(attrs))
+			for i, def := range attrs {
+				keywords[i] = def.Ident
+			}
+			return d.ResolveEntityAttributes(entity, keywords)
+		}
+	}
+
+	// No schema: must scan EAVT to discover all attributes for this entity
+	eBytes := entity.Bytes()
+	encoder := d.store.encoder
+	start, end := encoder.EncodePrefixRange(EAVT, eBytes[:])
+
+	iter, err := d.store.Scan(EAVT, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("EAVT scan failed: %w", err)
+	}
+	defer iter.Close()
+
+	// Discover unique attributes
+	seenAttrs := make(map[Attribute]datalog.Keyword)
+	for iter.Next() {
+		datom, err := iter.Datom()
+		if err != nil {
+			continue
+		}
+		sd := ToStorageDatom(*datom)
+		if _, seen := seenAttrs[sd.A]; !seen {
+			seenAttrs[sd.A] = datom.A
+		}
+	}
+
+	// Resolve each attribute using cache
+	matcher := d.Matcher().(*BadgerMatcher)
+	eEntity := Entity(eBytes)
+	result := make(map[datalog.Keyword]interface{})
+
+	for aBytes, kw := range seenAttrs {
+		key := CacheKey{E: eEntity, A: aBytes}
+		entry := d.cache.GetOrResolve(key, matcher)
+		if entry == nil {
+			continue
+		}
+
+		// Determine cardinality for proper value conversion
+		card := schema.CardinalityOne
+		if d.schema != nil {
+			if def := d.schema.GetAttribute(kw); def != nil {
+				card = def.Cardinality
+			}
+		}
+
+		switch card {
+		case schema.CardinalityOne:
+			if v := entry.OneValue(); v != nil {
+				result[kw] = v
+			}
+		case schema.CardinalityMany:
+			set := entry.ManySet()
+			if len(set) > 0 {
+				values := make([]interface{}, 0, len(set))
+				for v := range set {
+					values = append(values, v)
+				}
+				result[kw] = values
+			}
+		case schema.CardinalityVector:
+			list := entry.VectorList()
+			if len(list) > 0 {
+				result[kw] = list
+			}
+		}
+	}
+
+	return result, nil
 }
 
 // PullInto retrieves entity data and populates the provided struct.
@@ -2379,7 +2562,7 @@ func (d *Database) PullInto(entityID datalog.Identity, v interface{}) error {
 
 	// Create pull executor and execute
 	matcher := d.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, d)
 	result, err := puller.PullResolved(entityID, resolved)
 	if err != nil {
 		return err
@@ -2432,7 +2615,7 @@ func (d *Database) PullIntoMany(entityIDs []datalog.Identity, v interface{}) err
 
 	// Create pull executor and execute
 	matcher := d.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, d)
 	results, err := puller.PullResolvedMany(entityIDs, resolved)
 	if err != nil {
 		return err

--- a/datalog/storage/entity_resolve_test.go
+++ b/datalog/storage/entity_resolve_test.go
@@ -1,0 +1,283 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// Helper to create test database with schema
+func createEntityResolveTestDB(t *testing.T) (*Database, func()) {
+	dir := t.TempDir()
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	return db, func() { db.Close() }
+}
+
+func TestResolveEntityAttributes_SingleAttribute(t *testing.T) {
+	db, cleanup := createEntityResolveTestDB(t)
+	defer cleanup()
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Add data
+	tx := db.NewTransaction()
+	e1 := datalog.NewIdentity("person1")
+	err = tx.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Clear cache to ensure we resolve from storage
+	db.Cache().Clear()
+
+	// Resolve single attribute
+	attrs := []datalog.Keyword{datalog.NewKeyword(":person/name")}
+	result, err := db.ResolveEntityAttributes(e1, attrs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alice", result[datalog.NewKeyword(":person/name")])
+}
+
+func TestResolveEntityAttributes_MultipleAttributes(t *testing.T) {
+	db, cleanup := createEntityResolveTestDB(t)
+	defer cleanup()
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Attribute(":person/age").Type(schema.TypeLong).One().Add().
+		Attribute(":person/email").Type(schema.TypeString).One().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Add data
+	tx := db.NewTransaction()
+	e1 := datalog.NewIdentity("person1")
+	err = tx.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	err = tx.Set(e1, datalog.NewKeyword(":person/age"), int64(30))
+	require.NoError(t, err)
+	err = tx.Set(e1, datalog.NewKeyword(":person/email"), "alice@example.com")
+	require.NoError(t, err)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Clear cache
+	db.Cache().Clear()
+
+	// Resolve all attributes
+	attrs := []datalog.Keyword{
+		datalog.NewKeyword(":person/name"),
+		datalog.NewKeyword(":person/age"),
+		datalog.NewKeyword(":person/email"),
+	}
+	result, err := db.ResolveEntityAttributes(e1, attrs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alice", result[datalog.NewKeyword(":person/name")])
+	assert.Equal(t, int64(30), result[datalog.NewKeyword(":person/age")])
+	assert.Equal(t, "alice@example.com", result[datalog.NewKeyword(":person/email")])
+}
+
+func TestResolveEntityAttributes_CardinalityMany(t *testing.T) {
+	db, cleanup := createEntityResolveTestDB(t)
+	defer cleanup()
+
+	// Create schema with cardinality-many
+	s, err := schema.NewBuilder().
+		Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Add data
+	tx := db.NewTransaction()
+	e1 := datalog.NewIdentity("person1")
+	err = tx.Add(e1, datalog.NewKeyword(":person/tags"), "developer")
+	require.NoError(t, err)
+	err = tx.Add(e1, datalog.NewKeyword(":person/tags"), "go")
+	require.NoError(t, err)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Clear cache
+	db.Cache().Clear()
+
+	// Resolve
+	attrs := []datalog.Keyword{datalog.NewKeyword(":person/tags")}
+	result, err := db.ResolveEntityAttributes(e1, attrs)
+	require.NoError(t, err)
+
+	// Should return both values
+	tags := result[datalog.NewKeyword(":person/tags")].([]interface{})
+	assert.Len(t, tags, 2)
+	assert.Contains(t, tags, "developer")
+	assert.Contains(t, tags, "go")
+}
+
+func TestResolveEntityAttributes_CardinalityVector(t *testing.T) {
+	db, cleanup := createEntityResolveTestDB(t)
+	defer cleanup()
+
+	// Create schema with cardinality-vector
+	s, err := schema.NewBuilder().
+		Attribute(":person/skills").Type(schema.TypeString).Vector().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Add data (tx.Add appends to vector)
+	tx := db.NewTransaction()
+	e1 := datalog.NewIdentity("person1")
+	err = tx.Add(e1, datalog.NewKeyword(":person/skills"), "Go")
+	require.NoError(t, err)
+	err = tx.Add(e1, datalog.NewKeyword(":person/skills"), "Python")
+	require.NoError(t, err)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Clear cache
+	db.Cache().Clear()
+
+	// Resolve
+	attrs := []datalog.Keyword{datalog.NewKeyword(":person/skills")}
+	result, err := db.ResolveEntityAttributes(e1, attrs)
+	require.NoError(t, err)
+
+	// Should return a slice
+	skills, ok := result[datalog.NewKeyword(":person/skills")].([]any)
+	require.True(t, ok, "expected []any for cardinality-vector")
+	assert.Equal(t, []any{"Go", "Python"}, skills)
+}
+
+func TestResolveEntityAttributes_LWWResolution(t *testing.T) {
+	db, cleanup := createEntityResolveTestDB(t)
+	defer cleanup()
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Add data then update
+	e1 := datalog.NewIdentity("person1")
+
+	tx1 := db.NewTransaction()
+	err = tx1.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	tx2 := db.NewTransaction()
+	err = tx2.Set(e1, datalog.NewKeyword(":person/name"), "Alicia") // Update
+	require.NoError(t, err)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Clear cache
+	db.Cache().Clear()
+
+	// Resolve should return latest value
+	attrs := []datalog.Keyword{datalog.NewKeyword(":person/name")}
+	result, err := db.ResolveEntityAttributes(e1, attrs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alicia", result[datalog.NewKeyword(":person/name")])
+}
+
+func TestResolveEntityAttributes_MissingAttribute(t *testing.T) {
+	db, cleanup := createEntityResolveTestDB(t)
+	defer cleanup()
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Attribute(":person/age").Type(schema.TypeLong).One().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Add only name, not age
+	tx := db.NewTransaction()
+	e1 := datalog.NewIdentity("person1")
+	err = tx.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Clear cache
+	db.Cache().Clear()
+
+	// Resolve both - age should be missing
+	attrs := []datalog.Keyword{
+		datalog.NewKeyword(":person/name"),
+		datalog.NewKeyword(":person/age"),
+	}
+	result, err := db.ResolveEntityAttributes(e1, attrs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alice", result[datalog.NewKeyword(":person/name")])
+	_, hasAge := result[datalog.NewKeyword(":person/age")]
+	assert.False(t, hasAge, "missing attribute should not be in result")
+}
+
+func TestResolveEntityAttributes_UsesCachedEntries(t *testing.T) {
+	db, cleanup := createEntityResolveTestDB(t)
+	defer cleanup()
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Add data
+	tx := db.NewTransaction()
+	e1 := datalog.NewIdentity("person1")
+	err = tx.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// First call should populate cache
+	attrs := []datalog.Keyword{datalog.NewKeyword(":person/name")}
+	result1, err := db.ResolveEntityAttributes(e1, attrs)
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", result1[datalog.NewKeyword(":person/name")])
+
+	// Verify entity attrs are tracked
+	eBytes := Entity(e1.Hash())
+	cachedAttrs := db.Cache().GetCachedAttrs(eBytes)
+	assert.NotNil(t, cachedAttrs, "should have cached attrs tracked")
+
+	// Second call should use cache
+	result2, err := db.ResolveEntityAttributes(e1, attrs)
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", result2[datalog.NewKeyword(":person/name")])
+}
+
+func TestResolveEntityAttributes_NonexistentEntity(t *testing.T) {
+	db, cleanup := createEntityResolveTestDB(t)
+	defer cleanup()
+
+	// No data added
+	e1 := datalog.NewIdentity("nonexistent")
+	attrs := []datalog.Keyword{datalog.NewKeyword(":person/name")}
+
+	result, err := db.ResolveEntityAttributes(e1, attrs)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/datalog/storage/gopher_street_exact_bug_test.go
+++ b/datalog/storage/gopher_street_exact_bug_test.go
@@ -35,7 +35,7 @@ func TestGopherStreetExactBug(t *testing.T) {
 		EnableTrueStreaming: true,
 	}
 	matcher := NewBadgerMatcherWithOptions(db.store, opts)
-	exec := executor.NewExecutor(matcher)
+	exec := executor.NewExecutor(matcher, db)
 
 	result, err := exec.Execute(q)
 	require.NoError(t, err)

--- a/datalog/storage/hash_join_column_index_test.go
+++ b/datalog/storage/hash_join_column_index_test.go
@@ -73,7 +73,7 @@ func TestHashJoinColumnIndexBug(t *testing.T) {
 	matcher := NewBadgerMatcherWithOptions(db.Store(), executor.ExecutorOptions{
 		IndexNestedLoopThreshold: 0, // Always use HashJoinScan
 	})
-	exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{})
+	exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{})
 
 	result, err := exec.Execute(q)
 	assert.NoError(t, err)
@@ -150,7 +150,7 @@ func TestHashJoinColumnIndexMultiColumn(t *testing.T) {
 	matcher := NewBadgerMatcherWithOptions(db.Store(), executor.ExecutorOptions{
 		IndexNestedLoopThreshold: 0,
 	})
-	exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{})
+	exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{})
 
 	result, err := exec.Execute(q)
 	assert.NoError(t, err)

--- a/datalog/storage/hash_join_scan_range_test.go
+++ b/datalog/storage/hash_join_scan_range_test.go
@@ -208,7 +208,7 @@ func BenchmarkHashJoinScanRangeComparison(b *testing.B) {
 		matcher := NewBadgerMatcherWithOptions(db.Store(), executor.ExecutorOptions{
 			IndexNestedLoopThreshold: 0, // Force HashJoinScan
 		})
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{})
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{})
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -226,7 +226,7 @@ func BenchmarkHashJoinScanRangeComparison(b *testing.B) {
 		matcher := NewBadgerMatcherWithOptions(db.Store(), executor.ExecutorOptions{
 			IndexNestedLoopThreshold: 999999, // Force IndexNestedLoop
 		})
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{})
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{})
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/datalog/storage/high_cardinality_benchmark_test.go
+++ b/datalog/storage/high_cardinality_benchmark_test.go
@@ -186,7 +186,7 @@ func BenchmarkHighCardinalityKeywords(b *testing.B) {
 		}
 
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnableFineGrainedPhases: true,
 		})
 
@@ -216,7 +216,7 @@ func BenchmarkHighCardinalityKeywords(b *testing.B) {
 		}
 
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnableFineGrainedPhases: true,
 		})
 
@@ -243,7 +243,7 @@ func BenchmarkHighCardinalityKeywords(b *testing.B) {
 		}
 
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnableFineGrainedPhases: true,
 		})
 

--- a/datalog/storage/join_bench_test.go
+++ b/datalog/storage/join_bench_test.go
@@ -83,7 +83,7 @@ func BenchmarkStorageBackedJoin(b *testing.B) {
 				DefaultHashTableSize:    256,
 			}
 			matcher := NewBadgerMatcherWithOptions(db.Store(), opts)
-			exec := executor.NewExecutor(matcher)
+			exec := executor.NewExecutor(matcher, db)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -118,7 +118,7 @@ func BenchmarkStorageBackedJoin(b *testing.B) {
 				DefaultHashTableSize:    256,
 			}
 			matcher := NewBadgerMatcherWithOptions(db.Store(), opts)
-			exec := executor.NewExecutor(matcher)
+			exec := executor.NewExecutor(matcher, db)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -174,7 +174,7 @@ func BenchmarkStorageBackedJoinLimit(b *testing.B) {
 				DefaultHashTableSize:    256,
 			}
 			matcher := NewBadgerMatcherWithOptions(db.Store(), opts)
-			exec := executor.NewExecutor(matcher)
+			exec := executor.NewExecutor(matcher, db)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -209,7 +209,7 @@ func BenchmarkStorageBackedJoinLimit(b *testing.B) {
 				DefaultHashTableSize:    256,
 			}
 			matcher := NewBadgerMatcherWithOptions(db.Store(), opts)
-			exec := executor.NewExecutor(matcher)
+			exec := executor.NewExecutor(matcher, db)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -261,7 +261,7 @@ func BenchmarkStorageBackedJoinWithFilter(b *testing.B) {
 			DefaultHashTableSize:    256,
 		}
 		matcher := NewBadgerMatcherWithOptions(db.Store(), opts)
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -292,7 +292,7 @@ func BenchmarkStorageBackedJoinWithFilter(b *testing.B) {
 			DefaultHashTableSize:    256,
 		}
 		matcher := NewBadgerMatcherWithOptions(db.Store(), opts)
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/datalog/storage/join_e2e_test.go
+++ b/datalog/storage/join_e2e_test.go
@@ -198,7 +198,7 @@ func TestStorageBackedJoinE2E(t *testing.T) {
 			}
 
 			matcher := NewBadgerMatcherWithOptions(db.Store(), opts)
-			exec := executor.NewExecutor(matcher)
+			exec := executor.NewExecutor(matcher, db)
 
 			// Execute through full pipeline
 			result, err := exec.Execute(q)
@@ -310,7 +310,7 @@ func TestStorageBackedJoinLimitE2E(t *testing.T) {
 			}
 
 			matcher := NewBadgerMatcherWithOptions(db.Store(), opts)
-			exec := executor.NewExecutor(matcher)
+			exec := executor.NewExecutor(matcher, db)
 
 			result, err := exec.Execute(q)
 			if err != nil {

--- a/datalog/storage/join_strategy_test.go
+++ b/datalog/storage/join_strategy_test.go
@@ -77,7 +77,7 @@ func BenchmarkIndexNestedLoopVsHashJoin(b *testing.B) {
 		indexNested := IndexNestedLoop
 		matcher.ForceJoinStrategy(&indexNested)
 
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -114,7 +114,7 @@ func BenchmarkIndexNestedLoopVsHashJoin(b *testing.B) {
 		hashJoin := HashJoinScan
 		matcher.ForceJoinStrategy(&hashJoin)
 
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -151,7 +151,7 @@ func BenchmarkIndexNestedLoopVsHashJoin(b *testing.B) {
 		indexNested := IndexNestedLoop
 		matcher.ForceJoinStrategy(&indexNested)
 
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -183,7 +183,7 @@ func BenchmarkIndexNestedLoopVsHashJoin(b *testing.B) {
 		hashJoin := HashJoinScan
 		matcher.ForceJoinStrategy(&hashJoin)
 
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -226,7 +226,7 @@ func BenchmarkIndexNestedLoopVsHashJoin(b *testing.B) {
 		indexNested := IndexNestedLoop
 		matcher.ForceJoinStrategy(&indexNested)
 
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -257,7 +257,7 @@ func BenchmarkIndexNestedLoopVsHashJoin(b *testing.B) {
 		hashJoin := HashJoinScan
 		matcher.ForceJoinStrategy(&hashJoin)
 
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -345,7 +345,7 @@ func TestVerifyStrategyUsed(t *testing.T) {
 			}
 		})
 
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		result, err := exec.Execute(q)
 		if err != nil {
@@ -386,7 +386,7 @@ func TestVerifyStrategyUsed(t *testing.T) {
 			}
 		})
 
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		result, err := exec.Execute(q)
 		if err != nil {
@@ -437,7 +437,7 @@ func TestVerifyStrategyUsed(t *testing.T) {
 			}
 		})
 
-		exec := executor.NewExecutor(matcher)
+		exec := executor.NewExecutor(matcher, db)
 
 		result, err := exec.Execute(q)
 		if err != nil {
@@ -551,7 +551,7 @@ func TestMaterializationDetection(t *testing.T) {
 	}
 	matcher.SetHandler(handler)
 
-	exec := executor.NewExecutor(matcher)
+	exec := executor.NewExecutor(matcher, db)
 
 	t.Log("Executing query...")
 	result, err := exec.Execute(q)

--- a/datalog/storage/matcher_tuple_copy_bug_test.go
+++ b/datalog/storage/matcher_tuple_copy_bug_test.go
@@ -63,7 +63,7 @@ func TestMatcherTupleCopyBug(t *testing.T) {
 		EnableTrueStreaming: true,
 	}
 	matcher := NewBadgerMatcherWithOptions(db.store, opts)
-	exec := executor.NewExecutor(matcher)
+	exec := executor.NewExecutor(matcher, db)
 
 	result, err := exec.Execute(q)
 	require.NoError(t, err)

--- a/datalog/storage/ohlc_benchmark_test.go
+++ b/datalog/storage/ohlc_benchmark_test.go
@@ -105,7 +105,7 @@ func BenchmarkOHLCQuery(b *testing.B) {
 	// Benchmark without predicate pushdown
 	b.Run("WithoutPushdown", func(b *testing.B) {
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnablePredicatePushdown: false,
 			EnableFineGrainedPhases: true,
 		})
@@ -127,7 +127,7 @@ func BenchmarkOHLCQuery(b *testing.B) {
 	// Benchmark with predicate pushdown
 	b.Run("WithPushdown", func(b *testing.B) {
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnablePredicatePushdown: true,
 			EnableFineGrainedPhases: true,
 		})
@@ -149,7 +149,7 @@ func BenchmarkOHLCQuery(b *testing.B) {
 	// Benchmark with time-range optimization (semantic rewriting)
 	b.Run("WithTimeRangeOpt", func(b *testing.B) {
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnablePredicatePushdown: true,
 			EnableSemanticRewriting: true, // Enables time-range optimization
 			EnableFineGrainedPhases: true,
@@ -278,7 +278,7 @@ func BenchmarkOHLCQueryLargeDataset(b *testing.B) {
 
 	b.Run("WithoutPushdown", func(b *testing.B) {
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnablePredicatePushdown: false,
 			EnableFineGrainedPhases: true,
 		})
@@ -299,7 +299,7 @@ func BenchmarkOHLCQueryLargeDataset(b *testing.B) {
 
 	b.Run("WithPushdown", func(b *testing.B) {
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnablePredicatePushdown: true,
 			EnableFineGrainedPhases: true,
 		})

--- a/datalog/storage/ohlc_bug_reproduction_test.go
+++ b/datalog/storage/ohlc_bug_reproduction_test.go
@@ -72,7 +72,7 @@ func TestOHLCQueryBug(t *testing.T) {
 	require.NoError(t, err)
 
 	matcher := NewBadgerMatcher(db.store)
-	exec := executor.NewExecutor(matcher)
+	exec := executor.NewExecutor(matcher, db)
 
 	// Set a timeout channel to prevent hanging forever
 	done := make(chan bool)

--- a/datalog/storage/ohlc_realistic_test.go
+++ b/datalog/storage/ohlc_realistic_test.go
@@ -87,7 +87,7 @@ func TestOHLCRealisticQueries(t *testing.T) {
 
 	// Create executor
 	matcher := NewBadgerMatcher(db.store)
-	exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+	exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 		EnablePredicatePushdown: true,
 		EnableFineGrainedPhases: true,
 	})

--- a/datalog/storage/ohlc_time_range_profile_test.go
+++ b/datalog/storage/ohlc_time_range_profile_test.go
@@ -150,7 +150,7 @@ func BenchmarkOHLCBadgerDBTimeRanges(b *testing.B) {
 
 			// Create executor with BadgerMatcher
 			matcher := NewBadgerMatcher(db.store)
-			exec := executor.NewExecutor(matcher)
+			exec := executor.NewExecutor(matcher, db)
 
 			// Warmup
 			result, err := exec.Execute(q)
@@ -218,7 +218,7 @@ func BenchmarkSimpleTimeQuery(b *testing.B) {
 	}
 
 	matcher := NewBadgerMatcher(db.store)
-	exec := executor.NewExecutor(matcher)
+	exec := executor.NewExecutor(matcher, db)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/datalog/storage/or_clause_bug_test.go
+++ b/datalog/storage/or_clause_bug_test.go
@@ -131,7 +131,7 @@ func TestOrClauseBugTraced(t *testing.T) {
 	wrappedMatcher := executor.WrapMatcher(baseMatcher, handler)
 	opts := DefaultPlannerOptions()
 	opts.EnableDebugLogging = true
-	exec := executor.NewExecutorWithOptions(wrappedMatcher, opts)
+	exec := executor.NewExecutorWithOptions(wrappedMatcher, db, opts)
 
 	// First, test what the OR branches return individually
 	t.Log("\n=== Testing OR branch 1: [?t :task/type :type/a] ===")

--- a/datalog/storage/parallel_decorrelation_column_order_test.go
+++ b/datalog/storage/parallel_decorrelation_column_order_test.go
@@ -140,7 +140,7 @@ func TestParallelDecorrelationColumnOrderBadger(t *testing.T) {
 
 	t.Run("ParallelDecorrelation", func(t *testing.T) {
 		matcher := db.Matcher()
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: true,
 		})
@@ -199,7 +199,7 @@ func TestParallelDecorrelationColumnOrderBadger(t *testing.T) {
 
 	t.Run("SequentialDecorrelation", func(t *testing.T) {
 		matcher := db.Matcher()
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnableSubqueryDecorrelation: true,
 			EnableParallelDecorrelation: false,
 		})

--- a/datalog/storage/production_query_test.go
+++ b/datalog/storage/production_query_test.go
@@ -364,7 +364,7 @@ func TestPlannerPredicatePushdownIntegration(t *testing.T) {
 	t.Run("WithoutPredicatePushdown", func(t *testing.T) {
 		// Create executor with predicate pushdown disabled
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
+		exec := executor.NewExecutorWithOptions(matcher, db, planner.PlannerOptions{
 			EnablePredicatePushdown: false,
 			EnableFineGrainedPhases: true,
 		})
@@ -395,7 +395,7 @@ func TestPlannerPredicatePushdownIntegration(t *testing.T) {
 	t.Run("WithPredicatePushdown", func(t *testing.T) {
 		// Create executor with predicate pushdown enabled (default)
 		matcher := NewBadgerMatcher(db.store)
-		exec := executor.NewExecutor(matcher) // Has pushdown enabled by default
+		exec := executor.NewExecutor(matcher, db) // Has pushdown enabled by default
 
 		result, err := exec.Execute(q)
 		if err != nil {

--- a/datalog/storage/pull_benchmark_test.go
+++ b/datalog/storage/pull_benchmark_test.go
@@ -60,7 +60,7 @@ func BenchmarkPullBadger_SingleAttribute(b *testing.B) {
 
 	pattern, _ := parser.ParsePullPattern(`[:entity/attr0]`)
 	matcher := db.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, db)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -75,7 +75,7 @@ func BenchmarkPullBadger_MultipleAttributes(b *testing.B) {
 
 	pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1 :entity/attr2 :entity/attr3 :entity/attr4]`)
 	matcher := db.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, db)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -90,7 +90,7 @@ func BenchmarkPullBadger_Wildcard(b *testing.B) {
 
 	pattern, _ := parser.ParsePullPattern(`[*]`)
 	matcher := db.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, db)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -121,7 +121,7 @@ func BenchmarkPullBadger_NestedReference(b *testing.B) {
 
 	pattern, _ := parser.ParsePullPattern(`[:entity/name {:entity/child [:entity/name :entity/value]}]`)
 	matcher := db.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, db)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -148,7 +148,7 @@ func BenchmarkPullBadger_StandaloneAPICached(b *testing.B) {
 	// Pre-parse to measure just execution
 	pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1 :entity/attr2]`)
 	matcher := db.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, db)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -162,7 +162,7 @@ func BenchmarkPullManyBadger(b *testing.B) {
 
 	pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1]`)
 	matcher := db.Matcher()
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, db)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -177,7 +177,7 @@ func BenchmarkPullBadger_ScalingWithEntities(b *testing.B) {
 
 		pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1]`)
 		matcher := db.Matcher()
-		puller := executor.NewPullExecutor(matcher)
+		puller := executor.NewPullExecutor(matcher, db)
 
 		b.Run(fmt.Sprintf("Entities_%d", numEntities), func(b *testing.B) {
 			b.ResetTimer()
@@ -205,7 +205,7 @@ func BenchmarkPullBadger_ScalingWithAttributes(b *testing.B) {
 
 		pattern, _ := parser.ParsePullPattern(fmt.Sprintf("[%s]", patternStr))
 		matcher := db.Matcher()
-		puller := executor.NewPullExecutor(matcher)
+		puller := executor.NewPullExecutor(matcher, db)
 
 		b.Run(fmt.Sprintf("Attrs_%d", numAttrs), func(b *testing.B) {
 			b.ResetTimer()
@@ -224,7 +224,7 @@ func BenchmarkPullBadger_VsQuery(b *testing.B) {
 	b.Run("Pull", func(b *testing.B) {
 		pattern, _ := parser.ParsePullPattern(`[:entity/attr0 :entity/attr1 :entity/attr2]`)
 		matcher := db.Matcher()
-		puller := executor.NewPullExecutor(matcher)
+		puller := executor.NewPullExecutor(matcher, db)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/datalog/storage/pull_expression_crdt_test.go
+++ b/datalog/storage/pull_expression_crdt_test.go
@@ -1,0 +1,174 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// PullExprTestEntity is a minimal entity with a status field that gets updated multiple times.
+type PullExprTestEntity struct {
+	ID     datalog.Identity `datalog:"db/id"`
+	Name   string           `datalog:"task/name"`
+	Status datalog.Keyword  `datalog:"task/status"` // CardinalityOne
+}
+
+func TestPullInto_CardinalityOne_MultipleWrites(t *testing.T) {
+	// Create schema with CardinalityOne status attribute
+	s, err := schema.NewBuilder().
+		Attribute(":task/name").Type(schema.TypeString).Add().
+		Attribute(":task/status").Type(schema.TypeKeyword).Add(). // CardinalityOne (no .Many())
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build schema: %v", err)
+	}
+
+	// Create temp database
+	dir, err := os.MkdirTemp("", "pullinto-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:   dir,
+		Schema: s,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create entity with initial status
+	task := &PullExprTestEntity{
+		Name:   "test-task",
+		Status: datalog.NewKeyword(":status/pending"),
+	}
+	tx := db.NewTransaction()
+	_, err = tx.SaveStruct(task)
+	if err != nil {
+		t.Fatalf("Failed to save initial task: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Update status to running via SaveStruct (2nd write to same attribute)
+	task.Status = datalog.NewKeyword(":status/running")
+	tx2 := db.NewTransaction()
+	if _, err := tx2.SaveStruct(task); err != nil {
+		t.Fatalf("Failed to save running status: %v", err)
+	}
+	if _, err := tx2.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Update status to complete via SaveStruct (3rd write to same attribute)
+	task.Status = datalog.NewKeyword(":status/complete")
+	tx3 := db.NewTransaction()
+	if _, err := tx3.SaveStruct(task); err != nil {
+		t.Fatalf("Failed to save complete status: %v", err)
+	}
+	if _, err := tx3.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// PullInto should return the current (latest) value, not all historical values
+	var loaded PullExprTestEntity
+	if err := db.PullInto(task.ID, &loaded); err != nil {
+		t.Fatalf("PullInto failed: %v", err)
+	}
+
+	// Expected: Status == :status/complete (the latest value per LWW semantics)
+	// Actual: Error "expected Keyword, got []interface {}" because PullInto
+	// returns all historical values [pending, running, complete] instead of
+	// resolving to the current value via CRDT LWW semantics.
+	expected := datalog.NewKeyword(":status/complete")
+	if loaded.Status != expected {
+		t.Errorf("Expected status %v, got %v", expected, loaded.Status)
+	}
+}
+
+func TestPullExpression_CardinalityOne_MultipleWrites(t *testing.T) {
+	// Create schema with CardinalityOne status attribute
+	s, err := schema.NewBuilder().
+		Attribute(":task/name").Type(schema.TypeString).Add().
+		Attribute(":task/status").Type(schema.TypeKeyword).Add(). // CardinalityOne (no .Many())
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build schema: %v", err)
+	}
+
+	// Create temp database
+	dir, err := os.MkdirTemp("", "pullexpr-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:   dir,
+		Schema: s,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create entity with initial status
+	task := &PullExprTestEntity{
+		Name:   "test-task",
+		Status: datalog.NewKeyword(":status/pending"),
+	}
+	tx := db.NewTransaction()
+	_, err = tx.SaveStruct(task)
+	if err != nil {
+		t.Fatalf("Failed to save initial task: %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Update status to running via SaveStruct (2nd write to same attribute)
+	task.Status = datalog.NewKeyword(":status/running")
+	tx2 := db.NewTransaction()
+	if _, err := tx2.SaveStruct(task); err != nil {
+		t.Fatalf("Failed to save running status: %v", err)
+	}
+	if _, err := tx2.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Update status to complete via SaveStruct (3rd write to same attribute)
+	task.Status = datalog.NewKeyword(":status/complete")
+	tx3 := db.NewTransaction()
+	if _, err := tx3.SaveStruct(task); err != nil {
+		t.Fatalf("Failed to save complete status: %v", err)
+	}
+	if _, err := tx3.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Query using pull expression (pull ?e [*]) - this is where the bug manifests
+	// The pull expression should return CRDT-resolved values, not raw historical data
+	var loaded PullExprTestEntity
+	found, err := db.QueryOneInto(&loaded,
+		`[:find (pull ?e [*]) :where [?e :task/name "test-task"]]`)
+	if err != nil {
+		t.Fatalf("QueryOneInto with pull expression failed: %v", err)
+	}
+	if !found {
+		t.Fatal("Entity not found")
+	}
+
+	// Expected: Status == :status/complete (the latest value per LWW semantics)
+	// Actual bug: Error "expected Keyword, got []interface {}" because pull expression
+	// returns all historical values [pending, running, complete] instead of
+	// resolving to the current value via CRDT LWW semantics.
+	expected := datalog.NewKeyword(":status/complete")
+	if loaded.Status != expected {
+		t.Errorf("Expected status %v, got %v", expected, loaded.Status)
+	}
+}

--- a/datalog/storage/pullinto_crdt_test.go
+++ b/datalog/storage/pullinto_crdt_test.go
@@ -1,0 +1,312 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// Test struct for PullInto
+type Person struct {
+	ID   datalog.Identity `datalog:"-,id"`
+	Name string           `datalog:"person/name"`
+	Age  int64            `datalog:"person/age"`
+}
+
+type PersonWithTags struct {
+	ID   datalog.Identity `datalog:"-,id"`
+	Name string           `datalog:"person/name"`
+	Tags []string         `datalog:"person/tags"`
+}
+
+type PersonWithSkills struct {
+	ID     datalog.Identity `datalog:"-,id"`
+	Name   string           `datalog:"person/name"`
+	Skills []string         `datalog:"person/skills"`
+}
+
+func createPullIntoCRDTTestDB(t *testing.T) (*Database, func()) {
+	dir := t.TempDir()
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	return db, func() { db.Close() }
+}
+
+// TestPullInto_CardinalityOne_LWW verifies that PullInto returns the
+// LWW-resolved value for cardinality-one attributes, not all historical values.
+func TestPullInto_CardinalityOne_LWW(t *testing.T) {
+	db, cleanup := createPullIntoCRDTTestDB(t)
+	defer cleanup()
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Attribute(":person/age").Type(schema.TypeLong).One().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Create entity and update multiple times
+	e1 := datalog.NewIdentity("person1")
+
+	tx1 := db.NewTransaction()
+	err = tx1.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	err = tx1.Set(e1, datalog.NewKeyword(":person/age"), int64(25))
+	require.NoError(t, err)
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	// Update name
+	tx2 := db.NewTransaction()
+	err = tx2.Set(e1, datalog.NewKeyword(":person/name"), "Alicia")
+	require.NoError(t, err)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Update age
+	tx3 := db.NewTransaction()
+	err = tx3.Set(e1, datalog.NewKeyword(":person/age"), int64(30))
+	require.NoError(t, err)
+	_, err = tx3.Commit()
+	require.NoError(t, err)
+
+	// Clear cache to ensure we resolve from storage
+	db.Cache().Clear()
+
+	// PullInto should return the latest values, not historical
+	var person Person
+	err = db.PullInto(e1, &person)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alicia", person.Name, "should return LWW-resolved name")
+	assert.Equal(t, int64(30), person.Age, "should return LWW-resolved age")
+}
+
+// TestPullInto_CardinalityMany_AddWins verifies that PullInto returns
+// the add-wins resolved set for cardinality-many attributes.
+func TestPullInto_CardinalityMany_AddWins(t *testing.T) {
+	db, cleanup := createPullIntoCRDTTestDB(t)
+	defer cleanup()
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Create entity with tags
+	e1 := datalog.NewIdentity("person1")
+
+	tx1 := db.NewTransaction()
+	err = tx1.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/tags"), "developer")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/tags"), "go")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/tags"), "python")
+	require.NoError(t, err)
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	// Remove a tag
+	tx2 := db.NewTransaction()
+	err = tx2.Remove(e1, datalog.NewKeyword(":person/tags"), "python")
+	require.NoError(t, err)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Clear cache
+	db.Cache().Clear()
+
+	// PullInto should return only current set members
+	var person PersonWithTags
+	err = db.PullInto(e1, &person)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alice", person.Name)
+	// Should have "developer" and "go", but NOT "python"
+	assert.Contains(t, person.Tags, "developer")
+	assert.Contains(t, person.Tags, "go")
+	assert.NotContains(t, person.Tags, "python", "removed tag should not be in result")
+	assert.Len(t, person.Tags, 2)
+}
+
+// TestPullInto_CardinalityVector_RGA verifies that PullInto returns
+// the RGA-resolved ordered list for cardinality-vector attributes.
+func TestPullInto_CardinalityVector_RGA(t *testing.T) {
+	db, cleanup := createPullIntoCRDTTestDB(t)
+	defer cleanup()
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Attribute(":person/skills").Type(schema.TypeString).Vector().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Create entity with ordered skills
+	e1 := datalog.NewIdentity("person1")
+
+	tx1 := db.NewTransaction()
+	err = tx1.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/skills"), "Go")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/skills"), "Python")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/skills"), "Rust")
+	require.NoError(t, err)
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	// Clear cache
+	db.Cache().Clear()
+
+	// PullInto should return ordered skills
+	var person PersonWithSkills
+	err = db.PullInto(e1, &person)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alice", person.Name)
+	assert.Equal(t, []string{"Go", "Python", "Rust"}, person.Skills)
+}
+
+// TestPull_Wildcard_CRDTResolution verifies that wildcard pulls (*)
+// return CRDT-resolved values, not all historical values.
+func TestPull_Wildcard_CRDTResolution(t *testing.T) {
+	db, cleanup := createPullIntoCRDTTestDB(t)
+	defer cleanup()
+
+	// Create schema
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	e1 := datalog.NewIdentity("person1")
+
+	// Add initial data
+	tx1 := db.NewTransaction()
+	err = tx1.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/tags"), "developer")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/tags"), "python")
+	require.NoError(t, err)
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	// Update name and remove a tag
+	tx2 := db.NewTransaction()
+	err = tx2.Set(e1, datalog.NewKeyword(":person/name"), "Alicia")
+	require.NoError(t, err)
+	err = tx2.Remove(e1, datalog.NewKeyword(":person/tags"), "python")
+	require.NoError(t, err)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Clear cache
+	db.Cache().Clear()
+
+	// Wildcard pull should return CRDT-resolved values
+	result, err := db.Pull(e1, "[*]")
+	require.NoError(t, err)
+
+	// Name should be the latest (LWW)
+	assert.Equal(t, "Alicia", result["person/name"], "should return LWW-resolved name")
+
+	// Tags should only contain non-removed values (add-wins)
+	tags, ok := result["person/tags"].([]interface{})
+	require.True(t, ok, "tags should be []interface{}")
+	assert.Len(t, tags, 1, "should have 1 tag after removal")
+	assert.Contains(t, tags, "developer")
+}
+
+// TestPull_Wildcard_CardinalityVector verifies that wildcard pulls
+// return ordered values for cardinality-vector attributes.
+func TestPull_Wildcard_CardinalityVector(t *testing.T) {
+	db, cleanup := createPullIntoCRDTTestDB(t)
+	defer cleanup()
+
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Attribute(":person/skills").Type(schema.TypeString).Vector().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	e1 := datalog.NewIdentity("person1")
+
+	// Add ordered skills
+	tx1 := db.NewTransaction()
+	err = tx1.Set(e1, datalog.NewKeyword(":person/name"), "Alice")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/skills"), "Go")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/skills"), "Python")
+	require.NoError(t, err)
+	err = tx1.Add(e1, datalog.NewKeyword(":person/skills"), "Rust")
+	require.NoError(t, err)
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	// Clear cache
+	db.Cache().Clear()
+
+	// Wildcard pull should return ordered skills
+	result, err := db.Pull(e1, "[*]")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alice", result["person/name"])
+
+	skills, ok := result["person/skills"].([]interface{})
+	require.True(t, ok, "skills should be []interface{}")
+	require.Len(t, skills, 3)
+	assert.Equal(t, "Go", skills[0])
+	assert.Equal(t, "Python", skills[1])
+	assert.Equal(t, "Rust", skills[2])
+}
+
+// TestPullInto_AfterCacheClear verifies that PullInto works correctly
+// after the cache is cleared (simulating a restart).
+func TestPullInto_AfterCacheClear(t *testing.T) {
+	db, cleanup := createPullIntoCRDTTestDB(t)
+	defer cleanup()
+
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	e1 := datalog.NewIdentity("person1")
+
+	// Multiple updates
+	for i, name := range []string{"Alice", "Alicia", "Alice Updated"} {
+		tx := db.NewTransaction()
+		err = tx.Set(e1, datalog.NewKeyword(":person/name"), name)
+		require.NoError(t, err, "update %d", i)
+		_, err = tx.Commit()
+		require.NoError(t, err, "commit %d", i)
+	}
+
+	// Clear cache to simulate restart
+	db.Cache().Clear()
+
+	// PullInto should still resolve correctly
+	var person Person
+	err = db.PullInto(e1, &person)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alice Updated", person.Name)
+}

--- a/datalog/storage/pure_aggregation_badger_test.go
+++ b/datalog/storage/pure_aggregation_badger_test.go
@@ -81,7 +81,7 @@ func TestPureAggregationWithBadgerDB(t *testing.T) {
 		EnableStreamingAggregation:  execOpts.EnableStreamingAggregation,
 		EnableDebugLogging:          execOpts.EnableDebugLogging,
 	}
-	exec := executor.NewExecutorWithOptions(matcher, opts)
+	exec := executor.NewExecutorWithOptions(matcher, db, opts)
 
 	// Test 1: Non-aggregated query (should work)
 	t.Run("NonAggregated", func(t *testing.T) {

--- a/datalog/storage/rga_reconstruct.go
+++ b/datalog/storage/rga_reconstruct.go
@@ -86,14 +86,14 @@ type RGAElementWithPosition struct {
 // This is used for building position indexes (position -> ElementID mapping).
 //
 // Returns a slice of (ElementID, Value) pairs in the correct order.
+// Tombstoned elements are excluded from the result but kept in the tree structure
+// so their children remain reachable.
 func ReconstructRGAWithIDs(elements []RGAElement) []RGAElementWithPosition {
 	// Build children map: afterRef -> []elements
-	// Only include non-deleted elements
+	// Include ALL elements (even tombstoned) to maintain tree structure
 	children := make(map[datalog.ElementID][]RGAElement)
 	for _, e := range elements {
-		if e.Tombstone == nil { // Skip deleted elements
-			children[e.AfterRef] = append(children[e.AfterRef], e)
-		}
+		children[e.AfterRef] = append(children[e.AfterRef], e)
 	}
 
 	// Sort each child list by ElementID for deterministic order
@@ -104,14 +104,18 @@ func ReconstructRGAWithIDs(elements []RGAElement) []RGAElementWithPosition {
 	}
 
 	// DFS from HEAD to build ordered result with positions
+	// Only emit non-tombstoned elements
 	var result []RGAElementWithPosition
 	var walk func(id datalog.ElementID)
 	walk = func(id datalog.ElementID) {
 		for _, child := range children[id] {
-			result = append(result, RGAElementWithPosition{
-				Element:  child,
-				Position: len(result),
-			})
+			if child.Tombstone == nil {
+				result = append(result, RGAElementWithPosition{
+					Element:  child,
+					Position: len(result),
+				})
+			}
+			// Always walk children, even if this element is tombstoned
 			walk(child.ID)
 		}
 	}

--- a/datalog/storage/schema_bench_test.go
+++ b/datalog/storage/schema_bench_test.go
@@ -179,7 +179,7 @@ func BenchmarkPullCardinalityOne(b *testing.B) {
 	resolved := schema.ResolvePullPattern(pattern, s)
 
 	matcher := NewBadgerMatcher(db.Store())
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, db)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -216,7 +216,7 @@ func BenchmarkPullCardinalityMany(b *testing.B) {
 	resolved := schema.ResolvePullPattern(pattern, s)
 
 	matcher := NewBadgerMatcher(db.Store())
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, db)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/datalog/storage/tuple_copying_bug_test.go
+++ b/datalog/storage/tuple_copying_bug_test.go
@@ -59,7 +59,7 @@ func TestMatcherRelationsTupleCopyingBug(t *testing.T) {
 	require.NoError(t, err)
 
 	matcher := NewBadgerMatcher(db.store)
-	exec := executor.NewExecutor(matcher)
+	exec := executor.NewExecutor(matcher, db)
 
 	result, err := exec.Execute(q)
 	require.NoError(t, err)

--- a/docs/bugs/resolved/PULLINTO_CRDT_RESOLUTION.md
+++ b/docs/bugs/resolved/PULLINTO_CRDT_RESOLUTION.md
@@ -1,0 +1,695 @@
+# PullInto Returns Raw Historical Values Instead of CRDT-Resolved Values
+
+## Summary
+
+When using `PullInto` to load an entity struct, CardinalityOne attributes return `[]interface{}` (all historical values) instead of the resolved current value. The CRDT resolution layer is being bypassed.
+
+## Reproduction
+
+```go
+// Schema defines :task/status as CardinalityOne (no .Many())
+Attribute(":task/status").Type(schema.TypeKeyword).Add()
+
+// Entity struct expects single value
+type TaskEntity struct {
+    ID     datalog.Identity `datalog:"db/id"`
+    Status datalog.Keyword  `datalog:"task/status"`  // Single value
+}
+
+// Write status twice (simulating status transitions)
+tx.Set(taskID, ":task/status", StatusPending)
+tx.Commit()
+
+tx2.Set(taskID, ":task/status", StatusComplete)
+tx2.Commit()
+
+// PullInto fails
+var task TaskEntity
+err := db.PullInto(taskID, &task)
+// Error: field Status (attr task/status): expected Keyword, got []interface {}
+```
+
+## Expected Behavior
+
+PullInto should use CRDT resolution based on cardinality:
+
+| Cardinality | Storage | PullInto Returns |
+|-------------|---------|------------------|
+| One | All historical values | Single current value (LWW - highest ElementID) |
+| Many | All add/remove ops | Resolved set (add-wins) |
+| Vector | All RGA ops | Ordered slice (RGA reconstruction) |
+
+## Actual Behavior
+
+PullInto returns raw storage data (all historical values as `[]interface{}`) without applying CRDT resolution.
+
+## Test Case
+
+From `narrative-generators/pkg/db`:
+
+```
+=== RUN   TestIsTaskComplete_AfterInvalidation
+    database_test.go:278: Failed to invalidate task: field Status (attr task/status): expected Keyword, got []interface {}
+--- FAIL: TestIsTaskComplete_AfterInvalidation (0.04s)
+```
+
+The test writes multiple status values to the same task (pending → running → complete → invalidated), then tries to load the entity. PullInto returns the slice of all historical statuses instead of the current one.
+
+---
+
+## Detailed Analysis
+
+### Code Path Overview
+
+The PullInto call chain:
+
+1. `Database.PullInto` (database.go:2364)
+2. Creates matcher via `d.Matcher()` which sets schema and cache
+3. Creates `PullExecutor` with that matcher
+4. Calls `PullResolved` → `processResolvedSpec`
+5. For `IsMany=false`, calls `lookupAttribute` (pull.go:385)
+6. `lookupAttribute` checks for `EntityLookupMatcher` interface
+7. `BadgerMatcher.LookupAttribute` is called (matcher.go:767)
+
+### What Works: Cache Path
+
+When the cache path is taken (`matchFromCache` in matcher_relations.go:527), CRDT resolution is applied correctly:
+
+```go
+case schema.CardinalityOne:
+    val := entry.OneValue()
+    if val == nil {
+        return executor.NewMaterializedRelationWithOptions(columns, nil, m.options), true
+    }
+    // Returns single-tuple relation with resolved value
+    tuple := buildTuple(val, entry.Version())
+    return executor.NewMaterializedRelationWithOptions(columns, []executor.Tuple{tuple}, m.options), true
+```
+
+- CardinalityOne → returns `entry.OneValue()` (single value)
+- CardinalityMany → returns resolved add-wins set
+- CardinalityVector → returns RGA-reconstructed list
+
+### What Breaks: Multiple Failure Modes
+
+#### 1. Wildcard Pulls (`getAllAttributes`)
+
+Location: `pull.go:237-301`
+
+When E is bound but A is unbound (wildcard pull `[*]`), the code:
+- Creates pattern `[entity, ?a, ?v]`
+- Scans EAVT and returns ALL datoms including historical values
+- No CRDT resolution is applied
+
+Then in `processResolvedSpec` for `*query.ResolvedPullWildcard` (pull.go:390-409):
+
+```go
+for _, datom := range datoms {
+    key := query.KeyName(datom.A)
+    if existing, ok := result[key]; ok {
+        // Attribute already seen - accumulate into slice (cardinality-many)
+        switch v := existing.(type) {
+        case []interface{}:
+            result[key] = append(v, datom.V)
+        default:
+            result[key] = []interface{}{v, datom.V}
+        }
+    } else {
+        result[key] = datom.V
+    }
+}
+```
+
+**Bug**: Blindly accumulates duplicate attributes into slices without checking cardinality or applying CRDT resolution.
+
+#### 2. Cache Miss Fallback
+
+When `matchFromCache` returns `handled=false` (cache miss), the code falls through to storage. The storage path in `matchUnboundAsRelation` (lines 229-312) sets CRDT flags like `returnOnlyFirst`, but these may not be consistently applied in all code paths.
+
+#### 3. Potential Keyword Interning Issues
+
+Schema lookup uses pointer equality for `datalog.Keyword` map keys:
+
+```go
+func (s *Schema) GetAttribute(attr datalog.Keyword) *AttributeDefinition {
+    if def, ok := s.attrs[attr]; ok {
+        return def
+    }
+    return nil
+}
+```
+
+Since `datalog.Keyword` is `*keyword` (a pointer type), map lookup compares by pointer address. If the keyword passed to `GetAttribute` isn't the exact same interned pointer used when building the schema, the lookup fails silently and:
+
+- `card` defaults to `CardinalityOne`
+- But storage may still return multiple historical values if the fallback path doesn't apply CRDT resolution
+
+### Why `LookupAttribute` May Return `[]interface{}`
+
+In `BadgerMatcher.LookupAttribute` (matcher.go:767-910):
+
+```go
+// Determine cardinality for correct resolution
+card := schema.CardinalityOne // default
+if m.schema != nil {
+    if def := m.schema.GetAttribute(attr); def != nil {
+        card = def.Cardinality
+    }
+}
+
+// Try cache first...
+if m.cache != nil && m.txID == 0 {
+    entry := m.cache.GetOrResolve(key, m)
+    if entry != nil {
+        switch card {
+        case schema.CardinalityOne:
+            return entry.OneValue(), true  // Single value ✓
+        case schema.CardinalityMany:
+            return result, true  // []interface{} - multiple values
+        case schema.CardinalityVector:
+            return list, true    // []any - multiple values
+        }
+    }
+}
+```
+
+If the schema lookup fails (returns nil), `card` stays as `CardinalityOne`. But if the cache entry was built with a different cardinality (due to `GetCardinality` succeeding via `decodeAttribute`), there's a mismatch.
+
+### The Fundamental Problem
+
+**CRDT resolution is inconsistent across code paths:**
+
+| Code Path | CRDT Resolution | Notes |
+|-----------|-----------------|-------|
+| `matchFromCache` | ✓ Correct | Uses cache entry's resolved values |
+| `LookupAttribute` cache hit | ✓ Correct | Returns `entry.OneValue()` etc. |
+| `LookupAttribute` storage fallback | ⚠ Partial | Uses `returnOnlyFirst` but may miss edge cases |
+| `getAllAttributes` (wildcard) | ✗ Broken | Returns all historical datoms |
+| `lookupAllValues` | ⚠ Depends | Goes through `Match` which may or may not resolve |
+
+---
+
+## Suggested Fix
+
+### Option 1: Direct Cache Access in PullExecutor (Recommended)
+
+PullExecutor should directly use the EA cache rather than going through the Match interface:
+
+```go
+// New interface for cache-aware attribute lookup
+type CacheAwareLookup interface {
+    LookupResolved(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool)
+}
+
+// In PullExecutor.lookupAttribute:
+if cacheLookup, ok := pe.matcher.(CacheAwareLookup); ok {
+    return cacheLookup.LookupResolved(entity, attr)
+}
+```
+
+Implementation in BadgerMatcher:
+
+```go
+func (m *BadgerMatcher) LookupResolved(entity datalog.Identity, attr datalog.Keyword) (interface{}, bool) {
+    if m.cache == nil {
+        return m.LookupAttribute(entity, attr) // Fallback
+    }
+
+    key := buildCacheKey(entity, attr)
+    entry := m.cache.GetOrResolve(key, m)
+    if entry == nil {
+        return nil, false
+    }
+
+    switch entry.Cardinality() {
+    case schema.CardinalityOne:
+        return entry.OneValue(), entry.OneValue() != nil
+    case schema.CardinalityMany:
+        return sliceFromSet(entry.ManySet()), len(entry.ManySet()) > 0
+    case schema.CardinalityVector:
+        return entry.VectorList(), len(entry.VectorList()) > 0
+    }
+    return nil, false
+}
+```
+
+### Option 2: Fix Wildcard Pull Path
+
+Update `getAllAttributes` to apply CRDT resolution:
+
+```go
+func (pe *PullExecutor) getAllAttributes(entity datalog.Identity) ([]datalog.Datom, error) {
+    // Get unique attributes for entity
+    attrs := pe.getEntityAttributes(entity)
+
+    var datoms []datalog.Datom
+    for _, attr := range attrs {
+        // Use cache-aware lookup for each attribute
+        if val, ok := pe.lookupAttribute(entity, attr); ok {
+            datoms = append(datoms, datalog.Datom{E: entity, A: attr, V: val})
+        }
+    }
+    return datoms, nil
+}
+```
+
+### Required Changes
+
+1. **PullExecutor** needs access to cache or a cache-aware lookup interface
+2. **BadgerMatcher** needs a new method that guarantees CRDT resolution
+3. **Wildcard pull** needs to iterate attributes and resolve each one
+4. **Add tests** for PullInto with multiple writes to same attribute
+
+---
+
+## Option 3: Entity-Level Cache Integration (Recommended)
+
+The above options fix the immediate bug but don't address the fundamental design tension between scan efficiency and CRDT resolution.
+
+### The Design Tension
+
+PullInto's efficiency comes from its single EAVT scan to get all attributes for an entity. But this bypasses the EA cache which is keyed by (Entity, Attribute) pairs.
+
+**Current state:**
+
+| Operation | Index | Warms Cache | CRDT Resolution |
+|-----------|-------|-------------|-----------------|
+| `WarmCache(attrs)` | AEVT | ✓ All entities for given attrs | ✓ via GetOrResolve |
+| `getAllAttributes(entity)` | EAVT | ✗ | ✗ Returns raw datoms |
+| `LookupAttribute(e, a)` | Per (E,A) | ✓ On demand | ✓ via cache |
+
+**The problem:** PullInto for an entity with 10 attributes has two bad options:
+
+1. **Scan path** (`getAllAttributes`): 1 seek, no CRDT resolution → **broken**
+2. **Per-attribute path**: 10 cache lookups, each potentially hitting storage → **N+1 problem**
+
+### The Solution: `ResolveEntityAttributes`
+
+Add entity-level cache warming that preserves scan efficiency:
+
+```
+Current WarmCache:  AEVT scan → warms all entities for specific attributes
+New method needed:  EAVT scan → warms all attributes for specific entity
+```
+
+### Current Flow (Broken)
+
+```
+PullInto(entity)
+  → getAllAttributes(entity)
+    → EAVT scan → raw datoms (includes historical values)
+    → processResolvedSpec accumulates duplicates into []interface{}
+    → ReadStructWithID fails: "expected Keyword, got []interface{}"
+```
+
+### Proposed Flow
+
+```
+PullInto(entity)
+  → ResolveEntityAttributes(entity)  // NEW
+    → EAVT scan → group by attribute
+    → For each unique (E, A): cache.GetOrResolve(key, resolver)
+    → Return map[Keyword]interface{} with CRDT-resolved values
+  → ReadStructWithID succeeds
+```
+
+### Implementation
+
+**Extend the cache** to track which attributes we've cached per entity:
+
+```go
+// In storage/cache.go - add to Cache struct
+
+type Cache struct {
+    entries      sync.Map // map[CacheKey]*CacheEntry      (existing)
+    maxVersions  sync.Map // map[CacheKey]datalog.ElementID (existing)
+    attrVersions sync.Map // map[Attribute]datalog.ElementID (existing)
+
+    // NEW: track which attributes we've cached per entity
+    // This is NOT source of truth - just tracks what's in cache
+    entityAttrs  sync.Map // map[Entity]map[Attribute]bool
+}
+
+// Update entityAttrs whenever we cache an (E, A) entry
+func (c *Cache) trackEntityAttr(key CacheKey) {
+    attrs, _ := c.entityAttrs.LoadOrStore(key.E, make(map[Attribute]bool))
+    attrs.(map[Attribute]bool)[key.A] = true
+}
+
+func (c *Cache) GetCachedAttrs(e Entity) map[Attribute]bool {
+    if attrs, ok := c.entityAttrs.Load(e); ok {
+        return attrs.(map[Attribute]bool)
+    }
+    return nil
+}
+```
+
+**PullInto flow - smart decision between individual lookups vs scan:**
+
+```go
+const scanThreshold = 5 // if more than N attrs missing, scan is cheaper
+
+func (d *Database) ResolveEntityAttributes(entity datalog.Identity, needed []datalog.Keyword) (map[datalog.Keyword]interface{}, error) {
+    eBytes := Entity(entity.Hash())
+    matcher := d.Matcher().(*BadgerMatcher)
+    result := make(map[datalog.Keyword]interface{})
+
+    // What do we have cached for this entity?
+    cachedAttrs := d.cache.GetCachedAttrs(eBytes)
+
+    // Partition needed attrs into cached vs missing
+    var missing []datalog.Keyword
+    for _, kw := range needed {
+        aBytes := toAttribute(kw)
+        if cachedAttrs != nil && cachedAttrs[aBytes] {
+            // Already cached - GetOrResolve (freshness check, usually cache hit)
+            key := CacheKey{E: eBytes, A: aBytes}
+            if entry := d.cache.GetOrResolve(key, matcher); entry != nil {
+                result[kw] = entryToValue(entry)
+            }
+        } else {
+            missing = append(missing, kw)
+        }
+    }
+
+    if len(missing) == 0 {
+        return result, nil // All cached
+    }
+
+    // Decision: individual lookups vs full scan
+    if len(missing) <= scanThreshold {
+        // Few missing - individual GetOrResolve calls
+        for _, kw := range missing {
+            aBytes := toAttribute(kw)
+            key := CacheKey{E: eBytes, A: aBytes}
+            if entry := d.cache.GetOrResolve(key, matcher); entry != nil {
+                result[kw] = entryToValue(entry)
+            }
+        }
+    } else {
+        // Many missing - full EAVT scan is cheaper
+        scanned, err := d.scanAndResolveEntity(entity)
+        if err != nil {
+            return nil, err
+        }
+        // Merge scanned results (only take what we need)
+        for _, kw := range missing {
+            if val, ok := scanned[kw]; ok {
+                result[kw] = val
+            }
+        }
+    }
+
+    return result, nil
+}
+
+func (d *Database) scanAndResolveEntity(entity datalog.Identity) (map[datalog.Keyword]interface{}, error) {
+    eBytes := Entity(entity.Hash())
+    matcher := d.Matcher().(*BadgerMatcher)
+
+    // ONE EAVT scan for this entity
+    prefix := buildEAVTPrefix(eBytes)
+    iter, err := d.store.Scan(EAVT, prefix, prefixEnd(prefix))
+    if err != nil {
+        return nil, err
+    }
+    defer iter.Close()
+
+    // Group datoms by attribute
+    attrDatoms := make(map[Attribute][]datalog.Datom)
+    for iter.Next() {
+        datom, _ := iter.Datom()
+        attr := toAttribute(datom.A)
+        attrDatoms[attr] = append(attrDatoms[attr], *datom)
+    }
+
+    // Resolve each attribute using factored resolution logic
+    result := make(map[datalog.Keyword]interface{})
+    for attr, datoms := range attrDatoms {
+        kw := datalog.NewKeyword(decodeAttribute(attr))
+        card := d.getCardinality(kw)
+
+        entry := resolveFromDatoms(datoms, card)
+
+        // Populate cache
+        key := CacheKey{E: eBytes, A: attr}
+        d.cache.Store(key, entry)
+        d.cache.UpdateMaxVersion(key, entry.version)
+        d.cache.trackEntityAttr(key)
+
+        result[kw] = entryToValue(entry)
+    }
+
+    return result, nil
+}
+```
+
+**Factor the resolution logic** so it can be used by both `GetOrResolve` (single E,A scan) and `scanAndResolveEntity` (batch from EAVT scan):
+
+```go
+// In storage/cache_resolver.go
+
+// resolveFromDatoms applies CRDT resolution to a slice of datoms
+// Used by both single-attribute resolution and batch entity resolution
+func resolveFromDatoms(datoms []datalog.Datom, card schema.Cardinality) *CacheEntry {
+    switch card {
+    case schema.CardinalityOne:
+        return resolveLWWFromDatoms(datoms)
+    case schema.CardinalityMany:
+        return resolveAddWinsFromDatoms(datoms)
+    case schema.CardinalityVector:
+        return resolveRGAFromDatoms(datoms)
+    }
+    return nil
+}
+
+// Existing ResolveLWW can call this after scanning
+func (m *BadgerMatcher) ResolveLWW(e Entity, a Attribute) (any, datalog.ElementID, error) {
+    datoms, err := m.scanEATVForDatoms(e, a)
+    if err != nil {
+        return nil, datalog.ElementID{}, err
+    }
+    entry := resolveLWWFromDatoms(datoms)
+    return entry.oneValue, entry.version, nil
+}
+```
+
+### Integration with PullInto
+
+```go
+// In storage/database.go - updated PullInto
+
+func (d *Database) PullInto(entityID datalog.Identity, v interface{}) error {
+    // For simple struct pulls, use the optimized path
+    if d.cache != nil {
+        resolved, err := d.ResolveEntityAttributes(entityID)
+        if err != nil {
+            return err
+        }
+        return dlreflect.ReadStructWithID(resolved, v, d.schema, entityID)
+    }
+
+    // Fallback to existing pull executor path for complex patterns
+    // ... existing implementation ...
+}
+```
+
+### Benefits
+
+| Scenario | Current (`getAllAttributes`) | Proposed (`ResolveEntityAttributes`) |
+|----------|------------------------------|--------------------------------------|
+| All attrs cached | 1 scan, no resolution | 0 scans, N cache hits |
+| Few attrs missing | 1 scan, no resolution | K individual `GetOrResolve` calls |
+| Many attrs missing | 1 scan, no resolution | 1 scan + resolve + cache |
+| CRDT resolution | ✗ | ✓ |
+| Handles history | ✗ (returns all values) | ✓ (resolves to current) |
+
+The heuristic (`scanThreshold`) balances individual lookup cost vs scan overhead.
+
+### Implementation Notes
+
+1. **Storage is source of truth**: `entityAttrs` only tracks what's *in the cache*, not what exists in storage. New attributes can appear at any time; the cache doesn't need to know about them until requested.
+
+2. **Factor resolution logic**: Extract `resolveFromDatoms(datoms, cardinality)` for use by both `GetOrResolve` (single E,A scan) and `scanAndResolveEntity` (batch EAVT scan).
+
+3. **Threshold tuning**: `scanThreshold` should be tuned based on typical entity size and storage latency. Start with ~5, measure, adjust.
+
+4. **entityAttrs concurrency**: The inner `map[Attribute]bool` needs synchronization. Consider `sync.Map` or per-entity mutex.
+
+5. **Wildcard pulls**: Always require a scan since we don't know which attributes exist. Can't optimize with `entityAttrs` alone.
+
+### Why This Is Better Than Options 1 & 2
+
+**Option 1** (per-attribute cache lookup) always does individual lookups - misses opportunity to batch when many attrs are missing.
+
+**Option 2** (fix wildcard processing) still requires full scan every time, doesn't leverage cache.
+
+**Option 3** (smart cache with difference-based decision):
+- Tracks what's cached per entity (`entityAttrs`)
+- Computes difference: needed - cached = missing
+- Small difference → individual `GetOrResolve` (avoids scan overhead)
+- Large difference → one scan cheaper than N lookups
+- Storage remains source of truth
+- Cache is pure optimization layer
+
+### Additional Integration Points
+
+1. **PullExecutor.getAllAttributes** → delegate to `ResolveEntityAttributes` when available
+2. **Wildcard pull** → use resolved map instead of raw datoms
+3. **PullIntoMany** → batch entity resolution with shared scan patterns
+
+---
+
+## Impact
+
+Any code using PullInto/SaveStruct with entities that have been updated (multiple writes to same attribute) will fail after upgrading to CRDT storage.
+
+### Affected APIs
+
+- `Database.PullInto`
+- `Database.PullIntoMany`
+- Any code using wildcard pulls `[*]`
+- Any code relying on `LookupAttribute` for cardinality-one attributes with history
+
+### Workaround
+
+Until fixed, users can query attributes directly using Datalog queries which properly use the cache resolution path:
+
+```go
+// Instead of:
+db.PullInto(taskID, &task)
+
+// Use:
+result, _ := db.Query(`[:find ?status :where [?e :task/status ?status]]`,
+    datalog.Inputs{"?e": taskID})
+task.Status = result[0][0].(datalog.Keyword)
+```
+
+---
+
+## Additional Finding: Pull Expressions in Queries
+
+**Standalone `PullInto` works correctly. Pull expressions `(pull ?e [*])` in queries do not.**
+
+### Test
+
+See: `datalog/storage/pull_expression_crdt_test.go`
+
+```go
+// Write status 3 times via SaveStruct
+task.Status = ":status/pending"
+tx.SaveStruct(task)
+
+task.Status = ":status/running"
+tx2.SaveStruct(task)
+
+task.Status = ":status/complete"
+tx3.SaveStruct(task)
+
+// Standalone PullInto - WORKS
+var loaded TaskEntity
+db.PullInto(task.ID, &loaded)  // loaded.Status == :status/complete ✓
+
+// Pull expression in query - BROKEN
+db.QueryOneInto(&loaded,
+    `[:find (pull ?e [*]) :where [?e :task/name "test-task"]]`)
+// Error: field Status (attr task/status): expected Keyword, got []interface {}
+```
+
+### Test Output
+
+```
+=== RUN   TestPullInto_CardinalityOne_MultipleWrites
+--- PASS: TestPullInto_CardinalityOne_MultipleWrites (0.04s)
+=== RUN   TestPullExpression_CardinalityOne_MultipleWrites
+    pull_expression_crdt_test.go:160: QueryOneInto with pull expression failed: field Status (attr task/status): expected Keyword, got []interface {}
+--- FAIL: TestPullExpression_CardinalityOne_MultipleWrites (0.03s)
+```
+
+### Implication
+
+The CRDT resolution path differs between:
+- `db.PullInto(id, &struct)` → uses cache, resolves correctly
+- `[:find (pull ?e [*]) ...]` → bypasses cache, returns raw historical values
+
+---
+
+## Resolution
+
+**Fixed in commit: [pending]**
+
+### Root Causes
+
+Two separate bugs were identified and fixed:
+
+#### Bug 1: `ResolveAllAttributes` always scanned storage
+
+`ResolveAllAttributes` (used by wildcard pulls) always performed a full EAVT scan, ignoring the difference-based logic in `ResolveEntityAttributes` that checks the cache first.
+
+**Fix:** When schema exists, `ResolveAllAttributes` now delegates to `ResolveEntityAttributes` with all schema attributes. This uses the cache when data is already cached, only scanning when necessary.
+
+```go
+// datalog/storage/database.go
+func (d *Database) ResolveAllAttributes(entity datalog.Identity) (map[datalog.Keyword]interface{}, error) {
+    // If schema exists, delegate to ResolveEntityAttributes with all schema attrs.
+    // This uses difference-based logic: check cache first, scan only if needed.
+    if d.schema != nil {
+        if s, ok := d.schema.(*schema.Schema); ok && s.HasSchema() {
+            attrs := s.Attributes()
+            keywords := make([]datalog.Keyword, len(attrs))
+            for i, def := range attrs {
+                keywords[i] = def.Ident
+            }
+            return d.ResolveEntityAttributes(entity, keywords)
+        }
+    }
+    // No schema: must scan EAVT to discover all attributes
+    // ... existing scan logic ...
+}
+```
+
+#### Bug 2: `entityResolver` not propagated to temporary executor
+
+In `Executor.ExecuteWithRelations`, a temporary executor was created for annotation wrapping, but it did not copy the `entityResolver` field. This caused pull expressions in queries to have a nil `entityResolver`, bypassing CRDT resolution.
+
+**Fix:** Added `entityResolver` to the temporary executor struct initialization.
+
+```go
+// datalog/executor/executor.go - ExecuteWithRelations
+executor := &Executor{
+    matcher:                  matcher,
+    entityResolver:           e.entityResolver,  // WAS MISSING
+    planner:                  e.planner,
+    options:                  e.options,
+    enableParallelSubqueries: e.enableParallelSubqueries,
+    maxSubqueryWorkers:       e.maxSubqueryWorkers,
+}
+```
+
+#### Bug 3: `entryToValue` returned raw map for CardinalityMany
+
+`entryToValue` returned `map[any]bool` for CardinalityMany attributes instead of converting to `[]interface{}`, breaking API consistency with Pull.
+
+**Fix:** Convert set to slice in `entryToValue`:
+
+```go
+case schema.CardinalityMany:
+    set := entry.ManySet()
+    if len(set) == 0 {
+        return nil
+    }
+    values := make([]interface{}, 0, len(set))
+    for v := range set {
+        values = append(values, v)
+    }
+    return values
+```
+
+### Tests
+
+All tests now pass:
+- `TestBugVerification_PullInto_CardinalityOne` - Original bug repro
+- `TestPullExpression_CardinalityOne_MultipleWrites` - Pull expressions in queries
+- `TestPull_Wildcard_CRDTResolution` - Wildcard with CardinalityOne and CardinalityMany
+- `TestPull_Wildcard_CardinalityVector` - Wildcard with ordered vector (new test)
+- `TestPullInto_CardinalityVector_RGA` - Vector ordering preserved

--- a/docs/reference/CRDT.md
+++ b/docs/reference/CRDT.md
@@ -705,3 +705,55 @@ All writes are preserved. Use history predicates for time-travel queries:
 ```
 
 The cache stores current value only. History queries bypass the cache and scan storage directly.
+
+---
+
+## Pull API and CRDT Resolution
+
+The Pull API (`db.Pull()`, `db.PullInto()`, and pull expressions in queries) uses CRDT resolution to return current values.
+
+### EntityResolver Interface
+
+Pull operations use the `EntityResolver` interface to resolve attributes with proper CRDT semantics:
+
+```go
+type EntityResolver interface {
+    ResolveAllAttributes(entity datalog.Identity) (map[datalog.Keyword]interface{}, error)
+}
+```
+
+The Database implements this interface, delegating to `ResolveEntityAttributes` which uses the EA cache for efficient resolution.
+
+### Wildcard Pulls
+
+Wildcard pulls (`[*]`) resolve all attributes for an entity:
+
+```go
+result, _ := db.Pull(entity, "[*]")
+// Returns CRDT-resolved values:
+// - CardinalityOne: single value (LWW)
+// - CardinalityMany: []interface{} (add-wins set)
+// - CardinalityVector: []interface{} (RGA ordered list)
+```
+
+**With schema**: Uses schema attributes as the resolution list, leveraging the cache when data is already cached.
+
+**Without schema**: Scans EAVT to discover all attributes for the entity.
+
+### Pull Expressions in Queries
+
+Pull expressions in queries also use CRDT resolution:
+
+```clojure
+[:find (pull ?e [*]) :where [?e :task/name "test"]]
+```
+
+Both standalone `db.PullInto()` and query pull expressions use the same resolution path through `EntityResolver`.
+
+### Return Types by Cardinality
+
+| Cardinality | Pull Return Type | Example |
+|-------------|------------------|---------|
+| One | Single value | `"Alice"` |
+| Many | `[]interface{}` | `["admin", "user"]` |
+| Vector | `[]interface{}` (ordered) | `["Go", "Python", "Rust"]` |

--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -220,10 +220,10 @@ pattern := &query.PullPattern{
     },
 }
 
-// Resolve and execute
+// Resolve and execute (recommended: use db.Pull() instead)
 resolved := schema.ResolvePullPattern(pattern, s)
 matcher := storage.NewBadgerMatcher(db.Store())
-puller := executor.NewPullExecutor(matcher)
+puller := executor.NewPullExecutor(matcher, db) // db implements EntityResolver for CRDT resolution
 result, _ := puller.PullResolved(alice, resolved)
 
 // Result:

--- a/tests/aggregate_subquery_nil_bug_test.go
+++ b/tests/aggregate_subquery_nil_bug_test.go
@@ -93,7 +93,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse verify query: %v", verifyErr)
 	}
 	verifyMatcher := storage.NewBadgerMatcher(db.Store())
-	verifyExec := executor.NewExecutor(verifyMatcher)
+	verifyExec := executor.NewExecutor(verifyMatcher, nil)
 	vresult, verifyErr := verifyExec.Execute(vq)
 	if verifyErr != nil {
 		t.Fatalf("Failed to execute verify query: %v", verifyErr)
@@ -111,7 +111,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse symbol query: %v", symbolErr)
 	}
 	symbolMatcher := storage.NewBadgerMatcher(db.Store())
-	symbolExec := executor.NewExecutor(symbolMatcher)
+	symbolExec := executor.NewExecutor(symbolMatcher, nil)
 	sresult, symbolErr := symbolExec.Execute(sq)
 	if symbolErr != nil {
 		t.Fatalf("Failed to execute symbol query: %v", symbolErr)
@@ -129,7 +129,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse morning query: %v", morningErr)
 	}
 	morningMatcher := storage.NewBadgerMatcher(db.Store())
-	morningExec := executor.NewExecutor(morningMatcher)
+	morningExec := executor.NewExecutor(morningMatcher, nil)
 	mresult, morningErr := morningExec.Execute(mq)
 	if morningErr != nil {
 		t.Fatalf("Failed to execute morning query: %v", morningErr)
@@ -147,7 +147,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse check minute query: %v", checkErr)
 	}
 	checkMatcher := storage.NewBadgerMatcher(db.Store())
-	checkExec := executor.NewExecutor(checkMatcher)
+	checkExec := executor.NewExecutor(checkMatcher, nil)
 	checkResult, checkErr := checkExec.Execute(cmq)
 	if checkErr != nil {
 		t.Fatalf("Failed to execute check minute query: %v", checkErr)
@@ -166,7 +166,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse check high query: %v", chErr)
 	}
 	chMatcher := storage.NewBadgerMatcher(db.Store())
-	chExec := executor.NewExecutor(chMatcher)
+	chExec := executor.NewExecutor(chMatcher, nil)
 	chResult, chErr := chExec.Execute(chq)
 	if chErr != nil {
 		t.Fatalf("Failed to execute check high query: %v", chErr)
@@ -180,7 +180,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse check low query: %v", clErr)
 	}
 	clMatcher := storage.NewBadgerMatcher(db.Store())
-	clExec := executor.NewExecutor(clMatcher)
+	clExec := executor.NewExecutor(clMatcher, nil)
 	clResult, clErr := clExec.Execute(clq)
 	if clErr != nil {
 		t.Fatalf("Failed to execute check low query: %v", clErr)
@@ -198,7 +198,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse simple bound query: %v", sbErr)
 	}
 	sbMatcher := storage.NewBadgerMatcher(db.Store())
-	sbExec := executor.NewExecutor(sbMatcher)
+	sbExec := executor.NewExecutor(sbMatcher, nil)
 	sbResult, sbErr := sbExec.Execute(sbq)
 	if sbErr != nil {
 		t.Fatalf("Failed to execute simple bound query: %v", sbErr)
@@ -216,7 +216,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse bar join query: %v", bjErr)
 	}
 	bjMatcher := storage.NewBadgerMatcher(db.Store())
-	bjExec := executor.NewExecutor(bjMatcher)
+	bjExec := executor.NewExecutor(bjMatcher, nil)
 	bjResult, bjErr := bjExec.Execute(bjq)
 	if bjErr != nil {
 		t.Fatalf("Failed to execute bar join query: %v", bjErr)
@@ -237,7 +237,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse bar-minute query: %v", bmErr)
 	}
 	bmMatcher := storage.NewBadgerMatcher(db.Store())
-	bmExec := executor.NewExecutor(bmMatcher)
+	bmExec := executor.NewExecutor(bmMatcher, nil)
 	bmResult, bmErr := bmExec.Execute(bmq)
 	if bmErr != nil {
 		t.Fatalf("Failed to execute bar-minute query: %v", bmErr)
@@ -258,7 +258,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 		t.Fatalf("Failed to parse minute query: %v", minuteErr)
 	}
 	minuteMatcher := storage.NewBadgerMatcher(db.Store())
-	minuteExec := executor.NewExecutor(minuteMatcher)
+	minuteExec := executor.NewExecutor(minuteMatcher, nil)
 	minresult, minuteErr := minuteExec.Execute(minq)
 	if minuteErr != nil {
 		t.Fatalf("Failed to execute minute query: %v", minuteErr)
@@ -284,7 +284,7 @@ func TestMultipleAggregateSubqueriesNilBug(t *testing.T) {
 	}
 
 	matcher := storage.NewBadgerMatcher(db.Store())
-	exec := executor.NewExecutor(matcher)
+	exec := executor.NewExecutor(matcher, nil)
 	result, execErr := exec.Execute(q)
 	if execErr != nil {
 		t.Fatalf("Failed to execute main query: %v", execErr)

--- a/tests/badger_profile_test.go
+++ b/tests/badger_profile_test.go
@@ -97,7 +97,7 @@ func TestBadgerParallelProfile(t *testing.T) {
 	defer pprof.StopCPUProfile()
 
 	// Run parallel execution
-	parExec := executor.NewExecutor(matcher)
+	parExec := executor.NewExecutor(matcher, nil)
 	parExec.EnableParallelSubqueries(8)
 
 	start := time.Now()

--- a/tests/comparison_binding_or_subquery_test.go
+++ b/tests/comparison_binding_or_subquery_test.go
@@ -87,7 +87,7 @@ func TestComparisonBindingWithOrSubquery_E2E(t *testing.T) {
 
 	// Use executor with annotations to trace execution
 	opts := storage.DefaultPlannerOptions()
-	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), opts)
+	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), nil, opts)
 
 	ctx := executor.NewContext(func(event annotations.Event) {
 		t.Logf("[ANNOTATION] %s: %v", event.Name, event.Data)

--- a/tests/entity_join_bug_test.go
+++ b/tests/entity_join_bug_test.go
@@ -48,7 +48,7 @@ func TestEntityJoinBug(t *testing.T) {
 	highQuery := `[:find ?bar :where [?bar :price/high ?h]]`
 	hq, _ := parser.ParseQuery(highQuery)
 	matcher := storage.NewBadgerMatcher(db.Store())
-	exec := executor.NewExecutor(matcher)
+	exec := executor.NewExecutor(matcher, nil)
 	hresult, _ := exec.Execute(hq)
 
 	// Collect results by iterating
@@ -132,7 +132,7 @@ func TestEntityJoinBug(t *testing.T) {
 		EnableDebugLogging: true,
 	}
 	annotatedMatcher := storage.NewBadgerMatcherWithOptions(db.Store(), opts)
-	annotatedExec := executor.NewExecutor(annotatedMatcher)
+	annotatedExec := executor.NewExecutor(annotatedMatcher, nil)
 
 	jresult, _ := annotatedExec.Execute(jq)
 

--- a/tests/parallel_badgerdb_test.go
+++ b/tests/parallel_badgerdb_test.go
@@ -82,7 +82,7 @@ func TestParallelSubqueryWithBadgerDB(t *testing.T) {
 	inputRel := executor.NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y"), datalog.NewSymbol("?m")}, inputTuples)
 
 	t.Run("sequential with BadgerDB", func(t *testing.T) {
-		seqExec := executor.NewExecutor(matcher)
+		seqExec := executor.NewExecutor(matcher, nil)
 		seqExec.DisableParallelSubqueries()
 
 		start := time.Now()
@@ -101,7 +101,7 @@ func TestParallelSubqueryWithBadgerDB(t *testing.T) {
 	})
 
 	t.Run("parallel with BadgerDB", func(t *testing.T) {
-		parExec := executor.NewExecutor(matcher)
+		parExec := executor.NewExecutor(matcher, nil)
 		parExec.EnableParallelSubqueries(8)
 
 		start := time.Now()
@@ -121,7 +121,7 @@ func TestParallelSubqueryWithBadgerDB(t *testing.T) {
 
 	t.Run("correctness and performance: sequential vs parallel", func(t *testing.T) {
 		// Sequential execution
-		seqExec := executor.NewExecutor(matcher)
+		seqExec := executor.NewExecutor(matcher, nil)
 		seqExec.DisableParallelSubqueries()
 		seqStart := time.Now()
 		seqResult, err := seqExec.ExecuteWithRelations(ctx, parsed, []executor.Relation{inputRel})
@@ -131,7 +131,7 @@ func TestParallelSubqueryWithBadgerDB(t *testing.T) {
 		}
 
 		// Parallel execution
-		parExec := executor.NewExecutor(matcher)
+		parExec := executor.NewExecutor(matcher, nil)
 		parExec.EnableParallelSubqueries(8)
 		parStart := time.Now()
 		parResult, err := parExec.ExecuteWithRelations(ctx, parsed, []executor.Relation{inputRel})

--- a/tests/pull_schema_test.go
+++ b/tests/pull_schema_test.go
@@ -56,7 +56,7 @@ func TestPullResolvedCardinalityMany(t *testing.T) {
 	// Execute pull with resolved pattern
 	matcher := storage.NewBadgerMatcher(db.Store())
 	matcher.SetSchema(s) // Required for cardinality-aware resolution
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, nil)
 	result, err := puller.PullResolved(alice, resolved)
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -132,7 +132,7 @@ func TestPullResolvedCardinalityManyRefs(t *testing.T) {
 	// Execute pull with resolved pattern
 	matcher := storage.NewBadgerMatcher(db.Store())
 	matcher.SetSchema(s) // Required for cardinality-aware resolution
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, nil)
 	result, err := puller.PullResolved(alice, resolved)
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -198,7 +198,7 @@ func TestPullResolvedLimit(t *testing.T) {
 	// Execute pull with resolved pattern
 	matcher := storage.NewBadgerMatcher(db.Store())
 	matcher.SetSchema(s) // Required for cardinality-aware resolution
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, nil)
 	result, err := puller.PullResolved(alice, resolved)
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -249,7 +249,7 @@ func TestPullResolvedDefault(t *testing.T) {
 	// Execute pull with resolved pattern
 	matcher := storage.NewBadgerMatcher(db.Store())
 	matcher.SetSchema(s) // Required for cardinality-aware resolution
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, nil)
 	result, err := puller.PullResolved(alice, resolved)
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -296,7 +296,7 @@ func TestPullResolvedWithoutSchema(t *testing.T) {
 
 	// Execute pull with resolved pattern
 	matcher := storage.NewBadgerMatcher(db.Store())
-	puller := executor.NewPullExecutor(matcher)
+	puller := executor.NewPullExecutor(matcher, nil)
 	result, err := puller.PullResolved(alice, resolved)
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/tests/tuple_ground_test.go
+++ b/tests/tuple_ground_test.go
@@ -47,7 +47,7 @@ func TestTupleGroundBasic(t *testing.T) {
 	}
 
 	opts := storage.DefaultPlannerOptions()
-	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), opts)
+	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), nil, opts)
 
 	result, err := exec.Execute(q)
 	if err != nil {
@@ -150,7 +150,7 @@ func TestTupleGroundOrFallback(t *testing.T) {
 	t.Logf("Parsed query: %s", q.String())
 
 	opts := storage.DefaultPlannerOptions()
-	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), opts)
+	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), nil, opts)
 
 	ctx := executor.NewContext(func(event annotations.Event) {
 		t.Logf("[ANNOTATION] %s: %v", event.Name, event.Data)
@@ -262,7 +262,7 @@ func TestTupleGroundBackwardCompatibility(t *testing.T) {
 	}
 
 	opts := storage.DefaultPlannerOptions()
-	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), opts)
+	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), nil, opts)
 
 	result, err := exec.Execute(q)
 	if err != nil {
@@ -327,7 +327,7 @@ func TestTupleGroundQB(t *testing.T) {
 	t.Logf("Query built: %s", q.String())
 
 	opts := storage.DefaultPlannerOptions()
-	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), opts)
+	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), nil, opts)
 
 	result, err := exec.Execute(q)
 	if err != nil {
@@ -430,7 +430,7 @@ func TestTupleGroundQBInOr(t *testing.T) {
 	t.Logf("Query built: %s", q.String())
 
 	opts := storage.DefaultPlannerOptions()
-	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), opts)
+	exec := executor.NewExecutorWithOptions(storage.NewBadgerMatcher(db.Store()), nil, opts)
 
 	result, err := exec.Execute(q)
 	if err != nil {


### PR DESCRIPTION
## Summary

Wildcard pulls (`[*]`) and pull expressions in queries were returning raw historical values instead of CRDT-resolved current values. This caused type errors like "expected Keyword, got []interface{}" when PullInto encountered CardinalityOne attributes with multiple historical writes.

## Root Causes

Three separate bugs were identified and fixed:

### 1. `ResolveAllAttributes` always scanned storage

The wildcard pull path always performed a full EAVT scan, ignoring the difference-based cache logic. With schema, it now delegates to `ResolveEntityAttributes` which checks the cache first.

### 2. `entityResolver` not propagated to temporary executor

In `Executor.ExecuteWithRelations`, a temporary executor was created for annotation wrapping but did not copy the `entityResolver` field. Pull expressions in queries had a nil resolver, bypassing CRDT resolution.

### 3. `entryToValue` returned raw map for CardinalityMany

The cache entry conversion returned `map[any]bool` instead of `[]interface{}` for CardinalityMany attributes, breaking API consistency.

## Changes

### API (Breaking for direct executor users)

- `NewExecutor(matcher, resolver)` - added EntityResolver parameter
- `NewExecutorWithOptions(matcher, resolver, opts)` - added EntityResolver
- `NewPullExecutor(matcher, resolver)` - added EntityResolver parameter
- `NewPullExecutorWithHandler(matcher, resolver, handler)` - added EntityResolver

**Users of `db.Query()`, `db.Pull()`, `db.PullInto()` are not affected.**

### New Interface

```go
type EntityResolver interface {
    ResolveAllAttributes(entity datalog.Identity) (map[datalog.Keyword]interface{}, error)
}
```

### Implementation

- `datalog/executor/executor.go`: Propagate entityResolver in ExecuteWithRelations
- `datalog/executor/pull.go`: Use EntityResolver for wildcard pulls
- `datalog/storage/database.go`: Add ResolveAllAttributes, ResolveEntityAttributes
- `datalog/storage/cache.go`: Add entityAttrs tracking for difference-based resolution

### Documentation

- `docs/reference/CRDT.md`: Added "Pull API and CRDT Resolution" section
- `docs/reference/SCHEMA.md`: Updated NewPullExecutor example
- `CLAUDE.md`: Updated NewExecutor example

## Tests

- `TestBugVerification_PullInto_CardinalityOne` - Original bug repro
- `TestPullExpression_CardinalityOne_MultipleWrites` - Pull expressions in queries
- `TestPull_Wildcard_CRDTResolution` - Wildcard with CardinalityOne/Many
- `TestPull_Wildcard_CardinalityVector` - Vector ordering preserved (new)

Bug documentation: `docs/bugs/resolved/PULLINTO_CRDT_RESOLUTION.md`