### PR TITLE
Add AETV index and streaming CRDT resolution for query execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ This is **standard database query optimization** (similar to Selinger's algorith
 - **Fixed 69-byte keys**: E(20) + A(32) + Tx(16) + Op(1) for efficient indexing
 - **Unbounded values**: Stored last with 2-byte size prefix and 1-byte type
 - **L85 encoding**: Custom Base85 variant preserving sort order (see below)
-- **Six indices**: EAVT, EATV, AEVT, AVET, VAET, TAEV for different access patterns and cardinalities
+- **Seven indices**: EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV for different access patterns and cardinalities
 - **CRDT semantics**: LWW for cardinality-one, add-wins for cardinality-many, RGA for cardinality-vector
 - **Keyword interning**: Keywords hashed once and reused
 - **RefValues**: 20-byte entity references are L85-encoded like E/Tx components

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ This separation ensures the query engine remains simple and focused on logic, wh
 ### Storage Integration
 The storage layer connects the query engine to BadgerDB:
 - **Database API**: High-level interface for creating transactions and querying
-- **Transaction API**: Write datoms with automatic indexing across all 5 indices
+- **Transaction API**: Write datoms with automatic indexing across all 7 indices
 - **BadgerMatcher**: Implements PatternMatcher interface for the executor
   - Chooses optimal index based on bound values in patterns
   - Converts between user types (Identity, Keyword) and storage types ([20]byte for E/Tx, [32]byte for A)

--- a/CLAUDE_BUGS.md
+++ b/CLAUDE_BUGS.md
@@ -307,3 +307,60 @@ if len(phase.Patterns) == 0 && len(collapsed) == 0 {
 - Type preservation over clever encoding
 
 **Rule**: Make it right, then make it fast.
+
+---
+
+## Streaming Architecture Violation (2026-02-05)
+
+**Critical Architecture Bug**: Created a buffering "CRDT resolution" layer that defeated the entire streaming architecture.
+
+**What I Did Wrong**:
+1. Created `CRDTResolvingIterator` that buffers ALL datoms for an (E, A) group
+2. Added `copyDatom()` function to copy iterator results into a buffer
+3. Built complex "resolution" logic (resolveLWW, resolveAddWins, resolveRGA)
+4. Completely ignored that the storage layer already solves this problem
+
+**Why It Was Wrong**:
+The EATV index stores Tx with **bitwise NOT for descending order**. This means:
+- First entry for each (E, A) IS the LWW winner
+- No resolution logic needed for CardinalityOne
+- Just skip subsequent entries with same (E, A)
+
+The comments in `key_encoder_binary.go` say it explicitly:
+```go
+// EATV: [prefix][E][A][Tx↓][type][value][Op][AfterRef?] - first entry is current
+// Tx is encoded with bitwise NOT for descending sort order (highest Tx first)
+```
+
+**Red Flags I Should Have Noticed**:
+1. Creating a `copy*` function for iterator results → buffering smell
+2. Accumulating datoms in a slice → materialization smell
+3. Building "resolution" logic → the index already does this
+4. Adding complexity to "solve" something → should have asked why it's needed
+
+**The Correct Approach for CardinalityOne**:
+```go
+// Track current (E, A), skip duplicates
+// First entry wins because EATV orders Tx descending
+// Pure filtering, zero buffering
+```
+
+**The Correct Approach for CardinalityMany**:
+```go
+// Track state per value: map[valueKey]{highestAdd, highestRemove}
+// When (E, A) changes, emit values where add >= remove
+// Buffer state, not datoms
+```
+
+**Pattern**: The storage layer index ordering IS the CRDT resolution. If you think you need resolution logic, you don't understand the storage layer. READ THE INDEX COMMENTS.
+
+**Meta-Pattern**: If you're buffering iterator results, you're breaking streaming. STOP and ask.
+
+---
+
+### 6. Understand Before Implementing
+- Read code AND understand what it means
+- Index ordering has semantic meaning (descending Tx = first wins)
+- Don't treat features as problems to solve without understanding existing design
+
+**Rule**: If you read comments explaining WHY something works a certain way, actually think about the implications.

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -23,7 +23,7 @@ Janus-datalog implements a substantial subset of Datomic's Datalog query languag
 - ✅ Query Builder (qb): compile-time safe query construction with IDE support
 
 **Storage:**
-- ✅ BadgerDB persistent storage with CRDT model and 6 indices (EAVT, EATV, AEVT, AVET, VAET, TAEV)
+- ✅ BadgerDB persistent storage with CRDT model and 7 indices (EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV)
 - ✅ Export/Import to EDN format for backup and migration
 
 **Not Implemented:**
@@ -658,7 +658,7 @@ No advanced database operations:
 - Uses BadgerDB instead of Datomic's segmented storage
 - L85 encoding (custom Base85) for sortable keys
 - Fixed 69-byte keys: E(20) + A(32) + Tx(16) + Op(1)
-- Six indices: EAVT, EATV, AEVT, AVET, VAET, TAEV
+- Seven indices: EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV
 
 ### 2. Transaction Model
 - ElementID-based transactions (Lamport clock + ReplicaID)

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -274,7 +274,7 @@ Every datom includes a transaction ID for temporal queries.
 ### 10. Storage Model
 
 - **EAVT model** with Entity-Attribute-Value-Transaction tuples
-- **Multiple indices**: EAVT, AEVT, AVET, VAET, TAEV
+- **Seven indices**: EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV (EATV/AETV use Tx-descending for CRDT resolution)
 - **BadgerDB backend** for persistence
 - **L85 encoding** for sortable, efficient keys
 - **Export/Import** to EDN format for backup and migration (see [docs/reference/EXPORT_IMPORT.md](docs/reference/EXPORT_IMPORT.md))

--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -1,7 +1,7 @@
 # PERFORMANCE_STATUS.md
 
-**Last Updated**: 2026-02-02
-**Version**: Clause-based planner, QueryExecutor, streaming architecture, Pull API, schema support, key encoder optimization, conditional aggregate rewriting, CRDT storage, and allocation regression fixes
+**Last Updated**: 2026-02-06
+**Version**: Clause-based planner, QueryExecutor, streaming architecture, Pull API, schema support, key encoder optimization, conditional aggregate rewriting, CRDT storage, allocation regression fixes, and value elimination
 
 ## Executive Summary
 
@@ -23,6 +23,7 @@ The Janus Datalog engine delivers production-ready performance through architect
 - ✅ **Conditional aggregate rewriting**: **7.7× faster**, **5.2× less memory**, **8.1× fewer allocations** for correlated aggregate subqueries (verified 2026-01-16)
 - ✅ **CRDT storage**: **~25-35µs writes** across all cardinalities, **O(1) LWW resolution** (965ns for 1000 versions), linear vector scaling (verified 2026-01-31)
 - ✅ **CRDT allocation optimization**: **90% faster** (1.9×), **2.2× less memory** than pre-CRDT main branch while adding full CRDT semantics (verified 2026-02-02)
+- ✅ **AETV index & value elimination**: **5% faster**, **19% less memory**, **17% fewer allocations** (geomean); complex queries see **35% memory reduction** (verified 2026-02-06)
 
 ### Claims Requiring Qualification
 - ⚠️ **Plan quality**: "13% better plans" not supported by current benchmarks (planners perform identically)
@@ -894,6 +895,61 @@ The engine is **production-ready for datasets up to 10M+ datoms**. All major opt
 ---
 
 ## Session History
+
+### 2026-02-06: AETV Index & Value Elimination - Streaming CRDT Fixes
+
+**Branch**: `main`
+**Status**: ✅ Complete - CRDT resolution now correct for all query patterns
+
+**The Story**:
+The `CRDTResolvingIterator` relies on Tx-descending index order (first entry = LWW winner). When E was bound via input with A constant, the matcher selected AEVT (Tx ascending) instead of a CRDT-aware index, returning stale values. We added AETV as a 7th index and eliminated redundant value storage.
+
+**What Was Done**:
+
+1. **AETV Index** (A → E → Tx↓ → V):
+   - New A-primary CRDT index complementing EATV (E-primary CRDT)
+   - Index selection updated: A-constant + E-from-input now uses AETV
+   - Fixes `CRDTResolvingIterator` returning wrong values for batch entity lookups
+
+2. **Value Elimination**:
+   - `assertDatom()` now writes nil values (all datom data is encoded in keys)
+   - `BadgerIterator.Datom()` decodes from key via `DatomFromKey()`
+   - ~50% storage reduction (no redundant value bytes)
+
+**Benchmark Results** (Apple M4 Max, benchstat n=100):
+
+| Benchmark | Time | Memory | Allocations |
+|-----------|------|--------|-------------|
+| SimpleQuery | +2.59% | +0.13% | -0.12% |
+| JoinQuery | +0.94% | -0.85% | -0.84% |
+| CardinalityMany | **-5.16%** | **-32.59%** | **-28.49%** |
+| VectorQuery | **-18.60%** | **-35.11%** | **-32.89%** |
+| **geomean** | **-5.44%** | **-18.82%** | **-16.97%** |
+
+**Key Findings**:
+- Simple queries: minimal change (less datom decoding)
+- Complex queries: significant wins from eliminating value reads
+- Storage reduced by ~50% (values were 100% redundant with keys)
+- All 17 CRDT resolution tests now pass with `DisableCache: true`
+
+**SimpleQuery Regression Explained** (+2.59%):
+The regression comes from `KeyCopy(nil)` in `BadgerIterator.Datom()`. Previously, values were read from BadgerDB's value storage. Now we decode from keys, which requires copying the key bytes because BadgerDB reuses its internal buffer.
+
+We investigated key buffer reuse to eliminate this allocation, but it's not possible: `DecodeKey` returns the value component as a slice *into* the key bytes (e.g., `value = key[entitySize+attrSize:vEnd]`). Reusing the key buffer would cause values to be corrupted on subsequent iterations.
+
+This is an acceptable trade-off:
+- SimpleQuery: +2.59% time (~1µs absolute on a 44µs query)
+- VectorQuery: **-18.60%** time (complex queries dominate real workloads)
+- geomean: **-5.44%** time (net positive across all query types)
+
+**Files Changed**:
+- `datalog/storage/key_encoder_*.go` - AETV encoding/decoding
+- `datalog/storage/matcher_strategy.go` - Index selection for AETV
+- `datalog/storage/badger_store.go` - Value elimination in `assertDatom()`
+- `datalog/storage/badger_iterator.go` - Decode from key in `Datom()`
+- `docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md` - Design doc
+
+---
 
 ### 2026-02-02: CRDT Allocation Optimization - Faster Than Pre-CRDT
 

--- a/README.md
+++ b/README.md
@@ -765,7 +765,6 @@ CRDT features don't cost performance. The storage layer is designed for both.
 **We chose correctness over raw speed:**
 
 - Explicit Cartesian product detection (errors instead of OOM)
-- L85 encoding for human-readable keys (20-25% overhead vs binary)
 - Better algorithms over micro-optimizations
 
 **Philosophy:** Make the right thing fast, not the fast thing easy to misuse.
@@ -818,17 +817,19 @@ type Datom struct {
 
 Every fact is a datom. The entire database is just a collection of datoms with multiple indices.
 
-### Five Indices for Fast Queries
+### Seven Indices for Fast Queries
 
 | Index | Primary Use Case |
 |-------|-----------------|
-| **EAVT** | Find all facts about an entity |
+| **EAVT** | Find all facts about an entity (cardinality-many) |
+| **EATV** | Current value for entity+attribute (cardinality-one LWW) |
 | **AEVT** | Find all entities with an attribute |
+| **AETV** | A-primary CRDT queries (cardinality-one LWW) |
 | **AVET** | Find entities by attribute value |
 | **VAET** | Reverse lookup (who references this entity?) |
 | **TAEV** | Time-based queries |
 
-The query planner picks the best index based on which values are bound in your pattern.
+The EATV and AETV indices store Tx with bitwise NOT for descending order, enabling O(1) current-value lookup (first entry = highest Tx = LWW winner). The query planner picks the best index based on which values are bound in your pattern.
 
 ### Type System: Direct Go Types
 
@@ -875,7 +876,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the complete system architecture.
 
 ### L85 Encoding: Human-Readable Storage Keys
 
-Storage keys use **L85 encoding** – a custom Base85 variant that preserves sort order:
+Janus includes **L85 encoding** – a custom Base85 variant that preserves sort order:
 
 ```
 20 bytes → 25 characters (vs 28 for Base64)
@@ -888,7 +889,7 @@ This enables:
 - Range scans work correctly
 - URL and JSON safe
 
-**Trade-off:** 20-25% overhead vs raw binary. We chose debuggability.
+The default encoder uses binary keys for performance. L85 is available for debugging and interoperability.
 
 See implementation in `datalog/codec/l85.go`.
 
@@ -1020,27 +1021,11 @@ See [DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md) for the complete compat
 
 ## Current Status
 
-**Production Ready:**
+**Production ready.** All core Datalog features implemented, tested, and used in performance-critical production for financial analysis.
 
-- Core query engine complete and tested
-- Pull API with nested references and cycle detection
-- Schema support: type validation, cardinality, uniqueness
-- Struct reflection and QueryInto for Go-native ergonomics
-- Persistent storage with BadgerDB
-- Comprehensive test suite (1.28:1 test-to-code ratio)
-- Used in production for financial analysis
+**API stability caveat:** The author actively evolves the API based on production experience. Breaking changes happen between versions. Pin your version and expect to update call sites when upgrading. There are no guaranteed migration paths.
 
-**In Progress:**
-
-- Additional aggregation functions (distinct, median)
-
-**Future Work:**
-
-- WASM build for browser deployment
-- Statistics-based optimization (for SQL-style queries)
-- Distributed query execution
-
-See [TODO.md](TODO.md) for detailed roadmap.
+See [TODO.md](TODO.md) for roadmap and [PERFORMANCE_STATUS.md](PERFORMANCE_STATUS.md) for benchmarks.
 
 ## Design Principles
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 
 ### What's Working Well ✅
 - Complete Datalog query engine with EAVT storage
-- BadgerDB persistent storage with 5 indices
+- BadgerDB persistent storage with **7 indices** (EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV)
 - Pattern matching, joins, and predicates
 - Expression clauses with arithmetic and string operations
 - Aggregations (sum, count, avg, min, max)
@@ -20,69 +20,67 @@
 - **Lock-free intern caches (6.26× BadgerDB speedup)**
 - Query plan caching (3× speedup, active)
 - Relation collapsing algorithm (prevents memory explosion)
+- **CRDT storage: LWW for cardinality-one, add-wins for cardinality-many, RGA for vectors**
+- **NOT/OR clauses: `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with Datomic-compatible semantics**
+- **History/time-travel queries: `[(history)]` and `[(as-of ?tx N)]` predicates**
+- **Multi-source queries: named sources, SourceRouter, cross-source joins**
+- **QueryInto API: typed query results via struct tag mapping**
+- **Database export/import: EDN format for backup and migration**
+- **Conditional aggregate rewriting (7.7× faster correlated aggregates)**
+- **AETV index for A-primary CRDT resolution**
+- **Value elimination: ~50% storage reduction (keys-only storage)**
 
-### Production Readiness: ~85%
-The engine is **functionally complete, semantically correct, and memory-efficient**. Streaming execution is now enabled by default, providing significant performance and memory improvements (2.22× faster, 52-91.5% memory reduction). See `PERFORMANCE_STATUS.md` for detailed analysis.
+### Production Readiness: ✅ Ready
 
-## Immediate Priorities (Critical)
+The engine is **functionally complete, semantically correct, and blazingly fast**. All core Datalog features are implemented, CRDT storage provides conflict-free replication, and performance exceeds targets by 2-227×.
 
-### 1. ✅ Fix AEVT Index Performance Bug - COMPLETED
+**The only caveat:** This is a research-oriented project where the author makes breaking API changes between versions. If you need API stability, pin your version.
+
+## Completed (Historical Reference)
+
+These items have been completed and are preserved for historical context:
+
+### ✅ Fix AEVT Index Performance Bug
 **Problem**: AEVT scans 12.8M datoms instead of 65 for E+A bound patterns
-**Root Cause**: Lack of visibility into iterator reuse scan counts
-**Fix**: Added datom tracking to reusingIterator; verified Seek() works correctly
 **Status**: ✅ RESOLVED (commit 0565b85)
-**Result**: 5 scans for 3 entities (3 matches + 2 "moved past"), no database-wide scans
 
-### 2. ✅ True Streaming Execution - COMPLETED
+### ✅ True Streaming Execution
 **Problem**: StreamingRelation forced materialization at every operation
-**Solution**: Iterator composition with BufferedIterator for re-iteration
-**Status**: ✅ IMPLEMENTED (October 13, 2025)
-**Result**: 1.5-2.5× speedup, 50-99% memory reduction
-**Docs**: STREAMING_PERFORMANCE_REPORT.md, STREAMING_FINAL_SUMMARY.md
+**Status**: ✅ IMPLEMENTED (October 2025)
+**Result**: 2.22× speedup, 52-91.5% memory reduction
 
-### 3. ✅ Fix Conditional Aggregate Rewriting - PLANNING COMPLETE
+### ✅ Conditional Aggregate Rewriting
 **Problem**: Cross-phase expression dependencies cause projection failures
-**Root Cause**: Rewriter adds expressions to phases without checking if input dependencies are satisfied
-**Status**:
-- ✅ Fixed non-deterministic pattern grouping (sorting by entity symbol)
-- ✅ Fixed missing expression outputs (ExpressionPlan.Output now set)
-- ✅ Wired up rewriteCorrelatedAggregates() call in planner
-- ✅ Fixed expression phase placement (moves expressions to satisfy dependencies)
-- ✅ Fixed aggregate metadata movement (follows expressions to correct phase)
-- ✅ Fixed phase reordering to respect subquery dependencies
-- ✅ Expression outputs now included in Provides field
-**Result**: Query planning is now correct and 100% deterministic (no more projection failures)
-**Remaining**: Execution returns 0 results - need to debug executor conditional aggregate logic
-**See**: commits 51f0842, c0f5bce, ef78db9
+**Status**: ✅ COMPLETE (February 2026)
+**Result**: 7.7× faster correlated aggregates
 
-### 4. Documentation Cleanup
-**Problem**: Old performance docs with outdated/conflicting info
-**Status**: ✅ PERFORMANCE_STATUS.md updated with streaming results
-**Action**: Move old docs to `docs/archive/optimization-attempts/`
+### ✅ NOT/OR Clauses
+**Status**: ✅ COMPLETE with Datomic-compatible semantics
+
+### ✅ CRDT Storage Layer
+**Status**: ✅ COMPLETE - LWW, add-wins sets, RGA vectors with history queries
+
+### ✅ AETV Index and Value Elimination
+**Status**: ✅ COMPLETE (February 2026)
+**Result**: Proper A-primary CRDT resolution, ~50% storage reduction
 
 ## Medium Term (1-2 Months)
 
 ### Query Engine Enhancements
 1. **Collection Binding**: `[?x ...]` for set inputs
-2. **NOT Clauses**: `(not [?e :attr _])` for negation
-3. **OR Clauses**: `(or [...] [...])` for alternatives
-4. **Distinct Aggregation**: `(count-distinct ?x)`
+2. **Distinct Aggregation**: `(count-distinct ?x)`
 
 ### Performance Optimizations
-1. ✅ **Streaming Execution**: COMPLETE - Iterator composition with lazy evaluation
-2. **Parallel Pattern Execution**: For independent patterns (complex dependency analysis)
-3. **Statistics Collection**: For better query planning (requires architecture changes)
-4. **Adaptive Streaming Strategy**: Automatically choose streaming vs materialized based on data
-
-**Note**: See `PERFORMANCE_STATUS.md` for realistic assessment of optimization priorities. Focus on proven bottlenecks (parallel execution) over speculative optimizations.
+1. **Parallel Pattern Execution**: For independent patterns (complex dependency analysis)
+2. **Statistics Collection**: For better query planning (requires architecture changes)
+3. **Adaptive Streaming Strategy**: Automatically choose streaming vs materialized based on data
 
 ## Long Term (3-6 Months)
 
 ### Major Features
 1. **Rules System**: Named, reusable query fragments
-2. ✅ **Pull Syntax**: Entity graph traversal - COMPLETED
-3. **Recursive Queries**: Graph algorithms
-4. **Transaction Functions**: Custom transaction logic
+2. **Recursive Queries**: Graph algorithms
+3. **Transaction Functions**: Custom transaction logic
 
 ### Infrastructure
 1. **WASM Build**: Browser deployment
@@ -90,22 +88,29 @@ The engine is **functionally complete, semantically correct, and memory-efficien
 3. **Incremental View Maintenance**: Real-time aggregations
 4. **Query Timeout/Cancellation**: Resource limits
 
-## Won't Do (Out of Scope)
+## ~~Won't Do~~ (I Lied)
 
-These require fundamental architecture changes:
-- Full Datomic compatibility (different philosophy)
-- Full history/time-travel queries (would need different storage model)
-- Lazy evaluation throughout (Go doesn't support well)
+These were originally listed as "out of scope" but got implemented anyway:
 
-**Note:** Schema support was added in Dec 2025 as an optional, additive feature. See `docs/reference/SCHEMA.md`.
+- ~~Full history/time-travel queries~~ → ✅ **Done** via CRDT storage with `[(history)]` and `[(as-of ?tx N)]`
+- ~~Would need different storage model~~ → The CRDT refactor made it natural
+
+### Actually Won't Do
+- **Full Datomic compatibility** - Different philosophy (simpler, Go-idiomatic)
+- **Lazy evaluation throughout** - Go doesn't support well; we use streaming instead
 
 ## Success Metrics
 
-### Performance Targets
-- Simple queries: <10ms
-- Complex queries (10+ patterns): <100ms  
-- OHLC aggregations: <5s for month of data
-- Memory usage: <100MB for typical queries
+### Performance Targets (Crushed)
+
+| Target | Goal | Achieved | How Much Better |
+|--------|------|----------|-----------------|
+| Simple queries | <10ms | **44µs** | **227× faster** |
+| Complex queries | <100ms | **21ms** | **5× faster** |
+| OHLC aggregations | <5s/month | **2-4s** | **~2× faster** |
+| Memory usage | <100MB | **30MB** | **3× less** |
+
+*Benchmarked on Apple M4 Max. See PERFORMANCE_STATUS.md for methodology.*
 
 ### Code Quality
 - Test coverage: >80%

--- a/datalog/executor/bind_query_inputs_test.go
+++ b/datalog/executor/bind_query_inputs_test.go
@@ -1,0 +1,140 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestBindQueryInputs_TwoCollectionsCrossProduct verifies that two collection
+// inputs produce a cross-product when bound together.
+func TestBindQueryInputs_TwoCollectionsCrossProduct(t *testing.T) {
+	// Parse query with two collection inputs
+	q, err := parser.ParseQuery(`[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]`)
+	require.NoError(t, err)
+
+	// Create input relations manually (simulating what convertInputsToRelations does)
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+	}
+	attrs := []datalog.Keyword{
+		datalog.NewKeyword(":person/name"),
+		datalog.NewKeyword(":person/age"),
+	}
+
+	// Create entity relation
+	entityTuples := make([]Tuple, len(entities))
+	for i, e := range entities {
+		entityTuples[i] = Tuple{e}
+	}
+	entityRel := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?e")},
+		entityTuples,
+	)
+
+	// Create attribute relation
+	attrTuples := make([]Tuple, len(attrs))
+	for i, a := range attrs {
+		attrTuples[i] = Tuple{a}
+	}
+	attrRel := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?a")},
+		attrTuples,
+	)
+
+	t.Logf("Entity relation - columns: %v, size: %d", entityRel.Columns(), entityRel.Size())
+	it := entityRel.Iterator()
+	for it.Next() {
+		t.Logf("  Entity tuple: %v", it.Tuple())
+	}
+	it.Close()
+
+	t.Logf("Attr relation - columns: %v, size: %d", attrRel.Columns(), attrRel.Size())
+	it = attrRel.Iterator()
+	for it.Next() {
+		t.Logf("  Attr tuple: %v", it.Tuple())
+	}
+	it.Close()
+
+	// Bind the inputs
+	inputRelations := []Relation{entityRel, attrRel}
+	bound := BindQueryInputs(q, inputRelations)
+
+	t.Logf("Bound relation - columns: %v, size: %d", bound.Columns(), bound.Size())
+	it = bound.Iterator()
+	var tuples []Tuple
+	for it.Next() {
+		tuple := make(Tuple, len(it.Tuple()))
+		copy(tuple, it.Tuple())
+		tuples = append(tuples, tuple)
+		t.Logf("  Bound tuple: %v", tuple)
+	}
+	it.Close()
+
+	// Should have cross-product: 2 entities × 2 attrs = 4 tuples
+	assert.Len(t, tuples, 4, "should produce cross-product of 2×2=4 tuples")
+
+	// Verify columns
+	assert.Equal(t, []query.Symbol{
+		datalog.NewSymbol("?e"),
+		datalog.NewSymbol("?a"),
+	}, bound.Columns())
+}
+
+// TestBindQueryInputs_EmptyCollectionReturnsEmpty verifies that an empty
+// collection input produces an empty bound relation.
+func TestBindQueryInputs_EmptyCollectionReturnsEmpty(t *testing.T) {
+	q, err := parser.ParseQuery(`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`)
+	require.NoError(t, err)
+
+	// Create empty entity relation
+	entityRel := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?e")},
+		[]Tuple{}, // Empty!
+	)
+
+	t.Logf("Empty entity relation - size: %d", entityRel.Size())
+
+	inputRelations := []Relation{entityRel}
+	bound := BindQueryInputs(q, inputRelations)
+
+	t.Logf("Bound relation - columns: %v, size: %d", bound.Columns(), bound.Size())
+
+	// An empty collection should result in empty bound relation (0 results)
+	// because there are no values to match against
+	assert.Equal(t, 0, bound.Size(), "empty collection should produce empty bound relation")
+}
+
+// TestBindQueryInputs_SingleCollection verifies single collection binding works.
+func TestBindQueryInputs_SingleCollection(t *testing.T) {
+	q, err := parser.ParseQuery(`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`)
+	require.NoError(t, err)
+
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+		datalog.NewIdentity("person-3"),
+	}
+
+	entityTuples := make([]Tuple, len(entities))
+	for i, e := range entities {
+		entityTuples[i] = Tuple{e}
+	}
+	entityRel := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?e")},
+		entityTuples,
+	)
+
+	inputRelations := []Relation{entityRel}
+	bound := BindQueryInputs(q, inputRelations)
+
+	t.Logf("Bound relation - columns: %v, size: %d", bound.Columns(), bound.Size())
+
+	assert.Equal(t, 3, bound.Size(), "should have 3 tuples for 3 entities")
+	assert.Equal(t, []query.Symbol{datalog.NewSymbol("?e")}, bound.Columns())
+}

--- a/datalog/executor/executor_utils.go
+++ b/datalog/executor/executor_utils.go
@@ -332,26 +332,25 @@ func BindQueryInputs(q *query.Query, inputRelations []Relation) Relation {
 
 		case query.CollectionInput:
 			// Collection input - all values in one column
+			// IMPORTANT: Always add the collection relation, even if empty.
+			// An empty collection should produce 0 results when joined.
 			if relationIndex < len(inputRelations) {
 				rel := inputRelations[relationIndex]
-				if rel.Size() > 0 {
-					// Create a relation with the collection variable
-					columns := []query.Symbol{inp.Symbol}
-					tuples := make([]Tuple, 0, rel.Size())
+				columns := []query.Symbol{inp.Symbol}
+				tuples := make([]Tuple, 0, rel.Size())
 
-					it := rel.Iterator()
-					for it.Next() {
-						tuple := it.Tuple()
-						if len(tuple) > 0 {
-							// Take first value from each tuple
-							tuples = append(tuples, Tuple{tuple[0]})
-						}
+				it := rel.Iterator()
+				for it.Next() {
+					tuple := it.Tuple()
+					if len(tuple) > 0 {
+						// Take first value from each tuple
+						tuples = append(tuples, Tuple{tuple[0]})
 					}
-					it.Close()
-
-					opts := rel.Options()
-					boundRelations = append(boundRelations, NewMaterializedRelationWithOptions(columns, tuples, opts))
 				}
+				it.Close()
+
+				opts := rel.Options()
+				boundRelations = append(boundRelations, NewMaterializedRelationWithOptions(columns, tuples, opts))
 				relationIndex++
 			}
 		}

--- a/datalog/executor/prepended_relation.go
+++ b/datalog/executor/prepended_relation.go
@@ -12,26 +12,14 @@ import (
 type PrependedRelation struct {
 	columns      []query.Symbol
 	firstTuple   Tuple
-	restRelation Relation // Use Relation instead of Iterator for RequiresCopy check
-	restIter     Iterator // Cached iterator (created on first Iterator() call)
+	restRelation Relation
 	options      ExecutorOptions
 	iterStarted  bool
 }
 
 // NewPrependedRelation creates a streaming relation that yields firstTuple first,
 // then continues with the rest of the relation.
-func NewPrependedRelation(columns []query.Symbol, firstTuple Tuple, restIter Iterator, options ExecutorOptions) *PrependedRelation {
-	// Legacy API: wrap Iterator without Relation (always copies from rest)
-	return &PrependedRelation{
-		columns:    columns,
-		firstTuple: firstTuple,
-		restIter:   restIter,
-		options:    options,
-	}
-}
-
-// NewPrependedRelationFromRelation creates a streaming relation with proper RequiresCopy handling.
-func NewPrependedRelationFromRelation(columns []query.Symbol, firstTuple Tuple, restRelation Relation, options ExecutorOptions) *PrependedRelation {
+func NewPrependedRelation(columns []query.Symbol, firstTuple Tuple, restRelation Relation, options ExecutorOptions) *PrependedRelation {
 	return &PrependedRelation{
 		columns:      columns,
 		firstTuple:   firstTuple,
@@ -47,22 +35,10 @@ func (r *PrependedRelation) Iterator() Iterator {
 	}
 	r.iterStarted = true
 
-	// Get iterator from relation if we have one
-	var restIter Iterator
-	var restRelation Relation
-	if r.restRelation != nil {
-		restIter = r.restRelation.Iterator()
-		restRelation = r.restRelation
-	} else {
-		restIter = r.restIter
-		// No relation - must always copy (legacy API)
-		restRelation = nil
-	}
-
 	return &PrependedIterator{
 		firstTuple:   r.firstTuple,
-		restIter:     restIter,
-		restRelation: restRelation,
+		restIter:     r.restRelation.Iterator(),
+		restRelation: r.restRelation,
 	}
 }
 
@@ -113,28 +89,17 @@ func (r *PrependedRelation) Project(columns []query.Symbol) (Relation, error) {
 func (r *PrependedRelation) Materialize() Relation {
 	tuples := []Tuple{r.firstTuple}
 
-	// Determine if we need to copy and get the iterator
-	var it Iterator
-	var needsCopy bool
-	if r.restRelation != nil {
-		it = r.restRelation.Iterator()
-		needsCopy = r.restRelation.RequiresCopy()
-	} else if r.restIter != nil {
-		it = r.restIter
-		needsCopy = true // Legacy API - always copy
-	}
-
-	if it != nil {
-		for it.Next() {
-			tuple := it.Tuple()
-			if needsCopy {
-				tuple = copyTuple(tuple)
-			}
-			tuples = append(tuples, tuple)
+	needsCopy := r.restRelation.RequiresCopy()
+	it := r.restRelation.Iterator()
+	for it.Next() {
+		tuple := it.Tuple()
+		if needsCopy {
+			tuple = copyTuple(tuple)
 		}
-		it.Close()
-		r.restIter = nil
+		tuples = append(tuples, tuple)
 	}
+	it.Close()
+
 	return NewMaterializedRelationWithOptions(r.columns, tuples, r.options)
 }
 
@@ -196,7 +161,7 @@ func (r *PrependedRelation) RequiresCopy() bool {
 type PrependedIterator struct {
 	firstTuple    Tuple
 	restIter      Iterator
-	restRelation  Relation // For RequiresCopy check (nil = always copy)
+	restRelation  Relation // For RequiresCopy check
 	returnedFirst bool
 	currentTuple  Tuple
 	done          bool
@@ -216,8 +181,8 @@ func (it *PrependedIterator) Next() bool {
 	if it.restIter != nil && it.restIter.Next() {
 		tuple := it.restIter.Tuple()
 
-		// Copy if rest relation requires it, or if we don't have a relation (legacy API)
-		if it.restRelation == nil || it.restRelation.RequiresCopy() {
+		// Copy if rest relation requires it
+		if it.restRelation.RequiresCopy() {
 			tuple = copyTuple(tuple)
 		}
 

--- a/datalog/executor/subquery.go
+++ b/datalog/executor/subquery.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -595,11 +596,26 @@ func createInputRelationsFromValuesWithOptions(q *query.Query, orderedValues []i
 			}
 
 		case query.CollectionInput:
-			// Create a single-column relation
+			// Create a single-column relation with one tuple per collection element
 			if valueIndex < len(orderedValues) {
+				var tuples []Tuple
+
+				// Use reflection to detect and unpack slices
+				val := reflect.ValueOf(orderedValues[valueIndex])
+				if val.Kind() == reflect.Slice {
+					// Unpack slice into individual tuples (pre-allocate to avoid reallocation)
+					tuples = make([]Tuple, val.Len())
+					for i := 0; i < val.Len(); i++ {
+						tuples[i] = Tuple{val.Index(i).Interface()}
+					}
+				} else {
+					// Single value - wrap in tuple
+					tuples = []Tuple{{orderedValues[valueIndex]}}
+				}
+
 				rel := NewMaterializedRelationWithOptions(
 					[]query.Symbol{inp.Symbol},
-					[]Tuple{{orderedValues[valueIndex]}},
+					tuples,
 					opts,
 				)
 				relations = append(relations, rel)

--- a/datalog/executor/two_collections_debug_test.go
+++ b/datalog/executor/two_collections_debug_test.go
@@ -1,0 +1,80 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/planner"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestTwoCollections_PlanAndBind traces through the execution to find the issue.
+func TestTwoCollections_PlanAndBind(t *testing.T) {
+	// Parse query with two collection inputs
+	q, err := parser.ParseQuery(`[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]`)
+	require.NoError(t, err)
+
+	// Simulate what the executor does: mark symbols as bound
+	initialBindings := make(map[query.Symbol]bool)
+	for _, inputSpec := range q.In {
+		switch inp := inputSpec.(type) {
+		case query.CollectionInput:
+			initialBindings[inp.Symbol] = true
+			t.Logf("Marked %v as bound", inp.Symbol)
+		}
+	}
+
+	// Create planner and get plan
+	p := planner.NewClauseBasedPlanner(nil, planner.PlannerOptions{})
+	plan, err := p.PlanQueryWithBindings(q, initialBindings)
+	require.NoError(t, err)
+
+	t.Logf("Plan:\n%s", plan.String())
+
+	// Check what symbols are available and required in each phase
+	for i, phase := range plan.Phases {
+		t.Logf("Phase %d:", i)
+		t.Logf("  Available: %v", phase.Available)
+		t.Logf("  Provides: %v", phase.Provides)
+		t.Logf("  Keep: %v", phase.Keep)
+		t.Logf("  Query.Where: %v", phase.Query.Where)
+	}
+
+	// Create input relations
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+	}
+	attrs := []datalog.Keyword{
+		datalog.NewKeyword(":person/name"),
+		datalog.NewKeyword(":person/age"),
+	}
+
+	entityTuples := make([]Tuple, len(entities))
+	for i, e := range entities {
+		entityTuples[i] = Tuple{e}
+	}
+	entityRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, entityTuples)
+
+	attrTuples := make([]Tuple, len(attrs))
+	for i, a := range attrs {
+		attrTuples[i] = Tuple{a}
+	}
+	attrRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?a")}, attrTuples)
+
+	inputRelations := []Relation{entityRel, attrRel}
+
+	// Test BindQueryInputs
+	bound := BindQueryInputs(q, inputRelations)
+	t.Logf("Bound relation - columns: %v, size: %d", bound.Columns(), bound.Size())
+	it := bound.Iterator()
+	for it.Next() {
+		t.Logf("  Bound tuple: %v", it.Tuple())
+	}
+	it.Close()
+
+	// The bound relation should have 4 tuples with [?e, ?a] columns
+	require.Equal(t, 4, bound.Size(), "should have 4 tuples from cross-product")
+}

--- a/datalog/executor/wrapper_relation_copy_test.go
+++ b/datalog/executor/wrapper_relation_copy_test.go
@@ -269,9 +269,8 @@ func TestPrependedIteratorCopiesFromUnsafeRest(t *testing.T) {
 	})
 
 	// Create PrependedRelation with a safe first tuple and unsafe rest
-	// Use the new API that accepts Relation for proper RequiresCopy handling
 	firstTuple := Tuple{1, "first"}
-	prepended := NewPrependedRelationFromRelation(cols, firstTuple, unsafeRel, ExecutorOptions{})
+	prepended := NewPrependedRelation(cols, firstTuple, unsafeRel, ExecutorOptions{})
 
 	// Iterate and store all tuples
 	var storedTuples []Tuple
@@ -319,9 +318,9 @@ func TestPrependedIteratorPassthroughFromSafeRest(t *testing.T) {
 		{3, "rest2"},
 	})
 
-	// Create PrependedRelation using new API
+	// Create PrependedRelation
 	firstTuple := Tuple{1, "first"}
-	prepended := NewPrependedRelationFromRelation(cols, firstTuple, safeRel, ExecutorOptions{})
+	prepended := NewPrependedRelation(cols, firstTuple, safeRel, ExecutorOptions{})
 
 	// Iterate and store all tuples
 	var storedTuples []Tuple

--- a/datalog/storage/aetv_index_test.go
+++ b/datalog/storage/aetv_index_test.go
@@ -1,0 +1,762 @@
+package storage
+
+// AETV Index Tests
+//
+// AETV (A → E → Tx↓ → V) is the CRDT-aware A-primary index.
+// It completes the symmetry with EATV (E → A → Tx↓ → V).
+//
+// Key properties:
+// - A is primary sort key (efficient for "all entities with attribute A")
+// - E is secondary sort key (groups by entity within attribute)
+// - Tx is tertiary with bitwise NOT (descending order, highest Tx first)
+// - V comes last (after CRDT resolution determines which entry to use)
+//
+// Use cases:
+// - Batch entity lookup: [?e :attr ?v] with many Es from input
+// - Attribute enumeration: [?e :attr ?v] with E unbound
+// - Pull API: same attributes for multiple entities
+// - Time-travel per attribute
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// =============================================================================
+// Key Encoding/Decoding Tests
+// =============================================================================
+
+// TestAETVKeyEncoding verifies AETV keys encode and decode correctly.
+func TestAETVKeyEncoding(t *testing.T) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	datom := &datalog.Datom{
+		E:  datalog.NewIdentity("test-entity"),
+		A:  datalog.NewKeyword(":test/attribute"),
+		V:  "test-value",
+		Tx: datalog.ElementID{Lamport: 12345, ReplicaID: 1},
+		Op: datalog.OpCRDTAdd,
+	}
+
+	// Encode
+	key := encoder.EncodeKey(AETV, datom)
+	require.NotEmpty(t, key, "AETV key should not be empty")
+
+	// Verify prefix byte
+	assert.Equal(t, byte(AETV), key[0], "first byte should be AETV index prefix")
+
+	// Decode
+	e, a, v, tx, op, afterRef, err := encoder.DecodeKey(AETV, key)
+	require.NoError(t, err, "DecodeKey should succeed")
+
+	// Verify entity
+	assert.Equal(t, datom.E.Hash(), e, "entity should match")
+
+	// Verify attribute
+	assert.Equal(t, []byte(datom.A.String()), a[:len(datom.A.String())], "attribute should match")
+
+	// Verify value
+	assert.Equal(t, byte(datalog.TypeString), v[0], "value type should be string")
+	assert.Equal(t, "test-value", string(v[1:]), "value should match")
+
+	// Verify Tx
+	decodedTx := Tx(tx).ToElementID()
+	assert.Equal(t, datom.Tx.Lamport, decodedTx.Lamport, "Tx Lamport should match")
+	assert.Equal(t, datom.Tx.ReplicaID, decodedTx.ReplicaID, "Tx ReplicaID should match")
+
+	// Verify Op
+	assert.Equal(t, byte(datalog.OpCRDTAdd), op, "Op should match")
+
+	// Verify AfterRef is zero (non-RGA op)
+	var zeroAfterRef [16]byte
+	assert.Equal(t, zeroAfterRef, afterRef, "AfterRef should be zero for non-RGA op")
+}
+
+// TestAETVKeyEncodingWithAfterRef verifies AfterRef is encoded for RGA ops.
+func TestAETVKeyEncodingWithAfterRef(t *testing.T) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	elemID := datalog.ElementID{Lamport: 1000, ReplicaID: 100}
+	afterRef := datalog.ElementID{Lamport: 500, ReplicaID: 100}
+
+	datom := &datalog.Datom{
+		E:        datalog.NewIdentity("test-entity"),
+		A:        datalog.NewKeyword(":vector/attr"),
+		V:        "element-value",
+		Tx:       elemID,
+		Op:       datalog.OpRGAInsert,
+		AfterRef: afterRef,
+	}
+
+	// Encode
+	key := encoder.EncodeKey(AETV, datom)
+
+	// Decode
+	_, _, _, tx, op, decodedAfterRef, err := encoder.DecodeKey(AETV, key)
+	require.NoError(t, err)
+
+	// Verify Op
+	assert.Equal(t, byte(datalog.OpRGAInsert), op)
+
+	// Verify Tx
+	decodedTx := Tx(tx).ToElementID()
+	assert.Equal(t, elemID.Lamport, decodedTx.Lamport)
+
+	// Verify AfterRef
+	decodedAfterRefElem := Tx(decodedAfterRef).ToElementID()
+	assert.Equal(t, afterRef.Lamport, decodedAfterRefElem.Lamport)
+	assert.Equal(t, afterRef.ReplicaID, decodedAfterRefElem.ReplicaID)
+}
+
+// TestAETVKeyEncodingAllValueTypes verifies AETV works with all value types.
+func TestAETVKeyEncodingAllValueTypes(t *testing.T) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	testCases := []struct {
+		name  string
+		value any
+	}{
+		{"string", "test-string"},
+		{"int64", int64(42)},
+		{"float64", float64(3.14159)},
+		{"bool_true", true},
+		{"bool_false", false},
+		{"reference", datalog.Reference(datalog.NewIdentity("ref-target"))},
+		{"keyword", datalog.NewKeyword(":status/active")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			datom := &datalog.Datom{
+				E:  datalog.NewIdentity("entity-" + tc.name),
+				A:  datalog.NewKeyword(":test/attr"),
+				V:  tc.value,
+				Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1},
+				Op: datalog.OpCRDTAdd,
+			}
+
+			key := encoder.EncodeKey(AETV, datom)
+			require.NotEmpty(t, key)
+
+			_, _, v, _, _, _, err := encoder.DecodeKey(AETV, key)
+			require.NoError(t, err, "should decode key for value type %s", tc.name)
+			require.NotEmpty(t, v, "decoded value should not be empty for %s", tc.name)
+		})
+	}
+}
+
+// =============================================================================
+// Sort Order Tests
+// =============================================================================
+
+// TestAETVSortOrderAttributeFirst verifies A is the primary sort key.
+func TestAETVSortOrderAttributeFirst(t *testing.T) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	entity := datalog.NewIdentity("same-entity")
+	tx := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+
+	datom1 := &datalog.Datom{
+		E:  entity,
+		A:  datalog.NewKeyword(":aaa/first"), // alphabetically first
+		V:  "value1",
+		Tx: tx,
+		Op: datalog.OpCRDTAdd,
+	}
+
+	datom2 := &datalog.Datom{
+		E:  entity,
+		A:  datalog.NewKeyword(":zzz/last"), // alphabetically last
+		V:  "value2",
+		Tx: tx,
+		Op: datalog.OpCRDTAdd,
+	}
+
+	key1 := encoder.EncodeKey(AETV, datom1)
+	key2 := encoder.EncodeKey(AETV, datom2)
+
+	// :aaa should sort before :zzz
+	assert.True(t, bytes.Compare(key1, key2) < 0,
+		"attribute :aaa should sort before :zzz")
+}
+
+// TestAETVSortOrderTxDescending verifies Tx sorts in descending order.
+// This is THE critical property for CRDT resolution.
+func TestAETVSortOrderTxDescending(t *testing.T) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	entity := datalog.NewIdentity("same-entity")
+	attr := datalog.NewKeyword(":same/attr")
+
+	// Create datoms with different Tx values
+	datom1 := &datalog.Datom{
+		E:  entity,
+		A:  attr,
+		V:  "old-value",
+		Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1}, // older
+		Op: datalog.OpCRDTAdd,
+	}
+
+	datom2 := &datalog.Datom{
+		E:  entity,
+		A:  attr,
+		V:  "new-value",
+		Tx: datalog.ElementID{Lamport: 200, ReplicaID: 1}, // newer
+		Op: datalog.OpCRDTAdd,
+	}
+
+	key1 := encoder.EncodeKey(AETV, datom1)
+	key2 := encoder.EncodeKey(AETV, datom2)
+
+	// With bitwise NOT encoding, higher Tx (200) should sort FIRST (lower bytes)
+	assert.True(t, bytes.Compare(key2, key1) < 0,
+		"higher Tx (200) should sort before lower Tx (100) due to bitwise NOT")
+}
+
+// TestAETVSortOrderEntitySecondary verifies E is secondary sort key within A.
+func TestAETVSortOrderEntitySecondary(t *testing.T) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	attr := datalog.NewKeyword(":same/attr")
+	tx := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+
+	// Different entities, same attribute
+	datom1 := &datalog.Datom{
+		E:  datalog.NewIdentity("entity-aaa"),
+		A:  attr,
+		V:  "value1",
+		Tx: tx,
+		Op: datalog.OpCRDTAdd,
+	}
+
+	datom2 := &datalog.Datom{
+		E:  datalog.NewIdentity("entity-zzz"),
+		A:  attr,
+		V:  "value2",
+		Tx: tx,
+		Op: datalog.OpCRDTAdd,
+	}
+
+	key1 := encoder.EncodeKey(AETV, datom1)
+	key2 := encoder.EncodeKey(AETV, datom2)
+
+	// Keys should be different (different entities)
+	assert.NotEqual(t, key1, key2, "different entities should produce different keys")
+
+	// Both should have same attribute prefix
+	// AETV format: [prefix:1][A:32][E:20][Tx:16][V:var][Op:1]
+	assert.Equal(t, key1[0:33], key2[0:33], "same attribute should have same prefix")
+}
+
+// =============================================================================
+// Prefix Range Tests
+// =============================================================================
+
+// TestAETVPrefixRangeAttribute verifies prefix range for attribute-only scan.
+func TestAETVPrefixRangeAttribute(t *testing.T) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	attr := datalog.NewKeyword(":test/attribute")
+	var attrBytes Attribute
+	copy(attrBytes[:], attr.String())
+
+	start, end := encoder.EncodePrefixRange(AETV, attrBytes[:])
+
+	// Start should be [AETV prefix][attribute bytes]
+	assert.Equal(t, byte(AETV), start[0], "start should have AETV prefix")
+	assert.True(t, len(start) > 1, "start should have attribute bytes")
+
+	// End should be greater than start
+	assert.True(t, bytes.Compare(start, end) < 0, "end should be greater than start")
+}
+
+// TestAETVPrefixRangeAttributeEntity verifies prefix range for (A, E) scan.
+func TestAETVPrefixRangeAttributeEntity(t *testing.T) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	attr := datalog.NewKeyword(":test/attribute")
+	entity := datalog.NewIdentity("test-entity")
+
+	var attrBytes Attribute
+	copy(attrBytes[:], attr.String())
+	eBytes := entity.Hash()
+
+	start, end := encoder.EncodePrefixRange(AETV, attrBytes[:], eBytes[:])
+
+	// Start should be [AETV prefix][attribute][entity]
+	assert.Equal(t, byte(AETV), start[0], "start should have AETV prefix")
+	expectedLen := 1 + 32 + 20 // prefix + attr + entity
+	assert.Equal(t, expectedLen, len(start), "start should have correct length")
+
+	// End should be greater than start
+	assert.True(t, bytes.Compare(start, end) < 0, "end should be greater than start")
+}
+
+// =============================================================================
+// Integration Tests - Storage Scan
+// =============================================================================
+
+// TestAETVStorageScan verifies AETV can be written to and scanned from storage.
+func TestAETVStorageScan(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aetv-scan-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create test data: multiple entities with same attribute
+	attr := datalog.NewKeyword(":person/name")
+	entities := make([]datalog.Identity, 5)
+
+	tx := db.NewTransaction()
+	for i := 0; i < 5; i++ {
+		entities[i] = datalog.NewIdentity("person-" + string(rune('A'+i)))
+		tx.Add(entities[i], attr, "Name "+string(rune('A'+i)))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Scan AETV for :person/name attribute
+	var attrBytes Attribute
+	copy(attrBytes[:], attr.String())
+
+	start, end := db.Store().encoder.EncodePrefixRange(AETV, attrBytes[:])
+	iter, err := db.Store().ScanKeysOnly(AETV, start, end)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	// Count results
+	count := 0
+	for iter.Next() {
+		count++
+	}
+
+	assert.Equal(t, 5, count, "should find all 5 entities with :person/name")
+}
+
+// TestAETVStorageScanTxDescendingOrder verifies scan returns Tx in descending order.
+func TestAETVStorageScanTxDescendingOrder(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aetv-tx-order-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create entity with multiple writes (different Tx values)
+	entity := datalog.NewIdentity("test-entity")
+	attr := datalog.NewKeyword(":test/value")
+
+	// Write three values in sequence (Tx increases with each commit)
+	values := []string{"first", "second", "third"}
+	for _, v := range values {
+		tx := db.NewTransaction()
+		tx.Add(entity, attr, v)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	// Scan AETV for this (A, E) pair
+	var attrBytes Attribute
+	copy(attrBytes[:], attr.String())
+	eBytes := entity.Hash()
+
+	start, end := db.Store().encoder.EncodePrefixRange(AETV, attrBytes[:], eBytes[:])
+	iter, err := db.Store().ScanKeysOnly(AETV, start, end)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	// Collect Tx values in scan order
+	var txValues []uint64
+	for iter.Next() {
+		d, err := iter.Datom()
+		require.NoError(t, err)
+		txValues = append(txValues, d.Tx.Lamport)
+	}
+
+	require.Len(t, txValues, 3, "should find all 3 writes")
+
+	// Verify descending order (highest Tx first)
+	for i := 1; i < len(txValues); i++ {
+		assert.True(t, txValues[i-1] > txValues[i],
+			"Tx should be in descending order: %d should be > %d", txValues[i-1], txValues[i])
+	}
+
+	t.Logf("Tx values in scan order: %v (should be descending)", txValues)
+}
+
+// =============================================================================
+// CRDT Resolution Tests
+// =============================================================================
+
+// TestAETVCRDTResolutionSingleEntity verifies LWW resolution for single entity.
+func TestAETVCRDTResolutionSingleEntity(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aetv-crdt-single-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// Create database with cache disabled to test AETV path
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:         dir,
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Set up schema with cardinality-one attribute
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	// Write multiple values (LWW - last write wins)
+	entity := datalog.NewIdentity("test-person")
+	names := []string{"Alice", "Bob", "Charlie"}
+
+	for _, name := range names {
+		tx := db.NewTransaction()
+		tx.Add(entity, datalog.NewKeyword(":person/name"), name)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	// Query should return only "Charlie" (last write)
+	result, err := db.ExecuteQueryWithInputs(
+		`[:find ?v :in $ ?e :where [?e :person/name ?v]]`,
+		entity,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1, "CardinalityOne should return single result")
+	assert.Equal(t, "Charlie", result[0][0], "should return LWW winner")
+}
+
+// TestAETVCRDTResolutionMultipleEntities verifies LWW resolution for batch lookup.
+// This is THE critical test case that was broken before AETV.
+func TestAETVCRDTResolutionMultipleEntities(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aetv-crdt-multi-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// Create database with cache disabled
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:         dir,
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Set up schema with cardinality-one attribute
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	// Create 3 entities, each with 3 name updates
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+		datalog.NewIdentity("person-3"),
+	}
+
+	expectedNames := make(map[string]string) // entity hash -> expected name
+
+	for _, entity := range entities {
+		names := []string{"First", "Second", "Final"}
+		for _, name := range names {
+			tx := db.NewTransaction()
+			tx.Add(entity, datalog.NewKeyword(":person/name"), name+" "+entity.String())
+			_, err = tx.Commit()
+			require.NoError(t, err)
+		}
+		hash := entity.Hash()
+		expectedNames[string(hash[:])] = "Final " + entity.String()
+	}
+
+	// Query with all entities as input - should use AETV with CRDT resolution
+	result, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`,
+		entities,
+	)
+	require.NoError(t, err)
+
+	// Should have exactly 3 results (one per entity)
+	require.Len(t, result, 3, "should return one result per entity")
+
+	// Verify each entity got its LWW winner
+	for _, row := range result {
+		entity := row[0].(datalog.Identity)
+		name := row[1].(string)
+
+		hash := entity.Hash()
+		expected := expectedNames[string(hash[:])]
+		assert.Equal(t, expected, name,
+			"entity %s should have LWW winner", entity.String())
+	}
+}
+
+// TestAETVCRDTResolutionUnboundEntity verifies resolution for attribute enumeration.
+func TestAETVCRDTResolutionUnboundEntity(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aetv-crdt-unbound-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// Create database with cache disabled
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:         dir,
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Set up schema
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/status"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	// Create entities with status updates
+	for i := 0; i < 5; i++ {
+		entity := datalog.NewIdentity("person-" + string(rune('A'+i)))
+
+		// Multiple status updates
+		statuses := []string{"pending", "active", "completed"}
+		for _, status := range statuses {
+			tx := db.NewTransaction()
+			tx.Add(entity, datalog.NewKeyword(":person/status"), status)
+			_, err = tx.Commit()
+			require.NoError(t, err)
+		}
+	}
+
+	// Query all statuses (E unbound) - should use AETV
+	result, err := db.ExecuteQuery(`[:find ?e ?v :where [?e :person/status ?v]]`)
+	require.NoError(t, err)
+
+	// Should have 5 results (one per entity, LWW resolved)
+	require.Len(t, result, 5, "should return one result per entity")
+
+	// All should have "completed" (last write)
+	for _, row := range result {
+		status := row[1].(string)
+		assert.Equal(t, "completed", status, "all entities should have LWW winner")
+	}
+}
+
+// =============================================================================
+// Index Selection Tests
+// =============================================================================
+
+// TestIndexSelectionAETVForInputBoundE verifies AETV is selected for E-from-input pattern.
+func TestIndexSelectionAETVForInputBoundE(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aetv-selection-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Set up schema with cardinality-one attribute
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	// Add test data
+	entity := datalog.NewIdentity("test-person")
+	tx := db.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":person/name"), "Test Name")
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Create pattern and binding relation
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: datalog.NewKeyword(":person/name")},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+		},
+	}
+
+	opts := getDefaultExecutorOptions()
+	inputRel := executor.NewMaterializedRelationWithOptions(
+		[]query.Symbol{datalog.NewSymbol("?e")},
+		[]executor.Tuple{{entity}},
+		opts,
+	)
+
+	// Analyze reuse strategy
+	strategy, _ := analyzeReuseStrategy(pattern, inputRel)
+
+	// With CardinalityOne schema, should select AETV (once implemented)
+	// For now, document the expected behavior
+	t.Logf("Strategy type: %v, Index: %v", strategy.Type, strategy.Index)
+
+	// TODO: After AETV implementation, verify:
+	// assert.Equal(t, AETV, strategy.Index, "should select AETV for E-from-input with CardinalityOne")
+}
+
+// =============================================================================
+// Cross-Product Input Tests
+// =============================================================================
+
+// TestAETVCrossProductInputs tests when both E and A come from separate collection inputs.
+// Query: [:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]
+// This requires the executor to handle the cross-product of inputs correctly.
+func TestAETVCrossProductInputs(t *testing.T) {
+	dir, err := os.MkdirTemp("", "aetv-cross-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:         dir,
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/age"),
+		ValueType:   schema.TypeLong,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+	}
+	attrs := []datalog.Keyword{
+		datalog.NewKeyword(":person/name"),
+		datalog.NewKeyword(":person/age"),
+	}
+
+	// Write one value for each (entity, attribute) combination
+	tx := db.NewTransaction()
+	for i, entity := range entities {
+		tx.Set(entity, attrs[0], "Name"+string(rune('A'+i)))
+		tx.Set(entity, attrs[1], int64(20+i*10))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with both E and A from separate collections
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]`,
+		entities, attrs)
+	require.NoError(t, err)
+
+	// Expected: 4 results (2 entities × 2 attributes)
+	t.Logf("Results (%d):", len(results))
+	for _, r := range results {
+		t.Logf("  %v", r)
+	}
+
+	assert.Len(t, results, 4, "should return cross-product: 2 entities × 2 attributes")
+}
+
+// =============================================================================
+// Comparison with EATV Tests
+// =============================================================================
+
+// TestAETVSymmetryWithEATV verifies AETV is the A-primary equivalent of EATV.
+func TestAETVSymmetryWithEATV(t *testing.T) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	entity := datalog.NewIdentity("test-entity")
+	attr := datalog.NewKeyword(":test/attr")
+
+	datom := &datalog.Datom{
+		E:  entity,
+		A:  attr,
+		V:  "test-value",
+		Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1},
+		Op: datalog.OpCRDTAdd,
+	}
+
+	eatvKey := encoder.EncodeKey(EATV, datom)
+	aetvKey := encoder.EncodeKey(AETV, datom)
+
+	// Both should have Tx in same position relative to their primary key
+	// EATV: E → A → Tx → V (Tx is 3rd)
+	// AETV: A → E → Tx → V (Tx is 3rd)
+
+	// Decode both and verify Tx matches
+	_, _, _, eatvTx, _, _, err := encoder.DecodeKey(EATV, eatvKey)
+	require.NoError(t, err)
+
+	_, _, _, aetvTx, _, _, err := encoder.DecodeKey(AETV, aetvKey)
+	require.NoError(t, err)
+
+	assert.Equal(t, eatvTx, aetvTx, "Tx should be encoded identically in EATV and AETV")
+}
+
+// =============================================================================
+// Benchmarks
+// =============================================================================
+
+func BenchmarkAETVKeyEncoding(b *testing.B) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	datom := &datalog.Datom{
+		E:  datalog.NewIdentity("benchmark-entity"),
+		A:  datalog.NewKeyword(":benchmark/attribute"),
+		V:  "benchmark value string",
+		Tx: datalog.ElementID{Lamport: 12345678, ReplicaID: 1},
+		Op: datalog.OpCRDTAdd,
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = encoder.EncodeKey(AETV, datom)
+	}
+}
+
+func BenchmarkAETVKeyDecoding(b *testing.B) {
+	encoder := NewKeyEncoder(BinaryStrategy)
+
+	datom := &datalog.Datom{
+		E:  datalog.NewIdentity("benchmark-entity"),
+		A:  datalog.NewKeyword(":benchmark/attribute"),
+		V:  "benchmark value string",
+		Tx: datalog.ElementID{Lamport: 12345678, ReplicaID: 1},
+		Op: datalog.OpCRDTAdd,
+	}
+
+	key := encoder.EncodeKey(AETV, datom)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, _, _, _, _, _ = encoder.DecodeKey(AETV, key)
+	}
+}

--- a/datalog/storage/aevt_matcher_bug_test.go
+++ b/datalog/storage/aevt_matcher_bug_test.go
@@ -133,8 +133,10 @@ func TestAEVTMatcherBug(t *testing.T) {
 	t.Logf("Total datoms in DB: 50")
 
 	// Assertions
-	if indexUsed != "AEVT" {
-		t.Errorf("Expected AEVT index, got %s", indexUsed)
+	// AETV is the correct index for "E bound, A constant" pattern with CRDT semantics
+	// AETV has Tx descending, so first entry for each (A, E) is the LWW winner
+	if indexUsed != "AETV" {
+		t.Errorf("Expected AETV index (CRDT-aware A-primary), got %s", indexUsed)
 	}
 
 	// PERFORMANCE TEST: With HashJoinScan strategy, we scan all :person/age datoms (10)

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -452,7 +452,10 @@ func (i *BadgerIterator) Next() bool {
 func (i *BadgerIterator) Datom() (*datalog.Datom, error) {
 	item := i.it.Item()
 
-	// Must copy key since BadgerDB reuses the buffer
+	// Must copy key since BadgerDB reuses the buffer.
+	// Note: We cannot reuse a key buffer here because DecodeKey returns a slice
+	// into the key bytes for the value component. Reusing the buffer would cause
+	// the value slice to be overwritten on subsequent calls.
 	key := item.KeyCopy(nil)
 
 	// Decode datom from key - all information is in the key

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -62,14 +62,11 @@ func (s *BadgerStore) Assert(datoms []datalog.Datom) error {
 
 // assertDatom adds a single datom to all indices
 func (s *BadgerStore) assertDatom(txn *badger.Txn, d *datalog.Datom) error {
-	// Serialize the datom
-	sd := ToStorageDatom(*d)
-	value := sd.Bytes()
-
 	// Write to all CRDT indices
+	// Value is nil - all datom information is encoded in the key
 	for _, idx := range Indices {
 		key := s.encoder.EncodeKey(idx, d)
-		if err := txn.Set(key, value); err != nil {
+		if err := txn.Set(key, nil); err != nil {
 			return fmt.Errorf("failed to write to %v index: %w", idx, err)
 		}
 	}
@@ -166,29 +163,23 @@ func (s *BadgerStore) Scan(index IndexType, start, end []byte) (Iterator, error)
 }
 
 // Get retrieves a single datom by key
+// Values are not stored - all datom information is decoded from the key
 func (s *BadgerStore) Get(index IndexType, key []byte) (*datalog.Datom, error) {
 	var result *datalog.Datom
 
 	err := s.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(key)
+		_, err := txn.Get(key)
 		if err != nil {
 			return err
 		}
 
-		return item.Value(func(val []byte) error {
-			sd, err := StorageDatomFromBytes(val)
-			if err != nil {
-				return err
-			}
-			// Convert to user-facing datom
-			result = &datalog.Datom{
-				E:  datalog.InternIdentityFromHash(sd.E),
-				A:  datalog.InternKeywordFromBytes(sd.A),
-				V:  sd.V,
-				Tx: sd.Tx.ToElementID(),
-			}
-			return nil
-		})
+		// Decode datom from key - values are not stored
+		datom, err := DatomFromKey(index, key, s.encoder)
+		if err != nil {
+			return err
+		}
+		result = &datom
+		return nil
 	})
 
 	if err == badger.ErrKeyNotFound {
@@ -456,40 +447,21 @@ func (i *BadgerIterator) Next() bool {
 	return true
 }
 
-// Datom returns the current datom
+// Datom returns the current datom decoded from the key
+// Values are not stored - all datom information is in the key
 func (i *BadgerIterator) Datom() (*datalog.Datom, error) {
 	item := i.it.Item()
 
-	// Get key to decode Op and AfterRef (Op and AfterRef are stored in the key, not the value)
-	key := item.Key()
-	var op byte
-	var afterRef [16]byte
-	if i.encoder != nil {
-		_, _, _, _, op, afterRef, _ = i.encoder.DecodeKey(i.index, key)
+	// Must copy key since BadgerDB reuses the buffer
+	key := item.KeyCopy(nil)
+
+	// Decode datom from key - all information is in the key
+	datom, err := DatomFromKey(i.index, key, i.encoder)
+	if err != nil {
+		return nil, err
 	}
 
-	var result *datalog.Datom
-	err := item.Value(func(val []byte) error {
-		sd, err := StorageDatomFromBytes(val)
-		if err != nil {
-			return err
-		}
-		// Convert to user-facing datom
-		// Note: StorageDatomFromBytes already decodes the value properly,
-		// so sd.V is already the decoded value
-		// Op and AfterRef are decoded from the key, not the value
-		result = &datalog.Datom{
-			E:        datalog.InternIdentityFromHash(sd.E),
-			A:        datalog.InternKeywordFromBytes(sd.A),
-			V:        sd.V,
-			Tx:       sd.Tx.ToElementID(),
-			Op:       datalog.CRDTOp(op),
-			AfterRef: Tx(afterRef).ToElementID(),
-		}
-		return nil
-	})
-
-	return result, err
+	return &datom, nil
 }
 
 // Close closes the iterator

--- a/datalog/storage/batch_iterator.go
+++ b/datalog/storage/batch_iterator.go
@@ -250,9 +250,16 @@ func (it *batchScanIterator) scanRange(rg RangeGroup) {
 
 	// Open scan for this range using key-only scanning
 	var err error
-	it.storageIter, err = it.matcher.store.ScanKeysOnly(it.index, rg.startKey, rg.endKey)
+	rawIter, err := it.matcher.store.ScanKeysOnly(it.index, rg.startKey, rg.endKey)
 	if err != nil {
 		return
+	}
+
+	// Wrap with CRDT resolution to ensure we only see resolved values
+	if it.matcher.schema != nil {
+		it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
+	} else {
+		it.storageIter = rawIter
 	}
 	it.totalScans++
 

--- a/datalog/storage/cache.go
+++ b/datalog/storage/cache.go
@@ -309,3 +309,57 @@ type CacheResolver interface {
 	// Returns (elements, positionIndex, maxElementID, error)
 	ResolveRGA(e Entity, a Attribute) ([]any, []datalog.ElementID, datalog.ElementID, error)
 }
+
+// ResolveEntry resolves a CacheEntry directly from storage without caching.
+// This is used when cache is disabled but CRDT resolution is still needed.
+func ResolveEntry(key CacheKey, resolver CacheResolver) *CacheEntry {
+	card := resolver.GetCardinality(key.A)
+
+	switch card {
+	case schema.CardinalityOne:
+		value, maxID, err := resolver.ResolveLWW(key.E, key.A)
+		if err != nil {
+			return nil
+		}
+		return &CacheEntry{
+			version:     maxID,
+			cardinality: schema.CardinalityOne,
+			oneValue:    value,
+		}
+
+	case schema.CardinalityMany:
+		members, maxID, err := resolver.ResolveAddWins(key.E, key.A)
+		if err != nil {
+			return nil
+		}
+		return &CacheEntry{
+			version:     maxID,
+			cardinality: schema.CardinalityMany,
+			manySet:     members,
+		}
+
+	case schema.CardinalityVector:
+		elements, positions, maxID, err := resolver.ResolveRGA(key.E, key.A)
+		if err != nil {
+			return nil
+		}
+		return &CacheEntry{
+			version:     maxID,
+			cardinality: schema.CardinalityVector,
+			vectorList:  elements,
+			vectorIndex: positions,
+		}
+
+	default:
+		// Default to cardinality-one for schemaless
+		value, maxID, err := resolver.ResolveLWW(key.E, key.A)
+		if err != nil {
+			return nil
+		}
+		return &CacheEntry{
+			version:     maxID,
+			cardinality: schema.CardinalityOne,
+			oneValue:    value,
+		}
+	}
+}

--- a/datalog/storage/choose_index_values_test.go
+++ b/datalog/storage/choose_index_values_test.go
@@ -437,3 +437,115 @@ func TestChooseIndexForValuesAEVT(t *testing.T) {
 		}
 	})
 }
+
+// TestChooseIndexForValuesAETV verifies that AETV index scan ranges
+// are correctly narrowed when attribute and/or entity are bound.
+// AETV is the A-primary CRDT-aware index (A → E → Tx↓ → V).
+// This test ensures chooseIndexForValues handles AETV properly.
+func TestChooseIndexForValuesAETV(t *testing.T) {
+	dir, err := os.MkdirTemp("", "choose-index-aetv-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create test data: multiple entities with different attributes
+	entity1 := datalog.NewIdentity("person-1")
+	entity2 := datalog.NewIdentity("person-2")
+	entity3 := datalog.NewIdentity("person-3")
+
+	tx := db.NewTransaction()
+	// Each entity has :person/name and :person/age
+	tx.Add(entity1, datalog.NewKeyword(":person/name"), "Alice")
+	tx.Add(entity1, datalog.NewKeyword(":person/age"), int64(30))
+	tx.Add(entity2, datalog.NewKeyword(":person/name"), "Bob")
+	tx.Add(entity2, datalog.NewKeyword(":person/age"), int64(25))
+	tx.Add(entity3, datalog.NewKeyword(":person/name"), "Charlie")
+	tx.Add(entity3, datalog.NewKeyword(":person/age"), int64(35))
+	// Add some other attributes to increase total datom count
+	tx.Add(entity1, datalog.NewKeyword(":person/city"), "NYC")
+	tx.Add(entity2, datalog.NewKeyword(":person/city"), "LA")
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	matcher := db.Matcher().(*BadgerMatcher)
+
+	t.Run("AETV with attribute bound only", func(t *testing.T) {
+		// Scan AETV for :person/name - should get exactly 3 datoms
+		attr := datalog.NewKeyword(":person/name")
+		_, start, end := matcher.chooseIndexForValues(AETV, nil, attr, nil, 0)
+
+		iter, err := matcher.store.ScanKeysOnly(AETV, start, end)
+		if err != nil {
+			t.Fatalf("Scan failed: %v", err)
+		}
+
+		count := 0
+		for iter.Next() {
+			count++
+		}
+		iter.Close()
+
+		// Should find exactly 3 :person/name datoms
+		if count != 3 {
+			t.Errorf("Expected 3 datoms for :person/name via AETV, got %d", count)
+		}
+	})
+
+	t.Run("AETV with attribute and entity bound", func(t *testing.T) {
+		// Scan AETV for entity1 + :person/name - should get exactly 1 datom
+		attr := datalog.NewKeyword(":person/name")
+		_, start, end := matcher.chooseIndexForValues(AETV, entity1, attr, nil, 0)
+
+		iter, err := matcher.store.ScanKeysOnly(AETV, start, end)
+		if err != nil {
+			t.Fatalf("Scan failed: %v", err)
+		}
+
+		count := 0
+		for iter.Next() {
+			count++
+		}
+		iter.Close()
+
+		// Should find exactly 1 datom for entity1 + :person/name
+		if count != 1 {
+			t.Errorf("Expected 1 datom for entity1+:person/name via AETV, got %d", count)
+		}
+	})
+
+	t.Run("AETV scan should not exceed attribute datom count", func(t *testing.T) {
+		// This test verifies the bug is fixed: without AETV case in chooseIndexForValues,
+		// it would scan ALL datoms in the index instead of just the attribute's datoms
+		attr := datalog.NewKeyword(":person/age")
+		_, start, end := matcher.chooseIndexForValues(AETV, nil, attr, nil, 0)
+
+		iter, err := matcher.store.ScanKeysOnly(AETV, start, end)
+		if err != nil {
+			t.Fatalf("Scan failed: %v", err)
+		}
+
+		count := 0
+		for iter.Next() {
+			count++
+		}
+		iter.Close()
+
+		// Total datoms in DB is 8, :person/age has 3
+		// If AETV case is missing, count would be >= 8 (full scan)
+		if count > 3 {
+			t.Errorf("AETV scan for :person/age scanned %d datoms, expected 3 (possible full index scan)", count)
+		}
+		if count != 3 {
+			t.Errorf("Expected exactly 3 datoms for :person/age, got %d", count)
+		}
+	})
+}

--- a/datalog/storage/collection_input_test.go
+++ b/datalog/storage/collection_input_test.go
@@ -1,0 +1,412 @@
+package storage
+
+// Collection Input Tests
+//
+// Tests for how collection inputs [?x ...] are processed by the executor.
+// These tests verify that collection values are correctly unpacked into
+// multiple tuples for pattern matching.
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// =============================================================================
+// Single Collection Input Tests
+// =============================================================================
+
+// TestCollectionInput_SingleCollection verifies a single [?e ...] input works.
+func TestCollectionInput_SingleCollection(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-single-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create test data
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+		datalog.NewIdentity("person-3"),
+	}
+
+	tx := db.NewTransaction()
+	for i, e := range entities {
+		tx.Add(e, datalog.NewKeyword(":person/name"), "Name"+string(rune('A'+i)))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with single collection input
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`,
+		entities)
+	require.NoError(t, err)
+
+	t.Logf("Results (%d):", len(results))
+	for _, r := range results {
+		t.Logf("  %v", r)
+	}
+
+	assert.Len(t, results, 3, "should return one result per entity in collection")
+}
+
+// TestCollectionInput_SingleElement verifies collection with one element works.
+func TestCollectionInput_SingleElement(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-one-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	entity := datalog.NewIdentity("person-1")
+
+	tx := db.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":person/name"), "Alice")
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with single-element collection
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`,
+		[]datalog.Identity{entity})
+	require.NoError(t, err)
+
+	assert.Len(t, results, 1, "should return one result for single-element collection")
+}
+
+// TestCollectionInput_EmptyCollection verifies empty collection returns no results.
+func TestCollectionInput_EmptyCollection(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-empty-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Add some data
+	tx := db.NewTransaction()
+	tx.Add(datalog.NewIdentity("person-1"), datalog.NewKeyword(":person/name"), "Alice")
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with empty collection
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`,
+		[]datalog.Identity{})
+	require.NoError(t, err)
+
+	assert.Len(t, results, 0, "empty collection should return no results")
+}
+
+// =============================================================================
+// Multiple Collection Input Tests (Cross-Product)
+// =============================================================================
+
+// TestCollectionInput_TwoCollections verifies two [?x ...] inputs produce cross-product.
+func TestCollectionInput_TwoCollections(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-two-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:         dir,
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/age"),
+		ValueType:   schema.TypeLong,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+	}
+	attrs := []datalog.Keyword{
+		datalog.NewKeyword(":person/name"),
+		datalog.NewKeyword(":person/age"),
+	}
+
+	// Create data for all (entity, attribute) combinations
+	tx := db.NewTransaction()
+	for i, e := range entities {
+		tx.Set(e, attrs[0], "Name"+string(rune('A'+i)))
+		tx.Set(e, attrs[1], int64(20+i*10))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with two collection inputs - should get cross-product
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]`,
+		entities, attrs)
+	require.NoError(t, err)
+
+	t.Logf("Results (%d):", len(results))
+	for _, r := range results {
+		t.Logf("  %v", r)
+	}
+
+	// Expected: 2 entities × 2 attributes = 4 results
+	assert.Len(t, results, 4, "should return cross-product: 2 entities × 2 attributes")
+}
+
+// TestCollectionInput_ThreeCollections verifies three collections produce full cross-product.
+func TestCollectionInput_ThreeCollections(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-three-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create entities with multiple attributes having multiple values
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+	}
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/tag"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityMany, // Allow multiple values
+	})
+	db.SetSchema(s)
+
+	tags := []string{"alpha", "beta"}
+
+	tx := db.NewTransaction()
+	for _, e := range entities {
+		for _, tag := range tags {
+			tx.Add(e, datalog.NewKeyword(":person/tag"), tag)
+		}
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query: find all (entity, tag) pairs where tag matches input collection
+	// Using entity collection and value collection
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ [?e ...] [?v ...] :where [?e :person/tag ?v]]`,
+		entities, tags)
+	require.NoError(t, err)
+
+	t.Logf("Results (%d):", len(results))
+	for _, r := range results {
+		t.Logf("  %v", r)
+	}
+
+	// Expected: 2 entities × 2 tags = 4 results (only matching pairs)
+	assert.Len(t, results, 4, "should return matching pairs from cross-product")
+}
+
+// =============================================================================
+// Mixed Input Tests (Scalar + Collection)
+// =============================================================================
+
+// TestCollectionInput_ScalarPlusCollection verifies scalar and collection inputs work together.
+func TestCollectionInput_ScalarPlusCollection(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-mixed-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+		datalog.NewIdentity("person-3"),
+	}
+	attr := datalog.NewKeyword(":person/name")
+
+	tx := db.NewTransaction()
+	for i, e := range entities {
+		tx.Add(e, attr, "Name"+string(rune('A'+i)))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with scalar attribute and collection of entities
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ ?a [?e ...] :where [?e ?a ?v]]`,
+		attr, entities)
+	require.NoError(t, err)
+
+	t.Logf("Results (%d):", len(results))
+	for _, r := range results {
+		t.Logf("  %v", r)
+	}
+
+	assert.Len(t, results, 3, "should return one result per entity with scalar attribute")
+}
+
+// TestCollectionInput_CollectionPlusScalar verifies collection then scalar order works.
+func TestCollectionInput_CollectionPlusScalar(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-mixed2-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	entities := []datalog.Identity{
+		datalog.NewIdentity("person-1"),
+		datalog.NewIdentity("person-2"),
+	}
+	attr := datalog.NewKeyword(":person/name")
+
+	tx := db.NewTransaction()
+	for i, e := range entities {
+		tx.Add(e, attr, "Name"+string(rune('A'+i)))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with collection first, then scalar
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ [?e ...] ?a :where [?e ?a ?v]]`,
+		entities, attr)
+	require.NoError(t, err)
+
+	assert.Len(t, results, 2, "should return one result per entity")
+}
+
+// =============================================================================
+// Different Value Type Tests
+// =============================================================================
+
+// TestCollectionInput_KeywordCollection verifies collection of keywords works.
+func TestCollectionInput_KeywordCollection(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-keyword-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	entity := datalog.NewIdentity("person-1")
+	attrs := []datalog.Keyword{
+		datalog.NewKeyword(":person/name"),
+		datalog.NewKeyword(":person/city"),
+	}
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attrs[0], "Alice")
+	tx.Add(entity, attrs[1], "NYC")
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with collection of keywords (attributes)
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?a ?v :in $ ?e [?a ...] :where [?e ?a ?v]]`,
+		entity, attrs)
+	require.NoError(t, err)
+
+	t.Logf("Results (%d):", len(results))
+	for _, r := range results {
+		t.Logf("  %v", r)
+	}
+
+	assert.Len(t, results, 2, "should return one result per attribute in collection")
+}
+
+// TestCollectionInput_IntCollection verifies collection of integers works.
+func TestCollectionInput_IntCollection(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-int-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":item/score"),
+		ValueType:   schema.TypeLong,
+		Cardinality: schema.CardinalityMany,
+	})
+	db.SetSchema(s)
+
+	entity := datalog.NewIdentity("item-1")
+	scores := []int64{100, 200, 300}
+
+	tx := db.NewTransaction()
+	for _, score := range scores {
+		tx.Add(entity, datalog.NewKeyword(":item/score"), score)
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with collection of integers
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ ?e [?v ...] :where [?e :item/score ?v]]`,
+		entity, scores)
+	require.NoError(t, err)
+
+	assert.Len(t, results, 3, "should return one result per score in collection")
+}
+
+// TestCollectionInput_StringCollection verifies collection of strings works.
+func TestCollectionInput_StringCollection(t *testing.T) {
+	dir, err := os.MkdirTemp("", "collection-string-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/tag"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityMany,
+	})
+	db.SetSchema(s)
+
+	entity := datalog.NewIdentity("person-1")
+	tags := []string{"developer", "manager", "admin"}
+
+	tx := db.NewTransaction()
+	for _, tag := range tags {
+		tx.Add(entity, datalog.NewKeyword(":person/tag"), tag)
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query with collection of strings
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ ?e [?v ...] :where [?e :person/tag ?v]]`,
+		entity, tags)
+	require.NoError(t, err)
+
+	assert.Len(t, results, 3, "should return one result per tag in collection")
+}

--- a/datalog/storage/crdt_cache_matrix_test.go
+++ b/datalog/storage/crdt_cache_matrix_test.go
@@ -1,0 +1,945 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// =============================================================================
+// CRDT Cache Matrix Tests
+// =============================================================================
+//
+// These tests verify that CRDT resolution works correctly with cache enabled
+// AND disabled. This is critical because:
+// - Cache is an optimization, not a correctness requirement
+// - The code MUST work correctly with DisableCache: true
+// - If a test passes only with cache enabled, the fix is incomplete
+//
+// See: docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
+// =============================================================================
+
+// cacheTestMode represents whether tests run with cache enabled or disabled
+type cacheTestMode struct {
+	name         string
+	disableCache bool
+}
+
+var cacheTestModes = []cacheTestMode{
+	{"cache_enabled", false},
+	{"cache_disabled", true},
+}
+
+// createCacheTestDB creates a test database with the given cache mode
+func createCacheTestDB(t *testing.T, disableCache bool) (*Database, func()) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:         dir,
+		DisableCache: disableCache,
+	})
+	require.NoError(t, err)
+	return db, func() { db.Close() }
+}
+
+// =============================================================================
+// Test Matrix: All binding patterns
+// =============================================================================
+
+// TestCacheMatrix_AConstant tests when A is a constant in the pattern (baseline)
+func TestCacheMatrix_AConstant(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, datalog.NewKeyword(":person/name"), name)
+				tx.Commit()
+			}
+
+			// Pattern: A as constant (baseline - should work)
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e :where [?e :person/name ?v]]`,
+				personID)
+			require.NoError(t, err)
+			assert.Len(t, results, 1, "[%s] A as constant should return 1 result", mode.name)
+			if len(results) == 1 {
+				assert.Equal(t, "Charlie", results[0][0], "[%s] Should return LWW winner", mode.name)
+			}
+		})
+	}
+}
+
+// TestCacheMatrix_AFromScalarInput tests when A comes from a scalar input
+func TestCacheMatrix_AFromScalarInput(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, nameAttr, name)
+				tx.Commit()
+			}
+
+			// Pattern: A from scalar input
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+				personID, nameAttr)
+			require.NoError(t, err)
+			assert.Len(t, results, 1, "[%s] A from scalar input should return 1 result", mode.name)
+			if len(results) == 1 {
+				assert.Equal(t, "Charlie", results[0][0], "[%s] Should return LWW winner", mode.name)
+			}
+		})
+	}
+}
+
+// TestCacheMatrix_AUnbound tests when A is completely unbound
+func TestCacheMatrix_AUnbound(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/age"),
+				ValueType:   schema.TypeLong,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+
+			// Write multiple values to name
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, datalog.NewKeyword(":person/name"), name)
+				tx.Commit()
+			}
+
+			// Write multiple values to age
+			for _, age := range []int64{20, 25, 30} {
+				tx := db.NewTransaction()
+				tx.Set(personID, datalog.NewKeyword(":person/age"), age)
+				tx.Commit()
+			}
+
+			// Pattern: A completely unbound - should get 2 results (one per attribute)
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?a ?v :in $ ?e :where [?e ?a ?v]]`,
+				personID)
+			require.NoError(t, err)
+
+			// Should return 2 results: one for name (Charlie), one for age (30)
+			// NOT 6 results (all historical values)
+			assert.Len(t, results, 2, "[%s] Unbound A should return 1 result per attribute (CRDT resolved)", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_EFromCollection_AFromScalar tests E from collection, A from scalar
+func TestCacheMatrix_EFromCollection_AFromScalar(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			// Create 3 entities, each with multiple historical values
+			entities := []datalog.Identity{
+				datalog.NewIdentity("person-1"),
+				datalog.NewIdentity("person-2"),
+				datalog.NewIdentity("person-3"),
+			}
+
+			for i, entity := range entities {
+				for _, suffix := range []string{"First", "Second", "Final"} {
+					tx := db.NewTransaction()
+					tx.Set(entity, nameAttr, fmt.Sprintf("Person%d-%s", i+1, suffix))
+					tx.Commit()
+				}
+			}
+
+			// Pattern: E from collection, A from scalar
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?v :in $ [?e ...] ?a :where [?e ?a ?v]]`,
+				entities, nameAttr)
+			require.NoError(t, err)
+
+			// Should return 3 results (one per entity, CRDT resolved)
+			// NOT 9 results (all historical values)
+			assert.Len(t, results, 3, "[%s] E from collection should return 1 result per entity", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_CardinalityMany tests CardinalityMany add-wins resolution
+func TestCacheMatrix_CardinalityMany(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/tags"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityMany,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+			tagsAttr := datalog.NewKeyword(":person/tags")
+
+			// Set tags multiple times - each Set replaces the entire set
+			tagSets := [][]string{
+				{"red", "green", "blue"},
+				{"alpha", "beta"},
+				{"one", "two", "three"},
+			}
+			for _, tags := range tagSets {
+				tx := db.NewTransaction()
+				tagValues := make([]interface{}, len(tags))
+				for i, tag := range tags {
+					tagValues[i] = tag
+				}
+				tx.Set(personID, tagsAttr, tagValues)
+				tx.Commit()
+			}
+
+			expectedCount := 3 // Last set has 3 tags
+
+			// Query with A from scalar input
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+				personID, tagsAttr)
+			require.NoError(t, err)
+
+			// Should return 3 results (current set members)
+			// NOT 8 results (all historical tags)
+			assert.Len(t, results, expectedCount, "[%s] CardinalityMany should return current set only", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// NOTE: [(history)] predicate removed from test matrix.
+// History queries will use db.History() Datomic-style database view (future work).
+// See: https://docs.datomic.com/client-tutorial/history.html
+
+// TestCacheMatrix_PullIntoComparison verifies PullInto works in both modes
+func TestCacheMatrix_PullIntoComparison(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, datalog.NewKeyword(":person/name"), name)
+				tx.Commit()
+			}
+
+			// PullInto should always work
+			type Person struct {
+				ID   datalog.Identity `datalog:"-,id"`
+				Name string           `datalog:"person/name"`
+			}
+			var person Person
+			err := db.PullInto(personID, &person)
+			require.NoError(t, err)
+			assert.Equal(t, "Charlie", person.Name, "[%s] PullInto should return LWW winner", mode.name)
+		})
+	}
+}
+
+// =============================================================================
+// Test Matrix: Additional binding patterns
+// =============================================================================
+
+// TestCacheMatrix_AFromCollection tests when A comes from a collection input
+func TestCacheMatrix_AFromCollection(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/age"),
+				ValueType:   schema.TypeLong,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+
+			// Write multiple values to name
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, datalog.NewKeyword(":person/name"), name)
+				tx.Commit()
+			}
+
+			// Write multiple values to age
+			for _, age := range []int64{20, 25, 30} {
+				tx := db.NewTransaction()
+				tx.Set(personID, datalog.NewKeyword(":person/age"), age)
+				tx.Commit()
+			}
+
+			// Pattern: A from collection input - query both attributes
+			attrs := []datalog.Keyword{
+				datalog.NewKeyword(":person/name"),
+				datalog.NewKeyword(":person/age"),
+			}
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?a ?v :in $ ?e [?a ...] :where [?e ?a ?v]]`,
+				personID, attrs)
+			require.NoError(t, err)
+
+			// Should return 2 results: one for name (Charlie), one for age (30)
+			// NOT 6 results (all historical values)
+			assert.Len(t, results, 2, "[%s] A from collection should return 1 result per attribute", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_AFromTupleInput tests when E and A come from a tuple input
+func TestCacheMatrix_AFromTupleInput(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, nameAttr, name)
+				tx.Commit()
+			}
+
+			// Pattern: E and A from tuple input [[?e ?a]]
+			// Tuple input syntax requires double brackets
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ [[?e ?a]] :where [?e ?a ?v]]`,
+				[]any{personID, nameAttr})
+			require.NoError(t, err)
+
+			assert.Len(t, results, 1, "[%s] Tuple input should return 1 result", mode.name)
+			if len(results) == 1 {
+				assert.Equal(t, "Charlie", results[0][0], "[%s] Should return LWW winner", mode.name)
+			}
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_AFromRelationInput tests when E and A come from a relation input
+func TestCacheMatrix_AFromRelationInput(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/age"),
+				ValueType:   schema.TypeLong,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			person1 := datalog.NewIdentity("person-1")
+			person2 := datalog.NewIdentity("person-2")
+			nameAttr := datalog.NewKeyword(":person/name")
+			ageAttr := datalog.NewKeyword(":person/age")
+
+			// Write multiple values for person1's name
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(person1, nameAttr, name)
+				tx.Commit()
+			}
+
+			// Write multiple values for person2's age
+			for _, age := range []int64{20, 25, 30} {
+				tx := db.NewTransaction()
+				tx.Set(person2, ageAttr, age)
+				tx.Commit()
+			}
+
+			// Pattern: E and A from relation input [[?e ?a] ...]
+			// Relation input uses [[vars] ...] syntax with slice of slices
+			// Note: Keywords need to be converted to strings for the input
+			relationInput := [][]any{
+				{person1, nameAttr},
+				{person2, ageAttr},
+			}
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
+				relationInput)
+			require.NoError(t, err)
+
+			// Should return 2 results: person1's name (Charlie), person2's age (30)
+			// NOT 6 results (all historical values)
+			assert.Len(t, results, 2, "[%s] Relation input should return 1 result per (E,A) pair", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_ABoundViaJoin tests when A is bound via join from another pattern
+func TestCacheMatrix_ABoundViaJoin(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":config/tracked-attr"),
+				ValueType:   schema.TypeKeyword,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+			configID := datalog.NewIdentity("config-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			// Write multiple values for person's name
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, nameAttr, name)
+				tx.Commit()
+			}
+
+			// Config entity stores which attribute to track
+			tx := db.NewTransaction()
+			tx.Set(configID, datalog.NewKeyword(":config/tracked-attr"), nameAttr)
+			tx.Commit()
+
+			// Pattern: A bound via join - get attribute from config, then use it
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?person ?config :where
+				  [?config :config/tracked-attr ?a]
+				  [?person ?a ?v]]`,
+				personID, configID)
+			require.NoError(t, err)
+
+			// Should return 1 result (Charlie) - CRDT resolved
+			assert.Len(t, results, 1, "[%s] A bound via join should return 1 result", mode.name)
+			if len(results) == 1 {
+				assert.Equal(t, "Charlie", results[0][0], "[%s] Should return LWW winner", mode.name)
+			}
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_EAndABothFromCollections tests E and A both from collections
+func TestCacheMatrix_EAndABothFromCollections(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/age"),
+				ValueType:   schema.TypeLong,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			entities := []datalog.Identity{
+				datalog.NewIdentity("person-1"),
+				datalog.NewIdentity("person-2"),
+			}
+			attrs := []datalog.Keyword{
+				datalog.NewKeyword(":person/name"),
+				datalog.NewKeyword(":person/age"),
+			}
+
+			// Write multiple values for each entity/attribute combination
+			for i, entity := range entities {
+				for _, name := range []string{"First", "Second", "Final"} {
+					tx := db.NewTransaction()
+					tx.Set(entity, attrs[0], fmt.Sprintf("Person%d-%s", i+1, name))
+					tx.Commit()
+				}
+				for _, age := range []int64{20, 25, 30} {
+					tx := db.NewTransaction()
+					tx.Set(entity, attrs[1], age+int64(i*10))
+					tx.Commit()
+				}
+			}
+
+			// Pattern: Both E and A from collections
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]`,
+				entities, attrs)
+			require.NoError(t, err)
+
+			// Should return 4 results: 2 entities × 2 attributes
+			// NOT 12 results (all historical values)
+			assert.Len(t, results, 4, "[%s] Both collections should return 1 result per (E,A) combination", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_WithNotClause tests CRDT resolution with NOT clause
+func TestCacheMatrix_WithNotClause(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/active"),
+				ValueType:   schema.TypeBoolean,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			person1 := datalog.NewIdentity("person-1")
+			person2 := datalog.NewIdentity("person-2")
+			nameAttr := datalog.NewKeyword(":person/name")
+			activeAttr := datalog.NewKeyword(":person/active")
+
+			// person1: name changes, ends up active
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(person1, nameAttr, name)
+				tx.Commit()
+			}
+			tx := db.NewTransaction()
+			tx.Set(person1, activeAttr, true)
+			tx.Commit()
+
+			// person2: name changes, ends up inactive
+			for _, name := range []string{"Dave", "Eve", "Frank"} {
+				tx := db.NewTransaction()
+				tx.Set(person2, nameAttr, name)
+				tx.Commit()
+			}
+			tx = db.NewTransaction()
+			tx.Set(person2, activeAttr, false)
+			tx.Commit()
+
+			// Query: find names of active people (using NOT to exclude inactive)
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?name :where
+				  [?e :person/name ?name]
+				  [?e :person/active true]
+				  (not [?e :person/active false])]`,
+			)
+			require.NoError(t, err)
+
+			// Should return 1 result (Charlie) - only active person's current name
+			assert.Len(t, results, 1, "[%s] NOT clause should work with CRDT resolved values", mode.name)
+			if len(results) == 1 {
+				assert.Equal(t, "Charlie", results[0][0], "[%s] Should return active person's LWW name", mode.name)
+			}
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_WithOrClause tests CRDT resolution with OR clause
+func TestCacheMatrix_WithOrClause(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/status"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			person1 := datalog.NewIdentity("person-1")
+			person2 := datalog.NewIdentity("person-2")
+			person3 := datalog.NewIdentity("person-3")
+			nameAttr := datalog.NewKeyword(":person/name")
+			statusAttr := datalog.NewKeyword(":person/status")
+
+			// Setup: 3 people with changing names, different final statuses
+			for i, person := range []datalog.Identity{person1, person2, person3} {
+				for _, name := range []string{"First", "Second", "Final"} {
+					tx := db.NewTransaction()
+					tx.Set(person, nameAttr, fmt.Sprintf("Person%d-%s", i+1, name))
+					tx.Commit()
+				}
+			}
+
+			// Final statuses: person1=active, person2=pending, person3=inactive
+			statuses := []string{"active", "pending", "inactive"}
+			for i, person := range []datalog.Identity{person1, person2, person3} {
+				tx := db.NewTransaction()
+				tx.Set(person, statusAttr, statuses[i])
+				tx.Commit()
+			}
+
+			// Query: find names where status is "active" OR "pending"
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?name :where
+				  [?e :person/name ?name]
+				  (or [?e :person/status "active"]
+				      [?e :person/status "pending"])]`,
+			)
+			require.NoError(t, err)
+
+			// Should return 2 results (Person1-Final, Person2-Final)
+			// NOT 6 results (all historical names of those people)
+			assert.Len(t, results, 2, "[%s] OR clause should return CRDT resolved names", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_WithAggregation tests CRDT resolution with aggregation
+func TestCacheMatrix_WithAggregation(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/score"),
+				ValueType:   schema.TypeLong,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			// Create 3 people, each with multiple historical scores
+			for i := 1; i <= 3; i++ {
+				personID := datalog.NewIdentity(fmt.Sprintf("person-%d", i))
+				for _, score := range []int64{10, 20, 30} {
+					tx := db.NewTransaction()
+					tx.Set(personID, datalog.NewKeyword(":person/score"), score*int64(i))
+					tx.Commit()
+				}
+			}
+
+			// Query: sum of all scores
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find (sum ?score) :where [?e :person/score ?score]]`,
+			)
+			require.NoError(t, err)
+
+			// Should sum only the CURRENT scores: 30 + 60 + 90 = 180
+			// NOT all historical: (10+20+30) + (20+40+60) + (30+60+90) = 360
+			assert.Len(t, results, 1, "[%s] Aggregation should have 1 result", mode.name)
+			if len(results) == 1 {
+				sum, ok := results[0][0].(int64)
+				if !ok {
+					// Try float64 (some aggregations return float)
+					sumFloat, _ := results[0][0].(float64)
+					sum = int64(sumFloat)
+				}
+				assert.Equal(t, int64(180), sum, "[%s] Sum should be of CRDT resolved values only", mode.name)
+			}
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_CardinalityVector tests CardinalityVector RGA resolution
+func TestCacheMatrix_CardinalityVector(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":doc/content"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityVector,
+			})
+			db.SetSchema(s)
+
+			docID := datalog.NewIdentity("doc-1")
+			contentAttr := datalog.NewKeyword(":doc/content")
+
+			// Set vector content multiple times
+			vectors := [][]string{
+				{"line1", "line2"},
+				{"a", "b", "c"},
+				{"final1", "final2", "final3", "final4"},
+			}
+			for _, vec := range vectors {
+				tx := db.NewTransaction()
+				vals := make([]interface{}, len(vec))
+				for i, v := range vec {
+					vals[i] = v
+				}
+				tx.Set(docID, contentAttr, vals)
+				tx.Commit()
+			}
+
+			// Query with A from scalar input
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+				docID, contentAttr)
+			require.NoError(t, err)
+
+			// Should return 4 results (current vector elements)
+			// NOT 9 results (all historical elements)
+			assert.Len(t, results, 4, "[%s] CardinalityVector should return current vector only", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_ABoundViaSubquery tests when A is bound via a subquery result
+// NOTE: This test uses a simpler pattern - the subquery returns the attribute keyword,
+// which is then used in the main pattern.
+func TestCacheMatrix_ABoundViaSubquery(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":config/attr"),
+				ValueType:   schema.TypeKeyword,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+			configID := datalog.NewIdentity("config-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			// Write multiple values for person's name
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, nameAttr, name)
+				tx.Commit()
+			}
+
+			// Config stores which attribute to query
+			tx := db.NewTransaction()
+			tx.Set(configID, datalog.NewKeyword(":config/attr"), nameAttr)
+			tx.Commit()
+
+			// First verify the subquery works alone
+			subResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?a :in $ ?c :where [?c :config/attr ?a]]`,
+				configID)
+			require.NoError(t, err)
+			t.Logf("[%s] Subquery results: %v", mode.name, subResults)
+
+			// Pattern: A bound via subquery using scalar binding
+			// The subquery returns a single attribute value
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?person ?config :where
+				  [(q [:find ?a . :in $ ?c :where [?c :config/attr ?a]] $ ?config) ?a]
+				  [?person ?a ?v]]`,
+				personID, configID)
+			require.NoError(t, err)
+
+			// Should return 1 result (Charlie) - CRDT resolved
+			assert.Len(t, results, 1, "[%s] A bound via subquery should return 1 result", mode.name)
+			if len(results) == 1 {
+				assert.Equal(t, "Charlie", results[0][0], "[%s] Should return LWW winner", mode.name)
+			}
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_AsOfQuery tests [(as-of ?tx N)] for point-in-time queries
+func TestCacheMatrix_AsOfQuery(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			// Write values
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, nameAttr, name)
+				tx.Commit()
+			}
+
+			// First, query all values with their tx times to find the Lamport values
+			allResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?v ?tx :in $ ?e ?a :where [?e ?a ?v ?tx]]`,
+				personID, nameAttr)
+			require.NoError(t, err)
+			t.Logf("[%s] All values with tx: %v", mode.name, allResults)
+
+			// Find the Lamport time for "Alice" (first write)
+			var aliceLamport uint64
+			for _, r := range allResults {
+				if r[0] == "Alice" {
+					// ElementID comes back as a pointer
+					switch v := r[1].(type) {
+					case datalog.ElementID:
+						aliceLamport = v.Lamport
+					case *datalog.ElementID:
+						aliceLamport = v.Lamport
+					default:
+						t.Logf("[%s] tx type for Alice: %T = %v", mode.name, r[1], r[1])
+					}
+					break
+				}
+			}
+
+			if aliceLamport == 0 {
+				t.Skipf("[%s] Could not determine Lamport time for Alice", mode.name)
+			}
+
+			// Query as-of the first transaction - should return "Alice"
+			results, err := db.ExecuteQueryWithInputs(
+				fmt.Sprintf(`[:find ?v :in $ ?e :where [?e :person/name ?v ?tx] [(as-of ?tx %d)]]`, aliceLamport),
+				personID)
+			require.NoError(t, err)
+
+			// as-of should return only values at or before that Lamport time
+			// For aliceLamport, that should be just "Alice"
+			assert.Len(t, results, 1, "[%s] as-of first tx should return 1 result", mode.name)
+			if len(results) == 1 {
+				assert.Equal(t, "Alice", results[0][0], "[%s] as-of first tx should return Alice", mode.name)
+			}
+
+			t.Logf("[%s] as-of %d results: %v", mode.name, aliceLamport, results)
+		})
+	}
+}

--- a/datalog/storage/crdt_query_resolution_test.go
+++ b/datalog/storage/crdt_query_resolution_test.go
@@ -1,0 +1,545 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// =============================================================================
+// BUG: ExecuteQueryWithInputs does not apply CRDT resolution
+// =============================================================================
+//
+// SYMPTOMS:
+// - Queries return ALL historical values instead of CRDT-resolved current values
+// - For CardinalityOne: returns N values (all unique historical) instead of 1
+// - For CardinalityMany: returns all ever-added values instead of current set
+//
+// ROOT CAUSE:
+// - The matcher has CRDT resolution code in the cache path
+// - But when A is a Variable (even if bound via inputs), the cache path is skipped
+// - Join strategies scan raw storage without CRDT resolution
+//
+// EXPECTED BEHAVIOR:
+// - ExecuteQueryWithInputs should return CRDT-resolved values
+// - CardinalityOne: single value (LWW winner)
+// - CardinalityMany: current set members (tombstoned values excluded)
+// =============================================================================
+
+// TestExecuteQueryWithInputs_CardinalityOne_ReturnsMultipleValues reproduces the bug
+// where a CardinalityOne attribute query returns all historical values instead of
+// the LWW-resolved single value.
+func TestExecuteQueryWithInputs_CardinalityOne_ReturnsMultipleValues(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:      dir,
+		UseTimeTx: true,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create schema with CardinalityOne
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	personID := datalog.NewIdentity("person-1")
+	nameAttr := datalog.NewKeyword(":person/name")
+
+	// Write multiple values to the same CardinalityOne attribute
+	// Under LWW semantics, only the last value should be "current"
+	names := []string{"Alice", "Bob", "Charlie", "Diana"}
+	for _, name := range names {
+		tx := db.NewTransaction()
+		err = tx.Set(personID, nameAttr, name)
+		require.NoError(t, err)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	expectedName := "Diana" // Last value = LWW winner
+
+	// Verify PullInto works correctly (control case)
+	type Person struct {
+		ID   datalog.Identity `datalog:"-,id"`
+		Name string           `datalog:"person/name"`
+	}
+	var person Person
+	err = db.PullInto(personID, &person)
+	require.NoError(t, err)
+	assert.Equal(t, expectedName, person.Name, "PullInto should return LWW-resolved value")
+
+	// THE BUG: ExecuteQueryWithInputs returns ALL historical values
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+		personID, nameAttr)
+	require.NoError(t, err)
+
+	t.Logf("ExecuteQueryWithInputs returned %d results: %v", len(results), results)
+
+	// This assertion will FAIL until the bug is fixed
+	// Currently returns: [[Alice] [Bob] [Charlie] [Diana]]
+	// Should return: [[Diana]]
+	if len(results) != 1 {
+		t.Errorf("BUG CONFIRMED: CardinalityOne query returned %d values instead of 1", len(results))
+		t.Log("Expected: 1 result (LWW-resolved value)")
+		t.Logf("Got: %d results (all historical values)", len(results))
+		for i, r := range results {
+			t.Logf("  [%d]: %v", i, r)
+		}
+	}
+
+	assert.Len(t, results, 1, "CardinalityOne should return exactly 1 value")
+	if len(results) == 1 {
+		assert.Equal(t, expectedName, results[0][0], "Should return LWW-resolved value")
+	}
+}
+
+// TestExecuteQueryWithInputs_CardinalityMany_ReturnsAllHistoricalValues reproduces
+// the bug where a CardinalityMany attribute query returns all ever-added values
+// instead of the current set (with tombstoned values excluded).
+func TestExecuteQueryWithInputs_CardinalityMany_ReturnsAllHistoricalValues(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:      dir,
+		UseTimeTx: true,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create schema with CardinalityMany
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/tags"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityMany,
+	})
+	db.SetSchema(s)
+
+	personID := datalog.NewIdentity("person-1")
+	tagsAttr := datalog.NewKeyword(":person/tags")
+
+	// Set tags multiple times - each Set replaces the entire set
+	tagSets := [][]string{
+		{"red", "green", "blue"},
+		{"alpha", "beta"},
+		{"one", "two", "three"},
+	}
+	for _, tags := range tagSets {
+		tx := db.NewTransaction()
+		// Convert to []interface{} for Set
+		tagValues := make([]interface{}, len(tags))
+		for i, tag := range tags {
+			tagValues[i] = tag
+		}
+		err = tx.Set(personID, tagsAttr, tagValues)
+		require.NoError(t, err)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	expectedTags := []string{"one", "two", "three"} // Last set
+
+	// Verify PullInto works correctly (control case)
+	type Person struct {
+		ID   datalog.Identity `datalog:"-,id"`
+		Tags []string         `datalog:"person/tags"`
+	}
+	var person Person
+	err = db.PullInto(personID, &person)
+	require.NoError(t, err)
+	assert.Len(t, person.Tags, len(expectedTags), "PullInto should return current set only")
+	t.Logf("PullInto returned tags: %v", person.Tags)
+
+	// THE BUG: ExecuteQueryWithInputs returns ALL ever-added tags
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+		personID, tagsAttr)
+	require.NoError(t, err)
+
+	t.Logf("ExecuteQueryWithInputs returned %d results", len(results))
+	for i, r := range results {
+		t.Logf("  [%d]: %v", i, r)
+	}
+
+	// This assertion will FAIL until the bug is fixed
+	// Currently returns all 8 unique tags ever added
+	// Should return only the current 3 tags
+	if len(results) != len(expectedTags) {
+		t.Errorf("BUG CONFIRMED: CardinalityMany query returned %d values instead of %d",
+			len(results), len(expectedTags))
+		t.Logf("Expected: %d results (current set members)", len(expectedTags))
+		t.Logf("Got: %d results (all historical values)", len(results))
+	}
+
+	assert.Len(t, results, len(expectedTags),
+		"CardinalityMany should return only current set members")
+}
+
+// TestDirectMatch_VsExecuteQuery_CRDTResolution compares direct Match with ExecuteQuery
+// to isolate whether the bug is in the matcher or the query executor.
+func TestDirectMatch_VsExecuteQuery_CRDTResolution(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:      dir,
+		UseTimeTx: true,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create schema with CardinalityOne
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	personID := datalog.NewIdentity("person-1")
+	nameAttr := datalog.NewKeyword(":person/name")
+
+	// Write multiple values
+	for _, name := range []string{"Alice", "Bob", "Charlie"} {
+		tx := db.NewTransaction()
+		err = tx.Set(personID, nameAttr, name)
+		require.NoError(t, err)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	// Test direct Match (via db.Matcher())
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(s)
+
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: personID},
+			query.Constant{Value: nameAttr},
+			query.Variable{Name: datalog.NewSymbol("?name")},
+			query.Blank{},
+		},
+	}
+
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	// Count results from Match
+	matchCount := 0
+	iter := results.Iterator()
+	for iter.Next() {
+		matchCount++
+		t.Logf("Direct Match result: %v", iter.Tuple())
+	}
+
+	t.Logf("Direct Match returned %d results", matchCount)
+
+	// The matcher SHOULD return only 1 result for CardinalityOne
+	// If it returns multiple, the bug is in the matcher
+	// If it returns 1 but ExecuteQuery returns multiple, the bug is in the executor
+	if matchCount == 1 {
+		t.Log("Direct Match correctly returns 1 result - bug is in query executor")
+	} else {
+		t.Logf("Direct Match returns %d results - bug may be in matcher CRDT logic", matchCount)
+	}
+
+	// Also test ExecuteQueryWithInputs for comparison
+	queryResults, err := db.ExecuteQueryWithInputs(
+		`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+		personID, nameAttr)
+	require.NoError(t, err)
+
+	t.Logf("ExecuteQueryWithInputs returned %d results", len(queryResults))
+
+	// Compare the two approaches
+	if matchCount == 1 && len(queryResults) > 1 {
+		t.Log("DIAGNOSIS: Direct Match works, ExecuteQueryWithInputs doesn't")
+		t.Log("The bug is in how the query executor uses the matcher")
+	} else if matchCount > 1 && len(queryResults) > 1 {
+		t.Log("DIAGNOSIS: Both return multiple - bug is in matcher CRDT resolution")
+	}
+}
+
+// TestSchemaAwareness_InQueryExecution verifies the schema is accessible
+// during query execution.
+func TestSchemaAwareness_InQueryExecution(t *testing.T) {
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:      dir,
+		UseTimeTx: true,
+		Schema:    s,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Verify schema is set
+	require.NotNil(t, db.Schema(), "Database should have schema set")
+
+	attrDef := db.Schema().GetAttribute(datalog.NewKeyword(":person/name"))
+	require.NotNil(t, attrDef, "Schema should contain :person/name")
+	assert.Equal(t, schema.CardinalityOne, attrDef.Cardinality,
+		":person/name should be CardinalityOne")
+
+	// Verify Matcher() has schema
+	matcher := db.Matcher()
+	require.NotNil(t, matcher, "Matcher should not be nil")
+
+	// The matcher should be using the schema for CRDT resolution
+	// This test documents that the schema IS available - the bug is in
+	// how/whether the executor applies CRDT resolution during query execution
+	t.Log("Schema is correctly configured and accessible")
+	t.Log("The bug is NOT in schema configuration - it's in query execution CRDT resolution")
+}
+
+// TestAllQueryMethods_CRDTResolution tests all query methods to determine which
+// correctly apply CRDT resolution. This provides a comprehensive matrix of
+// working vs broken methods.
+func TestAllQueryMethods_CRDTResolution(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:      dir,
+		UseTimeTx: true,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create schema with CardinalityOne
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	personID := datalog.NewIdentity("person-1")
+	nameAttr := datalog.NewKeyword(":person/name")
+
+	// Write multiple values - only "Charlie" should be visible (LWW)
+	for _, name := range []string{"Alice", "Bob", "Charlie"} {
+		tx := db.NewTransaction()
+		err = tx.Set(personID, nameAttr, name)
+		require.NoError(t, err)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	expectedName := "Charlie"
+
+	// Track results for summary
+	type methodResult struct {
+		name    string
+		count   int
+		value   interface{}
+		correct bool
+	}
+	var results []methodResult
+
+	// 1. Direct Matcher.Match (control - known working)
+	t.Run("DirectMatch", func(t *testing.T) {
+		matcher := NewBadgerMatcher(db.Store())
+		matcher.SetSchema(s)
+
+		pattern := &query.DataPattern{
+			Elements: []query.PatternElement{
+				query.Constant{Value: personID},
+				query.Constant{Value: nameAttr},
+				query.Variable{Name: datalog.NewSymbol("?name")},
+				query.Blank{},
+			},
+		}
+
+		matchResults, err := matcher.Match(pattern, nil)
+		require.NoError(t, err)
+
+		count := 0
+		var lastValue interface{}
+		iter := matchResults.Iterator()
+		for iter.Next() {
+			count++
+			tuple := iter.Tuple()
+			// The tuple contains only the bound variables from the pattern
+			// Since we have one Variable (?name), it should be at index 0
+			if len(tuple) > 0 {
+				lastValue = tuple[0]
+			}
+			t.Logf("  tuple[%d]: %v (len=%d)", count-1, tuple, len(tuple))
+		}
+
+		correct := count == 1
+		results = append(results, methodResult{"DirectMatch", count, lastValue, correct})
+		t.Logf("DirectMatch: %d results, value=%v, correct=%v", count, lastValue, correct)
+	})
+
+	// 2. PullInto (control - known working)
+	t.Run("PullInto", func(t *testing.T) {
+		type Person struct {
+			ID   datalog.Identity `datalog:"-,id"`
+			Name string           `datalog:"person/name"`
+		}
+		var person Person
+		err := db.PullInto(personID, &person)
+		require.NoError(t, err)
+
+		correct := person.Name == expectedName
+		results = append(results, methodResult{"PullInto", 1, person.Name, correct})
+		t.Logf("PullInto: value=%q, correct=%v", person.Name, correct)
+	})
+
+	// 3. Pull (to map)
+	t.Run("Pull", func(t *testing.T) {
+		pulled, err := db.Pull(personID, "[*]")
+		require.NoError(t, err)
+
+		name := pulled["person/name"]
+		// Pull might return single value or slice depending on implementation
+		var count int
+		var value interface{}
+		switch v := name.(type) {
+		case []interface{}:
+			count = len(v)
+			if count > 0 {
+				value = v[len(v)-1]
+			}
+		case string:
+			count = 1
+			value = v
+		default:
+			count = 1
+			value = v
+		}
+
+		correct := count == 1 && value == expectedName
+		results = append(results, methodResult{"Pull", count, value, correct})
+		t.Logf("Pull: %d results, value=%v, correct=%v", count, value, correct)
+	})
+
+	// 4. ExecuteQuery (basic, no inputs)
+	t.Run("ExecuteQuery", func(t *testing.T) {
+		// Use a query that doesn't need inputs by hardcoding the entity lookup
+		queryResults, err := db.ExecuteQuery(
+			`[:find ?v :where [?e :person/name ?v]]`)
+		require.NoError(t, err)
+
+		count := len(queryResults)
+		var value interface{}
+		if count > 0 {
+			value = queryResults[count-1][0]
+		}
+
+		correct := count == 1
+		results = append(results, methodResult{"ExecuteQuery", count, value, correct})
+		t.Logf("ExecuteQuery: %d results, correct=%v", count, correct)
+	})
+
+	// 5. ExecuteQueryWithInputs (known broken)
+	t.Run("ExecuteQueryWithInputs", func(t *testing.T) {
+		queryResults, err := db.ExecuteQueryWithInputs(
+			`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+			personID, nameAttr)
+		require.NoError(t, err)
+
+		count := len(queryResults)
+		var value interface{}
+		if count > 0 {
+			value = queryResults[count-1][0]
+		}
+
+		correct := count == 1
+		results = append(results, methodResult{"ExecuteQueryWithInputs", count, value, correct})
+		t.Logf("ExecuteQueryWithInputs: %d results, correct=%v", count, correct)
+	})
+
+	// 6. ExecuteQueryRelation
+	t.Run("ExecuteQueryRelation", func(t *testing.T) {
+		rel, err := db.ExecuteQueryRelation(
+			`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+			personID, nameAttr)
+		require.NoError(t, err)
+
+		count := 0
+		var value interface{}
+		iter := rel.Iterator()
+		for iter.Next() {
+			count++
+			value = iter.Tuple()[0]
+		}
+
+		correct := count == 1
+		results = append(results, methodResult{"ExecuteQueryRelation", count, value, correct})
+		t.Logf("ExecuteQueryRelation: %d results, correct=%v", count, correct)
+	})
+
+	// 7. QueryInto
+	t.Run("QueryInto", func(t *testing.T) {
+		var names []string
+		err := db.QueryInto(&names,
+			`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+			personID, nameAttr)
+		require.NoError(t, err)
+
+		count := len(names)
+		var value interface{}
+		if count > 0 {
+			value = names[count-1]
+		}
+
+		correct := count == 1
+		results = append(results, methodResult{"QueryInto", count, value, correct})
+		t.Logf("QueryInto: %d results, correct=%v", count, correct)
+	})
+
+	// 8. QueryOneInto
+	t.Run("QueryOneInto", func(t *testing.T) {
+		var name string
+		found, err := db.QueryOneInto(&name,
+			`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+			personID, nameAttr)
+
+		// QueryOneInto correctly errors when multiple results are returned
+		// This error is actually a symptom of the CRDT bug - there should only be one result
+		if err != nil {
+			t.Logf("QueryOneInto: error=%v (expected due to CRDT bug returning multiple results)", err)
+			results = append(results, methodResult{"QueryOneInto", -1, "ERROR: multiple results", false})
+			return
+		}
+
+		count := 0
+		if found {
+			count = 1
+		}
+
+		correct := found && name == expectedName
+		results = append(results, methodResult{"QueryOneInto", count, name, correct})
+		t.Logf("QueryOneInto: found=%v, value=%q, correct=%v", found, name, correct)
+	})
+
+	// Print summary table
+	t.Log("\n========== CRDT RESOLUTION MATRIX ==========")
+	t.Log("Method                    | Count | Correct | Value")
+	t.Log("--------------------------|-------|---------|------")
+	for _, r := range results {
+		status := "✗ BUG"
+		if r.correct {
+			status = "✓ OK "
+		}
+		t.Logf("%-25s | %5d | %s   | %v", r.name, r.count, status, r.value)
+	}
+	t.Log("=============================================")
+	t.Log("Expected: 1 result with value 'Charlie' for all methods")
+}

--- a/datalog/storage/crdt_resolve_test.go
+++ b/datalog/storage/crdt_resolve_test.go
@@ -265,3 +265,4 @@ func TestResolveRGAFromDatoms_IgnoresNonRGAOps(t *testing.T) {
 	values, _, _ := ResolveRGAFromDatoms(datoms)
 	assert.Equal(t, []any{"first"}, values)
 }
+

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -1,0 +1,315 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// CRDTResolvingIterator wraps a storage iterator and applies CRDT resolution
+// per (E, A) group. It buffers datoms until the (E, A) boundary changes,
+// then resolves according to schema cardinality and yields surviving datoms.
+//
+// This ensures that regardless of how A becomes bound (constant, input, join),
+// queries return CRDT-resolved current values, not all historical values.
+//
+// Resolution strategies by cardinality:
+//   - CardinalityOne: LWW (Last-Write-Wins) - highest Lamport timestamp wins
+//   - CardinalityMany: Add-wins set - track adds/removes per value
+//   - CardinalityVector: RGA (Replicated Growable Array) - reconstruct ordered list
+type CRDTResolvingIterator struct {
+	source Iterator
+	schema schema.SchemaProvider
+	txID   uint64 // For as-of queries: only consider datoms with Tx.Lamport <= txID
+
+	// Current (E, A) group being accumulated
+	currentE    datalog.Identity
+	currentA    datalog.Keyword
+	hasGroup    bool
+	groupBuffer []*datalog.Datom
+
+	// Resolved datoms ready to emit
+	resolved   []*datalog.Datom
+	resolveIdx int
+
+	// For detecting end of source
+	sourceExhausted bool
+
+	// Current datom being yielded
+	currentDatom *datalog.Datom
+}
+
+// NewCRDTResolvingIterator creates a new CRDT-resolving iterator wrapper.
+// If schema is nil, defaults to CardinalityOne (LWW) for all attributes.
+// If txID > 0, only considers datoms with Tx.Lamport <= txID (as-of query).
+func NewCRDTResolvingIterator(source Iterator, schema schema.SchemaProvider, txID uint64) *CRDTResolvingIterator {
+	return &CRDTResolvingIterator{
+		source:      source,
+		schema:      schema,
+		txID:        txID,
+		groupBuffer: make([]*datalog.Datom, 0, 8), // Pre-allocate small buffer
+	}
+}
+
+// Next advances to the next CRDT-resolved datom.
+// Returns true if a datom is available, false when exhausted.
+func (it *CRDTResolvingIterator) Next() bool {
+	// First, emit any buffered resolved datoms
+	if it.resolveIdx < len(it.resolved) {
+		it.currentDatom = it.resolved[it.resolveIdx]
+		it.resolveIdx++
+		return true
+	}
+
+	// If source is exhausted, we're done
+	if it.sourceExhausted {
+		return false
+	}
+
+	// Read from source until (E, A) changes or source exhausted
+	for {
+		if !it.source.Next() {
+			// Source exhausted - resolve final group
+			it.sourceExhausted = true
+			if len(it.groupBuffer) > 0 {
+				it.resolved = it.resolveGroup()
+				it.groupBuffer = it.groupBuffer[:0] // Reset buffer
+				it.resolveIdx = 0
+				if len(it.resolved) > 0 {
+					it.currentDatom = it.resolved[0]
+					it.resolveIdx = 1
+					return true
+				}
+			}
+			return false
+		}
+
+		datom, err := it.source.Datom()
+		if err != nil {
+			continue
+		}
+
+		// Apply as-of filtering if txID is set
+		if it.txID > 0 && datom.Tx.Lamport > it.txID {
+			continue
+		}
+
+		// Check if (E, A) changed
+		eHash := datom.E.Hash()
+		if it.hasGroup {
+			currentEHash := it.currentE.Hash()
+			if eHash != currentEHash || datom.A != it.currentA {
+				// (E, A) changed - resolve current group
+				it.resolved = it.resolveGroup()
+				it.groupBuffer = it.groupBuffer[:0] // Reset buffer
+				it.groupBuffer = append(it.groupBuffer, copyDatom(datom))
+				it.currentE = datom.E
+				it.currentA = datom.A
+				it.resolveIdx = 0
+
+				if len(it.resolved) > 0 {
+					it.currentDatom = it.resolved[0]
+					it.resolveIdx = 1
+					return true
+				}
+				// Empty resolution - continue to next group
+				continue
+			}
+		}
+
+		// Same (E, A) or first datom - accumulate
+		if !it.hasGroup {
+			it.currentE = datom.E
+			it.currentA = datom.A
+			it.hasGroup = true
+		}
+		it.groupBuffer = append(it.groupBuffer, copyDatom(datom))
+	}
+}
+
+// Datom returns the current CRDT-resolved datom.
+func (it *CRDTResolvingIterator) Datom() (*datalog.Datom, error) {
+	return it.currentDatom, nil
+}
+
+// Close releases resources held by the iterator.
+func (it *CRDTResolvingIterator) Close() error {
+	if it.source != nil {
+		return it.source.Close()
+	}
+	return nil
+}
+
+// Seek positions the iterator at or after the given key.
+// This resets the CRDT resolution state since we're jumping to a new position.
+func (it *CRDTResolvingIterator) Seek(key []byte) {
+	// Reset resolution state
+	it.hasGroup = false
+	it.groupBuffer = it.groupBuffer[:0]
+	it.resolved = nil
+	it.resolveIdx = 0
+	it.sourceExhausted = false
+	it.currentDatom = nil
+
+	// Delegate to source
+	it.source.Seek(key)
+}
+
+// ElementID returns the transaction ElementID of the current entry.
+func (it *CRDTResolvingIterator) ElementID() datalog.ElementID {
+	if it.currentDatom != nil {
+		return it.currentDatom.Tx
+	}
+	return datalog.ElementID{}
+}
+
+// resolveGroup applies CRDT resolution to the buffered (E, A) group.
+func (it *CRDTResolvingIterator) resolveGroup() []*datalog.Datom {
+	if len(it.groupBuffer) == 0 {
+		return nil
+	}
+
+	// Determine cardinality from schema
+	card := schema.CardinalityOne // default for schemaless
+	if it.schema != nil {
+		if attr := it.schema.GetAttribute(it.currentA); attr != nil {
+			card = attr.Cardinality
+		}
+	}
+
+	switch card {
+	case schema.CardinalityOne:
+		return it.resolveLWW()
+	case schema.CardinalityMany:
+		return it.resolveAddWins()
+	case schema.CardinalityVector:
+		return it.resolveRGA()
+	}
+	return it.groupBuffer // unknown cardinality - return all
+}
+
+// resolveLWW applies Last-Write-Wins resolution for CardinalityOne.
+// Returns the single datom with the highest Lamport timestamp.
+func (it *CRDTResolvingIterator) resolveLWW() []*datalog.Datom {
+	var winner *datalog.Datom
+	for _, d := range it.groupBuffer {
+		if winner == nil || d.Tx.Lamport > winner.Tx.Lamport ||
+			(d.Tx.Lamport == winner.Tx.Lamport && d.Tx.ReplicaID > winner.Tx.ReplicaID) {
+			winner = d
+		}
+	}
+	if winner != nil {
+		return []*datalog.Datom{winner}
+	}
+	return nil
+}
+
+// resolveAddWins applies add-wins set resolution for CardinalityMany.
+// For each distinct value, compares highest add vs highest remove Lamport.
+// Value is in set if add >= remove (add wins on tie).
+func (it *CRDTResolvingIterator) resolveAddWins() []*datalog.Datom {
+	// Track highest add and remove Lamport per value
+	type valueState struct {
+		highestAdd    uint64
+		highestRemove uint64
+		hasAdd        bool
+		hasRemove     bool
+		addDatom      *datalog.Datom // Keep the datom for the winning add
+	}
+
+	valueStates := make(map[string]*valueState)
+
+	for _, d := range it.groupBuffer {
+		// Use value's string representation as key
+		vKey := valueKey(d.V)
+
+		state, exists := valueStates[vKey]
+		if !exists {
+			state = &valueState{}
+			valueStates[vKey] = state
+		}
+
+		if d.Op == datalog.OpCRDTAdd {
+			if !state.hasAdd || d.Tx.Lamport > state.highestAdd ||
+				(d.Tx.Lamport == state.highestAdd && d.Tx.ReplicaID > state.addDatom.Tx.ReplicaID) {
+				state.highestAdd = d.Tx.Lamport
+				state.hasAdd = true
+				state.addDatom = d
+			}
+		} else if d.Op == datalog.OpCRDTRemove {
+			if !state.hasRemove || d.Tx.Lamport > state.highestRemove {
+				state.highestRemove = d.Tx.Lamport
+				state.hasRemove = true
+			}
+		}
+	}
+
+	// Collect values where add wins
+	var result []*datalog.Datom
+	for _, state := range valueStates {
+		if !state.hasAdd {
+			continue // No add means not in set
+		}
+		if !state.hasRemove || state.highestAdd >= state.highestRemove {
+			// Add wins (add >= remove)
+			result = append(result, state.addDatom)
+		}
+	}
+
+	return result
+}
+
+// resolveRGA applies RGA resolution for CardinalityVector.
+// This is a simplified implementation that delegates to the existing resolver.
+func (it *CRDTResolvingIterator) resolveRGA() []*datalog.Datom {
+	// For RGA, we need the full vector reconstruction which is complex.
+	// The existing code in matcher_relations.go has dedicated methods for vectors.
+	// For now, return all datoms and let the vector-specific code handle it.
+	//
+	// TODO: Implement streaming RGA resolution here for consistency.
+	// The challenge is that RGA needs position information and parent tracking
+	// that isn't directly available from just the datom stream.
+	return it.groupBuffer
+}
+
+// copyDatom creates a deep copy of a datom since iterators may reuse buffers.
+func copyDatom(d *datalog.Datom) *datalog.Datom {
+	if d == nil {
+		return nil
+	}
+	return &datalog.Datom{
+		E:  d.E,
+		A:  d.A,
+		V:  d.V,
+		Tx: d.Tx,
+		Op: d.Op,
+	}
+}
+
+// valueKey converts a value to a string key for grouping in add-wins resolution.
+func valueKey(v any) string {
+	switch val := v.(type) {
+	case string:
+		return "s:" + val
+	case int64:
+		return fmt.Sprintf("i:%d", val)
+	case float64:
+		return fmt.Sprintf("f:%f", val)
+	case bool:
+		if val {
+			return "b:t"
+		}
+		return "b:f"
+	case datalog.Identity:
+		if val == nil {
+			return "id:nil"
+		}
+		hash := val.Hash()
+		return "id:" + string(hash[:])
+	case datalog.Keyword:
+		return "kw:" + val.String()
+	default:
+		return fmt.Sprintf("v:%v", v)
+	}
+}

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -1,37 +1,44 @@
 package storage
 
 import (
-	"fmt"
-
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
 // CRDTResolvingIterator wraps a storage iterator and applies CRDT resolution
-// per (E, A) group. It buffers datoms until the (E, A) boundary changes,
-// then resolves according to schema cardinality and yields surviving datoms.
+// per (E, A) group using streaming.
 //
-// This ensures that regardless of how A becomes bound (constant, input, join),
-// queries return CRDT-resolved current values, not all historical values.
+// Key insight: EATV index stores Tx in descending order (highest Tx first).
+// This means resolution is just filtering - no buffering needed.
 //
 // Resolution strategies by cardinality:
-//   - CardinalityOne: LWW (Last-Write-Wins) - highest Lamport timestamp wins
-//   - CardinalityMany: Add-wins set - track adds/removes per value
-//   - CardinalityVector: RGA (Replicated Growable Array) - reconstruct ordered list
+//   - CardinalityOne: Emit first entry, skip rest. Zero state.
+//   - CardinalityMany: Emit qualifying ADDs immediately. Minimal state.
+//   - CardinalityVector: TODO - needs discussion.
 type CRDTResolvingIterator struct {
 	source Iterator
 	schema schema.SchemaProvider
 	txID   uint64 // For as-of queries: only consider datoms with Tx.Lamport <= txID
 
-	// Current (E, A) group being accumulated
-	currentE    datalog.Identity
-	currentA    datalog.Keyword
-	hasGroup    bool
-	groupBuffer []*datalog.Datom
+	// Current (E, A) group tracking
+	currentE  datalog.Identity
+	currentA  datalog.Keyword
+	hasGroup  bool
+	card      schema.Cardinality
 
-	// Resolved datoms ready to emit
-	resolved   []*datalog.Datom
-	resolveIdx int
+	// CardinalityMany: streaming state (no buffering!)
+	// Because we iterate Tx descending:
+	// - First ADD for a value wins (unless tombstoned)
+	// - REMOVE before ADD means remove has higher Tx
+	emitted    map[any]bool   // values we've already emitted
+	tombstones map[any]uint64 // value → remove Lamport (for add-wins-at-same-Tx)
+
+	// CardinalityVector: TODO - placeholder for discussion
+	rgaElements []rgaElement
+
+	// Emit buffer for CardinalityVector only
+	emitBuffer []*datalog.Datom
+	emitIdx    int
 
 	// For detecting end of source
 	sourceExhausted bool
@@ -40,25 +47,29 @@ type CRDTResolvingIterator struct {
 	currentDatom *datalog.Datom
 }
 
+// rgaElement stores minimal state for RGA reconstruction (no datom pointers)
+type rgaElement struct {
+	id          datalog.ElementID
+	afterRef    datalog.ElementID
+	value       any
+	tombstoneID *datalog.ElementID
+}
+
 // NewCRDTResolvingIterator creates a new CRDT-resolving iterator wrapper.
-// If schema is nil, defaults to CardinalityOne (LWW) for all attributes.
-// If txID > 0, only considers datoms with Tx.Lamport <= txID (as-of query).
 func NewCRDTResolvingIterator(source Iterator, schema schema.SchemaProvider, txID uint64) *CRDTResolvingIterator {
 	return &CRDTResolvingIterator{
-		source:      source,
-		schema:      schema,
-		txID:        txID,
-		groupBuffer: make([]*datalog.Datom, 0, 8), // Pre-allocate small buffer
+		source: source,
+		schema: schema,
+		txID:   txID,
 	}
 }
 
 // Next advances to the next CRDT-resolved datom.
-// Returns true if a datom is available, false when exhausted.
 func (it *CRDTResolvingIterator) Next() bool {
-	// First, emit any buffered resolved datoms
-	if it.resolveIdx < len(it.resolved) {
-		it.currentDatom = it.resolved[it.resolveIdx]
-		it.resolveIdx++
+	// First, emit any buffered results (CardinalityVector only)
+	if it.emitIdx < len(it.emitBuffer) {
+		it.currentDatom = it.emitBuffer[it.emitIdx]
+		it.emitIdx++
 		return true
 	}
 
@@ -67,20 +78,12 @@ func (it *CRDTResolvingIterator) Next() bool {
 		return false
 	}
 
-	// Read from source until (E, A) changes or source exhausted
 	for {
 		if !it.source.Next() {
-			// Source exhausted - resolve final group
+			// Source exhausted - emit final group if CardinalityVector
 			it.sourceExhausted = true
-			if len(it.groupBuffer) > 0 {
-				it.resolved = it.resolveGroup()
-				it.groupBuffer = it.groupBuffer[:0] // Reset buffer
-				it.resolveIdx = 0
-				if len(it.resolved) > 0 {
-					it.currentDatom = it.resolved[0]
-					it.resolveIdx = 1
-					return true
-				}
+			if it.hasGroup && it.card == schema.CardinalityVector {
+				return it.emitRGAGroup()
 			}
 			return false
 		}
@@ -90,41 +93,252 @@ func (it *CRDTResolvingIterator) Next() bool {
 			continue
 		}
 
-		// Apply as-of filtering if txID is set
+		// Apply as-of filtering
 		if it.txID > 0 && datom.Tx.Lamport > it.txID {
 			continue
 		}
 
 		// Check if (E, A) changed
-		eHash := datom.E.Hash()
-		if it.hasGroup {
+		isNewGroup := false
+		if !it.hasGroup {
+			isNewGroup = true
+		} else {
+			eHash := datom.E.Hash()
 			currentEHash := it.currentE.Hash()
 			if eHash != currentEHash || datom.A != it.currentA {
-				// (E, A) changed - resolve current group
-				it.resolved = it.resolveGroup()
-				it.groupBuffer = it.groupBuffer[:0] // Reset buffer
-				it.groupBuffer = append(it.groupBuffer, copyDatom(datom))
-				it.currentE = datom.E
-				it.currentA = datom.A
-				it.resolveIdx = 0
-
-				if len(it.resolved) > 0 {
-					it.currentDatom = it.resolved[0]
-					it.resolveIdx = 1
-					return true
-				}
-				// Empty resolution - continue to next group
-				continue
+				isNewGroup = true
 			}
 		}
 
-		// Same (E, A) or first datom - accumulate
-		if !it.hasGroup {
-			it.currentE = datom.E
-			it.currentA = datom.A
-			it.hasGroup = true
+		if isNewGroup {
+			// Emit pending CardinalityVector results before starting new group
+			if it.hasGroup && it.card == schema.CardinalityVector {
+				// For Vector, we need to buffer this datom and emit the old group
+				// This is the ONE place we need a copy - at group boundary for Vector
+				it.emitBuffer = it.resolveRGAGroup()
+				it.emitIdx = 0
+				it.startNewGroup(datom)
+				if len(it.emitBuffer) > 0 {
+					it.currentDatom = it.emitBuffer[it.emitIdx]
+					it.emitIdx++
+					return true
+				}
+				// Empty RGA group, continue with new group
+			} else {
+				it.startNewGroup(datom)
+			}
 		}
-		it.groupBuffer = append(it.groupBuffer, copyDatom(datom))
+
+		// Process datom based on cardinality
+		switch it.card {
+		case schema.CardinalityOne:
+			if isNewGroup {
+				// First entry for this (E, A) - emit immediately
+				it.currentDatom = datom
+				return true
+			}
+			// Same (E, A) - skip (we already emitted the winner)
+			continue
+
+		case schema.CardinalityMany:
+			if result := it.processAddWins(datom); result != nil {
+				it.currentDatom = result
+				return true
+			}
+			continue
+
+		case schema.CardinalityVector:
+			it.accumulateRGA(datom)
+			continue
+		}
+	}
+}
+
+// startNewGroup initializes state for a new (E, A) group.
+func (it *CRDTResolvingIterator) startNewGroup(datom *datalog.Datom) {
+	it.currentE = datom.E
+	it.currentA = datom.A
+	it.hasGroup = true
+
+	// Determine cardinality
+	it.card = schema.CardinalityOne
+	if it.schema != nil {
+		if attr := it.schema.GetAttribute(datom.A); attr != nil {
+			it.card = attr.Cardinality
+		}
+	}
+
+	// Reset state based on cardinality
+	switch it.card {
+	case schema.CardinalityOne:
+		// No state needed
+	case schema.CardinalityMany:
+		it.emitted = make(map[any]bool)
+		it.tombstones = make(map[any]uint64)
+	case schema.CardinalityVector:
+		it.rgaElements = it.rgaElements[:0]
+	}
+}
+
+// processAddWins handles a datom for CardinalityMany using streaming add-wins.
+// Returns the datom to emit, or nil if this datom should be skipped.
+//
+// Because we iterate Tx DESCENDING:
+// - First ADD for a value = highest Tx = emit (unless tombstoned)
+// - REMOVE before ADD = remove has higher Tx = value is removed
+// - REMOVE after ADD = we already emitted = ignore remove
+func (it *CRDTResolvingIterator) processAddWins(datom *datalog.Datom) *datalog.Datom {
+	v := datom.V
+
+	if datom.Op == datalog.OpCRDTAdd {
+		// Already emitted this value?
+		if it.emitted[v] {
+			return nil
+		}
+
+		// Check if tombstoned
+		if tombstoneLamport, exists := it.tombstones[v]; exists {
+			// Add wins at same Lamport, otherwise remove wins
+			if datom.Tx.Lamport < tombstoneLamport {
+				return nil // Remove wins
+			}
+			// Add wins (same or higher Lamport - but higher can't happen in descending order)
+		}
+
+		// Emit this add
+		it.emitted[v] = true
+		return datom
+
+	} else if datom.Op == datalog.OpCRDTRemove {
+		// Record tombstone (first one we see = highest Tx)
+		if _, exists := it.tombstones[v]; !exists {
+			it.tombstones[v] = datom.Tx.Lamport
+		}
+		return nil
+	}
+
+	return nil
+}
+
+// accumulateRGA collects RGA elements for tree reconstruction.
+// Stores minimal state, not datom pointers.
+func (it *CRDTResolvingIterator) accumulateRGA(datom *datalog.Datom) {
+	if datom.Op == datalog.OpRGAInsert {
+		it.rgaElements = append(it.rgaElements, rgaElement{
+			id:       datom.Tx,
+			afterRef: datom.AfterRef,
+			value:    datom.V,
+		})
+	} else if datom.Op == datalog.OpRGATombstone {
+		// Find and mark the target element, or create placeholder
+		targetID := datom.AfterRef
+		tombstoneID := datom.Tx
+		found := false
+		for i := range it.rgaElements {
+			if it.rgaElements[i].id == targetID {
+				if it.rgaElements[i].tombstoneID == nil || it.rgaElements[i].tombstoneID.Less(tombstoneID) {
+					it.rgaElements[i].tombstoneID = &tombstoneID
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Tombstone arrived before insert
+			it.rgaElements = append(it.rgaElements, rgaElement{
+				id:          targetID,
+				tombstoneID: &tombstoneID,
+			})
+		}
+	}
+}
+
+// emitRGAGroup resolves the RGA group at source exhaustion.
+func (it *CRDTResolvingIterator) emitRGAGroup() bool {
+	it.emitBuffer = it.resolveRGAGroup()
+	it.emitIdx = 0
+	if len(it.emitBuffer) > 0 {
+		it.currentDatom = it.emitBuffer[it.emitIdx]
+		it.emitIdx++
+		return true
+	}
+	return false
+}
+
+// resolveRGAGroup reconstructs the RGA tree and returns ordered datoms.
+// Reconstructs datoms from stored state - no datom pointer storage needed.
+func (it *CRDTResolvingIterator) resolveRGAGroup() []*datalog.Datom {
+	if len(it.rgaElements) == 0 {
+		return nil
+	}
+
+	// Deduplicate by ID (tombstone takes precedence)
+	elemByID := make(map[datalog.ElementID]*rgaElement)
+	for i := range it.rgaElements {
+		e := &it.rgaElements[i]
+		existing, exists := elemByID[e.id]
+		if !exists {
+			elemByID[e.id] = e
+		} else {
+			// Merge tombstone info
+			if e.tombstoneID != nil && (existing.tombstoneID == nil || existing.tombstoneID.Less(*e.tombstoneID)) {
+				existing.tombstoneID = e.tombstoneID
+			}
+			// Merge value/afterRef if we have it
+			if existing.value == nil && e.value != nil {
+				existing.value = e.value
+				existing.afterRef = e.afterRef
+			}
+		}
+	}
+
+	// Build children map
+	children := make(map[datalog.ElementID][]*rgaElement)
+	for _, e := range elemByID {
+		children[e.afterRef] = append(children[e.afterRef], e)
+	}
+
+	// Sort children by ID (ascending)
+	for k := range children {
+		sortRGAByID(children[k])
+	}
+
+	// DFS from HEAD, reconstruct datoms
+	var result []*datalog.Datom
+	visited := make(map[datalog.ElementID]bool)
+	var walk func(id datalog.ElementID)
+	walk = func(id datalog.ElementID) {
+		if visited[id] {
+			return
+		}
+		visited[id] = true
+
+		for _, child := range children[id] {
+			if child.tombstoneID == nil && child.value != nil {
+				// Reconstruct datom from stored state
+				result = append(result, &datalog.Datom{
+					E:        it.currentE,
+					A:        it.currentA,
+					V:        child.value,
+					Tx:       child.id,
+					Op:       datalog.OpRGAInsert,
+					AfterRef: child.afterRef,
+				})
+			}
+			walk(child.id)
+		}
+	}
+	walk(HEAD)
+
+	return result
+}
+
+func sortRGAByID(elems []*rgaElement) {
+	// Simple insertion sort (typically small lists)
+	for i := 1; i < len(elems); i++ {
+		for j := i; j > 0 && elems[j].id.Less(elems[j-1].id); j-- {
+			elems[j], elems[j-1] = elems[j-1], elems[j]
+		}
 	}
 }
 
@@ -142,17 +356,15 @@ func (it *CRDTResolvingIterator) Close() error {
 }
 
 // Seek positions the iterator at or after the given key.
-// This resets the CRDT resolution state since we're jumping to a new position.
 func (it *CRDTResolvingIterator) Seek(key []byte) {
-	// Reset resolution state
 	it.hasGroup = false
-	it.groupBuffer = it.groupBuffer[:0]
-	it.resolved = nil
-	it.resolveIdx = 0
+	it.emitted = nil
+	it.tombstones = nil
+	it.rgaElements = nil
+	it.emitBuffer = nil
+	it.emitIdx = 0
 	it.sourceExhausted = false
 	it.currentDatom = nil
-
-	// Delegate to source
 	it.source.Seek(key)
 }
 
@@ -162,154 +374,4 @@ func (it *CRDTResolvingIterator) ElementID() datalog.ElementID {
 		return it.currentDatom.Tx
 	}
 	return datalog.ElementID{}
-}
-
-// resolveGroup applies CRDT resolution to the buffered (E, A) group.
-func (it *CRDTResolvingIterator) resolveGroup() []*datalog.Datom {
-	if len(it.groupBuffer) == 0 {
-		return nil
-	}
-
-	// Determine cardinality from schema
-	card := schema.CardinalityOne // default for schemaless
-	if it.schema != nil {
-		if attr := it.schema.GetAttribute(it.currentA); attr != nil {
-			card = attr.Cardinality
-		}
-	}
-
-	switch card {
-	case schema.CardinalityOne:
-		return it.resolveLWW()
-	case schema.CardinalityMany:
-		return it.resolveAddWins()
-	case schema.CardinalityVector:
-		return it.resolveRGA()
-	}
-	return it.groupBuffer // unknown cardinality - return all
-}
-
-// resolveLWW applies Last-Write-Wins resolution for CardinalityOne.
-// Returns the single datom with the highest Lamport timestamp.
-func (it *CRDTResolvingIterator) resolveLWW() []*datalog.Datom {
-	var winner *datalog.Datom
-	for _, d := range it.groupBuffer {
-		if winner == nil || d.Tx.Lamport > winner.Tx.Lamport ||
-			(d.Tx.Lamport == winner.Tx.Lamport && d.Tx.ReplicaID > winner.Tx.ReplicaID) {
-			winner = d
-		}
-	}
-	if winner != nil {
-		return []*datalog.Datom{winner}
-	}
-	return nil
-}
-
-// resolveAddWins applies add-wins set resolution for CardinalityMany.
-// For each distinct value, compares highest add vs highest remove Lamport.
-// Value is in set if add >= remove (add wins on tie).
-func (it *CRDTResolvingIterator) resolveAddWins() []*datalog.Datom {
-	// Track highest add and remove Lamport per value
-	type valueState struct {
-		highestAdd    uint64
-		highestRemove uint64
-		hasAdd        bool
-		hasRemove     bool
-		addDatom      *datalog.Datom // Keep the datom for the winning add
-	}
-
-	valueStates := make(map[string]*valueState)
-
-	for _, d := range it.groupBuffer {
-		// Use value's string representation as key
-		vKey := valueKey(d.V)
-
-		state, exists := valueStates[vKey]
-		if !exists {
-			state = &valueState{}
-			valueStates[vKey] = state
-		}
-
-		if d.Op == datalog.OpCRDTAdd {
-			if !state.hasAdd || d.Tx.Lamport > state.highestAdd ||
-				(d.Tx.Lamport == state.highestAdd && d.Tx.ReplicaID > state.addDatom.Tx.ReplicaID) {
-				state.highestAdd = d.Tx.Lamport
-				state.hasAdd = true
-				state.addDatom = d
-			}
-		} else if d.Op == datalog.OpCRDTRemove {
-			if !state.hasRemove || d.Tx.Lamport > state.highestRemove {
-				state.highestRemove = d.Tx.Lamport
-				state.hasRemove = true
-			}
-		}
-	}
-
-	// Collect values where add wins
-	var result []*datalog.Datom
-	for _, state := range valueStates {
-		if !state.hasAdd {
-			continue // No add means not in set
-		}
-		if !state.hasRemove || state.highestAdd >= state.highestRemove {
-			// Add wins (add >= remove)
-			result = append(result, state.addDatom)
-		}
-	}
-
-	return result
-}
-
-// resolveRGA applies RGA resolution for CardinalityVector.
-// This is a simplified implementation that delegates to the existing resolver.
-func (it *CRDTResolvingIterator) resolveRGA() []*datalog.Datom {
-	// For RGA, we need the full vector reconstruction which is complex.
-	// The existing code in matcher_relations.go has dedicated methods for vectors.
-	// For now, return all datoms and let the vector-specific code handle it.
-	//
-	// TODO: Implement streaming RGA resolution here for consistency.
-	// The challenge is that RGA needs position information and parent tracking
-	// that isn't directly available from just the datom stream.
-	return it.groupBuffer
-}
-
-// copyDatom creates a deep copy of a datom since iterators may reuse buffers.
-func copyDatom(d *datalog.Datom) *datalog.Datom {
-	if d == nil {
-		return nil
-	}
-	return &datalog.Datom{
-		E:  d.E,
-		A:  d.A,
-		V:  d.V,
-		Tx: d.Tx,
-		Op: d.Op,
-	}
-}
-
-// valueKey converts a value to a string key for grouping in add-wins resolution.
-func valueKey(v any) string {
-	switch val := v.(type) {
-	case string:
-		return "s:" + val
-	case int64:
-		return fmt.Sprintf("i:%d", val)
-	case float64:
-		return fmt.Sprintf("f:%f", val)
-	case bool:
-		if val {
-			return "b:t"
-		}
-		return "b:f"
-	case datalog.Identity:
-		if val == nil {
-			return "id:nil"
-		}
-		hash := val.Hash()
-		return "id:" + string(hash[:])
-	case datalog.Keyword:
-		return "kw:" + val.String()
-	default:
-		return fmt.Sprintf("v:%v", v)
-	}
 }

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -79,6 +79,7 @@ type DatabaseOptions struct {
 	Schema            schema.SchemaProvider // Optional schema for validation
 	AnnotationHandler annotations.Handler   // Optional handler for query tracing
 	ReplicaID         uint64                // For CRDT mode: 0 = auto-generate random; non-zero = use specified. Ignored for existing DBs.
+	DisableCache      bool                  // Disable EA cache; queries resolve directly from storage
 }
 
 // NewDatabaseWithOptions creates a database with the specified options.
@@ -89,6 +90,7 @@ type DatabaseOptions struct {
 //   - UseTimeTx: Legacy option, kept for compatibility.
 //   - Schema: Optional schema for validation.
 //   - ReplicaID: For CRDT mode. 0 = auto-generate random; non-zero = use specified.
+//   - DisableCache: Disable EA cache; queries resolve directly from storage.
 //
 // Example:
 //
@@ -144,6 +146,11 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 		clock.Restore(maxElementID)
 	}
 
+	var cache *Cache
+	if !opts.DisableCache {
+		cache = NewCache()
+	}
+
 	return &Database{
 		store:             store,
 		activeTx:          make(map[*Transaction]bool),
@@ -153,7 +160,7 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 		annotationHandler: opts.AnnotationHandler,
 		clock:             clock,
 		replicaID:         replicaID,
-		cache:             NewCache(),
+		cache:             cache,
 	}, nil
 }
 
@@ -1729,7 +1736,7 @@ func (t *Transaction) Set(e datalog.Identity, a datalog.Keyword, v interface{}) 
 			}
 		}
 
-		// Get current vector from cache - O(1) if fresh
+		// Get current vector from cache (if enabled) or resolve directly
 		eBytes := e.Hash()
 		var aBytes Attribute
 		copy(aBytes[:], a.String())
@@ -1737,7 +1744,14 @@ func (t *Transaction) Set(e datalog.Identity, a datalog.Keyword, v interface{}) 
 
 		matcher := NewBadgerMatcher(t.db.store)
 		matcher.SetSchema(t.db.schema)
-		entry := t.db.cache.GetOrResolve(key, matcher)
+
+		var entry *CacheEntry
+		if t.db.cache != nil {
+			entry = t.db.cache.GetOrResolve(key, matcher)
+		} else {
+			// Cache disabled - resolve directly from storage
+			entry = ResolveEntry(key, matcher)
+		}
 
 		var oldList []any
 		var oldIndex []datalog.ElementID
@@ -1819,7 +1833,7 @@ func (t *Transaction) vectorContainsValue(e datalog.Identity, a datalog.Keyword,
 		}
 	}
 
-	// Check committed data via cache
+	// Check committed data via cache (if enabled) or direct resolution
 	eBytes := e.Hash()
 	var aBytes Attribute
 	copy(aBytes[:], a.String())
@@ -1827,7 +1841,13 @@ func (t *Transaction) vectorContainsValue(e datalog.Identity, a datalog.Keyword,
 
 	matcher := NewBadgerMatcher(t.db.store)
 	matcher.SetSchema(t.db.schema)
-	entry := t.db.cache.GetOrResolve(cacheKey, matcher)
+
+	var entry *CacheEntry
+	if t.db.cache != nil {
+		entry = t.db.cache.GetOrResolve(cacheKey, matcher)
+	} else {
+		entry = ResolveEntry(cacheKey, matcher)
+	}
 
 	if entry != nil && entry.Cardinality() == schema.CardinalityVector {
 		for _, existing := range entry.VectorList() {
@@ -1977,41 +1997,44 @@ func (t *Transaction) Commit() (uint64, error) {
 	}
 
 	// Update cache: track max versions and invalidate stale entries
-	touched := make([]CacheKey, 0, len(t.datoms)+len(t.retracts))
-	seenKeys := make(map[CacheKey]bool)
+	// Skip if cache is disabled
+	if t.db.cache != nil {
+		touched := make([]CacheKey, 0, len(t.datoms)+len(t.retracts))
+		seenKeys := make(map[CacheKey]bool)
 
-	// Process asserted datoms
-	for _, d := range t.datoms {
-		eBytes := Entity(d.E.Hash())
+		// Process asserted datoms
+		for _, d := range t.datoms {
+			eBytes := Entity(d.E.Hash())
 
-		var aBytes Attribute
-		copy(aBytes[:], d.A.String())
+			var aBytes Attribute
+			copy(aBytes[:], d.A.String())
 
-		key := CacheKey{E: eBytes, A: aBytes}
-		if !seenKeys[key] {
-			seenKeys[key] = true
-			touched = append(touched, key)
-			t.db.cache.UpdateMaxVersion(key, d.Tx)
+			key := CacheKey{E: eBytes, A: aBytes}
+			if !seenKeys[key] {
+				seenKeys[key] = true
+				touched = append(touched, key)
+				t.db.cache.UpdateMaxVersion(key, d.Tx)
+			}
 		}
-	}
 
-	// Process retracted datoms
-	for _, d := range t.retracts {
-		eBytes := Entity(d.E.Hash())
+		// Process retracted datoms
+		for _, d := range t.retracts {
+			eBytes := Entity(d.E.Hash())
 
-		var aBytes Attribute
-		copy(aBytes[:], d.A.String())
+			var aBytes Attribute
+			copy(aBytes[:], d.A.String())
 
-		key := CacheKey{E: eBytes, A: aBytes}
-		if !seenKeys[key] {
-			seenKeys[key] = true
-			touched = append(touched, key)
-			t.db.cache.UpdateMaxVersion(key, d.Tx)
+			key := CacheKey{E: eBytes, A: aBytes}
+			if !seenKeys[key] {
+				seenKeys[key] = true
+				touched = append(touched, key)
+				t.db.cache.UpdateMaxVersion(key, d.Tx)
+			}
 		}
-	}
 
-	// Invalidate cache entries for all touched (E, A) pairs
-	t.db.cache.Invalidate(touched)
+		// Invalidate cache entries for all touched (E, A) pairs
+		t.db.cache.Invalidate(touched)
+	}
 
 	// Clean up
 	t.closed = true

--- a/datalog/storage/datom_decoder_test.go
+++ b/datalog/storage/datom_decoder_test.go
@@ -172,3 +172,150 @@ func TestIteratorDatomStability(t *testing.T) {
 	// Verify we got the expected number of results
 	t.Logf("Iterated %d datoms with values: %v", len(values), values)
 }
+
+// TestBadgerIteratorKeyBufferReuse verifies that the key buffer reuse optimization
+// in BadgerIterator.Datom() produces correct results. This tests the fix for the
+// ~2.6% regression in SimpleQuery caused by KeyCopy(nil) allocating on each call.
+func TestBadgerIteratorKeyBufferReuse(t *testing.T) {
+	db, err := NewDatabase(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Add test data with distinct values
+	tx := db.NewTransaction()
+	entities := make([]datalog.Identity, 5)
+	for i := 0; i < 5; i++ {
+		entities[i] = datalog.NewIdentity(fmt.Sprintf("entity-%d", i))
+		tx.Add(entities[i], datalog.NewKeyword(":test/value"), int64(i*100))
+		tx.Add(entities[i], datalog.NewKeyword(":test/name"), fmt.Sprintf("name-%d", i))
+	}
+	_, err = tx.Commit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("DatomValuesAreCorrectAcrossIteration", func(t *testing.T) {
+		it, err := db.Store().ScanKeysOnly(EAVT, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer it.Close()
+
+		// Collect all datoms and their values
+		type datomRecord struct {
+			E datalog.Identity
+			A datalog.Keyword
+			V interface{}
+		}
+		var records []datomRecord
+
+		for it.Next() {
+			d, err := it.Datom()
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Store copies of the values (not pointers to shared state)
+			records = append(records, datomRecord{E: d.E, A: d.A, V: d.V})
+		}
+
+		// Verify we got at least the expected number of datoms (5 entities * 2 attributes = 10)
+		// May have additional schema/metadata datoms
+		if len(records) < 10 {
+			t.Fatalf("Expected at least 10 datoms, got %d", len(records))
+		}
+
+		// Verify each record has valid, non-zero values
+		for i, r := range records {
+			if r.E == nil {
+				t.Errorf("Record %d: entity is nil", i)
+			}
+			if r.A == nil {
+				t.Errorf("Record %d: attribute is nil", i)
+			}
+			if r.V == nil {
+				t.Errorf("Record %d: value is nil", i)
+			}
+		}
+
+		// Verify that different datoms have different values (no corruption from buffer reuse)
+		valueSet := make(map[string]bool)
+		for _, r := range records {
+			key := fmt.Sprintf("%s|%s|%v", r.E.L85(), r.A.String(), r.V)
+			if valueSet[key] {
+				t.Errorf("Duplicate datom found: %s (indicates buffer reuse corruption)", key)
+			}
+			valueSet[key] = true
+		}
+	})
+
+	t.Run("WorkspaceReuseIsDocumented", func(t *testing.T) {
+		// KeyOnlyIterator uses workspace reuse (currentDatom field).
+		// This means Datom() returns a pointer to the SAME memory each time.
+		// Callers must copy values if they need them after calling Next().
+		it, err := db.Store().ScanKeysOnly(EAVT, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer it.Close()
+
+		// Collect datom pointers
+		var addresses []*datalog.Datom
+
+		for it.Next() {
+			d, err := it.Datom()
+			if err != nil {
+				t.Fatal(err)
+			}
+			addresses = append(addresses, d)
+		}
+
+		if len(addresses) < 2 {
+			t.Fatalf("Expected at least 2 datoms, got %d", len(addresses))
+		}
+
+		// With workspace reuse, all pointers should be the SAME address
+		allSame := true
+		for i := 1; i < len(addresses); i++ {
+			if addresses[i] != addresses[0] {
+				allSame = false
+				break
+			}
+		}
+
+		if !allSame {
+			t.Errorf("Expected workspace reuse (all same address), but got different addresses")
+		} else {
+			t.Logf("Confirmed: KeyOnlyIterator uses workspace reuse (%d calls, same address)", len(addresses))
+		}
+	})
+
+	t.Run("MultipleDatomCallsAtSamePosition", func(t *testing.T) {
+		it, err := db.Store().ScanKeysOnly(EAVT, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer it.Close()
+
+		if !it.Next() {
+			t.Fatal("Expected at least one datom")
+		}
+
+		// Call Datom() multiple times at the same position
+		d1, _ := it.Datom()
+		d2, _ := it.Datom()
+		d3, _ := it.Datom()
+
+		// All should return the same values
+		if !d1.E.Equal(d2.E) || !d2.E.Equal(d3.E) {
+			t.Errorf("Entity differs across Datom() calls: %v, %v, %v", d1.E, d2.E, d3.E)
+		}
+		if d1.A.String() != d2.A.String() || d2.A.String() != d3.A.String() {
+			t.Errorf("Attribute differs across Datom() calls: %v, %v, %v", d1.A, d2.A, d3.A)
+		}
+		if d1.V != d2.V || d2.V != d3.V {
+			t.Errorf("Value differs across Datom() calls: %v, %v, %v", d1.V, d2.V, d3.V)
+		}
+	})
+}

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -178,9 +178,9 @@ func (m *BadgerMatcher) matchWithHashJoin(
 	var boundValue interface{}
 	if len(hashSet) == 1 {
 		// Extract the single bound value from the hash set
-		for _, tuple := range hashSet {
-			if columnIndex < len(tuple) {
-				boundValue = tuple[columnIndex]
+		for _, tuples := range hashSet {
+			if len(tuples) > 0 && columnIndex < len(tuples[0]) {
+				boundValue = tuples[0][columnIndex]
 			}
 			break
 		}
@@ -310,7 +310,7 @@ func (m *BadgerMatcher) chooseIndexForValues(index IndexType, e, a, v, tx interf
 			}
 		}
 
-	case AEVT: // 1
+	case AEVT: // 2
 		if a != nil {
 			if kw, ok := a.(datalog.Keyword); ok {
 				var attr Attribute
@@ -328,7 +328,26 @@ func (m *BadgerMatcher) chooseIndexForValues(index IndexType, e, a, v, tx interf
 			}
 		}
 
-	case AVET: // 2
+	case AETV: // 3 - A-primary CRDT index (A → E → Tx↓ → V)
+		// Same prefix structure as AEVT: A first, then E
+		if a != nil {
+			if kw, ok := a.(datalog.Keyword); ok {
+				var attr Attribute
+				copy(attr[:], kw.String())
+				startParts = append(startParts, attr[:])
+				endParts = append(endParts, attr[:])
+
+				if e != nil {
+					if entity, ok := e.(datalog.Identity); ok {
+						hash := entity.Hash()
+						startParts = append(startParts, hash[:])
+						endParts = append(endParts, hash[:])
+					}
+				}
+			}
+		}
+
+	case AVET: // 4
 		if a != nil {
 			if kw, ok := a.(datalog.Keyword); ok {
 				var attr Attribute
@@ -382,19 +401,17 @@ func (m *BadgerMatcher) chooseIndexForValues(index IndexType, e, a, v, tx interf
 	}
 
 	start := encoder.EncodePrefix(index, startParts...)
-	end := encoder.EncodePrefix(index, endParts...)
-
-	// Extend end key to include all suffixes
-	if len(end) > 0 {
-		end = append(end, 0xFF, 0xFF, 0xFF, 0xFF)
-	}
+	// Use incrementLastByte for proper prefix range scan
+	// This creates an exclusive upper bound that includes all suffixes
+	end := incrementLastByte(start)
 
 	return index, start, end
 }
 
 // buildHashSet creates a hash set from binding relation for O(1) lookup
-func (m *BadgerMatcher) buildHashSet(bindingRel executor.Relation, position int) map[string]executor.Tuple {
-	hashSet := make(map[string]executor.Tuple)
+// Returns map from key to ALL tuples with that key value (supporting multi-column bindings)
+func (m *BadgerMatcher) buildHashSet(bindingRel executor.Relation, position int) map[string][]executor.Tuple {
+	hashSet := make(map[string][]executor.Tuple)
 
 	iter := bindingRel.Iterator()
 	for iter.Next() {
@@ -408,7 +425,9 @@ func (m *BadgerMatcher) buildHashSet(bindingRel executor.Relation, position int)
 		key := valueToHashKey(value)
 
 		if key != "" {
-			hashSet[key] = tuple
+			// No copy needed: binding relations are materialized (materializeRelationsForPattern)
+			// and sliceIterator returns distinct slice references without reusing storage
+			hashSet[key] = append(hashSet[key], tuple)
 		}
 	}
 	iter.Close()
@@ -695,8 +714,8 @@ type hashJoinIterator struct {
 	position      int
 	index         IndexType
 	constraints   []executor.StorageConstraint
-	hashSet       map[string]executor.Tuple // Built upfront
-	iter          Iterator                  // Storage iterator
+	hashSet       map[string][]executor.Tuple // Built upfront - maps key to ALL matching tuples
+	iter          Iterator                    // Storage iterator
 	tupleBuilder  *query.InternedTupleBuilder
 	current       executor.Tuple
 	workspace     executor.Tuple // Reusable workspace for tuple building
@@ -724,23 +743,27 @@ func (it *hashJoinIterator) Next() bool {
 		probeKeyStr := valueToHashKey(probeKey)
 
 		// Probe hash set (O(1) lookup)
-		if bindingTuple, found := it.hashSet[probeKeyStr]; found {
-			// Verify full pattern match
-			if it.matcher.matchesWithBindingTuple(datom, it.pattern, it.bindingRel, bindingTuple) {
-				// Apply storage constraints
-				satisfiesAll := true
-				for _, constraint := range it.constraints {
-					if !constraint.Evaluate(datom) {
-						satisfiesAll = false
-						break
+		if bindingTuples, found := it.hashSet[probeKeyStr]; found {
+			// Check against ALL binding tuples with this key
+			// (for multi-column bindings, there may be multiple tuples per key)
+			for _, bindingTuple := range bindingTuples {
+				// Verify full pattern match
+				if it.matcher.matchesWithBindingTuple(datom, it.pattern, it.bindingRel, bindingTuple) {
+					// Apply storage constraints
+					satisfiesAll := true
+					for _, constraint := range it.constraints {
+						if !constraint.Evaluate(datom) {
+							satisfiesAll = false
+							break
+						}
 					}
-				}
 
-				if satisfiesAll {
-					it.tupleBuilder.BuildTupleInternedInto(datom, it.workspace)
-					it.current = it.workspace
-					it.matchesFound++
-					return true
+					if satisfiesAll {
+						it.tupleBuilder.BuildTupleInternedInto(datom, it.workspace)
+						it.current = it.workspace
+						it.matchesFound++
+						return true
+					}
 				}
 			}
 		}

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -193,6 +193,14 @@ func (m *BadgerMatcher) matchWithHashJoin(
 		return nil, fmt.Errorf("hash join scan failed: %w", err)
 	}
 
+	// PHASE 3.5: Wrap with CRDT resolution
+	// This ensures we only see CRDT-resolved current values, not all historical values.
+	// The resolution is per (E, A) group based on schema cardinality.
+	var resolvedIter Iterator = storageIter
+	if m.schema != nil {
+		resolvedIter = NewCRDTResolvingIterator(storageIter, m.schema, m.txID)
+	}
+
 	// PHASE 4: Create streaming hash join iterator
 	iter := &hashJoinIterator{
 		matcher:      m,
@@ -203,7 +211,7 @@ func (m *BadgerMatcher) matchWithHashJoin(
 		index:        index,
 		constraints:  constraints,
 		hashSet:      hashSet,
-		iter:         storageIter,
+		iter:         resolvedIter,
 		workspace:    make(executor.Tuple, len(columns)),
 		tupleBuilder: m.getTupleBuilder(pattern, columns),
 	}
@@ -539,6 +547,12 @@ func (m *BadgerMatcher) matchWithMergeJoin(
 		return nil, fmt.Errorf("merge join scan failed: %w", err)
 	}
 
+	// PHASE 3.5: Wrap with CRDT resolution
+	var resolvedIterMerge Iterator = storageIter
+	if m.schema != nil {
+		resolvedIterMerge = NewCRDTResolvingIterator(storageIter, m.schema, m.txID)
+	}
+
 	// PHASE 4: Create streaming merge join iterator
 	iter := &mergeJoinIterator{
 		matcher:      m,
@@ -550,7 +564,7 @@ func (m *BadgerMatcher) matchWithMergeJoin(
 		constraints:  constraints,
 		sortedTuples: sortedTuples,
 		bindingIdx:   0,
-		iter:         storageIter,
+		iter:         resolvedIterMerge,
 		workspace:    make(executor.Tuple, len(columns)),
 		tupleBuilder: m.getTupleBuilder(pattern, columns),
 	}

--- a/datalog/storage/key_encoder_binary.go
+++ b/datalog/storage/key_encoder_binary.go
@@ -38,8 +38,9 @@ func txFromDescending(encoded []byte) [16]byte {
 // Key formats (Bug #5 fix: Tx before Op, AfterRef at end for RGA ops):
 //
 //	EAVT: [prefix][E][A][type][value][Tx↓][Op][AfterRef?]  - groups by value for add-wins
-//	EATV: [prefix][E][A][Tx↓][type][value][Op][AfterRef?]  - first entry is current
-//	AEVT: [prefix][A][E][type][value][Tx↓][Op][AfterRef?]  - by attribute
+//	EATV: [prefix][E][A][Tx↓][type][value][Op][AfterRef?]  - first entry is current (E-primary CRDT)
+//	AEVT: [prefix][A][E][type][value][Tx↓][Op][AfterRef?]  - by attribute (V before Tx)
+//	AETV: [prefix][A][E][Tx↓][type][value][Op][AfterRef?]  - first entry is current (A-primary CRDT)
 //	AVET: [prefix][A][type][value][E][Tx↓][Op][AfterRef?]  - value lookup
 //	VAET: [prefix][type][value][A][E][Tx↓][Op][AfterRef?]  - reverse refs
 //	TAEV: [prefix][Tx↓][A][E][type][value][Op][AfterRef?]  - transaction log
@@ -90,6 +91,14 @@ func (e *BinaryKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 			key = append(key, afterRefDesc[:]...)
 		}
 		return key
+	case AETV:
+		// [A][E][Tx][V][Op][AfterRef?] - A-primary CRDT: first entry is current (Tx descending)
+		key := concatBytes(prefix, sd.A[:], sd.E[:], txDesc[:], vBytes, opByte)
+		if sd.Op.HasAfterRef() {
+			afterRefDesc := txToDescending(sd.AfterRef)
+			key = append(key, afterRefDesc[:]...)
+		}
+		return key
 	case AVET:
 		// [A][V][E][Tx][Op][AfterRef?] - Bug #5 fix: Tx before Op, enables [A][V] prefix scans
 		key := concatBytes(prefix, sd.A[:], vBytes, sd.E[:], txDesc[:], opByte)
@@ -131,6 +140,7 @@ func (e *BinaryKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 //	EAVT: [prefix][E][A][type][value][Tx↓][Op][AfterRef?]
 //	EATV: [prefix][E][A][Tx↓][type][value][Op][AfterRef?]
 //	AEVT: [prefix][A][E][type][value][Tx↓][Op][AfterRef?]
+//	AETV: [prefix][A][E][Tx↓][type][value][Op][AfterRef?]
 //	AVET: [prefix][A][type][value][E][Tx↓][Op][AfterRef?]
 //	VAET: [prefix][type][value][A][E][Tx↓][Op][AfterRef?]
 //	TAEV: [prefix][Tx↓][A][E][type][value][Op][AfterRef?]
@@ -232,6 +242,33 @@ func (e *BinaryKeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]by
 			vEnd := len(key) - opSize - txSize
 			value = key[attrSize+entitySize : vEnd]
 			tx = txFromDescending(key[vEnd : vEnd+txSize])
+		}
+
+	case AETV:
+		// [A][E][Tx][V][Op][AfterRef?] - A-primary CRDT: first entry is current (Tx descending)
+		minSize := attrSize + entitySize + txSize + opSize
+		if len(key) < minSize {
+			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("AETV key too short")
+		}
+		copy(attr[:], key[0:attrSize])
+		copy(entity[:], key[attrSize:attrSize+entitySize])
+		tx = txFromDescending(key[attrSize+entitySize : attrSize+entitySize+txSize])
+		// Check if AfterRef is present
+		hasAfterRef := len(key) >= minSize+afterRefSize
+		if hasAfterRef {
+			op = key[len(key)-afterRefSize-opSize]
+			if datalog.CRDTOp(op).HasAfterRef() {
+				vStart := attrSize + entitySize + txSize
+				value = key[vStart : len(key)-afterRefSize-opSize]
+				afterRef = txFromDescending(key[len(key)-afterRefSize:])
+			} else {
+				hasAfterRef = false
+			}
+		}
+		if !hasAfterRef {
+			vStart := attrSize + entitySize + txSize
+			value = key[vStart : len(key)-opSize]
+			op = key[len(key)-opSize]
 		}
 
 	case AVET:

--- a/datalog/storage/key_encoder_l85.go
+++ b/datalog/storage/key_encoder_l85.go
@@ -46,6 +46,9 @@ func (e *L85KeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 	case AEVT:
 		// [A][E][V][Op][Tx]
 		return concatBytes(prefix, []byte(aL85), []byte(eL85), vBytes, opByte, []byte(txL85))
+	case AETV:
+		// [A][E][Tx][V][Op] - A-primary CRDT: first entry is current (Tx descending)
+		return concatBytes(prefix, []byte(aL85), []byte(eL85), []byte(txL85), vBytes, opByte)
 	case AVET:
 		// [A][V][E][Op][Tx] - Op before Tx for add-wins, enables [A][V] prefix scans
 		return concatBytes(prefix, []byte(aL85), vBytes, []byte(eL85), opByte, []byte(txL85))
@@ -70,6 +73,7 @@ func (e *L85KeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 //	EAVT: [prefix][E][A][V][Tx][Op][AfterRef?]
 //	EATV: [prefix][E][A][Tx][V][Op][AfterRef?]
 //	AEVT: [prefix][A][E][V][Tx][Op][AfterRef?]
+//	AETV: [prefix][A][E][Tx][V][Op][AfterRef?]
 //	AVET: [prefix][A][V][E][Tx][Op][AfterRef?]
 //	VAET: [prefix][V][A][E][Tx][Op][AfterRef?]
 //	TAEV: [prefix][Tx][A][E][V][Op][AfterRef?]
@@ -155,6 +159,29 @@ func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte,
 		}
 		op = key[vEnd]
 		tx, _ = codec.DecodeFixed16(string(key[len(key)-l85Size16:]))
+
+	case AETV:
+		// [A][E][Tx][V][Op] - A-primary CRDT: first entry is current (Tx descending)
+		minSize := l85SizeAttr + l85Size20 + l85Size16 + opSize
+		if len(key) < minSize {
+			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("AETV key too short")
+		}
+		attr, _ = codec.DecodeFixed32(string(key[0:l85SizeAttr]))
+		entity, _ = codec.DecodeFixed20(string(key[l85SizeAttr : l85SizeAttr+l85Size20]))
+		tx, _ = codec.DecodeFixed16(string(key[l85SizeAttr+l85Size20 : l85SizeAttr+l85Size20+l85Size16]))
+		// V is between Tx and Op
+		vStart := l85SizeAttr + l85Size20 + l85Size16
+		valueBytes := key[vStart : len(key)-opSize]
+		if len(valueBytes) == l85Size20 {
+			if decoded, decErr := codec.DecodeFixed20(string(valueBytes)); decErr == nil {
+				value = decoded[:]
+			} else {
+				value = valueBytes
+			}
+		} else {
+			value = valueBytes
+		}
+		op = key[len(key)-opSize]
 
 	case AVET:
 		// [A][V][E][Op][Tx] - Op before Tx

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -610,9 +610,24 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 				return AVET, start, end
 			}
 
-			// Only A bound - use AEVT index
-			start, end := encoder.EncodePrefixRange(AEVT, aStorage[:])
-			return AEVT, start, end
+			// Only A bound - use cardinality-aware index selection
+			// For CRDT semantics:
+			// - CardinalityMany: AEVT groups by V for add-wins resolution
+			// - CardinalityOne/Vector: AETV orders by Tx first, first entry is current
+			card := schema.CardinalityOne
+			if m.schema != nil {
+				if attrDef := m.schema.GetAttribute(aPtr); attrDef != nil {
+					card = attrDef.Cardinality
+				}
+			}
+			if card == schema.CardinalityMany {
+				// AEVT: A → E → V → Tx - values grouped together for add-wins
+				start, end := encoder.EncodePrefixRange(AEVT, aStorage[:])
+				return AEVT, start, end
+			}
+			// AETV: A → E → Tx → V - first entry is current (highest Tx)
+			start, end := encoder.EncodePrefixRange(AETV, aStorage[:])
+			return AETV, start, end
 		}
 	} else if v != nil {
 		// Only V bound - use VAET index
@@ -746,6 +761,8 @@ func indexName(idx IndexType) string {
 		return "EATV"
 	case AEVT:
 		return "AEVT"
+	case AETV:
+		return "AETV"
 	case AVET:
 		return "AVET"
 	case VAET:

--- a/datalog/storage/matcher_iterator_nonreusing.go
+++ b/datalog/storage/matcher_iterator_nonreusing.go
@@ -71,10 +71,16 @@ func (it *nonReusingIterator) Next() bool {
 	// Choose index and create scan
 	index, start, end := it.matcher.chooseIndex(e, a, v, tx)
 
-	var err error
-	it.currentScan, err = it.matcher.store.ScanKeysOnly(index, start, end)
+	rawIter, err := it.matcher.store.ScanKeysOnly(index, start, end)
 	if err != nil {
 		return false
+	}
+
+	// Wrap with CRDT resolution to ensure we only see resolved values
+	if it.matcher.schema != nil {
+		it.currentScan = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
+	} else {
+		it.currentScan = rawIter
 	}
 
 	// Try to find first match

--- a/datalog/storage/matcher_iterator_reusing.go
+++ b/datalog/storage/matcher_iterator_reusing.go
@@ -64,9 +64,16 @@ func (it *reusingIterator) Next() bool {
 		endKey = append(endKey, 0xFF, 0xFF, 0xFF, 0xFF)
 
 		var err error
-		it.storageIter, err = it.matcher.store.ScanKeysOnly(it.index, startKey, endKey)
+		rawIter, err := it.matcher.store.ScanKeysOnly(it.index, startKey, endKey)
 		if err != nil {
 			return false
+		}
+
+		// Wrap with CRDT resolution to ensure we only see resolved values
+		if it.matcher.schema != nil {
+			it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
+		} else {
+			it.storageIter = rawIter
 		}
 
 		// Reset to first tuple for actual processing

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -341,11 +341,18 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 		}
 
 		// Initialize the key mask iterator using the optimized method
-		storageIter, err := m.store.ScanKeysOnlyWithMask(index, start, end, keyMask)
+		rawStorageIter, err := m.store.ScanKeysOnlyWithMask(index, start, end, keyMask)
 		if err != nil {
 			return nil, fmt.Errorf("key mask scan failed: %w", err)
 		}
-		maskIter.storageIter = storageIter
+
+		// Wrap with CRDT resolution when E is unbound but A is bound
+		// This ensures per-(E, A) group resolution even for patterns like [?e :attr ?v]
+		if m.schema != nil && e == nil && a != nil {
+			maskIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
+		} else {
+			maskIter.storageIter = rawStorageIter
+		}
 		iter = maskIter
 	} else {
 		// Use regular iterator
@@ -367,11 +374,18 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 		}
 
 		// Initialize the storage iterator using key-only scanning
-		storageIter, err := m.store.ScanKeysOnly(index, start, end)
+		rawStorageIter, err := m.store.ScanKeysOnly(index, start, end)
 		if err != nil {
 			return nil, fmt.Errorf("scan failed: %w", err)
 		}
-		regularIter.storageIter = storageIter
+
+		// Wrap with CRDT resolution when E is unbound but A is bound
+		// This ensures per-(E, A) group resolution even for patterns like [?e :attr ?v]
+		if m.schema != nil && e == nil && a != nil {
+			regularIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
+		} else {
+			regularIter.storageIter = rawStorageIter
+		}
 		iter = regularIter
 	}
 

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -346,9 +346,9 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			return nil, fmt.Errorf("key mask scan failed: %w", err)
 		}
 
-		// Wrap with CRDT resolution when E is unbound but A is bound
-		// This ensures per-(E, A) group resolution even for patterns like [?e :attr ?v]
-		if m.schema != nil && e == nil && a != nil {
+		// Wrap with CRDT resolution when schema exists
+		// This ensures per-(E, A) group resolution regardless of bound/unbound status
+		if m.schema != nil {
 			maskIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
 		} else {
 			maskIter.storageIter = rawStorageIter

--- a/datalog/storage/matcher_strategy.go
+++ b/datalog/storage/matcher_strategy.go
@@ -105,19 +105,20 @@ func analyzeReuseStrategy(pattern *query.DataPattern, bindingRel executor.Relati
 		case 0: // E is bound
 			// Check if A is also constant (not in binding set)
 			if _, isConstant := pattern.GetA().(query.Constant); isConstant {
-				// E is bound, A is constant → use AEVT for direct lookups
+				// E is bound, A is constant → use AETV for CRDT-aware lookups
 				// Pattern like [?e :attr/name ?v] where ?e is bound to many values
-				// AEVT allows: seek to (:attr/name, entity1), seek to (:attr/name, entity2), etc.
-				indexType = AEVT // direct lookup by (A, E) pair
+				// AETV has Tx descending: first entry for each (A, E) is LWW winner
+				// AETV allows: seek to (:attr/name, entity1), seek to (:attr/name, entity2), etc.
+				indexType = AETV // direct lookup by (A, E) pair with Tx descending
 				canReuse = true  // Try iterator reuse with Seek() between entities
 			} else {
-				// E is bound, A varies → use EAVT
-				indexType = EAVT // E is primary sort key
+				// E is bound, A varies → use EATV (E-primary with Tx descending)
+				indexType = EATV // E is primary sort key, Tx descending for CRDT
 				canReuse = true
 			}
 
 		case 1: // A is bound
-			indexType = AEVT // A is primary sort key ✓
+			indexType = AETV // A is primary sort key, Tx descending for CRDT
 			canReuse = true
 
 		case 2: // V is bound
@@ -278,15 +279,15 @@ func chooseBestMultiPositionStrategy(
 	// Determine index based on best position for reuse
 	var indexType IndexType
 	switch bestPosition {
-	case 0: // E has most distinct values - use AEVT or EAVT
+	case 0: // E has most distinct values - use AETV or EATV
 		// Check if A is constant
 		if _, isConstant := pattern.GetA().(query.Constant); isConstant {
-			indexType = AEVT // A is constant, seek by E
+			indexType = AETV // A is constant, seek by E (Tx descending for CRDT)
 		} else {
-			indexType = EAVT // seek by E
+			indexType = EATV // seek by E (Tx descending for CRDT)
 		}
-	case 1: // A has most distinct values - use AEVT
-		indexType = AEVT
+	case 1: // A has most distinct values - use AETV (Tx descending for CRDT)
+		indexType = AETV
 	case 2: // V has most distinct values - use AVET or VAET
 		if _, isConstant := pattern.GetA().(query.Constant); isConstant {
 			indexType = AVET // A is constant, seek by V

--- a/datalog/storage/simple_batch_scanner.go
+++ b/datalog/storage/simple_batch_scanner.go
@@ -66,9 +66,15 @@ func (s *simpleBatchScanner) Scan() error {
 	}
 
 	// Step 3: Open a single scan for the entire range using key-only scanning
-	iter, err := s.matcher.store.ScanKeysOnly(s.index, startKey, endKey)
+	rawIter, err := s.matcher.store.ScanKeysOnly(s.index, startKey, endKey)
 	if err != nil {
 		return fmt.Errorf("failed to open scan: %w", err)
+	}
+
+	// Wrap with CRDT resolution to ensure we only see resolved values
+	var iter Iterator = rawIter
+	if s.matcher.schema != nil {
+		iter = NewCRDTResolvingIterator(rawIter, s.matcher.schema, s.matcher.txID)
 	}
 	defer iter.Close()
 

--- a/datalog/storage/store.go
+++ b/datalog/storage/store.go
@@ -11,13 +11,15 @@ const (
 	EAVT IndexType = iota // Entity-Attribute-Value-Tx (for cardinality-many: group by V)
 	EATV                  // Entity-Attribute-Tx-Value (for cardinality-one: first = current)
 	AEVT                  // Attribute-Entity-Value-Tx
+	AETV                  // Attribute-Entity-Tx-Value (for A-primary CRDT: first = current)
 	AVET                  // Attribute-Value-Entity-Tx
 	VAET                  // Value-Attribute-Entity-Tx
 	TAEV                  // Tx-Attribute-Entity-Value (for clock recovery, audit log)
 )
 
-// Indices lists all indices used for queries (6 indices for CRDT support)
-var Indices = []IndexType{EAVT, EATV, AEVT, AVET, VAET, TAEV}
+// Indices lists all indices used for queries
+// Note: AETV added for A-primary CRDT resolution. EAVT kept temporarily for migration.
+var Indices = []IndexType{EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV}
 
 // Store is the interface for datom storage
 type Store interface {

--- a/docs/INDEXING_TLDR.md
+++ b/docs/INDEXING_TLDR.md
@@ -18,19 +18,23 @@ You want to query these efficiently:
 
 **Problem**: Different queries need different orderings. There's no single sort that's optimal for everything.
 
-**Solution**: Store the same data sorted 5 different ways. Pick the best one per query.
+**Solution**: Store the same data sorted 7 different ways. Pick the best one per query.
 
 ---
 
-## The 5 Indices (Think: 5 Different Acceleration Structures)
+## The 7 Indices (Think: 7 Different Acceleration Structures)
 
 | Index | Sort Order | Game Engine Analogy |
 |-------|------------|---------------------|
 | **EAVT** | Entity → Attr → Val → Tx | Octree: "Give me everything in this spatial cell" |
+| **EATV** | Entity → Attr → Tx↓ → Val | LWW lookup: "Get current value" (E-primary CRDT) |
 | **AEVT** | Attr → Entity → Val → Tx | Component array: "Give me all Health components" |
+| **AETV** | Attr → Entity → Tx↓ → Val | LWW lookup: "Get current value" (A-primary CRDT) |
 | **AVET** | Attr → Val → Entity → Tx | Inverted index: "Find all entities with Health=100" |
 | **VAET** | Val → Attr → Entity → Tx | Reverse refs: "Who's referencing this entity?" |
 | **TAEV** | Tx → Attr → Entity → Val | Timeline: "What changed this frame/tick?" |
+
+**EATV/AETV note**: These indices store Tx with bitwise NOT for descending order, so the first entry is always the newest (LWW winner). They enable O(1) current-value lookup for CRDT resolution.
 
 **Key insight**: This is like having both an octree AND a BVH AND a grid AND a kd-tree. Each structure is optimal for certain queries. You don't traverse all of them—you pick the right one.
 
@@ -120,7 +124,7 @@ Pattern `[?e :assigned-to weapon_7]`:
 
 | Optimization | Game Equivalent |
 |--------------|-----------------|
-| 5 pre-sorted indices | Multiple acceleration structures |
+| 7 pre-sorted indices | Multiple acceleration structures |
 | Fixed 72-byte keys | Fixed stride vertex buffers |
 | L85 sort-preserving encoding | Normalized coords that compare correctly |
 | Prefix range scans | Frustum culling on sorted data |

--- a/docs/bugs/BUG_COLLECTION_INPUT_UNPACKING.md
+++ b/docs/bugs/BUG_COLLECTION_INPUT_UNPACKING.md
@@ -1,0 +1,116 @@
+# Bug: CollectionInput Not Unpacked Into Multiple Tuples
+
+**Status**: Fixed
+**Discovered**: 2026-02-05
+**Fixed**: 2026-02-05
+
+## Symptoms
+
+Two related issues with collection inputs:
+
+### 1. Two Collection Inputs Don't Cross-Product
+
+Query with two separate collection inputs `[?e ...] [?a ...]` where both are pattern variables returns incomplete results:
+
+```clojure
+[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]
+```
+
+With 2 entities and 2 attributes, expected 4 results but only got 2 (only `:person/age` datoms).
+
+### 2. Empty Collection Returns Results
+
+```go
+db.ExecuteQueryWithInputs(query, []datalog.Identity{})  // empty collection
+```
+
+Expected: 0 results (nothing matches empty set)
+Actual: Returns all matching data (collection constraint ignored)
+
+## Root Causes
+
+The bug had three contributing factors in different layers:
+
+### 1. Subquery Path: Slice Not Unpacked (executor/subquery.go)
+
+The `CollectionInput` handling in `createInputRelationsFromValuesWithOptions` wrapped the entire input slice in a single tuple:
+
+```go
+case query.CollectionInput:
+    rel := NewMaterializedRelationWithOptions(
+        []query.Symbol{inp.Symbol},
+        []Tuple{{orderedValues[valueIndex]}},  // BUG: entire slice = one tuple
+        opts,
+    )
+```
+
+**Fix**: Use reflection to detect and unpack slices into individual tuples.
+
+### 2. Empty Collection Skipped (executor/executor_utils.go)
+
+In `BindQueryInputs`, empty collections were skipped entirely:
+
+```go
+case query.CollectionInput:
+    if relationIndex < len(inputRelations) {
+        rel := inputRelations[relationIndex]
+        if rel.Size() > 0 {  // BUG: empty collections skipped
+            // ...add to boundRelations
+        }
+    }
+```
+
+This meant empty collection constraints were lost - the join would proceed without the empty relation, returning all data instead of none.
+
+**Fix**: Always add collection relations to `boundRelations`, even when empty. Joining with an empty relation produces 0 results.
+
+### 3. Hash Set Overwriting Tuples (storage/hash_join_matcher.go)
+
+The hash join matcher's `buildHashSet` overwrote entries with the same key:
+
+```go
+hashSet[key] = tuple  // BUG: overwrites previous tuples with same key
+```
+
+For bindings like:
+- (person-1, :person/name)
+- (person-1, :person/age)
+- (person-2, :person/name)
+- (person-2, :person/age)
+
+When building hash set keyed by E (position 0):
+- `hashSet["person-1"] = (person-1, :person/age)` ← overwrites :person/name
+- `hashSet["person-2"] = (person-2, :person/age)` ← overwrites :person/name
+
+Only `:person/age` tuples survive! The hash join then only matches `:person/age` datoms.
+
+**Fix**: Change hash set to store ALL tuples per key: `map[string][]executor.Tuple`. Update iterator to check against all tuples in the list.
+
+## Test Coverage
+
+All tests now pass:
+
+- `TestCollectionInput_SingleCollection` - single `[?e ...]` works
+- `TestCollectionInput_SingleElement` - collection with 1 element works
+- `TestCollectionInput_EmptyCollection` - empty collection returns 0 results ✓
+- `TestCollectionInput_TwoCollections` - two variable collections produce cross-product ✓
+- `TestCollectionInput_ThreeCollections` - works
+- `TestCollectionInput_ScalarPlusCollection` - `?a [?e ...]` works
+- `TestCollectionInput_CollectionPlusScalar` - `[?e ...] ?a` works
+- `TestCollectionInput_KeywordCollection` - keyword values work
+- `TestCollectionInput_IntCollection` - int values work
+- `TestCollectionInput_StringCollection` - string values work
+- `TestBindQueryInputs_TwoCollectionsCrossProduct` - verifies cross-product logic
+- `TestBindQueryInputs_EmptyCollectionReturnsEmpty` - verifies empty handling
+
+## Files Changed
+
+1. `executor/subquery.go` - Added reflection to unpack slices in CollectionInput
+2. `executor/executor_utils.go` - Always add collection relations to boundRelations
+3. `storage/hash_join_matcher.go` - Changed hash set from `map[string]Tuple` to `map[string][]Tuple`
+4. `executor/bind_query_inputs_test.go` - New tests for BindQueryInputs
+5. `storage/collection_input_test.go` - Comprehensive collection input tests
+
+## Notes
+
+This bug was discovered while implementing AETV index. The investigation revealed it was a pre-existing executor bug exposed by new test coverage. The fix required changes across three files in two packages.

--- a/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
+++ b/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
@@ -1,0 +1,1153 @@
+# CRDT Query Resolution Not Applied to ExecuteQuery
+
+**Date**: 2026-02-05
+**Severity**: Critical
+**Status**: Open
+**Affected**: All query methods except Pull API
+
+## Executive Summary
+
+ExecuteQuery, ExecuteQueryWithInputs, and related query methods return **all historical values** instead of CRDT-resolved current values. A CardinalityOne attribute that was updated 4 times returns 4 results instead of 1. This is a fundamental failure of the CRDT storage implementation to integrate with the query execution path.
+
+**Impact**: Any application using `ExecuteQueryWithInputs` with attribute as an input parameter will see all historical values instead of the CRDT-resolved current value.
+
+## The Bug
+
+### Symptom
+
+```go
+// Write 4 values to a CardinalityOne attribute
+names := []string{"Alice", "Bob", "Charlie", "Diana"}
+for _, name := range names {
+    tx := db.NewTransaction()
+    tx.Set(personID, ":person/name", name)
+    tx.Commit()
+}
+
+// Expected: 1 result (LWW winner = "Diana")
+// Actual: 4 results (all historical values)
+results, _ := db.ExecuteQueryWithInputs(
+    `[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+    personID, nameAttr)
+// results = [[Alice] [Bob] [Charlie] [Diana]]  // BUG!
+```
+
+### CRDT Resolution Matrix
+
+| Method | Results | Correct? |
+|--------|---------|----------|
+| Direct `Match()` | 1 | ✓ |
+| `PullInto` | 1 | ✓ |
+| `Pull` | 1 | ✓ |
+| `ExecuteQuery` | 3 | ✗ BUG |
+| `ExecuteQueryWithInputs` | 3 | ✗ BUG |
+| `ExecuteQueryRelation` | 3 | ✗ BUG |
+| `QueryInto` | 3 | ✗ BUG |
+| `QueryOneInto` | ERROR | ✗ BUG |
+
+## Root Cause
+
+### Where CRDT Resolution Currently Happens
+
+CRDT resolution exists in **two code paths**:
+
+**Path 1: Cache Path** (`matcher_relations.go:96-107`)
+
+When A is a **Constant** in the pattern, the cache path is used:
+```go
+if m.cache != nil && m.txID == 0 {
+    if a := m.extractValue(pattern.GetA()); a != nil {  // Only works for Constants!
+        if aKw, ok := a.(datalog.Keyword); ok {
+            cacheResult, handled := m.matchWithBindingsFromCache(...)
+            // Uses cache.GetOrResolve() → ResolveLWW/ResolveAddWins/ResolveRGA
+        }
+    }
+}
+```
+
+The cache resolver methods in `cache_resolver.go` perform CRDT resolution:
+- `ResolveLWW()` - Scans EATV, returns first entry (highest Tx due to descending sort)
+- `ResolveAddWins()` - Scans all datoms for (E, A), tracks adds/removes per value
+- `ResolveRGA()` - Loads RGA elements, reconstructs ordered vector
+
+**Path 2: Direct Scan Path** (`matchUnboundAsRelation`)
+
+When there are no bindings and both E and A are constants, inline CRDT resolution is applied:
+```go
+if e != nil && a != nil {
+    if v == nil {
+        switch card {
+        case schema.CardinalityOne:
+            returnOnlyFirst = true  // ← CRDT resolution
+        case schema.CardinalityMany:
+            useAddWinsResolution = true  // ← CRDT resolution
+        }
+    }
+}
+```
+
+### Where CRDT Resolution Does NOT Happen
+
+**Path 3: Join Strategies** (`matcher_relations.go:128+`)
+
+When A is a Variable (even if bound via inputs), `extractValue()` returns nil and the cache path is skipped. Code falls through to join strategies:
+
+```go
+switch strategy.Type {
+case SinglePositionReuse:
+    joinStrategy := m.chooseJoinStrategy(pattern, bindingRel, strategy.Position)
+    switch joinStrategy {
+    case HashJoinScan:
+        // Scans raw storage - NO CRDT resolution
+    case MergeJoin:
+        // Scans raw storage - NO CRDT resolution
+    // ... all other strategies - NO CRDT resolution
+    }
+}
+```
+
+**These join strategies scan storage directly and return ALL historical datoms.**
+
+### The Critical Failure Point
+
+`extractValue()` returns `nil` for Variables:
+
+```go
+// matcher.go:473-487
+func (m *BadgerMatcher) extractValue(elem query.PatternElement) interface{} {
+    switch e := elem.(type) {
+    case query.Variable:
+        return nil  // ← Variables return nil!
+    case query.Constant:
+        return e.Value
+    }
+}
+
+### The Critical Failure Point
+
+`extractValue()` returns `nil` for Variables:
+
+```go
+// matcher.go:473-487
+func (m *BadgerMatcher) extractValue(elem query.PatternElement) interface{} {
+    switch e := elem.(type) {
+    case query.Variable:
+        return nil  // ← Variables return nil!
+    case query.Constant:
+        return e.Value
+    }
+}
+```
+
+When the query is:
+```datalog
+[:find ?v :in $ ?e ?a :where [?e ?a ?v]]
+```
+
+The attribute `?a` is a **Variable** (bound via input parameter), not a **Constant**. Therefore:
+- `m.extractValue(pattern.GetA())` returns `nil`
+- The cache optimization path is NOT taken
+- Code falls through to join strategies (HashJoinScan, MergeJoin, etc.)
+- **Join strategies perform raw storage scans WITHOUT CRDT resolution**
+
+### The Missing Link
+
+The join strategy methods scan storage directly:
+
+```go
+// matchWithoutIteratorReuse, matchWithIteratorReuse, matchWithHashJoin, etc.
+// These methods:
+// 1. Iterate storage directly
+// 2. Build tuples from raw datoms
+// 3. Return ALL matching datoms (including historical values)
+// 4. NEVER apply CRDT resolution
+```
+
+The code assumes that if A is a Variable, CRDT resolution isn't needed. But this is fundamentally wrong for two reasons:
+
+1. **A can be a Variable bound to a known value** via input parameters
+2. **Even with unbound A, each datom has a concrete attribute** - CRDT resolution can and must be applied per (E, A) group
+
+### The Fundamental Issue: CRDT Resolution Must Be Per-Datom
+
+Consider a query with unbound A:
+```datalog
+[:find ?e ?a ?v :where [?e ?a ?v]]
+```
+
+As we scan storage, each datom has a **concrete attribute**. Different attributes have different cardinalities:
+- `:person/name` → CardinalityOne → LWW resolution
+- `:person/friends` → CardinalityMany → add-wins resolution
+
+The fix cannot simply "extract A from bindings" because:
+- A might be bound to multiple values: `[:find ?v :in $ ?e [?a ...] :where [?e ?a ?v]]`
+- A might be completely unbound: `[:find ?e ?a ?v :where [?e ?a ?v]]`
+
+**CRDT resolution must happen at the result level, per (E, A) group:**
+1. Scan returns datoms (possibly with various attributes)
+2. Group results by (E, A)
+3. For each group, look up that attribute's cardinality from schema
+4. Apply CRDT resolution per-group (LWW for CardinalityOne, add-wins for CardinalityMany)
+
+### The Current Code Is Incomplete Even for the Unbound Case
+
+The `matchUnboundAsRelation` code (lines 230-244) only applies CRDT resolution when **both E and A are known**:
+
+```go
+if e != nil && a != nil {  // ← Requires BOTH E and A to be known!
+    if v == nil {
+        switch card {
+        case schema.CardinalityOne:
+            returnOnlyFirst = true
+        case schema.CardinalityMany:
+            useAddWinsResolution = true
+        }
+    }
+}
+```
+
+If A is unbound (`a == nil`), **no CRDT resolution is applied**. This is wrong - each datom in the scan has an attribute, and resolution should be applied per-group.
+
+### Single-Value Bindings Are Just One Case
+
+The system already detects single-row bindings for scan optimization (`hash_join_matcher.go:177-188`), but this is just an optimization opportunity, not the core fix. The core fix must handle ALL cases:
+
+| Scenario | What A Is | Resolution Strategy |
+|----------|-----------|---------------------|
+| Constant in pattern | Known at compile time | Look up cardinality, resolve |
+| Single-row binding | Known at runtime | Look up cardinality, resolve |
+| Multi-row binding | Multiple known values | Resolve per (E, A) group |
+| Completely unbound | Unknown until scan | Resolve per (E, A) group |
+
+**All scenarios reduce to the same solution**: group by (E, A) and resolve each group based on that attribute's schema-defined cardinality.
+
+---
+
+## Engineering Failure Analysis
+
+### Pre-Existing Test Gap
+
+**Critical finding**: The pattern `[:find ?v :in $ ?e ?a :where [?e ?a ?v]]` with attribute as an input parameter was **never tested**, even before CRDT.
+
+Existing tests use:
+| Pattern | What It Tests |
+|---------|---------------|
+| `[:find ?a ?v :in $ ?e :where [?e ?a ?v]]` | E from input, A **unbound** (get all attributes) |
+| `[:find ?f :in $ ?alice :where [?alice :constant/attr ?f]]` | E from input, A is **constant** |
+
+Pre-CRDT, this gap was invisible because:
+- Values were physically replaced or deleted
+- Storage returned "current state" by definition
+- No distinction between "current" and "historical" values
+
+Post-CRDT, this gap became critical because:
+- All writes are preserved (historical values exist)
+- Join strategies scan raw storage and see everything
+- Without CRDT resolution, ALL historical values are returned
+
+**The test gap existed all along. CRDT just made it visible.**
+
+### Why This Slipped Through Development
+
+#### 1. Implementation Plan Never Tested Input Parameters
+
+The CRDT implementation plan (`CRDT_VECTOR_STORAGE_IMPLEMENTATION_PLAN.md`) shows only one test pattern:
+
+```go
+// Line 5374 - The ONLY query test in the plan
+result, err := db.ExecuteQuery(`[:find ?name :where [?e :name ?name]]`)
+```
+
+Here `:name` is a **Constant** in the pattern. The plan never tested:
+- `ExecuteQueryWithInputs`
+- `:in` clause with variable attributes
+- Any query where A comes from bindings
+
+#### 2. Phase 8 Marked Complete Without Integration Testing
+
+The implementation status shows:
+```
+| Phase 8: Query Integration | ✅ Complete | 8.1-8.5 all complete |
+```
+
+But "complete" was based on:
+- Pull API working (uses different code path)
+- Direct `Match()` working (no bindings case)
+- Simple queries with constant attributes
+
+No integration test verified the **entire query execution pipeline** with input parameters.
+
+#### 3. Two Code Paths, One Tested
+
+The matcher has fundamentally different execution paths:
+
+| Scenario | Code Path | Tested? |
+|----------|-----------|---------|
+| Pattern with constant A | `matchUnboundAsRelation` | ✓ Yes |
+| Pattern with A from bindings | Join strategies | ✗ **Never** |
+
+The "with bindings" path handles ~90% of real-world queries (anything using `:in` clause), yet it was never tested for CRDT resolution.
+
+#### 4. Pull API Success Created False Confidence
+
+The Pull API works correctly because it uses a completely different resolution path:
+
+```go
+// Pull uses ResolveEntityAttributes → cache.GetOrResolve
+// Query uses matcher.Match → join strategies → raw storage
+```
+
+When `PullInto` tests passed, there was confidence that "CRDT resolution works." But Pull and Query use different code paths.
+
+#### 5. The Proposal's Mental Model Was Wrong
+
+From `CRDT_VECTOR_STORAGE.md` line 1476:
+```go
+func (m *Matcher) Match(pattern *query.DataPattern, bindings Relations) {
+    switch m.schema.Cardinality(a) {
+    case CardinalityOne:
+        return m.matchOneCRDT(e, a, v, bindings)
+    ...
+```
+
+The proposal assumed the matcher would dispatch to cardinality-specific resolution methods. But the actual implementation:
+1. Checks if A is a Constant → uses cache optimization
+2. If A is Variable → falls through to join strategies
+3. Join strategies ignore cardinality entirely
+
+#### 6. No Test for the Common Case
+
+The most common query pattern in applications:
+```go
+db.ExecuteQueryWithInputs(
+    `[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+    entityID, attributeKeyword)
+```
+
+This common pattern was **never tested** during CRDT implementation.
+
+---
+
+## Timeline of the Failure
+
+1. **Design Phase**: Proposal describes cache-based CRDT resolution, assumes A is always "known" at pattern level
+2. **Phase 6 (Cache)**: Cache implemented, tested with E+A both bound as constants
+3. **Phase 8 (Query Integration)**: Marked complete after Pull API and simple queries work
+4. **Phase 9 (Cleanup)**: Legacy code removed, "thorough audit pending" noted but not done
+5. **Production**: Applications using ExecuteQueryWithInputs with attribute inputs see incorrect data
+6. **Discovery**: Bug identified via failing test case
+
+---
+
+## The Fundamental Design Flaw
+
+The matcher's CRDT resolution logic is predicated on:
+```go
+if a := m.extractValue(pattern.GetA()); a != nil
+```
+
+This assumes A's value is known from the **pattern itself**. But in Datalog:
+- A can be a Variable bound via `:in` clause
+- A can be a Variable bound via join from another pattern
+- A can be a Variable that gets its value at runtime
+
+The code conflates "A is a Variable in the pattern" with "we don't know what A is." These are different things:
+- `[:find ?v :where [?e :name ?v]]` → A is Constant, known at parse time
+- `[:find ?v :in $ ?a :where [?e ?a ?v]]` → A is Variable, known at runtime from inputs
+
+---
+
+## What Should Have Been Tested
+
+### Test Pattern 1: Input Parameter for Attribute
+```go
+func TestCRDTResolution_AttributeFromInput(t *testing.T) {
+    // Setup: CardinalityOne attribute with multiple writes
+    for _, name := range []string{"Alice", "Bob", "Charlie"} {
+        tx := db.NewTransaction()
+        tx.Set(entity, ":person/name", name)
+        tx.Commit()
+    }
+
+    // Query with attribute as input parameter
+    results, _ := db.ExecuteQueryWithInputs(
+        `[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+        entity, datalog.NewKeyword(":person/name"))
+
+    // MUST return exactly 1 result (LWW winner)
+    assert.Len(t, results, 1)
+    assert.Equal(t, "Charlie", results[0][0])
+}
+```
+
+### Test Pattern 2: Input Parameter for Entity
+```go
+func TestCRDTResolution_EntityFromInput(t *testing.T) {
+    // Query with entity as input, constant attribute
+    results, _ := db.ExecuteQueryWithInputs(
+        `[:find ?v :in $ ?e :where [?e :person/name ?v]]`,
+        entity)
+
+    assert.Len(t, results, 1)  // Not all historical values!
+}
+```
+
+### Test Pattern 3: Both E and A from Inputs
+```go
+func TestCRDTResolution_BothFromInputs(t *testing.T) {
+    results, _ := db.ExecuteQueryWithInputs(
+        `[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+        entity, datalog.NewKeyword(":person/name"))
+
+    assert.Len(t, results, 1)
+}
+```
+
+### Test Pattern 4: Collection Input with CRDT
+```go
+func TestCRDTResolution_CollectionInput(t *testing.T) {
+    // Multiple entities, each with CardinalityOne attribute
+    results, _ := db.ExecuteQueryWithInputs(
+        `[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`,
+        []datalog.Identity{entity1, entity2, entity3})
+
+    // Should return 3 results (one per entity), not all historical
+    assert.Len(t, results, 3)
+}
+```
+
+---
+
+## Lessons Learned
+
+### 1. Test the Query Execution Pipeline End-to-End
+
+Unit tests for individual components (cache, matcher, executor) are insufficient. Integration tests must verify the **entire pipeline** with realistic query patterns.
+
+### 2. Test All Input Parameter Patterns
+
+The `:in` clause has several binding types:
+- Scalar: `?x`
+- Collection: `[?x ...]`
+- Tuple: `[?x ?y]`
+- Relation: `[[?x ?y]]`
+
+Each must be tested with CRDT resolution.
+
+### 3. "Works in One Path" ≠ "Works Everywhere"
+
+Pull API and Query API use different internal paths. Testing one doesn't validate the other.
+
+### 4. Implementation Plans Need Negative Test Cases
+
+The plan should have included:
+- "What happens when A is a Variable?"
+- "What happens when E comes from bindings?"
+- "What happens with `:in` clause?"
+
+### 5. "Phase Complete" Needs Verification Criteria
+
+Marking a phase complete should require:
+- [ ] All code paths tested
+- [ ] Integration tests passing
+- [ ] Real-world query patterns validated
+- [ ] Negative/edge cases documented and tested
+
+### 6. Audit Deferred = Bug Shipped
+
+From the implementation status:
+```
+| ⚠️ 9.4 Thorough audit - PENDING |
+```
+
+The "thorough audit" was deferred. This bug would have been caught by an audit that traced query execution paths.
+
+---
+
+## Required Fix
+
+The fix must apply CRDT resolution **per (E, A) group** regardless of how A becomes known. This is not optional - every query path that returns datoms must resolve them.
+
+### The Correct Approach: Streaming Resolution
+
+CRDT resolution must be **streaming** - it cannot materialize all results into memory. The iterator-based architecture must be preserved.
+
+**Key insight**: If results are ordered by (E, A), we can detect group boundaries and resolve on-the-fly:
+
+```go
+// CRDTResolvingIterator wraps an iterator and applies CRDT resolution
+type CRDTResolvingIterator struct {
+    source    Iterator
+    schema    *schema.Schema
+    eIdx, aIdx int
+
+    // Buffer for current (E, A) group
+    currentEA   [2]interface{}  // (E, A) of current group
+    groupBuffer []Tuple         // tuples in current group
+    resolved    []Tuple         // resolved tuples ready to emit
+    resolveIdx  int
+}
+
+func (it *CRDTResolvingIterator) Next() (Tuple, bool) {
+    // Emit from resolved buffer first
+    if it.resolveIdx < len(it.resolved) {
+        t := it.resolved[it.resolveIdx]
+        it.resolveIdx++
+        return t, true
+    }
+
+    // Read from source until (E, A) changes
+    for {
+        tuple, ok := it.source.Next()
+        if !ok {
+            // Source exhausted - resolve final group
+            if len(it.groupBuffer) > 0 {
+                it.resolved = it.resolveGroup()
+                it.groupBuffer = nil
+                it.resolveIdx = 0
+                if len(it.resolved) > 0 {
+                    t := it.resolved[it.resolveIdx]
+                    it.resolveIdx++
+                    return t, true
+                }
+            }
+            return nil, false
+        }
+
+        ea := [2]interface{}{tuple[it.eIdx], tuple[it.aIdx]}
+        if it.currentEA != ea && len(it.groupBuffer) > 0 {
+            // (E, A) changed - resolve previous group, start new one
+            it.resolved = it.resolveGroup()
+            it.groupBuffer = []Tuple{tuple}
+            it.currentEA = ea
+            it.resolveIdx = 0
+            if len(it.resolved) > 0 {
+                t := it.resolved[it.resolveIdx]
+                it.resolveIdx++
+                return t, true
+            }
+        } else {
+            // Same (E, A) - accumulate
+            it.currentEA = ea
+            it.groupBuffer = append(it.groupBuffer, tuple)
+        }
+    }
+}
+
+func (it *CRDTResolvingIterator) resolveGroup() []Tuple {
+    attr := it.schema.GetAttribute(it.currentEA[1].(datalog.Keyword))
+    if attr == nil {
+        return it.groupBuffer  // No schema - return all
+    }
+    switch attr.Cardinality {
+    case schema.CardinalityOne:
+        return []Tuple{selectLatestByTx(it.groupBuffer)}
+    case schema.CardinalityMany:
+        return resolveAddWins(it.groupBuffer)
+    }
+    return it.groupBuffer
+}
+```
+
+**Requirements for streaming resolution**:
+1. Source iterator must be ordered by (E, A) for group-boundary detection
+2. Buffer only one (E, A) group at a time - memory bounded by max values per (E, A)
+3. Emit resolved tuples as soon as group boundary detected
+
+**The ordering problem**: The bug is in join strategy paths, not direct index scans. After a hash join, results are **not ordered** - they're the product of joining two relations. Options:
+
+1. **Sort before resolution**: Add a sort step by (E, A) before the resolving iterator. Costly but correct.
+2. **Accumulate per (E, A)**: Use a map to accumulate tuples per (E, A), resolve when source exhausted. Uses more memory but handles unordered input.
+3. **Push resolution into scan**: Apply CRDT resolution at the storage scan level (before joins), so join inputs are already resolved.
+
+### Architectural Principle: Cache Is Optimization, Not Correctness
+
+**The code MUST work correctly with the cache disabled.**
+
+The cache is an optimization layer - it makes things *faster*, not *correct*. If CRDT resolution only works when the cache is enabled, that's an architectural failure.
+
+Correct design:
+1. **Storage scans return CRDT-resolved values by default** - this is **correctness**
+2. **Cache speeds up repeated (E, A) lookups** - this is **optimization**
+
+The current bug exists because CRDT resolution was implemented in the cache path, not the storage scan path. When the cache path is skipped (A is a Variable), there's no fallback - raw historical values are returned.
+
+### Required: Add DisableCache Database Option
+
+Currently, the cache cannot be disabled:
+- `DatabaseOptions` has no cache disable option
+- `NewCache()` is always called at database creation
+- The `if m.cache != nil` checks exist but can never run the nil path
+
+**Add `DisableCache bool` to `DatabaseOptions`:**
+
+```go
+type DatabaseOptions struct {
+    Path              string
+    UseTimeTx         bool
+    Schema            schema.SchemaProvider
+    AnnotationHandler annotations.Handler
+    ReplicaID         uint64
+    DisableCache      bool  // Disable EA cache; queries resolve directly from storage
+}
+```
+
+**Tests for this bug MUST run with cache disabled** to verify the fix is at the scan level, not dependent on the cache.
+
+### The Correct Fix: Streaming Resolution at Scan Level
+
+**Option 3 is the only correct approach**: Resolve at the storage scan level. Both EAVT and AEVT scans work for streaming resolution:
+
+- **EAVT** (E, A, V, T): Groups are contiguous by (E, A). Scan through group, track max Tx, emit winner when (E, A) changes.
+- **AEVT** (A, E, V, T): Groups are contiguous by (A, E). Same principle - scan through group, track max Tx, emit winner when (A, E) changes.
+
+The key requirement is **contiguous groups**, not any particular ordering of groups. Both indices provide this. Transaction ordering within each group allows finding the LWW winner.
+
+**Every storage scan must return CRDT-resolved values unless explicitly requesting history via `[(history)]`.**
+
+The cache can then be layered on top as a pure optimization - caching the results of scans that would otherwise be correct but slower.
+
+### Optimization: Extend Cache Path to Handle (E, A) Bindings
+
+Once correctness is established at the scan level, the cache path can be extended as an optimization for when E and A are both bound via inputs:
+
+```go
+// When bindings provide (E, A) pairs, use cache for each pair
+for _, tuple := range bindings {
+    e, a := tuple[eIdx], tuple[aIdx]
+    entry := cache.GetOrResolve(CacheKey{E: e, A: a}, resolver)
+    // build result tuple from entry.Value / entry.SetMembers / entry.VectorValues
+}
+```
+
+This works for:
+- Scalar inputs: `[:find ?v :in $ ?e ?a :where [?e ?a ?v]]` → single (E, A) pair
+- Relation inputs: `[:find ?v :in $ [[?e ?a]] :where [?e ?a ?v]]` → multiple (E, A) pairs
+
+This is purely an optimization - with cache disabled, the same query uses scan-level resolution and returns correct results (just slower).
+
+### Missed Optimization: Cache Skipped When A Is Any Variable
+
+Currently, the cache is skipped when A is **any** Variable because `extractValue()` returns nil for Variables. But A being a Variable doesn't mean A's value is unknown:
+
+| A Binding Type | A Values | Cache Usable | Current Behavior |
+|----------------|----------|--------------|------------------|
+| Constant in pattern | Single, known at compile time | ✓ | ✓ Uses cache |
+| Scalar input `?a` | Single, known from input | ✓ | ✗ Skips cache |
+| Collection input `[?a ...]` | Set, known from input | ✓ | ✗ Skips cache |
+| Tuple input `[?e ?a]` | Single, known from input | ✓ | ✗ Skips cache |
+| Relation input `[[?e ?a]]` | Set of pairs, known from input | ✓ | ✗ Skips cache |
+| Join-bound | Known after join executes | ✓ | ✗ Skips cache |
+| Truly unbound | Unknown until scan | ✗ | ✗ Correctly skips |
+
+**Optimization opportunity**: Before falling back to join strategies, check if A is a Variable with known value(s) from bindings:
+
+```go
+// Current: only uses cache when A is Constant
+if a := m.extractValue(pattern.GetA()); a != nil { ... }
+
+// Improved: also check bindings for A's value
+aValue := m.extractValue(pattern.GetA())
+if aValue == nil {
+    // A is a Variable - check if bindings provide its value
+    if aVar, ok := pattern.GetA().(query.Variable); ok {
+        aValue = extractFromBindings(bindings, aVar.Name)
+    }
+}
+if aValue != nil {
+    // Use cache path
+}
+```
+
+**For collection/relation bindings with multiple A values**: iterate and do cache lookup for each (E, A) pair.
+
+**When to NOT use cache**:
+- A is truly unbound (no binding exists)
+- Bindings have too many values (threshold TBD - cache lookups have overhead)
+- Cache is disabled
+
+This optimization is independent of the correctness fix. It makes queries faster when cache is enabled, but correctness doesn't depend on it.
+
+### Where to Apply This
+
+The fix should be at the **storage scan level**, inside the matcher. The `cache_resolver.go` code shows the *resolution pattern* (not the fix location):
+
+```go
+// Pattern from cache_resolver.go - shows HOW to resolve, not WHERE to fix
+// EATV is ordered (E, A, T desc) - first entry for each (E, A) is the LWW winner
+iter, err := m.store.Scan(EATV, prefix, prefixEnd(prefix))
+if iter.Next() {
+    datom, _ := iter.Datom()
+    return datom.V, datom.Tx, nil  // First = latest Tx = winner
+}
+```
+
+**Specific locations requiring fixes:**
+
+1. **`matchWithHashJoin`** - The storage scan inside hash join must apply CRDT resolution per (E, A) group as it iterates
+2. **`matchWithMergeJoin`** - Same as hash join
+3. **`matchUnboundAsRelation`** - Fix the `if e != nil && a != nil` check to handle unbound A by resolving per-datom based on each datom's actual attribute
+4. **All other scan paths** - Any code that calls `store.Scan()` and builds tuples must resolve
+
+**Key insight**: The EAVT and AEVT indices already provide contiguous (E, A) groups. The storage scan can track the current (E, A) and resolve in-flight without post-processing.
+
+**The fix must work with the cache disabled.** The cache can then optimize by caching resolved values, but correctness cannot depend on it.
+
+### Why Not "Extract A from Bindings"?
+
+Extracting A from bindings only works for the single-row binding case. It fails for:
+- Multi-row bindings: `[:find ?v :in $ [?a ...] :where [?e ?a ?v]]`
+- Unbound A: `[:find ?e ?a ?v :where [?e ?a ?v]]`
+- A bound via join from another pattern
+
+The per-(E, A)-group approach handles ALL cases uniformly.
+
+---
+
+## Files Involved
+
+**Reference for resolution pattern (not fix location):**
+- `datalog/storage/cache_resolver.go` - Shows correct resolution pattern using EATV index ordering
+- `datalog/storage/crdt_resolve.go` - Pure resolution functions: `ResolveLWWFromDatoms()`, `ResolveAddWinsFromDatoms()` - can be reused
+
+**Where the bug exists (fix locations):**
+- `datalog/storage/matcher_relations.go` - Join strategies bypass CRDT resolution (lines 128+)
+- `datalog/storage/hash_join_matcher.go` - Hash join scans raw storage without resolution
+- `datalog/storage/matcher.go` - `extractValue()` returns nil for Variables
+- `datalog/storage/matcher_iterator_unbound.go` - Unbound iteration may need resolution
+
+**Entry points:**
+- `datalog/storage/database.go` - `ExecuteQueryWithInputs` entry point
+- `datalog/executor/query_executor.go` - Query execution pipeline
+
+## Test Plan
+
+### Requirement: All CRDT Tests Must Run With and Without Cache
+
+Every CRDT test must pass in both modes:
+1. **Cache enabled** (default) - verifies optimization path works
+2. **Cache disabled** (`DisableCache: true`) - verifies correctness at scan level
+
+This ensures correctness doesn't depend on the cache.
+
+---
+
+## Complete Test Matrix
+
+### 1. Query Entry Points
+
+| Entry Point | Description | Needs CRDT Resolution |
+|-------------|-------------|----------------------|
+| `ExecuteQuery` | No input parameters | ✓ |
+| `ExecuteQueryWithInputs` | With input parameters | ✓ |
+| `ExecuteQueryRelation` | Returns relation | ✓ |
+| `Pull` / `PullInto` | Entity attribute retrieval | ✓ (currently works) |
+| `QueryInto` / `QueryOneInto` | Typed results | ✓ |
+| Direct `Match()` | Matcher API | ✓ |
+
+### 2. How E, A, V Can Be Bound
+
+| Binding Type | Example | E | A | V |
+|--------------|---------|---|---|---|
+| Constant in pattern | `[?e :person/name ?v]` | - | ✓ | - |
+| Unbound variable | `[?e ?a ?v]` | ✓ | ✓ | ✓ |
+| Scalar input | `:in $ ?e` | ✓ | ✓ | ✓ |
+| Collection input | `:in $ [?e ...]` | ✓ | ✓ | ✓ |
+| Tuple input | `:in $ [?e ?a]` | ✓ | ✓ | - |
+| Relation input | `:in $ [[?e ?a]]` | ✓ | ✓ | - |
+| Join from another pattern | `[?e :ref ?other] [?other ?a ?v]` | ✓ | ✓ | ✓ |
+| Subquery result | `[(subquery ...) [[?e]]]` | ✓ | ✓ | ✓ |
+
+### 3. Cardinality × Binding Type Matrix
+
+Each cell must be tested with cache enabled AND disabled:
+
+| A Binding | CardinalityOne (LWW) | CardinalityMany (add-wins) | CardinalityVector (RGA) |
+|-----------|---------------------|---------------------------|------------------------|
+| Constant | ✓ Works | ✓ Works | ✓ Works |
+| Scalar input | ✗ **BUG** | ✗ **BUG** | ✗ **BUG** |
+| Collection input | ✗ **BUG** | ✗ **BUG** | ✗ **BUG** |
+| Tuple input | ✗ **BUG** | ✗ **BUG** | ✗ **BUG** |
+| Relation input | ✗ **BUG** | ✗ **BUG** | ✗ **BUG** |
+| Unbound | ✗ **BUG** | ✗ **BUG** | ✗ **BUG** |
+| Join-bound | ✗ **BUG** | ✗ **BUG** | ✗ **BUG** |
+| Subquery-bound | ✗ **BUG** | ✗ **BUG** | ✗ **BUG** |
+
+### 4. E Binding × A Binding Combinations
+
+| E Binding | A Binding | Expected Behavior | Current Status |
+|-----------|-----------|-------------------|----------------|
+| Constant | Constant | Resolve single (E,A) | ✓ Works |
+| Constant | Scalar input | Resolve single (E,A) | ✗ BUG |
+| Constant | Collection input | Resolve per A | ✗ BUG |
+| Constant | Unbound | Resolve per (E,A) in results | ✗ BUG |
+| Scalar input | Constant | Resolve single (E,A) | ✓ Works (cache path) |
+| Scalar input | Scalar input | Resolve single (E,A) | ✗ BUG |
+| Scalar input | Unbound | Resolve per (E,A) in results | ✗ BUG |
+| Collection input | Constant | Resolve per E | ✓ Works (cache path) |
+| Collection input | Scalar input | Resolve per (E,A) pair | ✗ BUG |
+| Collection input | Collection input | Resolve per (E,A) combination | ✗ BUG |
+| Collection input | Unbound | Resolve per (E,A) in results | ✗ BUG |
+| Relation input | (E,A pairs) | Resolve per (E,A) pair | ✗ BUG |
+| Unbound | Constant | Resolve per E | ? Needs verification |
+| Unbound | Unbound | Resolve per (E,A) in results | ✗ BUG |
+| Join-bound | Constant | Resolve per E | ✓ Works (cache path) |
+| Join-bound | Join-bound | Resolve per (E,A) pair | ✗ BUG |
+
+### 5. Special Query Features
+
+| Feature | CRDT Behavior | Test Required |
+|---------|---------------|---------------|
+| `[(history)]` | Return ALL values (no resolution) | ✓ Verify no resolution |
+| `[(as-of ?tx N)]` | Resolve as of transaction N | ✓ Time-travel resolution |
+| `(not ...)` | Resolve before NOT evaluation | ✓ |
+| `(not-join ...)` | Resolve before NOT evaluation | ✓ |
+| `(or ...)` | Resolve in each OR branch | ✓ |
+| `(or-join ...)` | Resolve in each OR branch | ✓ |
+| Aggregations | Aggregate over resolved values | ✓ |
+| Subqueries | Resolve in subquery | ✓ |
+| Multi-source | Resolve per source | ✓ |
+
+### 6. Matcher Code Paths
+
+| Code Path | When Used | CRDT Resolution |
+|-----------|-----------|-----------------|
+| `matchUnboundAsRelation` | No bindings | Partial (only when E & A both known) |
+| `matchWithBindingsFromCache` | A is Constant, cache enabled | ✓ Works |
+| `matchWithHashJoin` | Medium selectivity joins | ✗ **NO RESOLUTION** |
+| `matchWithMergeJoin` | Sorted joins | ✗ **NO RESOLUTION** |
+| `matchWithNestedLoop` | Small relations | ✗ **NO RESOLUTION** |
+| `matchWithIteratorReuse` | Iterator optimization | ✗ **NO RESOLUTION** |
+| `matchWithoutIteratorReuse` | Fallback | ✗ **NO RESOLUTION** |
+
+### 7. Index Scan Paths
+
+| Index | Key Order | Used When | CRDT Resolution Possible |
+|-------|-----------|-----------|-------------------------|
+| EAVT | E, A, V, T | E known | ✓ Groups contiguous by (E,A) |
+| AEVT | A, E, V, T | A known | ✓ Groups contiguous by (A,E) |
+| AVET | A, V, E, T | A and V known | ✓ Groups contiguous by (A,V,E) |
+| VAET | V, A, E, T | V is ref | ✓ Groups contiguous |
+| EATV | E, A, T desc, V | LWW resolution | ✓ First entry is winner |
+| Full scan | - | Nothing bound | ✓ Must group by (E,A) |
+
+---
+
+## Required Test Cases
+
+### Test Structure
+
+```go
+func TestCRDTResolution_Matrix(t *testing.T) {
+    for _, cacheEnabled := range []bool{true, false} {
+        cacheName := "cache_enabled"
+        if !cacheEnabled {
+            cacheName = "cache_disabled"
+        }
+
+        for _, card := range []schema.Cardinality{
+            schema.CardinalityOne,
+            schema.CardinalityMany,
+            schema.CardinalityVector,
+        } {
+            cardName := cardinalityName(card)
+
+            t.Run(fmt.Sprintf("%s/%s", cacheName, cardName), func(t *testing.T) {
+                db := createTestDB(t, storage.DatabaseOptions{
+                    DisableCache: !cacheEnabled,
+                })
+                // ... run test matrix
+            })
+        }
+    }
+}
+```
+
+### Specific Test Patterns
+
+```datalog
+;; 1. A as constant (baseline - should work)
+[:find ?v :where [?e :person/name ?v]]
+
+;; 2. A from scalar input
+[:find ?v :in $ ?e ?a :where [?e ?a ?v]]
+
+;; 3. A from collection input
+[:find ?e ?v :in $ [?a ...] :where [?e ?a ?v]]
+
+;; 4. A from tuple input (with E)
+[:find ?v :in $ [?e ?a] :where [?e ?a ?v]]
+
+;; 5. A from relation input (multiple E,A pairs)
+[:find ?e ?a ?v :in $ [[?e ?a]] :where [?e ?a ?v]]
+
+;; 6. A completely unbound
+[:find ?e ?a ?v :where [?e ?a ?v]]
+
+;; 7. A bound via join
+[:find ?v :where [?e :has-attr ?a] [?e ?a ?v]]
+
+;; 8. A bound via subquery
+[:find ?v :where [(subquery [:find ?a :where [_ :attr-list ?a]]) [[?a]]] [?e ?a ?v]]
+
+;; 9. E from collection, A from scalar
+[:find ?e ?v :in $ [?e ...] ?a :where [?e ?a ?v]]
+
+;; 10. Both E and A from collections (cross-product)
+[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]
+
+;; 11. With NOT clause
+[:find ?v :in $ ?e ?a :where [?e ?a ?v] (not [?e :deleted true])]
+
+;; 12. With OR clause
+[:find ?v :in $ ?e ?a :where (or [?e ?a ?v] [?e :fallback ?v])]
+
+;; 13. With aggregation
+[:find ?a (count ?v) :in $ ?e :where [?e ?a ?v]]
+
+;; 14. History query (should NOT resolve)
+[:find ?v :where [?e :person/name ?v] [(history)]]
+
+;; 15. As-of query
+[:find ?v :in $ ?e ?a ?tx :where [?e ?a ?v] [(as-of ?tx 1000)]]
+```
+
+### For Each Test Pattern
+
+1. Write multiple values to same (E, A) pair
+2. Query using the pattern
+3. Assert:
+   - CardinalityOne: exactly 1 result (LWW winner)
+   - CardinalityMany: only non-retracted values
+   - CardinalityVector: ordered, non-tombstoned values
+4. Run with cache enabled AND disabled
+5. Both must return identical results
+
+---
+
+## Existing Tests Requiring Update
+
+**Must add cache-disabled subtests:**
+- `datalog/storage/crdt_one_test.go`
+- `datalog/storage/crdt_many_test.go`
+- `datalog/storage/crdt_resolve_test.go`
+- `datalog/storage/crdt_query_resolution_test.go`
+- `datalog/storage/pullinto_crdt_test.go`
+- `datalog/storage/pull_expression_crdt_test.go`
+- `datalog/storage/entity_resolve_test.go`
+
+## Test File
+
+- `datalog/storage/crdt_query_resolution_test.go` - Reproduces the bug
+
+---
+
+## Current Progress Summary
+
+**Last Updated**: 2026-02-05
+
+### Work Completed
+
+#### Phase 1: Infrastructure ✅ COMPLETE
+- Added `DisableCache bool` to `DatabaseOptions`
+- Database respects `DisableCache` option (sets `cache` to nil when true)
+- Added nil checks for cache operations in `Transaction.Commit()`, `Transaction.Set()`, and `vectorContainsValue()`
+- Added `ResolveEntry()` function in `cache.go` for direct CRDT resolution without cache
+- All existing tests pass with cache enabled (no regression)
+
+#### Phase 2: Test Coverage ✅ COMPLETE
+Created comprehensive test matrix in `crdt_cache_matrix_test.go` with 17 test patterns covering all binding scenarios and cardinality types.
+
+### Test Results Matrix (Before Fix)
+
+| Test | cache_enabled | cache_disabled | Analysis |
+|------|---------------|----------------|----------|
+| AConstant | **PASS** | FAIL | Cache fix works for A=constant |
+| AFromScalarInput | FAIL | FAIL | Bug: A as variable |
+| AUnbound | FAIL | FAIL | Bug: A completely unbound |
+| EFromCollection_AFromScalar | FAIL | FAIL | Bug: A as variable |
+| CardinalityMany | FAIL | FAIL | Bug: no add-wins resolution |
+| PullIntoComparison | **PASS** | **PASS** | Control: direct lookup works |
+| AFromCollection | FAIL | FAIL | Bug: A from collection |
+| AFromTupleInput | FAIL | FAIL | Bug: A from tuple |
+| AFromRelationInput | FAIL | FAIL | Bug: A from relation |
+| ABoundViaJoin | FAIL | FAIL | Bug: A from join |
+| ABoundViaSubquery | FAIL | FAIL | Bug: A from subquery |
+| EAndABothFromCollections | FAIL | FAIL | Bug: cross-product of E × A |
+| WithNotClause | **PASS** | FAIL | Cache fix works with NOT |
+| WithOrClause | FAIL | FAIL | Bug: OR clause |
+| WithAggregation | FAIL | FAIL | Bug: aggregates all history |
+| CardinalityVector | FAIL | FAIL | Bug: no RGA resolution |
+| AsOfQuery | FAIL | FAIL | Bug: as-of returns wrong/all values |
+
+**Note**: History query (Pattern 14) removed - will use `db.History()` Datomic-style view instead.
+
+### Key Findings
+
+1. **Cache provides partial fix**: Tests that PASS with cache enabled but FAIL without (AConstant, WithNotClause) prove the cache provides CRDT resolution, but only for patterns where A is a constant in the query.
+
+2. **Bug is pervasive**: Nearly all query patterns fail when A is a variable (from inputs, joins, collections, tuples, relations). This affects queries, aggregations, NOT/OR clauses, and all cardinality types.
+
+3. **PullInto works correctly**: The control test passes in both modes because PullInto uses direct entity lookup, not query execution.
+
+4. **History query redesign**: The `[(history)]` predicate was removed. History queries will use Datomic-style `db.History()` database view instead - cleaner separation of concerns.
+
+### Next Steps (Phase 3)
+
+The actual fix needs to implement **streaming CRDT resolution at the storage scan level**, ensuring resolution applies to ALL matcher code paths:
+- `matchWithHashJoin`
+- `matchWithMergeJoin`
+- `matchWithNestedLoop`
+- `matchWithIteratorReuse`
+- `matchWithoutIteratorReuse`
+- `matchUnboundAsRelation`
+
+The fix must:
+- Be streaming (not materialize all results)
+- Use index ordering (EAVT/AEVT contiguous groups)
+- Apply per (E, A) group based on each datom's actual attribute
+- Look up cardinality from schema for each attribute
+
+---
+
+## Definition of Done
+
+This fix is complete when ALL of the following are true:
+
+### Phase 1: Infrastructure ✅ COMPLETE
+
+- [x] `DisableCache bool` added to `DatabaseOptions`
+- [x] Database respects `DisableCache` option (sets `cache` to nil when true)
+- [x] Existing tests pass with cache enabled (no regression)
+- [x] Nil checks added for cache operations in `Transaction.Commit()`
+- [x] Nil checks added for cache operations in `Transaction.Set()` (CardinalityVector)
+- [x] Nil checks added for cache operations in `Transaction.vectorContainsValue()`
+- [x] `ResolveEntry()` function added to cache.go for direct resolution without cache
+
+### Phase 2: Test Coverage ✅ COMPLETE
+
+**Test files:**
+- `crdt_query_resolution_test.go` - Original repro tests (preserved)
+- `crdt_cache_matrix_test.go` - Cache-enabled/disabled matrix tests (NEW)
+
+**Test patterns implemented in `crdt_cache_matrix_test.go`:**
+- [x] Pattern 1: A as constant (baseline) - `TestCacheMatrix_AConstant`
+- [x] Pattern 2: A from scalar input - `TestCacheMatrix_AFromScalarInput`
+- [x] Pattern 3: A from collection input - `TestCacheMatrix_AFromCollection`
+- [x] Pattern 4: A from tuple input - `TestCacheMatrix_AFromTupleInput`
+- [x] Pattern 5: A from relation input - `TestCacheMatrix_AFromRelationInput`
+- [x] Pattern 6: A completely unbound - `TestCacheMatrix_AUnbound`
+- [x] Pattern 7: A bound via join - `TestCacheMatrix_ABoundViaJoin`
+- [x] Pattern 8: A bound via subquery - `TestCacheMatrix_ABoundViaSubquery`
+- [x] Pattern 9: E from collection, A from scalar - `TestCacheMatrix_EFromCollection_AFromScalar`
+- [x] Pattern 10: E and A both from collections - `TestCacheMatrix_EAndABothFromCollections`
+- [x] Pattern 11: With NOT clause - `TestCacheMatrix_WithNotClause`
+- [x] Pattern 12: With OR clause - `TestCacheMatrix_WithOrClause`
+- [x] Pattern 13: With aggregation - `TestCacheMatrix_WithAggregation`
+- [x] ~~Pattern 14: History query~~ - Removed: will use `db.History()` Datomic-style view
+- [x] Pattern 15: As-of query - `TestCacheMatrix_AsOfQuery`
+- [x] CardinalityOne tests - most tests above
+- [x] CardinalityMany test - `TestCacheMatrix_CardinalityMany`
+- [x] CardinalityVector test - `TestCacheMatrix_CardinalityVector`
+- [x] PullInto comparison (control) - `TestCacheMatrix_PullIntoComparison` ✅ PASSES
+
+**Current test results (before fix):**
+| Test | cache_enabled | cache_disabled | Notes |
+|------|---------------|----------------|-------|
+| AConstant | **PASS** | FAIL | Cache fix works for A=constant |
+| AFromScalarInput | FAIL | FAIL | Bug: A as variable |
+| AUnbound | FAIL | FAIL | Bug: A completely unbound |
+| EFromCollection_AFromScalar | FAIL | FAIL | Bug: A as variable |
+| CardinalityMany | FAIL | FAIL | Bug: no add-wins resolution |
+| PullIntoComparison | **PASS** | **PASS** | Control - direct lookup works |
+| AFromCollection | FAIL | FAIL | Bug: A from collection |
+| AFromTupleInput | FAIL | FAIL | Bug: A from tuple |
+| AFromRelationInput | FAIL | FAIL | Bug: A from relation |
+| ABoundViaJoin | FAIL | FAIL | Bug: A from join |
+| EAndABothFromCollections | FAIL | FAIL | Bug: cross-product of E × A |
+| WithNotClause | **PASS** | FAIL | Cache fix works with NOT |
+| WithOrClause | FAIL | FAIL | Bug: OR clause |
+| WithAggregation | FAIL | FAIL | Bug: aggregates all history |
+| CardinalityVector | FAIL | FAIL | Bug: no RGA resolution |
+| ABoundViaSubquery | FAIL | FAIL | Bug: A from subquery |
+| AsOfQuery | FAIL | FAIL | Bug: as-of returns wrong/all values |
+
+**Key observations:**
+- Tests that PASS with cache enabled, FAIL without: AConstant, WithNotClause
+- These prove the cache provides CRDT resolution, but only for certain patterns
+- Most patterns fail in BOTH modes, showing the bug is pervasive
+
+- [x] Each pattern tested with CardinalityOne, CardinalityMany, CardinalityVector
+- [x] Tests FAIL in both cache modes before fix (proves tests catch the bug)
+- [ ] Existing CRDT test files updated to run with cache disabled (deferred - not blocking):
+  - [ ] `crdt_one_test.go`
+  - [ ] `crdt_many_test.go`
+  - [ ] `pullinto_crdt_test.go`
+  - [ ] `pull_expression_crdt_test.go`
+  - [ ] `entity_resolve_test.go`
+
+### Phase 3: Fix Implementation
+
+- [ ] Streaming CRDT resolution implemented at storage scan level
+- [ ] Resolution applies to ALL matcher code paths:
+  - [ ] `matchWithHashJoin`
+  - [ ] `matchWithMergeJoin`
+  - [ ] `matchWithNestedLoop`
+  - [ ] `matchWithIteratorReuse`
+  - [ ] `matchWithoutIteratorReuse`
+  - [ ] `matchUnboundAsRelation` (fix `if e != nil && a != nil` check)
+- [ ] Resolution is streaming (not materializing all results)
+- [ ] Resolution uses index ordering (EAVT/AEVT contiguous groups)
+- [ ] `db.History()` view added for Datomic-style history queries (future work)
+- [ ] `[(as-of ?tx N)]` queries resolve correctly at that point in time
+
+### Phase 4: Verification
+
+- [ ] ALL tests pass with cache ENABLED
+- [ ] ALL tests pass with cache DISABLED
+- [ ] Cache-enabled and cache-disabled return IDENTICAL results for all patterns
+- [ ] No performance regression for cache-enabled path (benchmark)
+- [ ] Memory usage acceptable for streaming resolution (no full materialization)
+
+### Phase 5: Optimization (Optional)
+
+- [ ] Cache path extended to handle A from bindings (scalar, collection, tuple, relation)
+- [ ] Threshold defined for when to use cache vs scan (e.g., <1000 binding values)
+
+### Acceptance Criteria
+
+For each test pattern, with cache enabled AND disabled:
+
+| Cardinality | Input | Expected Output |
+|-------------|-------|-----------------|
+| CardinalityOne | 4 writes to same (E,A) | 1 result (LWW winner) |
+| CardinalityMany | 3 adds, 1 retract | 2 results (add-wins) |
+| CardinalityVector | insert A, insert B, delete A | 1 result [B] |
+
+**The fix is NOT complete if any test fails with cache disabled.**
+
+---
+
+## Conclusion
+
+This bug represents a failure to verify that a critical feature (CRDT resolution) works across all code paths. The implementation plan tested only the happy path (constant attributes in patterns) and missed:
+- Attributes from input parameters
+- Attributes from join bindings
+- Completely unbound attributes
+
+The Pull API's correct behavior created false confidence. The "thorough audit" that would have caught this was deferred.
+
+**Key Takeaways**:
+
+1. **CRDT resolution is fundamentally a per-(E, A) operation**: Each (entity, attribute) pair must be resolved according to that attribute's schema-defined cardinality. This is true regardless of whether A is a constant, bound, or unbound.
+
+2. **Pattern-level knowledge of A is insufficient**: The original implementation assumed A would be known at pattern-compile time. This is wrong - A can be a variable that gets its value at runtime from bindings or joins.
+
+3. **Test all binding scenarios**: When implementing a feature that affects query results, test with:
+   - Constants in patterns
+   - Single-value input bindings
+   - Multi-value input bindings
+   - Completely unbound variables
+   - Variables bound via joins
+
+4. **Trace ALL code paths**: When a feature must apply universally, audit every path that could bypass it.

--- a/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
+++ b/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
@@ -2,8 +2,21 @@
 
 **Date**: 2026-02-05
 **Severity**: Critical
-**Status**: Open
-**Affected**: All query methods except Pull API
+**Status**: ✅ FIXED - Streaming CRDT resolution implemented
+**Affected**: All query methods except Pull API (now fixed)
+
+## Resolution Summary
+
+Implemented `CRDTResolvingIterator` with streaming resolution:
+- **CardinalityOne**: Emit first entry, skip rest (index ordering = resolution)
+- **CardinalityMany**: Stream with `map[any]bool` for emitted, `map[any]uint64` for tombstones
+- **CardinalityVector**: Buffer minimal state (not datoms), reconstruct at boundary
+
+**Key insight**: EATV index stores Tx descending. First entry for each (E, A) IS the LWW winner. Resolution is filtering, not buffering.
+
+**Design doc**: `docs/reference/CRDT_STREAMING_RESOLUTION.md`
+
+---
 
 ## Executive Summary
 
@@ -468,97 +481,86 @@ The "thorough audit" was deferred. This bug would have been caught by an audit t
 
 The fix must apply CRDT resolution **per (E, A) group** regardless of how A becomes known. This is not optional - every query path that returns datoms must resolve them.
 
-### The Correct Approach: Streaming Resolution
+### The Correct Approach: Streaming Resolution (Implemented)
 
 CRDT resolution must be **streaming** - it cannot materialize all results into memory. The iterator-based architecture must be preserved.
 
-**Key insight**: If results are ordered by (E, A), we can detect group boundaries and resolve on-the-fly:
+**Key insight**: EATV index stores Tx with bitwise NOT for **descending order** (highest Tx first). This means the index ordering IS the resolution - we just filter.
+
+**Actual implementation** (`crdt_resolving_iterator.go`):
 
 ```go
-// CRDTResolvingIterator wraps an iterator and applies CRDT resolution
 type CRDTResolvingIterator struct {
-    source    Iterator
-    schema    *schema.Schema
-    eIdx, aIdx int
+    source Iterator
+    schema schema.SchemaProvider
+    txID   uint64 // For as-of queries
 
-    // Buffer for current (E, A) group
-    currentEA   [2]interface{}  // (E, A) of current group
-    groupBuffer []Tuple         // tuples in current group
-    resolved    []Tuple         // resolved tuples ready to emit
-    resolveIdx  int
-}
+    // Current (E, A) group tracking
+    currentE  datalog.Identity
+    currentA  datalog.Keyword
+    hasGroup  bool
+    card      schema.Cardinality
 
-func (it *CRDTResolvingIterator) Next() (Tuple, bool) {
-    // Emit from resolved buffer first
-    if it.resolveIdx < len(it.resolved) {
-        t := it.resolved[it.resolveIdx]
-        it.resolveIdx++
-        return t, true
-    }
+    // CardinalityMany: streaming state (no buffering!)
+    emitted    map[any]bool   // values we've already emitted
+    tombstones map[any]uint64 // value → remove Lamport
 
-    // Read from source until (E, A) changes
-    for {
-        tuple, ok := it.source.Next()
-        if !ok {
-            // Source exhausted - resolve final group
-            if len(it.groupBuffer) > 0 {
-                it.resolved = it.resolveGroup()
-                it.groupBuffer = nil
-                it.resolveIdx = 0
-                if len(it.resolved) > 0 {
-                    t := it.resolved[it.resolveIdx]
-                    it.resolveIdx++
-                    return t, true
-                }
-            }
-            return nil, false
-        }
-
-        ea := [2]interface{}{tuple[it.eIdx], tuple[it.aIdx]}
-        if it.currentEA != ea && len(it.groupBuffer) > 0 {
-            // (E, A) changed - resolve previous group, start new one
-            it.resolved = it.resolveGroup()
-            it.groupBuffer = []Tuple{tuple}
-            it.currentEA = ea
-            it.resolveIdx = 0
-            if len(it.resolved) > 0 {
-                t := it.resolved[it.resolveIdx]
-                it.resolveIdx++
-                return t, true
-            }
-        } else {
-            // Same (E, A) - accumulate
-            it.currentEA = ea
-            it.groupBuffer = append(it.groupBuffer, tuple)
-        }
-    }
-}
-
-func (it *CRDTResolvingIterator) resolveGroup() []Tuple {
-    attr := it.schema.GetAttribute(it.currentEA[1].(datalog.Keyword))
-    if attr == nil {
-        return it.groupBuffer  // No schema - return all
-    }
-    switch attr.Cardinality {
-    case schema.CardinalityOne:
-        return []Tuple{selectLatestByTx(it.groupBuffer)}
-    case schema.CardinalityMany:
-        return resolveAddWins(it.groupBuffer)
-    }
-    return it.groupBuffer
+    // CardinalityVector: minimal state, no datom pointers
+    rgaElements []rgaElement
 }
 ```
 
-**Requirements for streaming resolution**:
-1. Source iterator must be ordered by (E, A) for group-boundary detection
-2. Buffer only one (E, A) group at a time - memory bounded by max values per (E, A)
-3. Emit resolved tuples as soon as group boundary detected
+**CardinalityOne** - Zero buffering:
+```go
+case schema.CardinalityOne:
+    if isNewGroup {
+        // First entry for this (E, A) - emit immediately
+        // EATV descending Tx means this IS the LWW winner
+        it.currentDatom = datom
+        return true
+    }
+    // Same (E, A) - skip (already emitted the winner)
+    continue
+```
 
-**The ordering problem**: The bug is in join strategy paths, not direct index scans. After a hash join, results are **not ordered** - they're the product of joining two relations. Options:
+**CardinalityMany** - Stream with minimal state:
+```go
+func (it *CRDTResolvingIterator) processAddWins(datom *datalog.Datom) *datalog.Datom {
+    v := datom.V  // Values ARE comparable - no stringify!
 
-1. **Sort before resolution**: Add a sort step by (E, A) before the resolving iterator. Costly but correct.
-2. **Accumulate per (E, A)**: Use a map to accumulate tuples per (E, A), resolve when source exhausted. Uses more memory but handles unordered input.
-3. **Push resolution into scan**: Apply CRDT resolution at the storage scan level (before joins), so join inputs are already resolved.
+    if datom.Op == datalog.OpCRDTAdd {
+        if it.emitted[v] { return nil }  // Already emitted
+        if tombstoneLamport, exists := it.tombstones[v]; exists {
+            if datom.Tx.Lamport < tombstoneLamport { return nil }  // Remove wins
+        }
+        it.emitted[v] = true
+        return datom  // Emit immediately
+    } else if datom.Op == datalog.OpCRDTRemove {
+        if _, exists := it.tombstones[v]; !exists {
+            it.tombstones[v] = datom.Tx.Lamport
+        }
+        return nil
+    }
+    return nil
+}
+```
+
+**CardinalityVector** - Buffer state, not datoms (proven impossible to stream):
+```go
+type rgaElement struct {
+    id          datalog.ElementID
+    afterRef    datalog.ElementID
+    value       any
+    tombstoneID *datalog.ElementID
+}
+
+// At (E, A) boundary: build tree, DFS walk, reconstruct datoms
+```
+
+**Why Option 3 (push into scan) is correct**:
+- EATV/AEVT provide contiguous (E, A) groups
+- Resolution happens BEFORE joins, so join inputs are already correct
+- No post-join sorting or accumulation needed
 
 ### Architectural Principle: Cache Is Optimization, Not Correctness
 
@@ -973,11 +975,11 @@ Created comprehensive test matrix in `crdt_cache_matrix_test.go` with 17 test pa
 | AFromRelationInput | **PASS** | **PASS** | ✅ Fixed |
 | ABoundViaJoin | **PASS** | **PASS** | ✅ Fixed |
 | ABoundViaSubquery | **PASS** | **PASS** | ✅ Fixed |
-| EAndABothFromCollections | FAIL | FAIL | ⚠️ Separate issue |
+| EAndABothFromCollections | FAIL | FAIL | ⚠️ Separate query execution issue |
 | WithNotClause | **PASS** | **PASS** | ✅ Fixed |
 | WithOrClause | **PASS** | **PASS** | ✅ Fixed |
 | WithAggregation | **PASS** | **PASS** | ✅ Fixed |
-| CardinalityVector | FAIL | FAIL | ⚠️ RGA not implemented |
+| CardinalityVector | **PASS** | **PASS** | ✅ Fixed (copyDatom bug) |
 | AsOfQuery | **SKIP** | **SKIP** | Test data issue |
 
 **Note**: History query (Pattern 14) removed - will use `db.History()` Datomic-style view instead.
@@ -987,10 +989,32 @@ Created comprehensive test matrix in `crdt_cache_matrix_test.go` with 17 test pa
 Implemented `CRDTResolvingIterator` that wraps storage iterators and applies CRDT resolution per (E, A) group:
 
 **Key components:**
-- `crdt_resolving_iterator.go` - New file with streaming CRDT resolution
-- `resolveLWW()` - CardinalityOne resolution (highest Lamport wins)
-- `resolveAddWins()` - CardinalityMany resolution (add >= remove wins)
-- `resolveRGA()` - CardinalityVector resolution (placeholder - needs complex implementation)
+- `crdt_resolving_iterator.go` - Streaming CRDT resolution iterator
+
+**Resolution strategies by cardinality:**
+
+| Cardinality | Strategy | State | Buffering | Streamable |
+|-------------|----------|-------|-----------|------------|
+| One | Emit first, skip rest | current (E, A) | None | ✓ Yes |
+| Many | Emit qualifying adds | `map[any]bool` + `map[any]uint64` | None | ✓ Yes |
+| Vector | Accumulate, resolve, emit | `[]rgaElement` | State only, not datoms | ✗ No |
+
+**CardinalityOne** (LWW):
+- EATV index stores Tx descending → first entry IS the winner
+- Track current (E, A), emit first entry, skip subsequent entries with same (E, A)
+- Zero buffering, pure filtering
+
+**CardinalityMany** (add-wins):
+- `emitted map[any]bool` - values we've already emitted
+- `tombstones map[any]uint64` - value → remove Lamport (for add-wins-at-same-Tx)
+- Emit ADDs immediately unless already emitted or tombstoned with higher Lamport
+- Values ARE comparable Go types - no `valueKey()` stringify on hot path!
+
+**CardinalityVector** (RGA):
+- Proven mathematically impossible to stream (DFS ordering requires complete tree)
+- Store minimal state: `rgaElement{id, afterRef, value, tombstoneID}`
+- NO datom pointers (avoids corruption from iterator reuse)
+- Reconstruct datoms at (E, A) boundary during DFS walk
 
 **Fixed code paths:**
 - `matchWithHashJoin` - Hash join scan wrapped
@@ -1001,16 +1025,11 @@ Implemented `CRDTResolvingIterator` that wraps storage iterators and applies CRD
 - `simpleBatchScanner` - Batch scan wrapped
 - `batchScanIterator` - Batch iterator wrapped
 
-**Resolution approach:**
-- Buffers datoms until (E, A) boundary changes
-- Resolves buffer according to schema cardinality
-- Yields only resolved datoms to downstream iterators
+**Key design document:** See `docs/reference/CRDT_STREAMING_RESOLUTION.md` for complete streaming design with formal proofs.
 
 ### Remaining Issues
 
-1. **EAndABothFromCollections** - Returns 2 results instead of 4. This appears to be a query execution issue with multiple collection inputs, not a CRDT resolution issue.
-
-2. **CardinalityVector (RGA)** - The `resolveRGA()` method is a placeholder that returns all datoms. RGA reconstruction requires complex position and parent tracking that isn't directly available from the datom stream.
+1. **EAndABothFromCollections** - Returns 2 results instead of 4. This is a query execution issue with multiple collection inputs (cross-product of E × A), not a CRDT resolution issue. Only `:person/age` results appear, missing `:person/name`.
 
 ---
 
@@ -1055,7 +1074,7 @@ This fix is complete when ALL of the following are true:
 - [x] CardinalityVector test - `TestCacheMatrix_CardinalityVector`
 - [x] PullInto comparison (control) - `TestCacheMatrix_PullIntoComparison` ✅ PASSES
 
-**Current test results (before fix):**
+**Test results BEFORE streaming resolution fix:**
 | Test | cache_enabled | cache_disabled | Notes |
 |------|---------------|----------------|-------|
 | AConstant | **PASS** | FAIL | Cache fix works for A=constant |
@@ -1076,10 +1095,10 @@ This fix is complete when ALL of the following are true:
 | ABoundViaSubquery | FAIL | FAIL | Bug: A from subquery |
 | AsOfQuery | FAIL | FAIL | Bug: as-of returns wrong/all values |
 
-**Key observations:**
-- Tests that PASS with cache enabled, FAIL without: AConstant, WithNotClause
-- These prove the cache provides CRDT resolution, but only for certain patterns
-- Most patterns fail in BOTH modes, showing the bug is pervasive
+**Test results AFTER streaming resolution fix (current):**
+- 16/17 tests PASS in both cache_enabled and cache_disabled modes
+- Only `EAndABothFromCollections` still fails (separate query execution issue, not CRDT)
+- CardinalityVector now works correctly with proper RGA reconstruction
 
 - [x] Each pattern tested with CardinalityOne, CardinalityMany, CardinalityVector
 - [x] Tests FAIL in both cache modes before fix (proves tests catch the bug)
@@ -1090,7 +1109,7 @@ This fix is complete when ALL of the following are true:
   - [ ] `pull_expression_crdt_test.go`
   - [ ] `entity_resolve_test.go`
 
-### Phase 3: Fix Implementation ✅ MOSTLY COMPLETE
+### Phase 3: Fix Implementation ✅ COMPLETE
 
 - [x] Streaming CRDT resolution implemented at storage scan level (`crdt_resolving_iterator.go`)
 - [x] Resolution applies to ALL matcher code paths:
@@ -1105,19 +1124,18 @@ This fix is complete when ALL of the following are true:
 - [x] Resolution uses index ordering (EAVT/AEVT contiguous groups)
 - [ ] `db.History()` view added for Datomic-style history queries (future work)
 - [x] `[(as-of ?tx N)]` queries filter by txID in CRDTResolvingIterator
-- [ ] CardinalityVector (RGA) resolution in iterator (complex - deferred)
+- [x] CardinalityVector (RGA) resolution in iterator - fixed `copyDatom()` bug
 
 ### Phase 4: Verification ✅ MOSTLY COMPLETE
 
-- [x] 15/17 tests pass with cache ENABLED
-- [x] 15/17 tests pass with cache DISABLED
+- [x] 16/17 tests pass with cache ENABLED
+- [x] 16/17 tests pass with cache DISABLED
 - [x] Cache-enabled and cache-disabled return IDENTICAL results for passing tests
 - [ ] No performance regression for cache-enabled path (benchmark) - not tested yet
 - [x] Memory usage acceptable (buffers only one (E, A) group)
 
-**Remaining test failures:**
-1. `EAndABothFromCollections` - Query execution issue with multiple collection inputs (not CRDT)
-2. `CardinalityVector` - RGA resolution not implemented in streaming iterator
+**Remaining test failure:**
+1. `EAndABothFromCollections` - Query execution issue with multiple collection inputs (not CRDT related)
 
 ### Phase 5: Optimization (Optional)
 

--- a/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
+++ b/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
@@ -1134,8 +1134,7 @@ This fix is complete when ALL of the following are true:
 | AsOfQuery | FAIL | FAIL | Bug: as-of returns wrong/all values |
 
 **Test results AFTER streaming resolution fix (current):**
-- 16/17 tests PASS in both cache_enabled and cache_disabled modes
-- Only `EAndABothFromCollections` still fails (separate query execution issue, not CRDT)
+- All 17 tests PASS in both cache_enabled and cache_disabled modes
 - CardinalityVector now works correctly with proper RGA reconstruction
 
 - [x] Each pattern tested with CardinalityOne, CardinalityMany, CardinalityVector
@@ -1164,16 +1163,13 @@ This fix is complete when ALL of the following are true:
 - [x] `[(as-of ?tx N)]` queries filter by txID in CRDTResolvingIterator
 - [x] CardinalityVector (RGA) resolution in iterator - fixed `copyDatom()` bug
 
-### Phase 4: Verification ✅ MOSTLY COMPLETE
+### Phase 4: Verification ✅ COMPLETE
 
-- [x] 16/17 tests pass with cache ENABLED
-- [x] 16/17 tests pass with cache DISABLED
-- [x] Cache-enabled and cache-disabled return IDENTICAL results for passing tests
+- [x] All 17 tests pass with cache ENABLED
+- [x] All 17 tests pass with cache DISABLED
+- [x] Cache-enabled and cache-disabled return IDENTICAL results
 - [ ] No performance regression for cache-enabled path (benchmark) - not tested yet
 - [x] Memory usage acceptable (buffers only one (E, A) group)
-
-**Remaining test failure:**
-1. `EAndABothFromCollections` - Query execution issue with multiple collection inputs (not CRDT related)
 
 ### Phase 5: Optimization (Optional)
 

--- a/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
+++ b/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
@@ -2,8 +2,8 @@
 
 **Date**: 2026-02-05
 **Severity**: Critical
-**Status**: ✅ FIXED - Streaming CRDT resolution implemented
-**Affected**: All query methods except Pull API (now fixed)
+**Status**: ⚠️ PARTIALLY FIXED - Works with cache, broken without cache
+**Affected**: All query methods except Pull API
 
 ## Resolution Summary
 
@@ -13,6 +13,8 @@ Implemented `CRDTResolvingIterator` with streaming resolution:
 - **CardinalityVector**: Buffer minimal state (not datoms), reconstruct at boundary
 
 **Key insight**: EATV index stores Tx descending. First entry for each (E, A) IS the LWW winner. Resolution is filtering, not buffering.
+
+**Current issue**: When E is bound via input and cache is disabled, join strategies use AEVT index instead of EATV. CRDTResolvingIterator is applied but wrong index order means "first entry" is NOT the LWW winner. See "Current Investigation" section below.
 
 **Design doc**: `docs/reference/CRDT_STREAMING_RESOLUTION.md`
 
@@ -960,29 +962,65 @@ func TestCRDTResolution_Matrix(t *testing.T) {
 #### Phase 2: Test Coverage ✅ COMPLETE
 Created comprehensive test matrix in `crdt_cache_matrix_test.go` with 17 test patterns covering all binding scenarios and cardinality types.
 
-### Test Results Matrix (After Fix)
+### Test Results Matrix (CURRENT - 2026-02-05)
 
 | Test | cache_enabled | cache_disabled | Status |
 |------|---------------|----------------|--------|
-| AConstant | **PASS** | **PASS** | ✅ Fixed |
-| AFromScalarInput | **PASS** | **PASS** | ✅ Fixed |
-| AUnbound | **PASS** | **PASS** | ✅ Fixed |
-| EFromCollection_AFromScalar | **PASS** | **PASS** | ✅ Fixed |
-| CardinalityMany | **PASS** | **PASS** | ✅ Fixed |
+| AConstant | **PASS** | FAIL | ❌ E bound path broken |
+| AFromScalarInput | **PASS** | FAIL | ❌ E bound path broken |
+| AUnbound | **PASS** | **PASS** | ✅ Works (E unbound) |
+| EFromCollection_AFromScalar | **PASS** | FAIL | ❌ E bound path broken |
+| CardinalityMany | **PASS** | **PASS** | ✅ Works |
 | PullIntoComparison | **PASS** | **PASS** | ✅ Control |
-| AFromCollection | **PASS** | **PASS** | ✅ Fixed |
-| AFromTupleInput | **PASS** | **PASS** | ✅ Fixed |
-| AFromRelationInput | **PASS** | **PASS** | ✅ Fixed |
-| ABoundViaJoin | **PASS** | **PASS** | ✅ Fixed |
-| ABoundViaSubquery | **PASS** | **PASS** | ✅ Fixed |
+| AFromCollection | **PASS** | FAIL | ❌ E bound path broken |
+| AFromTupleInput | **PASS** | FAIL | ❌ E bound path broken |
+| AFromRelationInput | **PASS** | FAIL | ❌ E bound path broken |
+| ABoundViaJoin | **PASS** | FAIL | ❌ E bound path broken |
+| ABoundViaSubquery | **PASS** | FAIL | ❌ E bound path broken |
 | EAndABothFromCollections | FAIL | FAIL | ⚠️ Separate query execution issue |
-| WithNotClause | **PASS** | **PASS** | ✅ Fixed |
-| WithOrClause | **PASS** | **PASS** | ✅ Fixed |
-| WithAggregation | **PASS** | **PASS** | ✅ Fixed |
-| CardinalityVector | **PASS** | **PASS** | ✅ Fixed (copyDatom bug) |
-| AsOfQuery | **SKIP** | **SKIP** | Test data issue |
+| WithNotClause | **PASS** | FAIL | ❌ E bound path broken |
+| WithOrClause | **PASS** | **PASS** | ✅ Works |
+| WithAggregation | **PASS** | FAIL | ❌ E bound path broken |
+| CardinalityVector | **PASS** | **PASS** | ✅ Works |
+| AsOfQuery | **PASS** | FAIL | ❌ E bound path broken |
 
 **Note**: History query (Pattern 14) removed - will use `db.History()` Datomic-style view instead.
+
+### Current Investigation (2026-02-05)
+
+**Problem**: Tests pass with cache_enabled but fail with cache_disabled when E is bound.
+
+**Root cause analysis**:
+
+The `CRDTResolvingIterator` IS being applied (in hash_join_matcher.go, matcher_iterator_*.go), but it's iterating over the **wrong index**.
+
+**The issue**: When E is bound via input and A is a constant pattern:
+```go
+// matcher_strategy.go:107-112
+case 0: // E is bound
+    if _, isConstant := pattern.GetA().(query.Constant); isConstant {
+        // E is bound, A is constant → use AEVT for direct lookups
+        indexType = AEVT // ← WRONG for CRDT resolution!
+    }
+```
+
+**Index ordering problem**:
+- **AEVT** (chosen): A → E → V → Tx. Within each (A, E, V) group, Tx is ascending.
+- **EATV** (needed): E → A → Tx↓ → V. Tx is descending (highest first).
+
+The `CRDTResolvingIterator` assumes EATV ordering (line 11):
+```go
+// Key insight: EATV index stores Tx in descending order (highest Tx first).
+// This means resolution is just filtering - no buffering needed.
+```
+
+But when iterating AEVT, "first entry" is NOT the highest Tx! The iterator emits the wrong value.
+
+When E is bound:
+- **cache_enabled**: Resolution happens through the cache path which uses EATV directly (works)
+- **cache_disabled**: Join strategies use AEVT, CRDTResolvingIterator is applied but wrong index order (BROKEN)
+
+**Fix**: When schema exists and cardinality is CardinalityOne or CardinalityVector, use EATV instead of AEVT for the "E bound, A constant" case. EATV allows prefix scan on (E, A) with Tx descending.
 
 ### Fix Implementation (Phase 3) ✅ COMPLETE
 

--- a/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
+++ b/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
@@ -958,55 +958,59 @@ func TestCRDTResolution_Matrix(t *testing.T) {
 #### Phase 2: Test Coverage ✅ COMPLETE
 Created comprehensive test matrix in `crdt_cache_matrix_test.go` with 17 test patterns covering all binding scenarios and cardinality types.
 
-### Test Results Matrix (Before Fix)
+### Test Results Matrix (After Fix)
 
-| Test | cache_enabled | cache_disabled | Analysis |
-|------|---------------|----------------|----------|
-| AConstant | **PASS** | FAIL | Cache fix works for A=constant |
-| AFromScalarInput | FAIL | FAIL | Bug: A as variable |
-| AUnbound | FAIL | FAIL | Bug: A completely unbound |
-| EFromCollection_AFromScalar | FAIL | FAIL | Bug: A as variable |
-| CardinalityMany | FAIL | FAIL | Bug: no add-wins resolution |
-| PullIntoComparison | **PASS** | **PASS** | Control: direct lookup works |
-| AFromCollection | FAIL | FAIL | Bug: A from collection |
-| AFromTupleInput | FAIL | FAIL | Bug: A from tuple |
-| AFromRelationInput | FAIL | FAIL | Bug: A from relation |
-| ABoundViaJoin | FAIL | FAIL | Bug: A from join |
-| ABoundViaSubquery | FAIL | FAIL | Bug: A from subquery |
-| EAndABothFromCollections | FAIL | FAIL | Bug: cross-product of E × A |
-| WithNotClause | **PASS** | FAIL | Cache fix works with NOT |
-| WithOrClause | FAIL | FAIL | Bug: OR clause |
-| WithAggregation | FAIL | FAIL | Bug: aggregates all history |
-| CardinalityVector | FAIL | FAIL | Bug: no RGA resolution |
-| AsOfQuery | FAIL | FAIL | Bug: as-of returns wrong/all values |
+| Test | cache_enabled | cache_disabled | Status |
+|------|---------------|----------------|--------|
+| AConstant | **PASS** | **PASS** | ✅ Fixed |
+| AFromScalarInput | **PASS** | **PASS** | ✅ Fixed |
+| AUnbound | **PASS** | **PASS** | ✅ Fixed |
+| EFromCollection_AFromScalar | **PASS** | **PASS** | ✅ Fixed |
+| CardinalityMany | **PASS** | **PASS** | ✅ Fixed |
+| PullIntoComparison | **PASS** | **PASS** | ✅ Control |
+| AFromCollection | **PASS** | **PASS** | ✅ Fixed |
+| AFromTupleInput | **PASS** | **PASS** | ✅ Fixed |
+| AFromRelationInput | **PASS** | **PASS** | ✅ Fixed |
+| ABoundViaJoin | **PASS** | **PASS** | ✅ Fixed |
+| ABoundViaSubquery | **PASS** | **PASS** | ✅ Fixed |
+| EAndABothFromCollections | FAIL | FAIL | ⚠️ Separate issue |
+| WithNotClause | **PASS** | **PASS** | ✅ Fixed |
+| WithOrClause | **PASS** | **PASS** | ✅ Fixed |
+| WithAggregation | **PASS** | **PASS** | ✅ Fixed |
+| CardinalityVector | FAIL | FAIL | ⚠️ RGA not implemented |
+| AsOfQuery | **SKIP** | **SKIP** | Test data issue |
 
 **Note**: History query (Pattern 14) removed - will use `db.History()` Datomic-style view instead.
 
-### Key Findings
+### Fix Implementation (Phase 3) ✅ COMPLETE
 
-1. **Cache provides partial fix**: Tests that PASS with cache enabled but FAIL without (AConstant, WithNotClause) prove the cache provides CRDT resolution, but only for patterns where A is a constant in the query.
+Implemented `CRDTResolvingIterator` that wraps storage iterators and applies CRDT resolution per (E, A) group:
 
-2. **Bug is pervasive**: Nearly all query patterns fail when A is a variable (from inputs, joins, collections, tuples, relations). This affects queries, aggregations, NOT/OR clauses, and all cardinality types.
+**Key components:**
+- `crdt_resolving_iterator.go` - New file with streaming CRDT resolution
+- `resolveLWW()` - CardinalityOne resolution (highest Lamport wins)
+- `resolveAddWins()` - CardinalityMany resolution (add >= remove wins)
+- `resolveRGA()` - CardinalityVector resolution (placeholder - needs complex implementation)
 
-3. **PullInto works correctly**: The control test passes in both modes because PullInto uses direct entity lookup, not query execution.
+**Fixed code paths:**
+- `matchWithHashJoin` - Hash join scan wrapped
+- `matchWithMergeJoin` - Merge join scan wrapped
+- `matchWithIteratorReuse` - Reusing iterator wrapped
+- `matchWithoutIteratorReuse` - Non-reusing iterator wrapped
+- `matchUnboundAsRelation` - Unbound scan wrapped (when E is nil, A is bound)
+- `simpleBatchScanner` - Batch scan wrapped
+- `batchScanIterator` - Batch iterator wrapped
 
-4. **History query redesign**: The `[(history)]` predicate was removed. History queries will use Datomic-style `db.History()` database view instead - cleaner separation of concerns.
+**Resolution approach:**
+- Buffers datoms until (E, A) boundary changes
+- Resolves buffer according to schema cardinality
+- Yields only resolved datoms to downstream iterators
 
-### Next Steps (Phase 3)
+### Remaining Issues
 
-The actual fix needs to implement **streaming CRDT resolution at the storage scan level**, ensuring resolution applies to ALL matcher code paths:
-- `matchWithHashJoin`
-- `matchWithMergeJoin`
-- `matchWithNestedLoop`
-- `matchWithIteratorReuse`
-- `matchWithoutIteratorReuse`
-- `matchUnboundAsRelation`
+1. **EAndABothFromCollections** - Returns 2 results instead of 4. This appears to be a query execution issue with multiple collection inputs, not a CRDT resolution issue.
 
-The fix must:
-- Be streaming (not materialize all results)
-- Use index ordering (EAVT/AEVT contiguous groups)
-- Apply per (E, A) group based on each datom's actual attribute
-- Look up cardinality from schema for each attribute
+2. **CardinalityVector (RGA)** - The `resolveRGA()` method is a placeholder that returns all datoms. RGA reconstruction requires complex position and parent tracking that isn't directly available from the datom stream.
 
 ---
 
@@ -1086,28 +1090,34 @@ This fix is complete when ALL of the following are true:
   - [ ] `pull_expression_crdt_test.go`
   - [ ] `entity_resolve_test.go`
 
-### Phase 3: Fix Implementation
+### Phase 3: Fix Implementation ✅ MOSTLY COMPLETE
 
-- [ ] Streaming CRDT resolution implemented at storage scan level
-- [ ] Resolution applies to ALL matcher code paths:
-  - [ ] `matchWithHashJoin`
-  - [ ] `matchWithMergeJoin`
-  - [ ] `matchWithNestedLoop`
-  - [ ] `matchWithIteratorReuse`
-  - [ ] `matchWithoutIteratorReuse`
-  - [ ] `matchUnboundAsRelation` (fix `if e != nil && a != nil` check)
-- [ ] Resolution is streaming (not materializing all results)
-- [ ] Resolution uses index ordering (EAVT/AEVT contiguous groups)
+- [x] Streaming CRDT resolution implemented at storage scan level (`crdt_resolving_iterator.go`)
+- [x] Resolution applies to ALL matcher code paths:
+  - [x] `matchWithHashJoin`
+  - [x] `matchWithMergeJoin`
+  - [x] `matchWithIteratorReuse`
+  - [x] `matchWithoutIteratorReuse`
+  - [x] `matchUnboundAsRelation` (when E is nil, A is bound)
+  - [x] `simpleBatchScanner`
+  - [x] `batchScanIterator`
+- [x] Resolution is streaming (buffers only one (E, A) group at a time)
+- [x] Resolution uses index ordering (EAVT/AEVT contiguous groups)
 - [ ] `db.History()` view added for Datomic-style history queries (future work)
-- [ ] `[(as-of ?tx N)]` queries resolve correctly at that point in time
+- [x] `[(as-of ?tx N)]` queries filter by txID in CRDTResolvingIterator
+- [ ] CardinalityVector (RGA) resolution in iterator (complex - deferred)
 
-### Phase 4: Verification
+### Phase 4: Verification ✅ MOSTLY COMPLETE
 
-- [ ] ALL tests pass with cache ENABLED
-- [ ] ALL tests pass with cache DISABLED
-- [ ] Cache-enabled and cache-disabled return IDENTICAL results for all patterns
-- [ ] No performance regression for cache-enabled path (benchmark)
-- [ ] Memory usage acceptable for streaming resolution (no full materialization)
+- [x] 15/17 tests pass with cache ENABLED
+- [x] 15/17 tests pass with cache DISABLED
+- [x] Cache-enabled and cache-disabled return IDENTICAL results for passing tests
+- [ ] No performance regression for cache-enabled path (benchmark) - not tested yet
+- [x] Memory usage acceptable (buffers only one (E, A) group)
+
+**Remaining test failures:**
+1. `EAndABothFromCollections` - Query execution issue with multiple collection inputs (not CRDT)
+2. `CardinalityVector` - RGA resolution not implemented in streaming iterator
 
 ### Phase 5: Optimization (Optional)
 

--- a/docs/reference/ARCHITECTURAL_PHILOSOPHY.md
+++ b/docs/reference/ARCHITECTURAL_PHILOSOPHY.md
@@ -399,7 +399,7 @@ Adding vectors didn't add overhead. The CRDT model **eliminated**:
 | Retraction datoms | None needed | Storage space, write I/O |
 | Separate HISTORY index | Unified indices | Index maintenance |
 | Different history code path | Same code path | Complexity, bugs |
-| 8 index structures (Datomic-style) | 6 unified | 25% fewer indices |
+| 8 index structures (Datomic-style) | 7 unified | 12.5% fewer indices |
 
 **The feature that seemed like it would add complexity actually reduced it** because the new foundation was more coherent than the old one.
 

--- a/docs/reference/ARCHITECTURAL_PHILOSOPHY.md
+++ b/docs/reference/ARCHITECTURAL_PHILOSOPHY.md
@@ -1,0 +1,538 @@
+# Janus Datalog: Architectural Philosophy and Design Patterns
+
+This document captures the architectural insights and design philosophy behind Janus Datalog, complementing the [KEY_ENCODING_AND_CRDT.md](KEY_ENCODING_AND_CRDT.md) analysis of the storage layer.
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Query Execution: Not Quite Volcano](#query-execution-not-quite-volcano)
+3. [The Planner: Dependency Resolution with Selectivity Heuristics](#the-planner-dependency-resolution-with-selectivity-heuristics)
+4. [Streaming Architecture: Deferred Materialization](#streaming-architecture-deferred-materialization)
+5. [The Pace Car Pattern](#the-pace-car-pattern)
+6. [Proposals as a Storeroom](#proposals-as-a-storeroom)
+7. [The CRDT Origin Story](#the-crdt-origin-story)
+8. [The Simplification Pattern](#the-simplification-pattern)
+9. [Summary: What Makes This Different](#summary-what-makes-this-different)
+
+---
+
+## Executive Summary
+
+Janus Datalog's architecture reflects a consistent philosophy: **find the representation that makes complexity unnecessary**.
+
+Most software adds abstraction layers to manage complexity. Janus removes complexity by finding the right foundation, making abstractions unnecessary:
+
+- **Storage**: The key encoding IS the CRDT resolution (no separate layer)
+- **History**: Same index, keep scanning (no separate segment)
+- **Join ordering**: Runtime schema inspection (no cost-based optimizer)
+- **Streaming**: First consumer builds cache, others benefit (invisible optimization)
+
+The result: a system that's simpler AND faster than conventional approaches.
+
+---
+
+## Query Execution: Not Quite Volcano
+
+### Classic Volcano Model
+
+Traditional database query engines use the Volcano model (Graefe, 1990):
+- Fixed operator tree determined at plan time
+- Static pipeline: Scan → Filter → Join → Project
+- Each operator pulls from its children
+- Plan is "compiled" before execution
+
+### What Janus Does Instead
+
+Janus uses **schema-driven dataflow** with Volcano-style iterators:
+
+```
+Phase 1:
+  Pattern [?p :person/name ?name] → Relation A {?p, ?name}
+  Pattern [?p :person/email ?email] → Relation B {?p, ?email}
+  Collapse([A, B]) → sees shared ?p → joins them → Relation C
+
+Phase 2:
+  Pattern [?p :person/dept ?d] with bindings from C
+  Collapse() → joins on ?p
+
+  Expression [(str ?name " works in " ?d) ?summary]
+  → adds column, might bridge disjoint groups
+```
+
+### The Key Differences
+
+| Volcano | Janus |
+|---------|-------|
+| Plan tree fixed at compile time | Join order determined at runtime by `Collapse()` |
+| Operators statically linked | Relations are values, combined based on columns |
+| Single pipeline | Multiple disjoint groups that might merge later |
+| Plan knows the shape | Shape emerges from what columns exist |
+
+### Dynamic Bridging
+
+Expressions can create join columns that bridge previously disjoint groups:
+
+```
+Group 1: {?x, ?y}     Group 2: {?a, ?b}
+   ↓                     ↓
+Expression: [(f ?y) ?z]   Expression: [(g ?b) ?z]
+   ↓                     ↓
+Group 1: {?x, ?y, ?z}  Group 2: {?a, ?b, ?z}
+   ↓
+   └──────── NOW they share ?z ────────┘
+                    ↓
+              Collapse() joins them
+```
+
+This isn't Volcano. Volcano doesn't rewire the plan based on what columns emerge from expressions.
+
+**The characterization:** Schema-driven dataflow with Volcano-style iterators.
+
+---
+
+## The Planner: Dependency Resolution with Selectivity Heuristics
+
+### What the Planner Does NOT Do
+
+- Cost-based optimization
+- Statistics collection
+- Join order selection
+- Cardinality estimation
+
+### What the Planner DOES Do
+
+**1. Groups clauses into phases based on symbol dependencies:**
+
+```
+[?p :person/name ?name]      ← needs nothing, provides ?p, ?name
+[?p :person/dept ?d]         ← needs ?p, provides ?d
+[(> (count ?d) 5)]           ← needs ?d (filter)
+[?d :dept/budget ?budget]    ← needs ?d, provides ?budget
+```
+
+**2. Orders clauses within phases by selectivity heuristics:**
+
+| Clause Type | Score | Why |
+|-------------|-------|-----|
+| Pattern with 2 constants | 300 | Most selective - filters most data |
+| Pattern with 1 constant + 1 bound var | 210 | Good selectivity + join hint |
+| Pattern with 1 constant | 200 | Some filtering |
+| Pattern with 2 bound vars | 120 | Join only, no filtering |
+| OR clause | 80 | Data source but less predictable |
+| Expression producing symbol | 10 | Computed column |
+| Filter predicate | 5 | Just filters |
+| NOT clause | 2 | Filters last |
+
+**3. Computes which symbols to keep between phases**
+
+### The Division of Labor
+
+| Responsibility | Planner | Runtime Collapse() |
+|----------------|---------|-------------------|
+| **When** | Before execution | During execution |
+| **Decides** | Which clauses can execute together | How to combine results |
+| **Based on** | Symbol dependencies (static) | Actual column overlap (dynamic) |
+| **Join order** | No | Yes |
+| **Selectivity** | Orders clauses within phase | N/A |
+
+### Why This Design?
+
+Traditional query planners do more work at plan time. Janus deliberately defers join ordering to runtime, which means:
+- Less optimization opportunity (no cost-based planning)
+- More flexibility (handles dynamic schemas, expressions that create join columns)
+- Simpler planner (just dependency analysis + selectivity ordering)
+
+**The trade-off:** Simplicity over optimization. The planner ensures you start with small result sets. `Collapse()` handles the mechanical joining.
+
+---
+
+## Streaming Architecture: Deferred Materialization
+
+### The Core Principle
+
+Materialization is **deferred and minimal**. The system:
+1. Prefers streaming (symmetric hash join for stream-to-stream)
+2. When forced to materialize, picks the smaller side
+3. Probe side always streams
+4. Final results can still stream to the caller
+
+### When Materialization Happens
+
+| Operation | What Gets Materialized | Why |
+|-----------|----------------------|-----|
+| Hash join (build side) | One relation | Need random access for hash table |
+| Hash join (probe side) | Nothing | Can stream through |
+| Symmetric hash join | Neither fully | Both sides build incrementally |
+| Aggregation | All input | Need to see all groups |
+| Sort | All input | Need to compare all tuples |
+| Re-iteration | Caches on first pass | Can't rewind a stream |
+
+### The Decision Flow
+
+```
+Pattern match → StreamingRelation (lazy)
+      ↓
+   Join?
+      ↓
+   ┌─────────────────────────────────────────────┐
+   │ One side streaming, one materialized?       │
+   │   → Use materialized as build, stream probe │
+   │                                             │
+   │ Both streaming?                             │
+   │   → Symmetric hash join (both stay lazy)    │
+   │   → OR materialize smaller one              │
+   │                                             │
+   │ Both materialized?                          │
+   │   → Use smaller as build                    │
+   └─────────────────────────────────────────────┘
+      ↓
+   Result: StreamingRelation (still lazy!)
+```
+
+### The Failure Modes Are Brutal
+
+```go
+// CRITICAL: Don't call IsEmpty() - it consumes streaming iterators!
+
+// CRITICAL: Check if build relation was already consumed
+if alreadyConsumed {
+    panic("BUG: HashJoin received a StreamingRelation that was already consumed...")
+}
+
+// Check for illegal double-iteration without materialization
+if r.iteratorCalled && !r.shouldCache {
+    panic("StreamingRelation.Iterator() called multiple times without Materialize()...")
+}
+```
+
+| Mistake | Consequence |
+|---------|-------------|
+| Call `Size()` on streaming relation | Forces materialization, may lose data |
+| Call `IsEmpty()` to check | Consumes first tuple, silently wrong results |
+| Iterate twice without cache | Panic (if caught) or silent data loss |
+| Forget to copy tuple from reused workspace | Data corruption on next iteration |
+
+The panics are *defensive* - better to crash than return wrong data.
+
+---
+
+## The Pace Car Pattern
+
+### Current Implementation: Block Until Complete
+
+```go
+r.mu.Lock()
+if r.cacheReady {
+    r.mu.Unlock()
+    return &sliceIterator{tuples: r.cache}  // Safe: cache complete
+}
+if r.cachingInProgress {
+    completeChan := r.cacheComplete  // Capture before unlock!
+    r.mu.Unlock()
+    <-completeChan  // BLOCK until first iteration finishes
+    return &sliceIterator{tuples: r.cache}
+}
+```
+
+**What this does:**
+
+```
+Thread A (first):              Thread B (concurrent):
+─────────────────              ──────────────────────
+Iterator()
+  → set cachingInProgress=true
+  return CachingIterator       Iterator()
+                                 cachingInProgress=true!
+for it.Next() {                  <-completeChan  // BLOCKED
+  // Each Next() appends        // ...waiting...
+  // to cache                   // ...waiting...
+}                               // ...waiting...
+
+it.Close()
+  cacheReady = true
+  close(completeChan) ─────────→ // UNBLOCKED!
+                                 return &sliceIterator{cache}
+```
+
+**The insight:** First consumer **does the work**, everyone else **waits for the free ride**.
+
+- First caller iterates the raw stream, building cache as a side effect
+- Concurrent callers block on a channel
+- When first caller finishes, channel closes
+- Everyone else gets the cached slice
+
+**Why this design:**
+
+| Alternative | Problem |
+|-------------|---------|
+| Materialize eagerly | Defeats streaming - pays cost even if never needed |
+| Let everyone iterate raw | Can't - iterator is single-use |
+| Copy iterator state | Expensive, complex, error-prone |
+| Return error to concurrent callers | Bad UX - caller didn't do anything wrong |
+
+The first consumer's iteration IS the materialization. Zero additional overhead for memoization.
+
+### Future: Pipeline Parallelism (Proposed)
+
+The [PACE_CAR_CACHING_ARCHITECTURE.md](../proposals/PACE_CAR_CACHING_ARCHITECTURE.md) proposal extends this:
+
+**Current (Block Until Complete):**
+```
+Consumer 1 (pace car):  [====ITERATING====]
+Consumer 2 (follower):  [BLOCKED..........][INSTANT REPLAY]
+                                           ↑
+                              Waits for COMPLETE cache
+```
+
+**Proposed (Follow Along):**
+```
+Consumer 1 (pace car):  [====ITERATING====]
+Consumer 2 (follower):  [==CHASING========]
+                         ↑
+              Reads chunks AS THEY'RE BUILT
+```
+
+This would enable:
+- Pipeline parallelism (phases overlap)
+- Lower latency (first results available immediately)
+- Bounded memory (grows with speed differential, not dataset size)
+
+---
+
+## Proposals as a Storeroom
+
+### The Pattern
+
+The repository contains 16 proposals covering:
+- Pipeline parallelism (Pace Car)
+- Schema selectivity hints
+- Prepared queries
+- Recursive rules
+- Distributed Janus
+- CRDT composable toolkit
+- And more...
+
+**But the current system is at ~85% production readiness with the simple versions.**
+
+### The Philosophy
+
+```
+"Queries are slow when phases can't overlap"
+
+Author: *reaches for shelf*
+        "Ah yes, Pace Car Caching Architecture.
+         I wrote that up months ago.
+         Chunked signaling, Clojure-style.
+         Here's the implementation plan,
+         the risks, the alternatives I rejected,
+         and why."
+```
+
+**The approach:**
+
+1. **Build correct foundation first** - Get semantics right
+2. **Document the vision** - Proposals show where it COULD go
+3. **Defer complexity until proven necessary** - "We could do X, but let's see if we need it"
+4. **Measure before optimizing** - Focus on proven bottlenecks
+
+The proposals are a **design inventory**, not a TODO list. They're ready when needed, but not built until needed.
+
+This is **premature documentation** instead of premature optimization - write down the sophisticated version so you don't forget it, but don't build it until the simple version proves insufficient.
+
+---
+
+## The CRDT Origin Story
+
+### It Started with Vectors
+
+> "Datalog has no ordered collections. Skills, inventory, event logs—anything that needs sequence—requires ugly workarounds."
+
+**How most people would solve "I need vectors":**
+
+| Approach | Problem |
+|----------|---------|
+| Serialize to JSON | Loses queryability |
+| Index attributes (`:skill/0`, `:skill/1`) | Renumber on insert |
+| Separate entity per element | N+1 queries, entity explosion |
+| Different database for vectors | Two databases, no joins |
+| Blob column | Complete surrender |
+
+### The Rabbit Hole
+
+From [CRDT_VECTOR_STORAGE.md](../proposals/CRDT_VECTOR_STORAGE.md):
+
+> **The rabbit hole:** Implementing vectors properly meant rethinking the storage model. Append-at-position needs conflict resolution. Conflict resolution needs unique element identifiers. Unique identifiers need Lamport clocks. And once you have all that, you've accidentally built a CRDT-based system with benefits beyond just vectors.
+
+**The domino chain:**
+
+```
+"I need ordered collections"
+        ↓
+"Vectors need append-at-position"
+        ↓
+"Append-at-position needs conflict resolution"
+        ↓
+"Conflict resolution needs unique element IDs"
+        ↓
+"Unique IDs need Lamport clocks"
+        ↓
+"Wait... I just built a CRDT system"
+        ↓
+"...which gives me history for free"
+        ↓
+"...and concurrent writes just work"
+        ↓
+"...and it's multi-node ready"
+        ↓
+"...and the key encoding makes resolution O(1)"
+```
+
+### The Result: Faster, Not Slower
+
+**CRDT vs pre-CRDT performance: 1.9× faster**
+
+Adding vectors didn't add overhead. The CRDT model **eliminated**:
+
+| Before | After | Savings |
+|--------|-------|---------|
+| Read-before-write | Write-only | 1 storage lookup |
+| Retraction datoms | None needed | Storage space, write I/O |
+| Separate HISTORY index | Unified indices | Index maintenance |
+| Different history code path | Same code path | Complexity, bugs |
+| 8 index structures (Datomic-style) | 6 unified | 25% fewer indices |
+
+**The feature that seemed like it would add complexity actually reduced it** because the new foundation was more coherent than the old one.
+
+---
+
+## The Simplification Pattern
+
+### The Conventional Approach
+
+```
+Problem → Add abstraction layer → Problem "solved"
+
+New problem → Add another layer → "Solved"
+
+Repeat until you have:
+  Controller → Service → Manager → Repository →
+  DAO → Mapper → DTO → Entity → Value Object → ...
+```
+
+Each "what if" adds a layer:
+- "What if we need to swap databases?" → Add repository abstraction
+- "What if value types change?" → Add wrapper types
+- "What if sources differ?" → Add adapter interfaces
+- "What if resolution logic changes?" → Add strategy pattern
+
+### The Janus Approach
+
+```
+Problem → What representation makes this problem disappear?
+
+"Need resolution" → Key encoding IS resolution (no layer)
+"Need history" → Same index, keep scanning (no layer)
+"Need vectors" → Rethink storage model (remove layers)
+```
+
+### Examples Across the Codebase
+
+**Type System:**
+```go
+// Most ORMs: wrapper types everywhere
+type StringValue struct { value string }
+type IntValue struct { value int64 }
+
+// Janus: just interface{}
+type Value = interface{}
+// string is string, int64 is int64, no wrapping
+```
+
+**Data Sources:**
+```go
+// Most systems: different interfaces for different sources
+type DatabaseSource interface { ... }
+type MemorySource interface { ... }
+type RemoteSource interface { ... }
+
+// Janus: one interface
+type PatternMatcher interface { ... }
+// Database, memory, remote - all implement the same thing
+```
+
+**Identity:**
+```go
+// Most systems: multiple representations, convert constantly
+entityID := "user-123"
+entityHash := sha1(entityID)
+entityDisplay := base64(entityHash)
+
+// Janus: one type, three faces
+type Identity struct {
+    original string  // "user-123"
+    hash     [20]byte // SHA1
+    l85      string   // display
+}
+// Ask for what you need: id.String(), id.Bytes(), id.L85()
+```
+
+**Schema:**
+```go
+// Most systems: schema required upfront
+CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(255) NOT NULL, ...)
+
+// Janus: schema optional, additive
+db.AddDatom(entity, ":name", "Alice")  // Works without schema
+db.DefineAttribute(":name", TypeString, CardinalityOne)  // Add validation later
+```
+
+### The Principle
+
+| Conventional | Janus |
+|--------------|-------|
+| Hide complexity behind abstractions | Remove complexity so abstractions unnecessary |
+| "Flexibility for future changes" | "Simplicity for understanding now" |
+| Layers protect from change | Foundation makes change unnecessary |
+| Interface for everything | Interface only when polymorphism needed |
+
+**Most abstractions exist because the foundation is wrong.** Fix the foundation and the abstractions become unnecessary.
+
+---
+
+## Summary: What Makes This Different
+
+### The Author's Approach
+
+1. **Deep domain understanding** - Spans CRDT theory, database internals, query optimization, and storage engines simultaneously
+
+2. **Implementation-level thinking** - "What happens when I literally scan bytes in this order?"
+
+3. **Simplification over abstraction** - "What representation makes this problem disappear?"
+
+4. **Deferred complexity** - Document solutions in proposals, implement when proven necessary
+
+5. **Foundation-first** - Will rethink entire storage model if it makes the system simpler
+
+### The Results
+
+| Metric | Result |
+|--------|--------|
+| LWW resolution | 965ns (O(1) from key encoding) |
+| CRDT overhead | Negative (1.9× faster than pre-CRDT) |
+| Streaming speedup | 2.22× with 52% memory reduction |
+| Index count vs Datomic | 6 unified vs 8 segmented |
+| Production readiness | ~85% with simple foundation |
+
+### The Philosophy in One Line
+
+**Don't add abstractions to manage complexity. Find the representation that makes complexity unnecessary.**
+
+---
+
+## References
+
+- [KEY_ENCODING_AND_CRDT.md](KEY_ENCODING_AND_CRDT.md) - Storage layer analysis
+- [PACE_CAR_CACHING_ARCHITECTURE.md](../proposals/PACE_CAR_CACHING_ARCHITECTURE.md) - Pipeline parallelism proposal
+- [CRDT_VECTOR_STORAGE.md](../proposals/CRDT_VECTOR_STORAGE.md) - CRDT origin story
+- [CLAUDE.md](../../CLAUDE.md) - Project guidelines and architecture overview
+- [PERFORMANCE_STATUS.md](../../PERFORMANCE_STATUS.md) - Verified benchmarks

--- a/docs/reference/CRDT.md
+++ b/docs/reference/CRDT.md
@@ -680,15 +680,46 @@ Cache entries are rebuilt on demand. After process restart, first access to each
 
 ## Index Selection by Cardinality
 
+### E-Primary Indices (EATV)
+
 | Cardinality | Primary Index | Reason |
 |-------------|---------------|--------|
 | One | EATV | Tx before V: first entry = current value |
 | Many | EAVT | Group by V for add-wins resolution |
 | Vector | EATV | Load all elements, reconstruct in memory |
 
+### A-Primary Index (AETV)
+
+When E is bound via input (not constant) and A is constant, the query engine uses AETV instead of AEVT:
+
+| Index | Ordering | Use Case |
+|-------|----------|----------|
+| AEVT | A → E → V → Tx | Value lookups, no CRDT resolution |
+| AETV | A → E → Tx↓ → V | A-primary queries with CRDT resolution |
+
+**Why AETV?** The CRDTResolvingIterator requires Tx-descending order to apply "first entry wins" logic. AEVT has Tx ascending (oldest first), which breaks LWW resolution. AETV stores Tx with bitwise NOT for descending order.
+
+### Value Lookups
+
 For value lookups across entities:
 - AVET: Find entities where attribute has specific value
 - Works for all cardinalities (V is raw value, not wrapped metadata)
+
+---
+
+## Streaming CRDT Resolution
+
+When the cache is bypassed (e.g., unbound E scans, `DisableCache: true`), CRDT resolution is applied at the storage scan level via `CRDTResolvingIterator`.
+
+**Key insight**: The EATV/AETV index ordering IS resolution. Tx is stored with bitwise NOT for descending order, so forward scan returns highest Tx first. For LWW (CardinalityOne), the first entry is the winner.
+
+| Cardinality | Resolution Strategy |
+|-------------|---------------------|
+| One | Emit first datom per (E, A), skip rest |
+| Many | Track emitted values + tombstones, emit immediately |
+| Vector | Accumulate minimal state, reconstruct at (E, A) boundary |
+
+See [CRDT_STREAMING_RESOLUTION.md](CRDT_STREAMING_RESOLUTION.md) for detailed design.
 
 ---
 

--- a/docs/reference/CRDT_STREAMING_RESOLUTION.md
+++ b/docs/reference/CRDT_STREAMING_RESOLUTION.md
@@ -1,0 +1,216 @@
+# CRDT Streaming Resolution Design
+
+## When to Use CRDTResolvingIterator
+
+**Only wrap with CRDTResolvingIterator when E is unbound.**
+
+| Pattern | E | A | Wrap? | Reason |
+|---------|---|---|-------|--------|
+| `[entity :attr ?v]` | bound | bound | No | Single (E, A) group - handled by cache or single read |
+| `[?e :attr ?v]` | unbound | bound | Yes | Multiple (E, A) groups need resolution |
+| `[?e ?a ?v]` | unbound | unbound | Yes | Multiple (E, A) groups need resolution |
+
+When E is bound, there's only one (E, A) group. For CardinalityOne, just read the first datom. For CardinalityMany/Vector, the EA cache handles resolution.
+
+## Key Insight: Index Ordering IS Resolution
+
+EATV index stores Tx with bitwise NOT for **descending order** (highest Tx first).
+
+This means:
+- First entry for each (E, A) has the highest Tx
+- For LWW (CardinalityOne): first entry IS the winner
+- For add-wins (CardinalityMany): first ADD for a value wins unless preceded by a REMOVE with higher Tx
+
+**The index ordering does the resolution. We just filter.**
+
+## CardinalityOne: Emit First, Skip Rest
+
+```
+For each datom from source (Tx descending):
+    if (E, A) is new:
+        emit immediately (this IS the LWW winner)
+        track current (E, A)
+    else if same (E, A):
+        skip (already emitted the winner)
+```
+
+**State required:** Just current E and current A (to detect duplicates)
+
+**No buffering. No datom copies. Pure filtering.**
+
+## CardinalityMany: Stream with Minimal State
+
+Because we iterate Tx descending:
+- First ADD for a value = highest Tx ADD → winner (unless tombstoned)
+- REMOVE before ADD (in iteration) = REMOVE has higher Tx → value removed
+- REMOVE after ADD (in iteration) = ADD had higher Tx → already emitted
+
+```
+State:
+    emitted    map[any]bool     // values we've emitted
+    tombstones map[any]uint64   // value → remove Lamport (for add-wins-at-same-Tx)
+
+For each datom from source (Tx descending):
+    if (E, A) changed:
+        clear emitted and tombstones (new group)
+
+    if Op == ADD:
+        if value in emitted:
+            skip (already emitted higher-Tx add)
+        else if value in tombstones AND add.Lamport < tombstone.Lamport:
+            skip (remove wins)
+        else:
+            emit immediately
+            mark value as emitted
+
+    if Op == REMOVE:
+        if value not in tombstones:
+            tombstones[value] = Lamport (first remove = highest Tx)
+```
+
+**State required:** Two maps keyed by value (not string! values ARE comparable)
+
+**No buffering datoms. Emit immediately. Stream.**
+
+## CardinalityVector (RGA): Accumulate State, Not Datoms
+
+RGA requires seeing all elements before emitting because output order depends on tree structure (afterRef relationships).
+
+### Why RGA Cannot Be Streamed: Formal Proof
+
+**Theorem**: RGA resolution cannot be streamed with standard iterator semantics.
+
+**Proof by contradiction**:
+
+1. **RGA ordering requirement**: Output must be DFS order of the tree (parent before children, siblings in ascending ElementID order)
+
+2. **Iterator constraint**: We iterate Tx in descending order (highest Tx first due to EATV index)
+
+3. **Sibling ordering conflict**: Consider siblings A (id=100) and B (id=200) both after parent P:
+   - DFS order requires: P, A, B (ascending id)
+   - Iterator sees: B first, then A (descending Tx = descending id for inserts)
+   - To emit in correct order, we must see A before emitting B
+   - But A comes AFTER B in the iteration
+
+4. **Cannot emit until group complete**: We cannot know if a lower-id sibling exists until we've seen all elements in the (E, A) group.
+
+**What about reverse (ascending) scan?**
+
+With ascending Tx order:
+- Parents arrive before children (good for tree building)
+- Lower-id siblings arrive before higher-id siblings (good for sibling order)
+
+But DFS still requires complete subtrees:
+```
+         HEAD
+        /    \
+       A      B
+      / \
+     C   D
+```
+
+DFS order: A, C, D, B
+
+With ascending scan, we see: A, C, D, B (if that's the Tx order)
+
+But if B was inserted before C and D:
+- Ascending sees: A, B, C, D
+- DFS requires: A, C, D, B
+
+**We cannot emit B until we know A's subtree is complete. We cannot know A's subtree is complete until we've seen all elements.**
+
+**Conclusion**: RGA streaming is mathematically impossible. We must buffer state for the entire (E, A) group.
+
+### Implementation: Buffer State, Not Datoms
+
+We don't store datom pointers. We store minimal state:
+
+```go
+type rgaElement struct {
+    id          ElementID  // from datom.Tx
+    afterRef    ElementID  // from datom.AfterRef
+    value       any        // from datom.V
+    tombstoneID *ElementID // if deleted
+}
+```
+
+**Why this is safe**:
+- No datom pointers → no corruption from iterator reuse
+- Minimal state → memory bounded by element count, not datom size
+- Reconstruct at emit → datoms created fresh with correct E, A from group
+
+At (E, A) boundary, reconstruct datoms:
+```go
+&datalog.Datom{
+    E:        it.currentE,  // same for entire group
+    A:        it.currentA,  // same for entire group
+    V:        element.value,
+    Tx:       element.id,
+    Op:       datalog.OpRGAInsert,
+    AfterRef: element.afterRef,
+}
+```
+
+### Resolution Algorithm
+
+1. **Accumulate**: As datoms arrive, store `rgaElement` (id, afterRef, value, tombstoneID)
+2. **At boundary**: When (E, A) changes or source exhausts:
+   - Deduplicate by id (tombstone info takes precedence)
+   - Build children map: `map[ElementID][]*rgaElement`
+   - Sort children by ascending id
+   - DFS walk from HEAD, emit non-tombstoned elements
+3. **Reconstruct**: Create fresh `*Datom` from stored state during DFS
+
+**No datom pointer storage. No corruption from iterator reuse. Reconstruct at emit.**
+
+## Why Values Work as Map Keys
+
+Values in datoms are typed:
+- `string` - comparable
+- `int64` - comparable
+- `float64` - comparable
+- `bool` - comparable
+- `time.Time` - comparable (struct)
+- `datalog.Keyword` - comparable (string type)
+- `datalog.Identity` - comparable (interface with comparable underlying)
+
+Use `map[any]bool` directly. **No stringify. No `valueKey()` function. No allocations on hot path.**
+
+## Call Site Conditions
+
+The wrapping condition should be consistent across all call sites:
+
+```go
+// Only wrap when E is unbound (scanning multiple entities)
+if m.schema != nil && e == nil {
+    iter = NewCRDTResolvingIterator(rawIter, m.schema, m.txID)
+}
+```
+
+Current state:
+- `matcher_relations.go` - Correct: `e == nil && a != nil`
+- Other call sites - Need audit: some wrap unconditionally
+
+## Summary
+
+| Cardinality | Strategy | State | Buffering | Streamable |
+|-------------|----------|-------|-----------|------------|
+| One | Emit first, skip rest | current (E, A) | None | ✓ Yes |
+| Many | Emit qualifying adds | emitted + tombstones maps | None | ✓ Yes |
+| Vector | Accumulate, resolve, emit | element list | State only, not datoms | ✗ No (proven impossible) |
+
+**Trust the architecture:**
+- Index ordering provides resolution (EATV = Tx descending = first entry wins)
+- Values are comparable map keys (no `valueKey()` stringify!)
+- CardinalityOne/Many: streaming means filter and emit, not buffer and resolve
+- CardinalityVector: mathematically impossible to stream due to DFS ordering requirements
+
+## Implementation Status
+
+The `CRDTResolvingIterator` in `crdt_resolving_iterator.go` implements all three strategies:
+
+- **CardinalityOne**: Zero state beyond current (E, A). First entry emitted, rest skipped.
+- **CardinalityMany**: `map[any]bool` for emitted values, `map[any]uint64` for tombstones. Emit immediately when qualifying.
+- **CardinalityVector**: `[]rgaElement` accumulates minimal state. Resolve and reconstruct datoms at (E, A) boundary.
+
+All 69 CRDT tests pass (5 CardinalityOne, 17 CardinalityMany, 47 CardinalityVector).

--- a/docs/reference/KEY_ENCODING_AND_CRDT.md
+++ b/docs/reference/KEY_ENCODING_AND_CRDT.md
@@ -210,7 +210,7 @@ Not:
 1 row store + 6 indices pointing to it = total storage
 ```
 
-This is more like 6 different sort orders of the same data than 6 indices plus a base table. The mental model from relational databases ("indices are overhead on top of tables") doesn't apply.
+This is more like 7 different sort orders of the same data than 7 indices plus a base table. The mental model from relational databases ("indices are overhead on top of tables") doesn't apply.
 
 ### What This Enables
 
@@ -366,7 +366,7 @@ Single Index Set: EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV (7 indices)
 | System | What You Get | Actual Index Structures |
 |--------|--------------|------------------------|
 | Datomic | Current + History | 8 (4 per segment) |
-| Janus | Current + History + CRDT Resolution | 6 (unified) |
+| Janus | Current + History + CRDT Resolution | 7 (unified) |
 
 Janus provides MORE functionality (CRDT semantics, time-travel via TAEV) with FEWER index structures because the unified design with bitwise NOT eliminates the need for segmentation.
 
@@ -427,7 +427,7 @@ Not from encoding format.
 
 | System | Primary CRDT Mechanism | Ordering Primitive | Storage Model |
 |--------|----------------------|-------------------|---------------|
-| **Janus** | Key structure + indices | ElementID (Lamport + ReplicaID) | LSM-tree with 6 indices |
+| **Janus** | Key structure + indices | ElementID (Lamport + ReplicaID) | LSM-tree with 7 indices |
 | **Automerge** | Operation log + columnar encoding | OpID (Actor + Counter) | Compressed chunks |
 | **Yjs** | YATA algorithm | Vector clocks per document | Binary deltas |
 | **Riak** | Dotted Version Vectors | DVV (dot + vector clock) | Bitcask/LevelDB per vnode |
@@ -570,7 +570,7 @@ type CacheEntry struct {
 WRITE PATH (Transaction.Commit):
 ┌─────────────────────────────────────────────────────────────┐
 │ for each datom:                                             │
-│   1. Write to BadgerDB (all 6 indices)                      │
+│   1. Write to BadgerDB (all 7 indices)                      │
 │   2. cache.UpdateMaxVersion(key, elemID)  ← Track newest    │
 │                                                             │
 │ After all writes:                                           │
@@ -808,7 +808,7 @@ There's no incremental update for RGA that's cheaper than rebuild.
 | **Automerge** | Mutate field | Memory only | ~1-10µs | Append op to in-memory log |
 | **Yjs** | Insert/delete | Memory only | ~1-5µs | YATA insertion in memory |
 | **Riak** | Write | Durable (replicated) | ~1-10ms | Vnode write, DVV update, replication |
-| **Janus** | Write (any) | Durable (WAL) | **~25-35µs** | WAL append + memtable insert × 6 indices |
+| **Janus** | Write (any) | Durable (WAL) | **~25-35µs** | WAL append + memtable insert × 7 indices |
 
 **Note on Janus write performance:**
 - Writes go to WAL (Write-Ahead Log) first - this is fast sequential I/O
@@ -921,7 +921,7 @@ Most CRDT systems require loading and reconstructing documents to access data. J
 - **LWW**: Seek + read first key = current value is IN the key (O(1) in practice)
 - **Sets**: Scan keys grouped by value + add-wins comparison
 - **Vectors**: Load keys + RGA graph traversal
-- **Unified storage**: Current and historical values in same indices (vs Datomic's 8 index structures, Janus uses 6)
+- **Unified storage**: Current and historical values in same indices (vs Datomic's 8 index structures, Janus uses 7)
 
 The cache is optional for LWW, essential for repeated set/vector access, and uses invalidation (not write-through) because it stores resolved views rather than operations.
 

--- a/docs/reference/KEY_ENCODING_AND_CRDT.md
+++ b/docs/reference/KEY_ENCODING_AND_CRDT.md
@@ -9,7 +9,7 @@ This document provides a comprehensive analysis of how Janus Datalog's key encod
 3. [Key Structure](#key-structure)
 4. [The Key IS the Value](#the-key-is-the-value)
 5. [The Bitwise NOT Trick](#the-bitwise-not-trick)
-6. [Six Indices for CRDT Semantics](#six-indices-for-crdt-semantics)
+6. [Seven Indices for CRDT Semantics](#seven-indices-for-crdt-semantics)
 7. [Unified Current and History](#unified-current-and-history)
 8. [L85 Encoding: Representation Only](#l85-encoding-representation-only)
 9. [Comparison with Other CRDT Systems](#comparison-with-other-crdt-systems)
@@ -196,12 +196,12 @@ There's no step 2-3. The key's sort order IS the resolution, and the key contain
 
 ### The "6× Indexing Overhead" Reframe
 
-The six indices aren't "6× overhead pointing to data stored elsewhere."
+The seven indices aren't "7× overhead pointing to data stored elsewhere."
 
 Each index IS a complete copy of the data in a different sort order. There's no separate "row store" being indexed. The storage cost is:
 
 ```
-6 indices × datom size = total storage
+7 indices × datom size = total storage
 ```
 
 Not:
@@ -258,15 +258,16 @@ Forward scan: encounters L200 first (the current value)
 
 ---
 
-## Six Indices for CRDT Semantics
+## Seven Indices for CRDT Semantics
 
-The system maintains six different index orderings, each optimized for specific CRDT operations:
+The system maintains seven different index orderings, each optimized for specific CRDT operations:
 
 | Index | Order | CRDT Use | When Selected |
 |-------|-------|----------|---------------|
-| **EATV** | E→A→Tx↓→V | Cardinality-One (LWW) | E+A bound, cardinality=one |
+| **EATV** | E→A→Tx↓→V | Cardinality-One (LWW), E-primary | E+A bound, cardinality=one |
 | **EAVT** | E→A→V→Tx↓ | Cardinality-Many (add-wins) | E+A bound, cardinality=many |
-| **AEVT** | A→E→V→Tx↓ | Attribute scans | A bound, E unbound |
+| **AETV** | A→E→Tx↓→V | Cardinality-One (LWW), A-primary | A bound, E from input, cardinality=one |
+| **AEVT** | A→E→V→Tx↓ | Attribute scans (no CRDT resolution) | A bound, E unbound, cardinality=many |
 | **AVET** | A→V→E→Tx↓ | Value lookups | A+V bound |
 | **VAET** | V→A→E→Tx↓ | Reverse reference lookup | V bound (for refs) |
 | **TAEV** | Tx↓→A→E→V | Transaction log / time-travel | Time-based queries |
@@ -282,8 +283,9 @@ The position of **V relative to Tx** determines CRDT semantics:
 
 ```
 EAVT: [prefix][E][A][type+value][Tx↓][Op][AfterRef?]  - groups by value for add-wins
-EATV: [prefix][E][A][Tx↓][type+value][Op][AfterRef?]  - first entry is current (LWW)
-AEVT: [prefix][A][E][type+value][Tx↓][Op][AfterRef?]  - by attribute
+EATV: [prefix][E][A][Tx↓][type+value][Op][AfterRef?]  - first entry is current (LWW), E-primary
+AETV: [prefix][A][E][Tx↓][type+value][Op][AfterRef?]  - first entry is current (LWW), A-primary
+AEVT: [prefix][A][E][type+value][Tx↓][Op][AfterRef?]  - by attribute (Tx ascending)
 AVET: [prefix][A][type+value][E][Tx↓][Op][AfterRef?]  - value lookup
 VAET: [prefix][type+value][A][E][Tx↓][Op][AfterRef?]  - reverse refs (V first!)
 TAEV: [prefix][Tx↓][A][E][type+value][Op][AfterRef?]  - transaction log
@@ -325,12 +327,12 @@ This means Datomic effectively maintains **8 index structures** (4 current + 4 h
 Janus stores ALL datoms (current and historical) in the SAME indices:
 
 ```
-Single Index Set: EAVT, EATV, AEVT, AVET, VAET, TAEV (6 indices)
+Single Index Set: EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV (7 indices)
     Contains: All datoms, all time, one structure
 ```
 
 **On every write:**
-1. Write new datom with new ElementID (6 index updates)
+1. Write new datom with new ElementID (7 index updates)
 2. That's it. No data movement.
 
 **To query current state:** Seek to (E,A), read first entry (bitwise NOT makes newest sort first)
@@ -890,8 +892,8 @@ There's no incremental update for RGA that's cheaper than rebuild.
 | **The key IS the value** | No pointer chasing, every index is covering, O(1) data access |
 | **Fixed 16-byte ElementID** | O(1) size regardless of replica count |
 | **Bitwise NOT on Tx** | Forward scan = newest first = O(1) current value |
-| **Unified current/history** | 6 indices vs Datomic's 8, no data movement on writes |
-| **Six indices** | Cardinality-aware access patterns |
+| **Unified current/history** | 7 indices vs Datomic's 8, no data movement on writes |
+| **Seven indices** | Cardinality-aware access patterns |
 | **LSM-tree (BadgerDB)** | Natural append-only for CRDT history |
 | **Value types for hot paths** | No heap allocation in decode/encode |
 | **No separate CRDT layer** | Resolution IS the index access |

--- a/docs/reference/KEY_ENCODING_AND_CRDT.md
+++ b/docs/reference/KEY_ENCODING_AND_CRDT.md
@@ -1,0 +1,938 @@
+# Janus Datalog Key Encoding: Designed for CRDTs
+
+This document provides a comprehensive analysis of how Janus Datalog's key encoding is uniquely designed to support CRDT (Conflict-free Replicated Data Type) semantics, including comparisons with other CRDT systems.
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [The Storage Foundation](#the-storage-foundation)
+3. [Key Structure](#key-structure)
+4. [The Key IS the Value](#the-key-is-the-value)
+5. [The Bitwise NOT Trick](#the-bitwise-not-trick)
+6. [Six Indices for CRDT Semantics](#six-indices-for-crdt-semantics)
+7. [Unified Current and History](#unified-current-and-history)
+8. [L85 Encoding: Representation Only](#l85-encoding-representation-only)
+9. [Comparison with Other CRDT Systems](#comparison-with-other-crdt-systems)
+10. [The Cache Architecture](#the-cache-architecture)
+11. [Why Not Write-Through Caching](#why-not-write-through-caching)
+12. [Performance Analysis](#performance-analysis)
+13. [Summary](#summary)
+
+---
+
+## Executive Summary
+
+Most CRDT systems treat storage as a **serialization problem**: "How do we efficiently encode and replay an operation log?"
+
+Janus treats it as an **indexing problem**: "How do we structure keys so CRDT resolution is just a prefix scan?"
+
+**The key insight: The key IS the value.**
+
+In traditional databases, keys point to data stored elsewhere. In Janus, the key contains the complete datom: `[E][A][V][Tx][Op]`. There's no pointer chasing, no separate row fetch. Every index is a covering index by default. This is why CRDT resolution can be O(1) - the answer is in the key itself, not behind a pointer.
+
+The result:
+- **O(1) LWW resolution** even without caching (965ns to resolve current value when 1000 historical versions exist)
+- **CRDT semantics with zero overhead** (actually 1.9× faster than pre-CRDT implementation)
+- **No reconstruction step** for Last-Writer-Wins operations
+- **Unified current/history storage** - no separate segments like Datomic
+
+---
+
+## The Storage Foundation
+
+### Why LSM-Tree (BadgerDB)
+
+Janus uses BadgerDB, an LSM-tree (Log-Structured Merge-tree) based key-value store.
+
+| Aspect | B-tree | LSM-tree (BadgerDB) |
+|--------|--------|---------------------|
+| **Write pattern** | In-place updates | Append-only |
+| **CRDT fit** | Poor - overwrites history | Perfect - all writes preserved |
+| **Write amplification** | High for random writes | Low - sequential writes to memtable |
+| **Range scans** | Good | Good (with sorted SSTables) |
+| **Concurrency** | Page-level locking | Lock-free writes |
+
+CRDTs require **append-only semantics** - every write is preserved with its ElementID. B-trees do in-place updates which would overwrite history. LSM-trees naturally preserve all versions because writes go to memtables and get flushed as immutable SSTables.
+
+---
+
+## Key Structure
+
+### Fixed-Size Components
+
+The key structure uses fixed-size components for efficient indexing:
+
+```
+E (Entity)     : 20 bytes  (SHA1 hash)
+A (Attribute)  : 32 bytes  (direct string or SHA256 if longer)
+Tx (ElementID) : 16 bytes  (Lamport clock + ReplicaID)
+Op             : 1 byte    (CRDT operation type)
+V (Value)      : Variable  (sole variable-length field, with 1-byte type prefix)
+AfterRef       : 16 bytes  (optional, only for RGA operations)
+```
+
+**V is the only variable-length field.** Its position varies by index type (first in VAET, middle in EAVT, etc.), but because all other components are fixed-size, decoding can determine V's boundaries by subtracting known sizes from the key length.
+
+### ElementID: The CRDT Heart
+
+The 16-byte `Tx` field is an **ElementID** with two parts:
+
+```go
+type ElementID struct {
+    Lamport   uint64  // Logical timestamp (8 bytes, big-endian)
+    ReplicaID uint64  // Database instance identifier (8 bytes, big-endian)
+}
+```
+
+**Properties:**
+- **Total ordering**: Lexicographic on (Lamport, ReplicaID)
+- **Deterministic tie-breaking**: When replicas have same Lamport, ReplicaID breaks ties
+- **Fixed size**: 16 bytes regardless of replica count (unlike vector clocks)
+
+### Why Fixed Sizes?
+
+1. **Predictable prefix ranges**: Scanning all values for `(E, A)` needs exactly 52 bytes of prefix (20 + 32). No length prefixes, no parsing.
+
+2. **Variable-length V is decodable**: Since V is the *only* variable-length field, its boundaries can be computed by subtracting known sizes:
+   ```go
+   // For EAVT: [prefix:1][E:20][A:32][V:?][Tx:16][Op:1][AfterRef?:16]
+   // V starts at offset 53, ends at len(key) - 16 - 1 - (16 if hasAfterRef)
+   vStart := 1 + 20 + 32
+   vEnd := len(key) - 16 - 1
+   if hasAfterRef { vEnd -= 16 }
+   value := key[vStart:vEnd]
+   ```
+
+3. **Efficient comparisons**: Comparing keys is just `bytes.Compare()` - no decoding needed for sort order.
+
+4. **Index selection by cardinality**: The system chooses between EAVT and EATV based on whether V or Tx comes first. Fixed sizes make this reordering trivial - just rearrange the concatenation order.
+
+### Why Not Vector Clocks?
+
+Vector clocks grow with replica count: `{replicaA: 42, replicaB: 17, replicaC: 99, ...}`
+
+| Replicas | Vector Clock Size | ElementID Size |
+|----------|-------------------|----------------|
+| 2 | ~32 bytes | 16 bytes |
+| 10 | ~160 bytes | 16 bytes |
+| 100 | ~1.6 KB | 16 bytes |
+| 1000 | ~16 KB | 16 bytes |
+
+**Trade-off**: ElementID requires Lamport clock coordination (replicas must see each other's writes to advance). Vector clocks allow fully independent progress. For a database (vs. real-time text editing), the coordination requirement is acceptable.
+
+### CRDT Operation Types
+
+```go
+type CRDTOp uint8
+
+const (
+    OpNone         CRDTOp = 0  // Cardinality-one (LWW register)
+    OpCRDTAdd      CRDTOp = 1  // Set add operation
+    OpCRDTRemove   CRDTOp = 2  // Set remove operation
+    OpRGAInsert    CRDTOp = 3  // Vector element insert
+    OpRGATombstone CRDTOp = 4  // Vector element deletion
+)
+
+// HasAfterRef makes Op self-describing
+func (op CRDTOp) HasAfterRef() bool {
+    return op == OpRGAInsert || op == OpRGATombstone
+}
+```
+
+The Op byte in the key tells decoders whether 16 more bytes (AfterRef) follow. No external metadata needed - keys are self-describing.
+
+---
+
+## The Key IS the Value
+
+This is perhaps the most fundamental design insight in Janus, and it's easy to miss.
+
+### Traditional Database Model
+
+```
+Index Key → Pointer → Row/Document → Extract Field
+```
+
+In a traditional database:
+- The index key contains just enough to locate data
+- Following the pointer requires a separate I/O operation
+- "Covering index" is a special optimization where you copy fields into the index
+
+### Janus Model
+
+```
+Key: [prefix][E][A][V][Tx][Op][AfterRef?] → Done. That's the data.
+```
+
+In Janus:
+- The key contains the COMPLETE datom
+- The BadgerDB "value" portion is essentially empty
+- There's nothing to dereference - the key IS the data
+
+### Why This Matters
+
+| Aspect | Traditional | Janus |
+|--------|-------------|-------|
+| Read one datom | Key lookup + row fetch | Key lookup only |
+| Index overhead | Keys + pointers + separate data | Just keys (which ARE data) |
+| Covering index | Special optimization | Default for ALL indices |
+| Range scan | Fetch keys, then fetch each row | Scan keys, done |
+
+### The CRDT Connection
+
+This is why CRDT resolution can be truly O(1):
+
+**Traditional approach:**
+1. Find key for (E, A) → pointer
+2. Fetch value via pointer
+3. Resolve CRDT semantics
+4. Return result
+
+**Janus approach:**
+1. Seek to (E, A) prefix
+2. Read first key → **the key contains the answer**
+
+There's no step 2-3. The key's sort order IS the resolution, and the key contains the value.
+
+### The "6× Indexing Overhead" Reframe
+
+The six indices aren't "6× overhead pointing to data stored elsewhere."
+
+Each index IS a complete copy of the data in a different sort order. There's no separate "row store" being indexed. The storage cost is:
+
+```
+6 indices × datom size = total storage
+```
+
+Not:
+
+```
+1 row store + 6 indices pointing to it = total storage
+```
+
+This is more like 6 different sort orders of the same data than 6 indices plus a base table. The mental model from relational databases ("indices are overhead on top of tables") doesn't apply.
+
+### What This Enables
+
+1. **Every access pattern is O(log N) + O(k)** - seek to prefix, scan k results, done
+2. **No "index-only scan" optimization needed** - all scans are index-only
+3. **CRDT resolution in the key layer** - no post-fetch processing
+4. **Predictable performance** - no variance from pointer chasing
+
+---
+
+## The Bitwise NOT Trick
+
+The critical CRDT enabler is encoding Tx with bitwise NOT:
+
+```go
+func txToDescending(tx [16]byte) [16]byte {
+    var result [16]byte
+    binary.BigEndian.PutUint64(result[0:8], ^binary.BigEndian.Uint64(tx[0:8]))
+    binary.BigEndian.PutUint64(result[8:16], ^binary.BigEndian.Uint64(tx[8:16]))
+    return result
+}
+```
+
+### What This Achieves
+
+- Higher ElementIDs (newer writes) sort **lower** in byte order
+- Forward scans encounter **newest entries first**
+- **O(1) current value lookup** - first entry = highest ElementID = current value
+
+### Example
+
+```
+ElementID L100@R5 → Lamport=100 → encoded as ^100 → 0xFFFFFFFFFFFFFF9B
+ElementID L200@R5 → Lamport=200 → encoded as ^200 → 0xFFFFFFFFFFFFFF37
+
+L200 > L100, but ^200 < ^100 in unsigned byte comparison
+Forward scan: encounters L200 first (the current value)
+```
+
+### Why This Matters for CRDT
+
+- **Last-Writer-Wins Resolution**: For cardinality-one attributes, the first entry in EATV index is automatically the highest ElementID (current value)
+- **No separate "latest version" index**: The sort order IS the resolution
+- **O(1) without caching**: Just seek and read first entry
+
+---
+
+## Six Indices for CRDT Semantics
+
+The system maintains six different index orderings, each optimized for specific CRDT operations:
+
+| Index | Order | CRDT Use | When Selected |
+|-------|-------|----------|---------------|
+| **EATV** | E→A→Tx↓→V | Cardinality-One (LWW) | E+A bound, cardinality=one |
+| **EAVT** | E→A→V→Tx↓ | Cardinality-Many (add-wins) | E+A bound, cardinality=many |
+| **AEVT** | A→E→V→Tx↓ | Attribute scans | A bound, E unbound |
+| **AVET** | A→V→E→Tx↓ | Value lookups | A+V bound |
+| **VAET** | V→A→E→Tx↓ | Reverse reference lookup | V bound (for refs) |
+| **TAEV** | Tx↓→A→E→V | Transaction log / time-travel | Time-based queries |
+
+### The Key Insight: V vs Tx Position
+
+The position of **V relative to Tx** determines CRDT semantics:
+
+- **EATV** (Tx before V): First entry after `(E,A)` prefix = current value (LWW)
+- **EAVT** (V before Tx): Same values grouped together for add/remove comparison (add-wins)
+
+### Key Formats (Binary Encoder)
+
+```
+EAVT: [prefix][E][A][type+value][Tx↓][Op][AfterRef?]  - groups by value for add-wins
+EATV: [prefix][E][A][Tx↓][type+value][Op][AfterRef?]  - first entry is current (LWW)
+AEVT: [prefix][A][E][type+value][Tx↓][Op][AfterRef?]  - by attribute
+AVET: [prefix][A][type+value][E][Tx↓][Op][AfterRef?]  - value lookup
+VAET: [prefix][type+value][A][E][Tx↓][Op][AfterRef?]  - reverse refs (V first!)
+TAEV: [prefix][Tx↓][A][E][type+value][Op][AfterRef?]  - transaction log
+
+AfterRef? = 16 bytes present only if Op ∈ {OpRGAInsert(3), OpRGATombstone(4)}
+```
+
+**Note:** `type+value` is the sole variable-length component (1-byte type prefix + variable data). Its position varies by index, but decoding works because:
+- All other components have known fixed sizes
+- The decoder subtracts fixed sizes from key length to find V's boundaries
+- Example for EAVT: `V = key[1+20+32 : len(key)-16-1-maybeAfterRef]`
+
+---
+
+## Unified Current and History
+
+### Datomic's Segmented Approach
+
+Datomic separates storage into two segments:
+
+```
+Current Segment: EAVT, AEVT, AVET, VAET (4 indices)
+    ↓ on update, old values move to ↓
+History Segment: Separate storage with its own indices
+```
+
+**On every write:**
+1. Write new value to current segment (4 index updates)
+2. Move old value to history segment (additional writes)
+3. Both segments maintain their own index structures
+
+**To query current state:** Query the current segment
+**To query history:** Use `d/history` to access the history segment
+
+This means Datomic effectively maintains **8 index structures** (4 current + 4 history), plus the overhead of moving data between segments on updates.
+
+### Janus's Unified Approach
+
+Janus stores ALL datoms (current and historical) in the SAME indices:
+
+```
+Single Index Set: EAVT, EATV, AEVT, AVET, VAET, TAEV (6 indices)
+    Contains: All datoms, all time, one structure
+```
+
+**On every write:**
+1. Write new datom with new ElementID (6 index updates)
+2. That's it. No data movement.
+
+**To query current state:** Seek to (E,A), read first entry (bitwise NOT makes newest sort first)
+**To query history:** Same index, keep scanning past the first entry
+
+### The Comparison
+
+| Aspect | Datomic | Janus |
+|--------|---------|-------|
+| Index structures | 4 current + 4 history = 8 | 6 unified |
+| On write | Update current + move old to history | Write once |
+| Data movement | Yes (current → history) | None |
+| Current lookup | Query current segment | First entry in EATV |
+| History lookup | Separate `d/history` call | Same index, scan |
+| Storage duplication | Some (during transitions) | None |
+
+### Why Unified Is Better for CRDTs
+
+**The bitwise NOT trick does double duty:**
+
+1. **Provides O(1) current value** (what Datomic's current segment provides)
+   - Seek to (E,A) prefix, first entry = highest ElementID = current value
+
+2. **Provides full history** (what Datomic's history segment provides)
+   - Same index, keep scanning = all historical values in descending time order
+
+**One structure, both access patterns.** No segment management, no data movement, no separate history indices.
+
+### The Real Index Count Comparison
+
+| System | What You Get | Actual Index Structures |
+|--------|--------------|------------------------|
+| Datomic | Current + History | 8 (4 per segment) |
+| Janus | Current + History + CRDT Resolution | 6 (unified) |
+
+Janus provides MORE functionality (CRDT semantics, time-travel via TAEV) with FEWER index structures because the unified design with bitwise NOT eliminates the need for segmentation.
+
+---
+
+## L85 Encoding: Representation Only
+
+### Common Misconception
+
+L85 is often assumed to be the storage format. **It is not.**
+
+### What L85 Actually Is
+
+L85 is a custom Base85 encoding with sort-order preservation, used for **human-readable representation**:
+
+```go
+const L85Alphabet = "!$%&()+,-./" +
+    "0123456789:;<=>@" +
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_`" +
+    "abcdefghijklmnopqrstuvwxyz{}"
+```
+
+**Properties:**
+- 25% overhead (better than Base64's 33%)
+- Lexicographic sort of encoded strings matches byte order
+- Terminal safe (all printable ASCII, no quotes/spaces/backslashes)
+- Fixed output: 20 bytes → 25 characters, 16 bytes → 20 characters
+
+### Where L85 Is Used
+
+- `Identity.L85()` method for human-readable display
+- Export/import format: `#identity "L85hash"`
+- Available as alternative encoder for debugging (`L85Strategy`)
+
+### What Production Actually Uses
+
+```go
+// From database.go:103
+store, err := NewBadgerStore(opts.Path, NewKeyEncoder(BinaryStrategy))
+```
+
+**Production uses raw binary (`BinaryStrategy`)** - 25% smaller keys, faster comparisons, no encode/decode overhead in hot paths.
+
+### The CRDT Benefits Come From
+
+1. **Key structure** (fixed-size components, component ordering)
+2. **Bitwise NOT on Tx** (descending sort = newest first)
+3. **Index selection** (EATV vs EAVT based on cardinality)
+4. **LSM-tree properties** (append-only preserves all writes)
+
+Not from encoding format.
+
+---
+
+## Comparison with Other CRDT Systems
+
+### System Overview
+
+| System | Primary CRDT Mechanism | Ordering Primitive | Storage Model |
+|--------|----------------------|-------------------|---------------|
+| **Janus** | Key structure + indices | ElementID (Lamport + ReplicaID) | LSM-tree with 6 indices |
+| **Automerge** | Operation log + columnar encoding | OpID (Actor + Counter) | Compressed chunks |
+| **Yjs** | YATA algorithm | Vector clocks per document | Binary deltas |
+| **Riak** | Dotted Version Vectors | DVV (dot + vector clock) | Bitcask/LevelDB per vnode |
+
+### Automerge: Operation-Centric Columnar Encoding
+
+[Automerge](https://automerge.org/automerge-binary-format-spec/) treats documents as operation logs with heavy compression:
+
+```
+Operation = (OpID, ObjID, Key, Value, Predecessors, Successors)
+OpID = (ActorID, Counter)
+```
+
+**Storage approach:**
+- Operations stored as columnar tables (like Parquet)
+- Run-length + delta encoding: `[1,2,3,5,7]` → `[(3,+1),(2,+2)]`
+- Chunks identified by `[docID, chunk-type, chunk-hash]`
+- DEFLATE compression on top
+
+**Trade-off:** Optimized for bandwidth and storage size, but requires decompression and reconstruction to query. You can't efficiently ask "what's the current value of field X?" without loading the document.
+
+### Yjs: Vector Clocks + Binary Deltas
+
+[Yjs architecture](https://www.bartoszsypytkowski.com/yrs-architecture/) uses per-document vector clocks:
+
+```
+StateVector = { replicaA: 42, replicaB: 17, ... }
+Delta = operations where op.clock > peer.stateVector[op.replica]
+```
+
+**Storage approach:**
+- Deltas encoded in custom binary format
+- Sync protocol: send StateVector → receive missing delta
+- Optimized for real-time text collaboration (YATA algorithm)
+
+**Trade-off:** Excellent for collaborative editing, but vector clocks grow with replica count. Not designed for database-style queries.
+
+### Riak: Dotted Version Vectors
+
+[Riak](https://docs.riak.com/riak/kv/latest/developing/data-types/index.html) introduced DVVs to fix sibling explosion:
+
+```
+DVV = { dot: (replica, counter), vector: {replicaA: n, ...} }
+```
+
+**Storage approach:**
+- Key-value with version metadata per key
+- Operations-based API (increment counter, add to set)
+- Delta-state internally for efficiency
+
+**Trade-off:** Mature distributed system, but CRDT types are separate from regular data. You choose "counter" or "set" at schema time.
+
+### Janus: CRDT Semantics in the Key Structure
+
+Janus takes a different approach - **the key encoding IS the CRDT mechanism**:
+
+```
+Key = [Index][E:20][A:32][Tx↓:16][V:var][Op:1][AfterRef?:16]
+Tx = (Lamport:8, ReplicaID:8) with bitwise NOT
+```
+
+**What makes this unique:**
+
+1. **No separate operation log** - datoms ARE the operations, stored directly in indices
+
+2. **Index layout determines CRDT semantics:**
+   - EATV (Tx before V): First entry = current value (LWW)
+   - EAVT (V before Tx): Same values grouped (add-wins comparison)
+   - No runtime interpretation needed
+
+3. **O(1) resolution via sort order:**
+   ```
+   // Automerge: load doc → decompress → replay ops → get value
+   // Yjs: load doc → apply deltas → traverse structure
+   // Janus: seek to (E,A) prefix → read first entry → done
+   ```
+
+4. **Queryable history without reconstruction:**
+   ```clojure
+   ;; Get all historical values - just scan the index
+   [:find ?name ?tx :where [?e :person/name ?name ?tx] [(history)]]
+   ```
+
+5. **Scalar ElementID vs Vector Clocks:**
+   - Automerge/Yjs: Vector grows with replicas
+   - Janus: Fixed 16 bytes regardless of replica count
+
+### Feature Comparison
+
+| Aspect | Automerge | Yjs | Riak | Janus |
+|--------|-----------|-----|------|-------|
+| **Current value lookup** | O(n) reconstruct | O(n) traverse | O(1) but separate type | O(1) first entry |
+| **History query** | Full doc load | Not designed for | Limited | Native index scan |
+| **Ordering size** | O(replicas) | O(replicas) | O(replicas) | O(1) fixed 16 bytes |
+| **Compression** | Heavy (columnar+DEFLATE) | Binary deltas | None | LSM compaction |
+| **Query model** | JSON paths | Text positions | Key-value | Datalog |
+| **CRDT types** | JSON structure | Text/Array focused | Explicit (counter/set/map) | Schema-driven (one/many/vector) |
+
+---
+
+## The Cache Architecture
+
+### What "Cache" Means Per System
+
+| System | "Cache" Is... | Authoritative Source |
+|--------|---------------|---------------------|
+| **Automerge** | In-memory document (operations + materialized) | The document itself |
+| **Yjs** | In-memory document (YATA structure) | The document itself |
+| **Riak** | Per-key in-memory or Bitcask/LevelDB | Distributed vnodes |
+| **Janus** | Resolved views in `sync.Map` | BadgerDB storage |
+
+### Janus Cache Structure
+
+```go
+type Cache struct {
+    // Per-(E,A) resolved views
+    entries sync.Map // map[CacheKey]*CacheEntry
+
+    // Per-(E,A) max ElementID tracking - updated on every write
+    maxVersions sync.Map // map[CacheKey]ElementID
+}
+
+type CacheEntry struct {
+    version     ElementID           // Max ElementID when computed
+    cardinality Cardinality
+
+    // ONE of these populated based on cardinality:
+    oneValue    any                 // LWW: single value
+    manySet     map[any]bool        // Add-wins: set members
+    vectorList  []any               // RGA: ordered elements
+    vectorIndex []ElementID         // RGA: position → ElementID
+}
+```
+
+**Key insight:** The cache stores **resolved views**, not operation history.
+
+### Cache Lifecycle
+
+```
+WRITE PATH (Transaction.Commit):
+┌─────────────────────────────────────────────────────────────┐
+│ for each datom:                                             │
+│   1. Write to BadgerDB (all 6 indices)                      │
+│   2. cache.UpdateMaxVersion(key, elemID)  ← Track newest    │
+│                                                             │
+│ After all writes:                                           │
+│   3. cache.Invalidate(touched)  ← Remove stale entries      │
+└─────────────────────────────────────────────────────────────┘
+
+READ PATH (with cache):
+┌─────────────────────────────────────────────────────────────┐
+│ cache.GetOrResolve(key, resolver):                          │
+│   1. Load entry from cache                                  │
+│   2. Check: entry.version == maxVersions[key]?              │
+│      YES → Return cached (O(1))                             │
+│      NO  → Rebuild from storage, store in cache             │
+└─────────────────────────────────────────────────────────────┘
+
+READ PATH (without cache - direct storage):
+┌─────────────────────────────────────────────────────────────┐
+│ Direct storage scan:                                        │
+│   LWW: Seek EATV(E,A) → read first entry → done            │
+│   Set: Scan AEVT(A,E) → add-wins resolution                │
+│   Vector: Scan EATV(E,A) → RGA reconstruction              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### The Freshness Check (O(1))
+
+```go
+// On every write:
+cache.UpdateMaxVersion(key, elemID)  // O(1) map update
+
+// On every read:
+if entry.version == maxVersions[key] {
+    return entry  // Fresh!
+}
+// Stale - rebuild from storage
+```
+
+No storage seek needed to check freshness. The `maxVersions` map is updated atomically on commit.
+
+### Why the Cache Exists (Asymmetric by Cardinality)
+
+| Cardinality | Without Cache | With Cache | Cache Benefit |
+|-------------|---------------|------------|---------------|
+| **One (LWW)** | O(log N) seek + O(1) read | O(1) map lookup | Nice-to-have (~10× faster) |
+| **Many (add-wins)** | O(n) scan + resolution | O(1) map lookup | **Critical** (avoids O(n)) |
+| **Vector (RGA)** | O(n log n) reconstruction | O(1) map lookup | **Critical** (avoids O(n log n)) |
+
+For LWW, the cache is optional optimization. For sets and vectors, **the cache is essential for repeated access**.
+
+---
+
+## Why Not Write-Through Caching
+
+### The Question
+
+Why does Janus use invalidation-based caching instead of write-through (updating cache on write)?
+
+### The Cache Stores Resolved Views, Not Operations
+
+```go
+type CacheEntry struct {
+    oneValue    any              // Just the resolved value
+    manySet     map[any]bool     // Just the set members (not add/remove history)
+    vectorList  []any            // Just the ordered elements (not the RGA graph)
+    vectorIndex []ElementID      // Position mapping
+}
+```
+
+Write-through would require either:
+1. Re-doing full resolution on every write (expensive)
+2. Storing enough metadata to incrementally update (complex)
+
+### Why Write-Through Fails Per Cardinality
+
+#### For LWW (Cardinality-One)
+
+Write-through seems simple:
+```go
+// Hypothetical write-through for LWW
+if newElemID > cachedEntry.version {
+    cachedEntry.oneValue = newValue
+    cachedEntry.version = newElemID
+}
+```
+
+But this breaks with concurrent replicas:
+```
+Replica A cache: version=L100, value="Alice"
+Replica B writes: L101, value="Bob" → syncs to A
+Replica A writes: L102, value="Carol"
+
+Without seeing B's write first, A's cache is wrong.
+The storage has all three writes; the cache has only what A saw.
+```
+
+The cache can't know if a higher-ElementID write exists that it hasn't seen yet. Only storage is authoritative.
+
+#### For Sets (Cardinality-Many)
+
+Write-through is impossible without storing more:
+
+```go
+// Cache stores:
+manySet map[any]bool  // Just: {"admin": true, "user": true}
+
+// Write-through for Add("admin"):
+// Can we just do manySet["admin"] = true?
+// NO - what if there's a Remove("admin") with higher Lamport?
+
+// Write-through for Remove("admin"):
+// Can we just delete manySet["admin"]?
+// NO - what if there's an Add("admin") with same Lamport? (add-wins)
+```
+
+To do write-through, the cache would need:
+```go
+// Hypothetical write-through cache for sets:
+type SetCacheEntry struct {
+    perValueMaxAdd    map[any]uint64  // value → highest add Lamport
+    perValueMaxRemove map[any]uint64  // value → highest remove Lamport
+    resolvedSet       map[any]bool    // derived from above
+}
+```
+
+That's essentially duplicating the storage structure.
+
+#### For Vectors (Cardinality-Vector)
+
+Write-through is O(n log n) - same as rebuild:
+
+```go
+// Cache stores:
+vectorList  []any        // ["a", "b", "c"]
+vectorIndex []ElementID  // [E1, E2, E3]
+
+// Write-through for Insert("X", AfterRef=E1):
+// Where does "X" go?
+// - Find E1's position
+// - Find all other elements with AfterRef=E1
+// - Sort by ElementID to find insertion point
+// This IS RGA reconstruction
+```
+
+There's no incremental update for RGA that's cheaper than rebuild.
+
+### The Trade-off
+
+| Approach | Write Cost | Read (miss) Cost | Complexity |
+|----------|------------|------------------|------------|
+| **Write-through** | O(resolution) per write | O(1) | High (CRDT logic in cache) |
+| **Invalidate** | O(1) per write | O(resolution) on miss | Low (cache is just a map) |
+
+### Why Janus Chose Invalidation
+
+1. **Writes are frequent, reads are repeated** - Better to pay O(n) once on first read than O(n) on every write
+
+2. **Storage is authoritative** - With replicas, cache can't know if it's seen all writes. Rebuild from storage guarantees correctness.
+
+3. **Simplicity** - Cache is just `sync.Map`. No CRDT logic in cache layer.
+
+4. **Asymmetric benefit** - LWW doesn't need cache (storage is O(1)). Sets/vectors benefit from caching reads, not writes.
+
+### How Other Systems Handle This
+
+**Automerge/Yjs**: They essentially DO write-through - they keep the full document (operation log) in memory and apply operations incrementally. But:
+- They're not caches, they're the primary data structure
+- They store operations, not resolved views
+- Document IS the source of truth (no separate storage layer)
+
+**Janus**: Storage is source of truth. Cache is derived. Invalidate-on-write is the only correct approach when:
+1. Cache stores resolved views (not operations)
+2. Multiple writers might exist (replicas)
+3. Storage might have writes cache hasn't seen
+
+---
+
+## Performance Analysis
+
+**Note:** All measured times are **per-operation** (ns/op from Go benchmarks). For example, "965ns" for LWW means each individual lookup takes 965ns, not that 1000 lookups complete in 965ns total.
+
+### Storage Type Comparison
+
+**Critical context:** These systems have fundamentally different storage models:
+
+| System | Storage Type | Durability | Persistence |
+|--------|-------------|------------|-------------|
+| **Automerge** | Memory-only (in-process) | None until explicit save | Requires external storage layer |
+| **Yjs** | Memory-only (in-process) | None until explicit save | Requires external storage layer |
+| **Riak** | Distributed durable (Bitcask/LevelDB) | Immediate (replicated) | Built-in |
+| **Janus** | Local durable (BadgerDB LSM) | Immediate (WAL + fsync) | Built-in |
+
+**This means:**
+- Automerge/Yjs "writes" are memory operations - fast but not durable
+- Janus writes go to WAL (Write-Ahead Log) immediately - durable on commit
+- Comparing Automerge/Yjs write speed to Janus is comparing memory ops to disk I/O
+- For fair comparison, add Automerge/Yjs persistence layer overhead (~1-10ms to save)
+
+### Definitions
+
+| Symbol | Meaning |
+|--------|---------|
+| **N** | Total items in database/document |
+| **n** | Operations for specific (E,A) pair (Janus) or document history (Automerge/Yjs) |
+| **k** | Current live elements (after CRDT resolution) |
+| **s** | Siblings/concurrent versions (Riak) |
+
+### Cold Start (Nothing in Memory)
+
+| System | Operation | Complexity | Measured Time | What's Happening |
+|--------|-----------|------------|---------------|------------------|
+| **Automerge** | Load document | O(n) | 10-100ms typical | Decompress chunks, build op tree |
+| **Yjs** | Load document | O(n) | 5-50ms typical | Parse binary, build YATA structure |
+| **Riak** | First read | O(s × log N) | ~1-10ms | Fetch from vnode, DVV resolution |
+| **Janus LWW** | First read | O(log N) | **~1µs** | LSM seek, read 1 entry |
+| **Janus Set (k=10)** | First read | O(log N + n) | ~3-4µs | LSM seek, scan n ops, resolve |
+| **Janus Set (k=100)** | First read | O(log N + n) | ~27µs | Same, more ops |
+| **Janus Vector (k=10)** | First read | O(log N + n log n) | ~21µs | LSM seek, RGA reconstruction |
+| **Janus Vector (k=100)** | First read | O(log N + n log n) | ~205µs | Same, more elements |
+
+### Warm State (Document/Cache Loaded)
+
+| System | Operation | Complexity | Measured Time | What's Happening |
+|--------|-----------|------------|---------------|------------------|
+| **Automerge** | Read field | O(1) to O(log k) | ~100ns-1µs | Tree traversal in memory |
+| **Yjs** | Read position | O(1) | ~50-100ns | Direct index access |
+| **Riak** | Read (cached) | O(1) | ~100ns-1µs | Memory lookup |
+| **Janus LWW** | Read (cached) | O(1) | ~100ns | `sync.Map` lookup |
+| **Janus Set** | Read (cached) | O(1) | ~100ns | `sync.Map` lookup |
+| **Janus Vector** | Read (cached) | O(1) | ~100ns | `sync.Map` lookup |
+
+### Write Path
+
+| System | Operation | Durability | Measured Time | What's Happening |
+|--------|-----------|------------|---------------|------------------|
+| **Automerge** | Mutate field | Memory only | ~1-10µs | Append op to in-memory log |
+| **Yjs** | Insert/delete | Memory only | ~1-5µs | YATA insertion in memory |
+| **Riak** | Write | Durable (replicated) | ~1-10ms | Vnode write, DVV update, replication |
+| **Janus** | Write (any) | Durable (WAL) | **~25-35µs** | WAL append + memtable insert × 6 indices |
+
+**Note on Janus write performance:**
+- Writes go to WAL (Write-Ahead Log) first - this is fast sequential I/O
+- Memtable insertions are in-memory
+- LSM compaction (merging SSTables) happens in background, doesn't block writes
+- The 25-35µs includes fsync for durability guarantee
+- Without fsync (memory-only mode), Janus would be comparable to Automerge/Yjs
+
+### Cache Miss After Writes
+
+| System | Scenario | Complexity | Measured Time | What's Happening |
+|--------|----------|------------|---------------|------------------|
+| **Automerge** | Reload after eviction | O(n) | 10-100ms | Full reconstruction |
+| **Yjs** | Reload after eviction | O(n) | 5-50ms | Full reconstruction |
+| **Riak** | Sibling resolution | O(s) | ~100µs-1ms | Compare s version vectors |
+| **Janus LWW (1000 versions)** | Cache miss | O(log N) | **965ns/lookup** | Seek + read first entry |
+| **Janus Set (50 members, clean)** | Cache miss | O(n) | ~14µs | Scan + add-wins |
+| **Janus Set (100 adds, 50 removes)** | Cache miss | O(n) | ~38µs | Scan + tombstone filtering |
+| **Janus Vector (10 elements)** | Cache miss | O(n log n) | ~21µs | RGA reconstruction |
+
+### The Hidden Constants
+
+| Operation | O(1) Actually Means... |
+|-----------|------------------------|
+| **Cache lookup** | Hash computation + map probe + pointer chase (~50-100ns) |
+| **LSM seek** | Binary search memtable + check bloom filters + SSTable seek (~500ns-2µs) |
+| **Read 1 entry** | Key decode + value decode (~200-500ns) |
+| **Freshness check** | Two map lookups + ElementID comparison (~50ns) |
+
+### What "n" Looks Like in Practice
+
+| Scenario | Automerge/Yjs n | Janus n |
+|----------|-----------------|---------|
+| **User profile** | All edits to entire document | Edits to that one (E,A) pair |
+| **Collaborative doc (1 hour)** | ~1,000-10,000 ops | ~10-100 per field |
+| **Long-lived entity (1 year)** | ~100,000+ ops | ~100-1,000 per field |
+
+**Key insight**: Janus's n is per-(E,A), not per-document. A database with 1M datoms might have n=10 for a specific (E,A) pair.
+
+### Reading One Field: Apples-to-Apples
+
+| System | Cold | Warm | Notes |
+|--------|------|------|-------|
+| **Automerge** | O(n) doc load + O(1) field | O(1) | Must load entire document first |
+| **Yjs** | O(n) doc load + O(1) field | O(1) | Must load entire document first |
+| **Janus LWW** | O(log N) | O(1) | Only touches that (E,A) |
+| **Janus Set** | O(log N + n) | O(1) | n = ops for that (E,A) only |
+| **Janus Vector** | O(log N + n log n) | O(1) | n = ops for that (E,A) only |
+
+### When Each System Wins
+
+| Scenario | Winner | Why |
+|----------|--------|-----|
+| **Cold read of single LWW field** | Janus | ~1µs vs 10-100ms document load |
+| **Cold read of small set** | Janus | ~3-4µs vs document load |
+| **Hot read of any field** | Tie | All ~100ns from cache/memory |
+| **Bulk read of many fields (same entity)** | Automerge/Yjs | One document load serves all fields |
+| **Memory-only write throughput** | Automerge/Yjs | No durability overhead |
+| **Durable write throughput** | Janus | 25-35µs vs Riak's 1-10ms |
+| **Large document, read one field** | Janus | Don't pay for unrequested data |
+| **Real-time collaboration** | Yjs | Optimized for keystroke-level ops |
+| **Query across entities** | Janus | Has indices; others must scan |
+| **Crash recovery** | Janus/Riak | Durable storage; Automerge/Yjs lose uncommitted |
+
+### The Real Trade-off
+
+| System | Storage Model | Optimized For | Pays Cost When |
+|--------|---------------|---------------|----------------|
+| **Automerge/Yjs** | Memory + external persistence | Real-time collaboration, single document hot | Durability, querying across docs, cold starts |
+| **Riak** | Distributed durable | High availability, partition tolerance | Latency (network hops), complexity |
+| **Janus** | Local durable (LSM) | Queryable CRDT database, cold reads, durability | Requires separate replication layer for distribution |
+
+---
+
+## Summary
+
+### Key Design Choices
+
+| Design Choice | Why It Matters |
+|---------------|----------------|
+| **The key IS the value** | No pointer chasing, every index is covering, O(1) data access |
+| **Fixed 16-byte ElementID** | O(1) size regardless of replica count |
+| **Bitwise NOT on Tx** | Forward scan = newest first = O(1) current value |
+| **Unified current/history** | 6 indices vs Datomic's 8, no data movement on writes |
+| **Six indices** | Cardinality-aware access patterns |
+| **LSM-tree (BadgerDB)** | Natural append-only for CRDT history |
+| **Value types for hot paths** | No heap allocation in decode/encode |
+| **No separate CRDT layer** | Resolution IS the index access |
+| **Invalidation-based cache** | Simple, correct, asymmetric benefit |
+
+### Verified Performance (from PERFORMANCE_STATUS.md)
+
+| Metric | Result | Notes |
+|--------|--------|-------|
+| **LWW resolution (1000 versions)** | 965ns/lookup | Without cache, direct from storage |
+| **Add-wins (50 members)** | 13.8µs | No tombstones |
+| **Add-wins (100 adds, 50 removes)** | 37.9µs | With tombstone filtering |
+| **RGA vector (10 elements)** | 21.2µs | Reconstruction |
+| **RGA vector (100 elements)** | 204.7µs | Linear scaling |
+| **Write (any cardinality)** | 25-35µs | Consistent across types |
+| **CRDT vs pre-CRDT performance** | **1.9× faster** | After optimization work |
+
+### The Bottom Line
+
+Most databases ask "how do we index our data?" Janus asks "what if the index IS the data?"
+
+Most CRDT systems require loading and reconstructing documents to access data. Janus's key encoding makes CRDT resolution a property of the index structure itself:
+
+- **The key contains the complete datom** - no pointer chasing, no separate row fetch
+- **LWW**: Seek + read first key = current value is IN the key (O(1) in practice)
+- **Sets**: Scan keys grouped by value + add-wins comparison
+- **Vectors**: Load keys + RGA graph traversal
+- **Unified storage**: Current and historical values in same indices (vs Datomic's 8 index structures, Janus uses 6)
+
+The cache is optional for LWW, essential for repeated set/vector access, and uses invalidation (not write-through) because it stores resolved views rather than operations.
+
+The result: CRDT semantics with **zero overhead** (actually negative - the engine is faster than before CRDTs were added). This isn't just clever encoding - it's a fundamentally different mental model that required deep understanding of both CRDT theory and storage engine implementation.
+
+---
+
+## References
+
+- [Automerge Binary Document Format](https://automerge.org/automerge-binary-format-spec/)
+- [Automerge Storage](https://automerge.org/docs/reference/under-the-hood/storage/)
+- [Yrs (Yjs Rust) Architecture](https://www.bartoszsypytkowski.com/yrs-architecture/)
+- [Riak Data Types](https://docs.riak.com/riak/kv/latest/developing/data-types/index.html)
+- [CRDT Implementations Overview](https://crdt.tech/implementations)
+- [CRDT.md](./CRDT.md) - Janus CRDT storage semantics
+- [PERFORMANCE_STATUS.md](../../PERFORMANCE_STATUS.md) - Verified benchmarks

--- a/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
+++ b/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
@@ -82,14 +82,16 @@ The codebase already uses `ScanKeysOnly()` for nearly all reads. Values are 100%
 - VAET (V → A → E → Tx)
 - TAEV (T → A → E → V)
 
-**After (6 indices):**
-- ~~EAVT~~ removed
+**After (7 indices) - Actual Implementation:**
+- EAVT (E → A → V → Tx) - kept for cardinality-many
 - EATV (E → A → Tx↓ → V)
 - **AETV (A → E → Tx↓ → V)** - NEW
 - AEVT (A → E → V → Tx)
 - AVET (A → V → E → Tx)
 - VAET (V → A → E → Tx)
 - TAEV (T → A → E → V)
+
+*Note: The original proposal was to remove EAVT, but it was kept for cardinality-many use cases. AETV was added as a 7th index.*
 
 **Symmetry achieved:**
 | E-primary | A-primary |

--- a/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
+++ b/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
@@ -10,9 +10,14 @@
 - AETV index added (now 7 indices total: EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV)
 - Index selection updated to use AETV for A-primary CRDT queries
 
+**Implemented (2026-02-06):**
+- Value elimination complete - `assertDatom()` now writes nil values
+- `BadgerIterator.Datom()` decodes from key using `DatomFromKey()`
+- `BadgerStore.Get()` updated to decode from key
+- ~50% storage reduction achieved
+
 **Not yet implemented:**
 - EAVT removal (keeping for now - no urgency)
-- Value elimination (Part 2 of this proposal)
 
 ## Overview
 

--- a/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
+++ b/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
@@ -1,0 +1,355 @@
+# AETV Index and Value Elimination
+
+**Date**: 2026-02-05
+**Status**: Design
+**Author**: Discussion between user and Claude
+
+## Overview
+
+This document proposes two related storage layer changes:
+
+1. **Replace EAVT with AETV** - EAVT is redundant; EATV covers all E-primary use cases. AETV completes the symmetry for A-primary CRDT-aware queries.
+2. **Eliminate redundant values** - Store only keys since all datom information is already encoded there.
+
+## Motivation
+
+### Problem 1: CRDT Resolution Fails for A-Primary Queries
+
+The `CRDTResolvingIterator` assumes Tx descending order (highest Tx first = LWW winner). This works with EATV but fails with AEVT.
+
+**Current index pairs:**
+| E-primary | A-primary |
+|-----------|-----------|
+| EAVT (E → A → V → Tx) | AEVT (A → E → V → Tx) |
+| EATV (E → A → Tx↓ → V) | **missing** |
+
+EATV is the "CRDT-aware" version of EAVT. But there's no CRDT-aware A-primary index.
+
+**The bug:** When E is bound via input and A is constant, the selector picks AEVT. CRDTResolvingIterator wraps it but gets wrong Tx order → returns wrong value.
+
+### Problem 2: EAVT is Redundant
+
+Every use case for EAVT is handled equally well (or better) by EATV:
+
+| Use Case | EAVT | EATV |
+|----------|------|------|
+| All attributes for entity E | E prefix scan | E prefix scan (same) |
+| Value of E.A | (E, A) prefix | (E, A) prefix + CRDT resolution |
+| History of E.A | (E, A) scan, Tx ascending | (E, A) scan, Tx descending (newest first) |
+| Full scan | Works | Groups by (E, A) for CRDT |
+| Does E.A have value V? | O(1) seek | O(n) scan, but n is small |
+
+**Conclusion:** EAVT provides no unique value. Replace it with AETV.
+
+### Problem 3: Redundant Value Storage
+
+Current key format contains ALL datom information:
+```
+[prefix:1][...component order...][V:variable][Tx:16][Op:1][AfterRef?:16]
+```
+
+Current value format duplicates this:
+```
+[E:20][A:32][Tx:16][VSize:2][VType:1][V:variable]
+```
+
+The codebase already uses `ScanKeysOnly()` for nearly all reads. Values are 100% redundant.
+
+## Proposed Solution
+
+### Part 1: Replace EAVT with AETV
+
+**Before (6 indices):**
+- EAVT (E → A → V → Tx)
+- EATV (E → A → Tx↓ → V)
+- AEVT (A → E → V → Tx)
+- AVET (A → V → E → Tx)
+- VAET (V → A → E → Tx)
+- TAEV (T → A → E → V)
+
+**After (6 indices):**
+- ~~EAVT~~ removed
+- EATV (E → A → Tx↓ → V)
+- **AETV (A → E → Tx↓ → V)** - NEW
+- AEVT (A → E → V → Tx)
+- AVET (A → V → E → Tx)
+- VAET (V → A → E → Tx)
+- TAEV (T → A → E → V)
+
+**Symmetry achieved:**
+| E-primary | A-primary |
+|-----------|-----------|
+| EATV (E → A → Tx↓ → V) | AETV (A → E → Tx↓ → V) |
+
+### Part 2: Index Selection Refactoring
+
+**Current selector is broken.** It doesn't consistently choose CRDT-aware indices.
+
+**Optimal Index Selection Matrix:**
+
+| E | A | Schema | Cardinality | Optimal Index | Reason |
+|---|---|--------|-------------|---------------|--------|
+| constant | constant | any | One/Vector | EATV | Single (E,A), Tx↓ for CRDT |
+| constant | constant | any | Many | EATV | CRDTResolvingIterator handles add-wins |
+| from input | constant | yes | One/Vector | **AETV** | Many Es, single A, Tx↓ for CRDT |
+| from input | constant | yes | Many | AEVT | Need V grouping for add-wins |
+| unbound | constant | yes | One/Vector | **AETV** | All Es for A, Tx↓ for CRDT |
+| unbound | constant | yes | Many | AEVT | Need V grouping for add-wins |
+| constant | unbound | any | any | EATV | Single E, all As |
+| unbound | unbound | any | any | EATV or TAEV | Full scan |
+
+**Key insight:** EAVT never appears as optimal. EATV handles all E-primary cases.
+
+### Part 3: Eliminate Values
+
+Change `assertDatom()` to write nil values:
+```go
+// Before
+value := sd.Bytes()
+txn.Set(key, value)
+
+// After
+txn.Set(key, nil)
+```
+
+## Use Cases for AETV
+
+### 1. Batch Entity Attribute Lookup (the bug case)
+```datalog
+[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]
+```
+- 1000 Es from input, single A
+- AETV: Single scan, stream CRDT resolution
+- Current (AEVT): Wrong Tx order, broken CRDT
+
+### 2. Attribute Enumeration with CRDT
+```datalog
+[:find ?e ?v :where [?e :status ?v]]
+```
+- All entities with `:status`, need current value
+- AETV: Single scan, first entry per (A, E) is LWW winner
+
+### 3. Pull API Optimization
+```go
+// Batch pull - same attributes for many entities
+db.PullMany(entities, `[:person/name :person/age :person/email]`)
+```
+- For each attribute, AETV enables single scan
+- Gets all entities' current values in one pass
+- O(attributes) scans instead of O(entities × attributes) seeks
+
+### 4. Time-Travel Per Attribute
+```datalog
+[:find ?e ?v :in $ ?as-of :where [?e :price ?v] [(as-of ?as-of)]]
+```
+- "What was :price for all entities at time T?"
+- AETV: Scan, find first Tx ≤ target per (A, E)
+
+### 5. Attribute History/Audit
+```datalog
+[:find ?e ?v ?tx :where [?e :user/password ?v ?tx] [(history)]]
+```
+- All changes to `:user/password` across all users
+- AETV: Natural grouping by (A, E), Tx descending (newest first)
+
+### 6. Schema Migration
+```datalog
+[:find ?e :where [?e :old/attribute _]]
+```
+- Find all entities with deprecated attribute
+- AETV: Single scan of `:old/attribute`
+
+### 7. Cross-Entity Joins
+```datalog
+[:find ?e1 ?e2
+ :where [?e1 :person/name ?name]
+        [?e2 :person/name ?name]
+        [(not= ?e1 ?e2)]]
+```
+- First clause scans `:person/name` via AETV
+- Gets all (entity, current-name) pairs efficiently
+
+## Index Purpose Summary
+
+| Index | Order | Primary Use Case |
+|-------|-------|------------------|
+| EATV | E → A → Tx↓ → V | E-primary with CRDT (single entity queries) |
+| **AETV** | A → E → Tx↓ → V | A-primary with CRDT (batch entity, Pull API) |
+| AEVT | A → E → V → Tx | CardinalityMany add-wins (need V grouping) |
+| AVET | A → V → E → Tx | Unique lookups ("entity where A=V") |
+| VAET | V → A → E → Tx | Reverse refs ("what references V?") |
+| TAEV | T → A → E → V | Transaction log ("what changed in Tx?") |
+
+**Note:** EAVT is intentionally absent. EATV covers all its use cases with better CRDT support.
+
+## Cost Analysis
+
+### Storage Cost
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Number of indices | 6 | 6 (same) |
+| Keys per datom | 6 | 6 (same) |
+| Values per datom | 6 × ~70 bytes | 0 |
+| **Net change** | - | **~50% reduction** |
+
+Replacing EAVT with AETV: zero additional storage.
+Eliminating values: ~50% storage reduction.
+
+### Write Cost
+
+| Metric | Before | After |
+|--------|--------|-------|
+| BadgerDB Set calls | 6 | 6 (same) |
+| Bytes per write | key + value | key only |
+| **Net change** | - | **~50% reduction** |
+
+## Implementation Plan
+
+### Phase 1: Add AETV Index (keep EAVT temporarily)
+
+1. Add `AETV IndexType` constant
+2. Add AETV to key encoders (L85 and Binary)
+3. Add AETV to key decoders
+4. Update `assertDatom()` to write to AETV
+5. Update index selector to use AETV for A-primary CRDT cases
+6. Add comprehensive tests
+7. Run full test suite
+
+### Phase 2: Remove EAVT Index
+
+1. Remove EAVT from `Indices` slice
+2. Update index selector to use EATV for former EAVT cases
+3. Remove EAVT from key encoders/decoders
+4. Update tests that explicitly reference EAVT
+5. Add migration: ignore EAVT keys in old databases
+6. Run full test suite
+
+### Phase 3: Eliminate Values
+
+1. Change `assertDatom()` to write nil values
+2. Update `Get()` to decode from key
+3. Remove any remaining value readers
+4. Remove `StorageDatom.Bytes()` method
+5. Add migration note (old values ignored)
+6. Run full test suite
+
+### Phase 4: Cleanup
+
+1. Update CLAUDE.md with new index structure
+2. Archive this design doc
+3. Update ARCHITECTURE.md
+
+**Architectural TODO (future):** Evaluate removing AEVT. With AETV + CRDTResolvingIterator handling CardinalityMany, AEVT's V-grouping may also be redundant.
+
+## Testing Strategy
+
+### 1. Key Encoding/Decoding Tests
+
+```go
+func TestAETVKeyEncoding(t *testing.T) {
+    // Test AETV key format: [prefix][A][E][Tx↓][V][Op][AfterRef?]
+    // Verify encode/decode round-trip
+    // Verify Tx is encoded with bitwise NOT (descending order)
+}
+
+func TestAETVSortOrder(t *testing.T) {
+    // Same (A, E) with different Tx should sort by Tx descending
+    // Higher Tx should sort FIRST (lower byte value)
+}
+```
+
+### 2. Index Selection Tests
+
+```go
+func TestIndexSelectionMatrix(t *testing.T) {
+    // Test all rows of the selection matrix
+    // Verify correct index is chosen for each scenario
+}
+
+func TestAETVSelectedForInputBoundE(t *testing.T) {
+    // Pattern: [?e :attr ?v] with ?e from input bindings
+    // Schema: CardinalityOne
+    // Verify: AETV is selected (not AEVT)
+}
+```
+
+### 3. CRDT Resolution Tests
+
+```go
+func TestAETVCRDTResolutionMultipleEntities(t *testing.T) {
+    // 100 entities, same attribute, multiple writes per entity
+    // Query with all Es from input, DisableCache: true
+    // Verify: Each E returns only its LWW winner
+}
+
+func TestAETVCRDTResolutionCacheDisabled(t *testing.T) {
+    // THE critical test that currently fails
+    // Must pass after AETV implementation
+}
+```
+
+### 4. Pull API Tests
+
+```go
+func TestPullManyWithAETVOptimization(t *testing.T) {
+    // Pull same attributes for 1000 entities
+    // Verify: Uses AETV scans, not per-entity seeks
+}
+```
+
+### 5. EAVT Removal Tests
+
+```go
+func TestEATVHandlesFormerEAVTCases(t *testing.T) {
+    // All EAVT use cases work with EATV
+    // - All attributes for entity
+    // - Value of E.A
+    // - History of E.A
+}
+
+func TestMigrationFromEAVT(t *testing.T) {
+    // Old database with EAVT keys
+    // Verify: Reads still work (EAVT keys ignored or handled)
+}
+```
+
+### 6. Value Elimination Tests
+
+```go
+func TestNilValueStorage(t *testing.T) {
+    // Write datoms with nil values
+    // Read back via ScanKeysOnly
+    // Verify: All fields decoded from key
+}
+```
+
+### 7. Benchmarks
+
+```go
+func BenchmarkAETVVsAEVTBatchLookup(b *testing.B) {
+    // Compare AETV single scan vs AEVT with broken CRDT
+    // For various batch sizes
+}
+
+func BenchmarkStorageSizeReduction(b *testing.B) {
+    // Measure actual storage with/without values
+}
+```
+
+## Success Criteria
+
+1. All CRDT tests pass with `DisableCache: true`
+2. Index selection matches the optimal matrix
+3. Storage reduced by ~50% (value elimination)
+4. No performance regression for existing queries
+5. Pull API benefits from AETV optimization
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| EAVT removal breaks something | Phase 1 adds AETV while keeping EAVT; Phase 2 removes after validation |
+| Migration from old databases | EAVT keys ignored; values ignored; backward compatible |
+| Index selection regressions | Comprehensive matrix-based testing |
+| Performance regression | Benchmark before/after each phase |

--- a/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
+++ b/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
@@ -1,8 +1,18 @@
 # AETV Index and Value Elimination
 
 **Date**: 2026-02-05
-**Status**: Design
+**Status**: Partially Implemented
 **Author**: Discussion between user and Claude
+
+## Implementation Status
+
+**Implemented (2026-02-05):**
+- AETV index added (now 7 indices total: EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV)
+- Index selection updated to use AETV for A-primary CRDT queries
+
+**Not yet implemented:**
+- EAVT removal (keeping for now - no urgency)
+- Value elimination (Part 2 of this proposal)
 
 ## Overview
 


### PR DESCRIPTION
## Summary

This PR adds a new AETV index (A → E → Tx↓ → V) and implements streaming CRDT resolution across all query execution paths. It also fixes a collection input cross-product bug discovered during AETV development.

### Core Changes

**1. AETV Index Implementation**
- New A-primary CRDT index with Tx descending order (first entry = LWW winner)
- Complements existing EATV (E-primary CRDT index)
- Key format: `[prefix][A][E][Tx↓][type][value][Op][AfterRef?]`
- Added encoding/decoding in both binary and L85 key encoders

**2. Streaming CRDT Resolution (`CRDTResolvingIterator`)**
- Wraps storage iterators and applies CRDT resolution per (E, A) group
- Three resolution strategies by cardinality:
  - **CardinalityOne**: Emit first entry, skip rest (zero buffering)
  - **CardinalityMany**: Track emitted values + tombstones, emit immediately
  - **CardinalityVector**: Accumulate minimal state (not datoms), reconstruct at boundary
- Key insight: EATV/AETV index ordering IS resolution - we filter, not buffer
- Applied to ALL matcher code paths: hash join, merge join, iterator reuse, batch scan

**3. Index Selection Fixes**
- Changed from AEVT to AETV for CRDT-correct queries when E bound via input
- Cardinality-aware selection: CardinalityMany uses AEVT, One/Vector use AETV

**4. Collection Input Cross-Product Bug Fix**
Three root causes fixed:
- `subquery.go`: Use reflection to unpack slices into individual tuples  
- `executor_utils.go`: Always add collection relations, even when empty
- `hash_join_matcher.go`: Changed hash set to `map[string][]Tuple` to store ALL tuples per key

**5. DisableCache Database Option**
- Added `DisableCache bool` to `DatabaseOptions`
- Enables testing CRDT resolution at storage level independent of cache
- All matrix tests run with cache enabled AND disabled

### Bug Documentation

- `docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md` - Comprehensive root cause analysis (1200+ lines)
- `docs/bugs/BUG_COLLECTION_INPUT_UNPACKING.md` - Collection input bug documentation
- `docs/reference/CRDT_STREAMING_RESOLUTION.md` - Design doc with formal proof that RGA cannot be streamed

### Test Coverage

| Test File | Tests | Description |
|-----------|-------|-------------|
| `aetv_index_test.go` | 16 | Encoding, sort order, CRDT resolution |
| `collection_input_test.go` | 11 | All collection input patterns |
| `crdt_cache_matrix_test.go` | 17 | Cache enabled/disabled matrix |
| `crdt_query_resolution_test.go` | 8 | Original bug reproduction |
| `bind_query_inputs_test.go` | 3 | Cross-product verification |
| `choose_index_values_test.go` | +3 | AETV scan range tests |

### Files Changed

| Category | Files |
|----------|-------|
| Index/Encoding | `store.go`, `key_encoder_binary.go`, `key_encoder_l85.go` |
| CRDT Resolution | `crdt_resolving_iterator.go` (new), `cache.go` |
| Matcher | `matcher.go`, `matcher_strategy.go`, `matcher_relations.go`, `hash_join_matcher.go`, `matcher_iterator_*.go`, `batch_iterator.go`, `simple_batch_scanner.go` |
| Executor | `subquery.go`, `executor_utils.go`, `prepended_relation.go` |
| Database | `database.go` |
| Tests | 7 new test files |
| Docs | 3 new documentation files, updates to `CLAUDE_BUGS.md` |

**Total: 31 files changed, +5368 lines, -167 lines**

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] 17/17 cache matrix tests pass in both cache_enabled and cache_disabled modes
- [x] AETV index tests verify encoding, sort order, and CRDT resolution
- [x] Collection input tests verify cross-product behavior