### PR TITLE
fix(storage): CRDT-correct resolution for all query paths and cardinalities

### DIFF
--- a/datalog/reflect/vector_test.go
+++ b/datalog/reflect/vector_test.go
@@ -19,7 +19,6 @@ type CharacterWithSkills struct {
 }
 
 // TestReflect_VectorOrderPreserved verifies that vector order is preserved through SaveStruct/PullInto.
-// CURRENT STATUS: EXPECTED TO FAIL - reflect layer treats vectors as sets, losing order.
 func TestReflect_VectorOrderPreserved(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "reflect-vector-order-test")
 	if err != nil {
@@ -92,7 +91,6 @@ func TestReflect_VectorOrderPreserved(t *testing.T) {
 }
 
 // TestReflect_VectorDuplicatesAllowed verifies that vectors allow duplicate values.
-// CURRENT STATUS: EXPECTED TO FAIL - reflect layer uses set semantics, deduplicating values.
 func TestReflect_VectorDuplicatesAllowed(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "reflect-vector-duplicates-test")
 	if err != nil {
@@ -154,7 +152,6 @@ func TestReflect_VectorDuplicatesAllowed(t *testing.T) {
 
 // TestReflect_VectorUpdatePreservesUnchangedPrefix verifies that updating a vector
 // uses the prefix-diff optimization (only changes what's different).
-// CURRENT STATUS: EXPECTED TO FAIL - reflect layer uses set diff, not prefix diff.
 func TestReflect_VectorUpdatePreservesUnchangedPrefix(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "reflect-vector-update-test")
 	if err != nil {
@@ -230,7 +227,6 @@ func TestReflect_VectorUpdatePreservesUnchangedPrefix(t *testing.T) {
 }
 
 // TestReflect_VectorReplaceMiddleElement verifies that replacing an element in the middle works.
-// CURRENT STATUS: EXPECTED TO FAIL - reflect layer uses set diff which doesn't understand position.
 func TestReflect_VectorReplaceMiddleElement(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "reflect-vector-replace-test")
 	if err != nil {
@@ -307,7 +303,6 @@ func TestReflect_VectorReplaceMiddleElement(t *testing.T) {
 
 // TestReflect_VectorRemoveFromMiddle verifies that removing an element from the middle
 // doesn't orphan subsequent elements.
-// CURRENT STATUS: EXPECTED TO FAIL - Remove() tombstones element, orphaning RGA descendants.
 func TestReflect_VectorRemoveFromMiddle(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "reflect-vector-remove-middle-test")
 	if err != nil {
@@ -380,7 +375,6 @@ func TestReflect_VectorRemoveFromMiddle(t *testing.T) {
 }
 
 // TestReflect_VectorReorder verifies that reordering elements works.
-// CURRENT STATUS: EXPECTED TO FAIL - set diff sees same values, does nothing.
 func TestReflect_VectorReorder(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "reflect-vector-reorder-test")
 	if err != nil {
@@ -453,7 +447,6 @@ func TestReflect_VectorReorder(t *testing.T) {
 }
 
 // TestReflect_VectorPrepend verifies that prepending an element works.
-// CURRENT STATUS: EXPECTED TO FAIL - Add() appends to end, doesn't prepend.
 func TestReflect_VectorPrepend(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "reflect-vector-prepend-test")
 	if err != nil {
@@ -526,7 +519,6 @@ func TestReflect_VectorPrepend(t *testing.T) {
 }
 
 // TestReflect_VectorInsertInMiddle verifies that inserting an element in the middle works.
-// CURRENT STATUS: EXPECTED TO FAIL - Add() appends to end, doesn't insert at position.
 func TestReflect_VectorInsertInMiddle(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "reflect-vector-insert-middle-test")
 	if err != nil {
@@ -599,7 +591,6 @@ func TestReflect_VectorInsertInMiddle(t *testing.T) {
 }
 
 // TestReflect_VectorClearAndRepopulate verifies that clearing and repopulating a vector works.
-// CURRENT STATUS: EXPECTED TO FAIL - tombstoning all elements orphans the chain.
 func TestReflect_VectorClearAndRepopulate(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "reflect-vector-clear-test")
 	if err != nil {

--- a/datalog/schema/types.go
+++ b/datalog/schema/types.go
@@ -23,9 +23,10 @@ const (
 type Cardinality string
 
 const (
-	CardinalityOne    Cardinality = "db.cardinality/one"
-	CardinalityMany   Cardinality = "db.cardinality/many"
-	CardinalityVector Cardinality = "db.cardinality/vector" // Ordered collection (RGA)
+	CardinalityOne     Cardinality = "db.cardinality/one"
+	CardinalityMany    Cardinality = "db.cardinality/many"
+	CardinalityVector  Cardinality = "db.cardinality/vector"  // Ordered collection (RGA)
+	CardinalityUnknown Cardinality = "db.cardinality/unknown" // No schema definition - return all values
 )
 
 // Unique represents uniqueness constraints on attribute values

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -516,9 +516,18 @@ func extractElementIDFromKey(index IndexType, key []byte) datalog.ElementID {
 		txBytes = key[prefixSize : prefixSize+txSize]
 
 	case EATV:
-		// EATV: [prefix:1][E:20][A:32][Tx:16][V:var]
+		// EATV: [prefix:1][E:20][A:32][Tx:16][V:var][Op:1]
 		// Tx is after E+A
 		offset := prefixSize + entitySize + attrSize
+		if len(key) < offset+txSize {
+			return datalog.ElementID{}
+		}
+		txBytes = key[offset : offset+txSize]
+
+	case AETV:
+		// AETV: [prefix:1][A:32][E:20][Tx:16][V:var][Op:1]
+		// Tx is after A+E
+		offset := prefixSize + attrSize + entitySize
 		if len(key) < offset+txSize {
 			return datalog.ElementID{}
 		}

--- a/datalog/storage/batch_iterator.go
+++ b/datalog/storage/batch_iterator.go
@@ -256,11 +256,8 @@ func (it *batchScanIterator) scanRange(rg RangeGroup) {
 	}
 
 	// Wrap with CRDT resolution to ensure we only see resolved values
-	if it.matcher.schema != nil {
-		it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
-	} else {
-		it.storageIter = rawIter
-	}
+	// Always applied: CRDTResolvingIterator handles nil schema correctly
+	it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
 	it.totalScans++
 
 	// Build a map of binding values for quick lookup

--- a/datalog/storage/crdt_cache_matrix_test.go
+++ b/datalog/storage/crdt_cache_matrix_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -167,6 +168,455 @@ func TestCacheMatrix_AUnbound(t *testing.T) {
 			// Should return 2 results: one for name (Charlie), one for age (30)
 			// NOT 6 results (all historical values)
 			assert.Len(t, results, 2, "[%s] Unbound A should return 1 result per attribute (CRDT resolved)", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_EConstantAUnbound tests when E is a constant in the pattern (not via input)
+// This exercises chooseIndex's E-only path, which previously used EAVT (wrong for CRDT)
+func TestCacheMatrix_EConstantAUnbound(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/age"),
+				ValueType:   schema.TypeLong,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			personID := datalog.NewIdentity("person-1")
+
+			// Write multiple values to name
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, datalog.NewKeyword(":person/name"), name)
+				tx.Commit()
+			}
+
+			// Write multiple values to age
+			for _, age := range []int64{20, 25, 30} {
+				tx := db.NewTransaction()
+				tx.Set(personID, datalog.NewKeyword(":person/age"), age)
+				tx.Commit()
+			}
+
+			// Pattern: E is CONSTANT in pattern (not via :in), A unbound
+			// This goes through matchUnboundAsRelation → chooseIndex with e != nil
+			// The bug was: chooseIndex used EAVT (V-before-Tx) for E-only case
+			// Fixed: now uses EATV (Tx-first) for proper CRDT resolution
+			results, err := db.ExecuteQuery(
+				`[:find ?a ?v :where ["person-1" ?a ?v]]`)
+			require.NoError(t, err)
+
+			// Should return 2 results: one for name (Charlie), one for age (30)
+			// NOT 6 results (all historical values)
+			assert.Len(t, results, 2, "[%s] E constant in pattern should return CRDT-resolved results", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_VOnlyBound tests when ONLY V is bound (E and A both unbound)
+// This exercises chooseIndex's V-only path, which uses VAET index with per-datom
+// cardinality resolution.
+//
+// VAET has order V → A → E → Tx↓. CRDTResolvingIterator wraps the scan and handles
+// many/vector/unknown correctly. Card-one emissions are post-validated with EATV.
+func TestCacheMatrix_VOnlyBound(t *testing.T) {
+
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/manager"),
+				ValueType:   schema.TypeRef,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":project/lead"),
+				ValueType:   schema.TypeRef,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			leader := datalog.NewIdentity("leader-1")
+			emp1 := datalog.NewIdentity("emp-1")
+			proj1 := datalog.NewIdentity("proj-1")
+
+			// emp1 has multiple manager changes, final is leader
+			for _, mgr := range []datalog.Identity{
+				datalog.NewIdentity("old-manager"),
+				leader,
+			} {
+				tx := db.NewTransaction()
+				tx.Set(emp1, datalog.NewKeyword(":person/manager"), mgr)
+				tx.Commit()
+			}
+
+			// proj1 has leader as lead
+			tx := db.NewTransaction()
+			tx.Set(proj1, datalog.NewKeyword(":project/lead"), leader)
+			tx.Commit()
+
+			// Enable annotations to trace query execution
+			db.SetAnnotationHandler(func(e annotations.Event) {
+				t.Logf("[TRACE] %s: %v", e.Name, e.Data)
+			})
+
+			// Pattern: ONLY V bound - "what entities/attributes reference leader?"
+			// This uses VAET index with per-datom cardinality resolution
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
+				leader)
+			require.NoError(t, err)
+
+			// Should return 2 results: emp1/:person/manager and proj1/:project/lead
+			// NOT extra results from historical assignments (old-manager)
+			assert.Len(t, results, 2, "[%s] V-only bound should return CRDT-resolved results", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_VOnlyBound_Supersede tests that V-bound queries correctly
+// handle superseded values. This is the critical test case from the proof review:
+//
+// If emp-1/:person/manager was "leader" but is now "new-leader", a query for
+// V="leader" should NOT return emp-1, because the CRDT-resolved current value
+// is "new-leader", not "leader".
+//
+// With VAET + cardinalityAwareVBoundIterator, card-one emissions are post-validated
+// with EATV point lookup, correctly filtering out stale candidates.
+func TestCacheMatrix_VOnlyBound_Supersede(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/manager"),
+				ValueType:   schema.TypeRef,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":project/lead"),
+				ValueType:   schema.TypeRef,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			leader := datalog.NewIdentity("leader-1")
+			newLeader := datalog.NewIdentity("new-leader-1")
+			emp1 := datalog.NewIdentity("emp-1")
+			proj1 := datalog.NewIdentity("proj-1")
+
+			// emp1 manager: leader → new-leader (SUPERSEDED)
+			tx := db.NewTransaction()
+			tx.Set(emp1, datalog.NewKeyword(":person/manager"), leader)
+			tx.Commit()
+
+			tx = db.NewTransaction()
+			tx.Set(emp1, datalog.NewKeyword(":person/manager"), newLeader) // supersedes leader
+			tx.Commit()
+
+			// proj1 still has leader as lead (NOT superseded)
+			tx = db.NewTransaction()
+			tx.Set(proj1, datalog.NewKeyword(":project/lead"), leader)
+			tx.Commit()
+
+			// Query: find all (E, A) where V = leader
+			// CRDT-resolved, emp-1/:person/manager is now "new-leader", NOT "leader"
+			// So only proj-1/:project/lead should be returned
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
+				leader)
+			require.NoError(t, err)
+
+			// Should return 1 result: ONLY proj1/:project/lead
+			// emp1/:person/manager should NOT be returned because its current value is new-leader
+			assert.Len(t, results, 1, "[%s] V-bound query should only return entities where V is the CURRENT value", mode.name)
+
+			if len(results) == 1 {
+				// Verify it's proj1, not emp1
+				e := results[0][0]
+				assert.Equal(t, proj1, e, "[%s] Should return proj-1, not emp-1", mode.name)
+			}
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestVOnlyBound_CardinalityMany_Retracted tests that V-bound queries with
+// CardinalityMany attributes correctly handle retracted values using add-wins.
+//
+// Scenario: Add tag "go" then retract it. Query for V="go" should return nothing.
+// This tests per-datom cardinality resolution for V-only bound (A is variable).
+func TestVOnlyBound_CardinalityMany_Retracted(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/tags"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityMany,
+			})
+			db.SetSchema(s)
+
+			emp1 := datalog.NewIdentity("emp-1")
+
+			// Debug: check schema
+			if db.schema != nil {
+				attr := db.schema.GetAttribute(datalog.NewKeyword(":person/tags"))
+				if attr != nil {
+					t.Logf("Schema has :person/tags with cardinality=%v", attr.Cardinality)
+				} else {
+					t.Log("Schema does NOT have :person/tags")
+				}
+			} else {
+				t.Log("No schema set")
+			}
+
+			// Add tag "go"
+			tx := db.NewTransaction()
+			t.Logf("Adding tag 'go' to emp1=%s, attr=:person/tags", emp1.String())
+			err := tx.Add(emp1, datalog.NewKeyword(":person/tags"), "go")
+			require.NoError(t, err, "Add tag 'go' should succeed")
+			txID, err := tx.Commit()
+			require.NoError(t, err, "Commit should succeed")
+			t.Logf("Committed transaction: %v", txID)
+
+			// Remove tag "go" using CRDT tombstone (not Retract which deletes)
+			tx = db.NewTransaction()
+			err = tx.Remove(emp1, datalog.NewKeyword(":person/tags"), "go")
+			require.NoError(t, err, "Remove tag 'go' should succeed")
+			_, err = tx.Commit()
+			require.NoError(t, err, "Commit should succeed")
+
+			// Enable annotations to trace query execution
+			db.SetAnnotationHandler(func(e annotations.Event) {
+				t.Logf("[TRACE] %s: %v", e.Name, e.Data)
+			})
+
+			// Debug: scan EATV index directly to see ALL datoms
+			t.Log("=== Scanning EATV index for all datoms ===")
+			store := db.Store()
+			startE := []byte{byte(EATV)}
+			endE := []byte{byte(EATV) + 1}
+			iterE, err := store.ScanKeysOnly(EATV, startE, endE)
+			require.NoError(t, err)
+			countE := 0
+			for iterE.Next() {
+				d, _ := iterE.Datom()
+				if d != nil {
+					t.Logf("  EATV datom: E=%s A=%s V=%v Tx=%s Op=%d",
+						d.E.String(), d.A.String(), d.V, d.Tx.String(), d.Op)
+					countE++
+				}
+			}
+			iterE.Close()
+			t.Logf("=== Found %d datoms in EATV ===", countE)
+
+			// Debug: scan VAET index directly to see what's there
+			t.Log("=== Scanning VAET index ===")
+			start := []byte{byte(VAET)}
+			end := []byte{byte(VAET) + 1}
+			iter, err := store.ScanKeysOnly(VAET, start, end)
+			require.NoError(t, err)
+			count := 0
+			for iter.Next() {
+				d, _ := iter.Datom()
+				if d != nil {
+					t.Logf("  VAET datom: E=%s A=%s V=%v Tx=%s Op=%d",
+						d.E.String(), d.A.String(), d.V, d.Tx.String(), d.Op)
+					count++
+				}
+			}
+			iter.Close()
+			t.Logf("=== Found %d datoms in VAET ===", count)
+
+			// Query: find all (E, A) where V = "go"
+			// Since "go" was retracted, should return nothing
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
+				"go")
+			require.NoError(t, err)
+
+			// Should return 0 results - "go" was retracted
+			assert.Len(t, results, 0, "[%s] V-bound query on retracted card-many value should return nothing", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestVOnlyBound_MixedCardinality tests V-only bound queries where different
+// attributes have different cardinalities. The per-datom resolution must handle
+// each attribute according to its cardinality.
+//
+// Scenario:
+// - :person/name (CardinalityOne): emp-1 had "Alice" then changed to "Bob"
+// - :person/tags (CardinalityMany): emp-1 has tag "Alice" (not retracted)
+// Query for V="Alice" should return only (:person/tags, emp-1), NOT (:person/name, emp-1)
+func TestVOnlyBound_MixedCardinality(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/tags"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityMany,
+			})
+			db.SetSchema(s)
+
+			emp1 := datalog.NewIdentity("emp-1")
+
+			// Set name to "Alice"
+			tx := db.NewTransaction()
+			tx.Set(emp1, datalog.NewKeyword(":person/name"), "Alice")
+			tx.Commit()
+
+			// Change name to "Bob" (supersedes "Alice")
+			tx = db.NewTransaction()
+			tx.Set(emp1, datalog.NewKeyword(":person/name"), "Bob")
+			tx.Commit()
+
+			// Add tag "Alice" (separate from name, still current)
+			tx = db.NewTransaction()
+			tx.Add(emp1, datalog.NewKeyword(":person/tags"), "Alice")
+			tx.Commit()
+
+			// Query: find all (E, A) where V = "Alice"
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
+				"Alice")
+			require.NoError(t, err)
+
+			// Should return 1 result: emp-1/:person/tags
+			// NOT emp-1/:person/name (because name is now "Bob")
+			assert.Len(t, results, 1, "[%s] V-bound query with mixed cardinality should apply per-datom resolution", mode.name)
+
+			if len(results) == 1 {
+				a := results[0][1]
+				assert.Equal(t, datalog.NewKeyword(":person/tags"), a,
+					"[%s] Should return :person/tags (card-many), not :person/name (card-one superseded)", mode.name)
+			}
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestVOnlyBound_Schemaless tests V-only bound queries on schemaless attributes.
+// Schemaless attributes default to CardinalityMany (add-wins) semantics.
+func TestVOnlyBound_Schemaless(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			// NO SCHEMA - all attributes are schemaless
+
+			emp1 := datalog.NewIdentity("emp-1")
+
+			// Add value "test" to schemaless attribute
+			tx := db.NewTransaction()
+			tx.Add(emp1, datalog.NewKeyword(":misc/data"), "test")
+			tx.Commit()
+
+			// Remove it using CRDT tombstone (not Retract which physically deletes)
+			tx = db.NewTransaction()
+			tx.Remove(emp1, datalog.NewKeyword(":misc/data"), "test")
+			tx.Commit()
+
+			// Query: find all (E, A) where V = "test"
+			// Schemaless uses add-wins, so retracted value should not appear
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
+				"test")
+			require.NoError(t, err)
+
+			// Should return 0 results - value was retracted
+			assert.Len(t, results, 0, "[%s] V-bound query on retracted schemaless value should return nothing", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+		})
+	}
+}
+
+// TestCacheMatrix_AVBound tests when A and V are bound (E unbound)
+// This exercises the AVET index path
+func TestCacheMatrix_AVBound(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/manager"),
+				ValueType:   schema.TypeRef,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			manager := datalog.NewIdentity("manager-1")
+			emp1 := datalog.NewIdentity("emp-1")
+			emp2 := datalog.NewIdentity("emp-2")
+
+			// emp1 has multiple manager changes
+			for _, mgr := range []datalog.Identity{
+				datalog.NewIdentity("old-manager-1"),
+				datalog.NewIdentity("old-manager-2"),
+				manager, // Final manager
+			} {
+				tx := db.NewTransaction()
+				tx.Set(emp1, datalog.NewKeyword(":person/manager"), mgr)
+				tx.Commit()
+			}
+
+			// emp2 also reports to manager
+			tx := db.NewTransaction()
+			tx.Set(emp2, datalog.NewKeyword(":person/manager"), manager)
+			tx.Commit()
+
+			// Pattern: A and V bound - "who has manager-1 as :person/manager?"
+			// This uses AVET index
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e :in $ ?mgr :where [?e :person/manager ?mgr]]`,
+				manager)
+			require.NoError(t, err)
+
+			// Should return 2 results: emp1 and emp2
+			assert.Len(t, results, 2, "[%s] A+V bound should return CRDT-resolved results", mode.name)
 
 			t.Logf("[%s] Results: %v", mode.name, results)
 		})
@@ -940,6 +1390,146 @@ func TestCacheMatrix_AsOfQuery(t *testing.T) {
 			}
 
 			t.Logf("[%s] as-of %d results: %v", mode.name, aliceLamport, results)
+		})
+	}
+}
+
+// TestCacheMatrix_SchemaAfterWrite tests CRDT resolution when data was written
+// BEFORE schema was set (schemaless mode). This simulates legacy data migrations
+// and the entity browser pattern for older databases.
+func TestCacheMatrix_SchemaAfterWrite(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			personID := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+			ageAttr := datalog.NewKeyword(":person/age")
+
+			// Write data WITHOUT schema - multiple values to same (E, A)
+			// This simulates legacy data written before schema existed
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Add(personID, nameAttr, name)
+				tx.Commit()
+			}
+			for _, age := range []int64{20, 25, 30} {
+				tx := db.NewTransaction()
+				tx.Add(personID, ageAttr, age)
+				tx.Commit()
+			}
+
+			// NOW set schema - read path should apply CRDT resolution
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       nameAttr,
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       ageAttr,
+				ValueType:   schema.TypeLong,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			// Pattern: E bound, A unbound - entity browser pattern
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?a ?v :in $ ?e :where [?e ?a ?v]]`,
+				personID)
+			require.NoError(t, err)
+
+			// Should return 2 results: one for name (Charlie), one for age (30)
+			// NOT 6 results (all historical values)
+			assert.Len(t, results, 2, "[%s] Schema-after-write should still apply CRDT resolution", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
+
+			// Also test with wildcard pull - same scenario (only when cache is enabled)
+			// Wildcard pull requires cache to enumerate attributes
+			if !mode.disableCache {
+				pullResult, err := db.Pull(personID, "[*]")
+				require.NoError(t, err)
+
+				// Pull should also return only current values
+				assert.Equal(t, "Charlie", pullResult["person/name"], "[%s] Pull should return LWW name", mode.name)
+				assert.Equal(t, int64(30), pullResult["person/age"], "[%s] Pull should return LWW age", mode.name)
+			}
+		})
+	}
+}
+
+// TestCacheMatrix_AllUnbound tests CRDT resolution when E, A, V are all unbound.
+// This goes through matchUnboundAsRelation - a different code path from join strategies.
+func TestCacheMatrix_AllUnbound(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/age"),
+				ValueType:   schema.TypeLong,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			// Create two entities with multiple historical values each
+			person1 := datalog.NewIdentity("person-1")
+			person2 := datalog.NewIdentity("person-2")
+
+			// person1: multiple name and age updates
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(person1, datalog.NewKeyword(":person/name"), name)
+				tx.Commit()
+			}
+			for _, age := range []int64{20, 25, 30} {
+				tx := db.NewTransaction()
+				tx.Set(person1, datalog.NewKeyword(":person/age"), age)
+				tx.Commit()
+			}
+
+			// person2: multiple name and age updates
+			for _, name := range []string{"Dave", "Eve", "Frank"} {
+				tx := db.NewTransaction()
+				tx.Set(person2, datalog.NewKeyword(":person/name"), name)
+				tx.Commit()
+			}
+			for _, age := range []int64{40, 45, 50} {
+				tx := db.NewTransaction()
+				tx.Set(person2, datalog.NewKeyword(":person/age"), age)
+				tx.Commit()
+			}
+
+			// Pattern: All unbound - scans entire database
+			// This goes through matchUnboundAsRelation
+			results, err := db.ExecuteQuery(`[:find ?e ?a ?v :where [?e ?a ?v]]`)
+			require.NoError(t, err)
+
+			// Count only person entities (filter out tx:* system entities)
+			// System entities like tx:* have :db/txInstant without schema, so return all values
+			personResults := 0
+			for _, r := range results {
+				if e, ok := r[0].(datalog.Identity); ok {
+					if len(e.String()) > 0 && e.String()[0] != 't' { // not tx:*
+						personResults++
+					}
+				}
+			}
+
+			// Should return 4 person results: 2 entities × 2 attributes
+			// NOT 12 results (all historical values for persons)
+			assert.Equal(t, 4, personResults, "[%s] Person entities should have CRDT-resolved results", mode.name)
+
+			t.Logf("[%s] Results: %v", mode.name, results)
 		})
 	}
 }

--- a/datalog/storage/crdt_many_test.go
+++ b/datalog/storage/crdt_many_test.go
@@ -1279,7 +1279,8 @@ func TestAddSchemaAware(t *testing.T) {
 	}
 }
 
-// TestRemoveCardinalityValidation verifies Remove() rejects non-cardinality-many attributes
+// TestRemoveCardinalityValidation verifies Remove() works for all cardinalities.
+// Remove writes OpCRDTRemove regardless of cardinality.
 func TestRemoveCardinalityValidation(t *testing.T) {
 	dir, err := os.MkdirTemp("", "crdt-remove-validation-*")
 	if err != nil {
@@ -1303,21 +1304,22 @@ func TestRemoveCardinalityValidation(t *testing.T) {
 
 	entityID := datalog.NewIdentity("test-entity")
 
+	// Remove() on CardinalityOne should succeed (writes OpCRDTRemove)
 	tx := db.NewTransaction()
 	err = tx.Remove(entityID, datalog.NewKeyword(":person/name"), "Alice")
-	if err == nil {
-		t.Error("Expected Remove() to fail for cardinality-one attribute")
+	if err != nil {
+		t.Errorf("Remove() should succeed for cardinality-one attribute: %v", err)
 	} else {
-		t.Logf("Remove correctly rejected for cardinality-one: %v", err)
+		t.Log("Remove correctly accepted for cardinality-one (writes OpCRDTRemove)")
 	}
 
-	// Also test that Remove() requires schema
+	// Remove() on unknown/schemaless attributes should succeed (CardinalityOne default)
 	tx2 := db.NewTransaction()
 	err = tx2.Remove(entityID, datalog.NewKeyword(":unknown/attr"), "value")
-	if err == nil {
-		t.Error("Expected Remove() to fail for unknown attribute (no schema)")
+	if err != nil {
+		t.Errorf("Remove() should succeed for unknown attribute: %v", err)
 	} else {
-		t.Logf("Remove correctly rejected for unknown attribute: %v", err)
+		t.Log("Remove correctly accepted for unknown attribute (CardinalityOne default)")
 	}
 }
 

--- a/datalog/storage/crdt_one_remove_test.go
+++ b/datalog/storage/crdt_one_remove_test.go
@@ -1,0 +1,372 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// =============================================================================
+// CardinalityOne Remove Tests
+// =============================================================================
+//
+// These tests verify that tx.Remove() works for CardinalityOne attributes.
+// CardinalityOne has one value per (E, A). Remove means "this attribute no
+// longer exists." The V parameter to Remove is irrelevant for resolution —
+// OpCRDTRemove at highest Tx means the attribute doesn't exist.
+//
+// Resolution: first entry in EATV (highest Tx) determines everything.
+//   - OpNone → emit (current value)
+//   - OpCRDTRemove → attribute doesn't exist, skip group
+//
+// See: docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md
+// =============================================================================
+
+// helper: create a database with a CardinalityOne schema
+func createCardinalityOneDB(t *testing.T) (*Database, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "crdt-one-remove-*")
+	require.NoError(t, err)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+	return db, cleanup
+}
+
+// helper: run a bound query for a single attribute value
+func queryBoundValue(t *testing.T, db *Database, e datalog.Identity, a datalog.Keyword) [][]interface{} {
+	t.Helper()
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+		e, a,
+	)
+	require.NoError(t, err)
+	return results
+}
+
+// helper: run an unbound query and filter for a specific (E, A)
+func queryUnboundForEA(t *testing.T, db *Database, e datalog.Identity, a datalog.Keyword) [][]interface{} {
+	t.Helper()
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?a ?v :where [?e ?a ?v]]`,
+	)
+	require.NoError(t, err)
+
+	var filtered [][]interface{}
+	for _, row := range results {
+		if len(row) >= 3 {
+			if rowE, ok := row[0].(datalog.Identity); ok {
+				if rowA, ok := row[1].(datalog.Keyword); ok {
+					if rowE.Hash() == e.Hash() && rowA == a {
+						filtered = append(filtered, row)
+					}
+				}
+			}
+		}
+	}
+	return filtered
+}
+
+// Test 1: Add value, Remove value, query → attribute doesn't exist
+func TestCardinalityOneRemove_RoundTrip(t *testing.T) {
+	db, cleanup := createCardinalityOneDB(t)
+	defer cleanup()
+
+	e := datalog.NewIdentity("alice")
+	a := datalog.NewKeyword(":person/name")
+
+	// Add
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, a, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Verify value exists
+	results := queryBoundValue(t, db, e, a)
+	require.Len(t, results, 1, "value should exist after Add")
+	assert.Equal(t, "Alice", results[0][0])
+
+	// Remove
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Remove(e, a, "Alice"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Bound query → doesn't exist
+	results = queryBoundValue(t, db, e, a)
+	assert.Len(t, results, 0, "bound query: attribute should not exist after Remove")
+
+	// Unbound query → also doesn't exist
+	unboundResults := queryUnboundForEA(t, db, e, a)
+	assert.Len(t, unboundResults, 0, "unbound query: attribute should not exist after Remove")
+}
+
+// Test 2: Add "Alice", Add "Bob", Remove (any V) → attribute doesn't exist
+// V is irrelevant for CardinalityOne remove. The OpCRDTRemove at highest Tx
+// means the attribute is gone.
+func TestCardinalityOneRemove_AfterOverwrite(t *testing.T) {
+	db, cleanup := createCardinalityOneDB(t)
+	defer cleanup()
+
+	e := datalog.NewIdentity("alice")
+	a := datalog.NewKeyword(":person/name")
+
+	// Add "Alice"
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, a, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Overwrite with "Bob"
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Add(e, a, "Bob"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Remove — passing "Bob" as V, but V doesn't matter
+	tx3 := db.NewTransaction()
+	require.NoError(t, tx3.Remove(e, a, "Bob"))
+	_, err = tx3.Commit()
+	require.NoError(t, err)
+
+	// Attribute doesn't exist
+	results := queryBoundValue(t, db, e, a)
+	assert.Len(t, results, 0, "attribute should not exist after Remove")
+}
+
+// Test 3: Add, Remove, Add again → latest Add wins
+func TestCardinalityOneRemove_ThenReAdd(t *testing.T) {
+	db, cleanup := createCardinalityOneDB(t)
+	defer cleanup()
+
+	e := datalog.NewIdentity("alice")
+	a := datalog.NewKeyword(":person/name")
+
+	// Add
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, a, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Remove
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Remove(e, a, "Alice"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Re-add with different value
+	tx3 := db.NewTransaction()
+	require.NoError(t, tx3.Add(e, a, "Bob"))
+	_, err = tx3.Commit()
+	require.NoError(t, err)
+
+	// Latest Add wins
+	results := queryBoundValue(t, db, e, a)
+	require.Len(t, results, 1, "attribute should exist after re-Add")
+	assert.Equal(t, "Bob", results[0][0])
+}
+
+// Test 4: Remove before any Add → then Add → value exists
+func TestCardinalityOneRemove_BeforeAnyAdd(t *testing.T) {
+	db, cleanup := createCardinalityOneDB(t)
+	defer cleanup()
+
+	e := datalog.NewIdentity("alice")
+	a := datalog.NewKeyword(":person/name")
+
+	// Remove first (no existing value)
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Remove(e, a, "phantom"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Then Add
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Add(e, a, "Alice"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Add has higher Tx, wins over pre-existing tombstone
+	results := queryBoundValue(t, db, e, a)
+	require.Len(t, results, 1, "Add should win over earlier Remove")
+	assert.Equal(t, "Alice", results[0][0])
+}
+
+// Test 5: V is irrelevant for CardinalityOne remove
+// Add "Alice", Remove("Bob") → attribute doesn't exist
+// Even though "Bob" was never the value, OpCRDTRemove at highest Tx means gone.
+func TestCardinalityOneRemove_VIsIrrelevant(t *testing.T) {
+	db, cleanup := createCardinalityOneDB(t)
+	defer cleanup()
+
+	e := datalog.NewIdentity("alice")
+	a := datalog.NewKeyword(":person/name")
+
+	// Add "Alice"
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, a, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Remove with completely different V — doesn't matter for CardinalityOne
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Remove(e, a, "Bob"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Attribute doesn't exist
+	results := queryBoundValue(t, db, e, a)
+	assert.Len(t, results, 0,
+		"attribute should not exist — V is irrelevant for CardinalityOne Remove")
+}
+
+// Test 6: Multiple entities — removing one doesn't affect the other
+func TestCardinalityOneRemove_MultipleEntities(t *testing.T) {
+	db, cleanup := createCardinalityOneDB(t)
+	defer cleanup()
+
+	e1 := datalog.NewIdentity("alice")
+	e2 := datalog.NewIdentity("bob")
+	a := datalog.NewKeyword(":person/name")
+
+	// Add values for both entities
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e1, a, "Alice"))
+	require.NoError(t, tx.Add(e2, a, "Bob"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Remove only entity1's value
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Remove(e1, a, "Alice"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// entity1: doesn't exist
+	results1 := queryBoundValue(t, db, e1, a)
+	assert.Len(t, results1, 0, "entity1 attribute should not exist after Remove")
+
+	// entity2: unaffected
+	results2 := queryBoundValue(t, db, e2, a)
+	require.Len(t, results2, 1, "entity2 attribute should still exist")
+	assert.Equal(t, "Bob", results2[0][0])
+}
+
+// =============================================================================
+// Query Path Coverage After Remove
+// =============================================================================
+
+// Test 11: Bound query (E and A via :in) after remove → empty
+func TestCardinalityOneRemove_BoundQuery(t *testing.T) {
+	db, cleanup := createCardinalityOneDB(t)
+	defer cleanup()
+
+	e := datalog.NewIdentity("alice")
+	a := datalog.NewKeyword(":person/name")
+
+	// Add then Remove
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, a, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Remove(e, a, "Alice"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Bound query with E and A from :in
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+		e, a,
+	)
+	require.NoError(t, err)
+	assert.Len(t, results, 0, "bound query should return empty after Remove")
+}
+
+// Test 12: V-bound query after remove → empty
+func TestCardinalityOneRemove_VBoundQuery(t *testing.T) {
+	db, cleanup := createCardinalityOneDB(t)
+	defer cleanup()
+
+	e := datalog.NewIdentity("alice")
+	a := datalog.NewKeyword(":person/name")
+
+	// Add then Remove
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, a, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Remove(e, a, "Alice"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// V-bound query: find entities where :person/name = "Alice"
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(db.Schema())
+
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: a},
+			query.Constant{Value: "Alice"},
+			query.Blank{},
+		},
+	}
+
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	count := 0
+	iter := results.Iterator()
+	for iter.Next() {
+		count++
+	}
+	iter.Close()
+
+	assert.Equal(t, 0, count, "V-bound query should return empty after Remove")
+}
+
+// Test 13: Unbound query after remove → entity/attribute absent from results
+func TestCardinalityOneRemove_UnboundQuery(t *testing.T) {
+	db, cleanup := createCardinalityOneDB(t)
+	defer cleanup()
+
+	e := datalog.NewIdentity("alice")
+	a := datalog.NewKeyword(":person/name")
+
+	// Add then Remove
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, a, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Remove(e, a, "Alice"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Unbound query — removed attribute should be absent
+	unboundResults := queryUnboundForEA(t, db, e, a)
+	assert.Len(t, unboundResults, 0, "unbound query should not find removed attribute")
+}

--- a/datalog/storage/crdt_resolve_test.go
+++ b/datalog/storage/crdt_resolve_test.go
@@ -265,4 +265,3 @@ func TestResolveRGAFromDatoms_IgnoresNonRGAOps(t *testing.T) {
 	values, _, _ := ResolveRGAFromDatoms(datoms)
 	assert.Equal(t, []any{"first"}, values)
 }
-

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -133,11 +133,15 @@ func (it *CRDTResolvingIterator) Next() bool {
 		switch it.card {
 		case schema.CardinalityOne:
 			if isNewGroup {
-				// First entry for this (E, A) - emit immediately
+				if datom.Op == datalog.OpCRDTRemove {
+					// Value was retracted — attribute doesn't exist. Skip group.
+					continue
+				}
+				// First entry for this (E, A) — emit (LWW winner)
 				it.currentDatom = datom
 				return true
 			}
-			// Same (E, A) - skip (we already emitted the winner)
+			// Same (E, A) — skip (already emitted or skipped the winner)
 			continue
 
 		case schema.CardinalityMany:
@@ -152,11 +156,12 @@ func (it *CRDTResolvingIterator) Next() bool {
 			continue
 
 		case schema.CardinalityUnknown:
-			// No schema definition - use add-wins (same as CardinalityMany)
-			// This respects explicit Remove() operations while not requiring schema
-			// See INDEX_SELECTION_PROOF.md Theorem 3b
-			if result := it.processAddWins(datom); result != nil {
-				it.currentDatom = result
+			// Default is CardinalityOne (LWW) — same resolution as CardinalityOne
+			if isNewGroup {
+				if datom.Op == datalog.OpCRDTRemove {
+					continue
+				}
+				it.currentDatom = datom
 				return true
 			}
 			continue
@@ -172,7 +177,7 @@ func (it *CRDTResolvingIterator) startNewGroup(datom *datalog.Datom) {
 
 	// Determine cardinality from schema
 	// If no schema definition exists for this attribute, use CardinalityUnknown
-	// which uses add-wins semantics (same as CardinalityMany)
+	// which defaults to CardinalityOne (LWW) semantics
 	it.card = schema.CardinalityUnknown
 	if it.schema != nil {
 		if attr := it.schema.GetAttribute(datom.A); attr != nil {
@@ -190,9 +195,7 @@ func (it *CRDTResolvingIterator) startNewGroup(datom *datalog.Datom) {
 	case schema.CardinalityVector:
 		it.rgaElements = it.rgaElements[:0]
 	case schema.CardinalityUnknown:
-		// Same as CardinalityMany - use add-wins
-		it.emitted = make(map[any]bool)
-		it.tombstones = make(map[any]uint64)
+		// Default is CardinalityOne (LWW) — no state needed
 	}
 }
 

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -21,10 +21,10 @@ type CRDTResolvingIterator struct {
 	txID   uint64 // For as-of queries: only consider datoms with Tx.Lamport <= txID
 
 	// Current (E, A) group tracking
-	currentE  datalog.Identity
-	currentA  datalog.Keyword
-	hasGroup  bool
-	card      schema.Cardinality
+	currentE datalog.Identity
+	currentA datalog.Keyword
+	hasGroup bool
+	card     schema.Cardinality
 
 	// CardinalityMany: streaming state (no buffering!)
 	// Because we iterate Tx descending:

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -150,6 +150,16 @@ func (it *CRDTResolvingIterator) Next() bool {
 		case schema.CardinalityVector:
 			it.accumulateRGA(datom)
 			continue
+
+		case schema.CardinalityUnknown:
+			// No schema definition - use add-wins (same as CardinalityMany)
+			// This respects explicit Remove() operations while not requiring schema
+			// See INDEX_SELECTION_PROOF.md Theorem 3b
+			if result := it.processAddWins(datom); result != nil {
+				it.currentDatom = result
+				return true
+			}
+			continue
 		}
 	}
 }
@@ -160,8 +170,10 @@ func (it *CRDTResolvingIterator) startNewGroup(datom *datalog.Datom) {
 	it.currentA = datom.A
 	it.hasGroup = true
 
-	// Determine cardinality
-	it.card = schema.CardinalityOne
+	// Determine cardinality from schema
+	// If no schema definition exists for this attribute, use CardinalityUnknown
+	// which uses add-wins semantics (same as CardinalityMany)
+	it.card = schema.CardinalityUnknown
 	if it.schema != nil {
 		if attr := it.schema.GetAttribute(datom.A); attr != nil {
 			it.card = attr.Cardinality
@@ -177,6 +189,10 @@ func (it *CRDTResolvingIterator) startNewGroup(datom *datalog.Datom) {
 		it.tombstones = make(map[any]uint64)
 	case schema.CardinalityVector:
 		it.rgaElements = it.rgaElements[:0]
+	case schema.CardinalityUnknown:
+		// Same as CardinalityMany - use add-wins
+		it.emitted = make(map[any]bool)
+		it.tombstones = make(map[any]uint64)
 	}
 }
 

--- a/datalog/storage/crdt_schemaless_attr_test.go
+++ b/datalog/storage/crdt_schemaless_attr_test.go
@@ -1,0 +1,433 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// =============================================================================
+// BUG: Schemaless Attributes Invisible to Bound Queries When Schema Present
+// =============================================================================
+//
+// When a database has a schema defined, attributes NOT registered in the schema
+// can be written successfully via tx.Add(), but bound queries via :in fail to
+// find them. The root cause is that CRDTResolvingIterator treats unregistered
+// attributes as CardinalityUnknown, which routes to processAddWins(). But
+// schemaless datoms have Op=0 (zero value), and processAddWins only handles
+// OpCRDTAdd (1) and OpCRDTRemove (2), silently dropping Op=0 datoms.
+//
+// See: docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md
+// =============================================================================
+
+// TestSchemalessAttrBoundQuery_BugRepro reproduces the exact bug from the doc:
+// schema exists, attribute not registered, bound query returns empty.
+func TestSchemalessAttrBoundQuery_BugRepro(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			// Create schema with some attributes, but NOT :module/input
+			s, err := schema.NewBuilder().
+				Attribute(":module/name").Type(schema.TypeString).One().Add().
+				Build()
+			require.NoError(t, err)
+			db.SetSchema(s)
+
+			entityID := datalog.NewIdentity("test-entity")
+
+			// Write schemaless attribute — should succeed (additive schema)
+			tx := db.NewTransaction()
+			err = tx.Add(entityID, datalog.NewKeyword(":module/input"), "some text")
+			require.NoError(t, err)
+			_, err = tx.Commit()
+			require.NoError(t, err)
+
+			// Bound query — should find the data
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+				entityID, datalog.NewKeyword(":module/input"),
+			)
+			require.NoError(t, err)
+
+			assert.Len(t, results, 1,
+				"[%s] Bound query for schemaless attribute should return 1 result", mode.name)
+			if len(results) > 0 {
+				assert.Equal(t, "some text", results[0][0],
+					"[%s] Should find the written value", mode.name)
+			}
+		})
+	}
+}
+
+// TestSchemalessAttrUnboundQuery_BugRepro tests that unbound queries also work
+// for schemaless attributes when a schema is present.
+func TestSchemalessAttrUnboundQuery_BugRepro(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			// Create schema with some attributes, but NOT :test/data
+			s, err := schema.NewBuilder().
+				Attribute(":test/name").Type(schema.TypeString).One().Add().
+				Build()
+			require.NoError(t, err)
+			db.SetSchema(s)
+
+			entityID := datalog.NewIdentity("test-entity")
+
+			// Write schemaless attribute
+			tx := db.NewTransaction()
+			err = tx.Add(entityID, datalog.NewKeyword(":test/data"), "hello")
+			require.NoError(t, err)
+			_, err = tx.Commit()
+			require.NoError(t, err)
+
+			// Unbound query — should find the data
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a ?v :where [?e ?a ?v]]`,
+			)
+			require.NoError(t, err)
+
+			// Should find at least the schemaless attribute
+			found := false
+			for _, row := range results {
+				if len(row) >= 3 {
+					if kw, ok := row[1].(datalog.Keyword); ok {
+						if kw.String() == ":test/data" {
+							found = true
+							assert.Equal(t, "hello", row[2],
+								"[%s] Should find correct value for schemaless attr", mode.name)
+						}
+					}
+				}
+			}
+			assert.True(t, found,
+				"[%s] Unbound query should find schemaless attribute :test/data", mode.name)
+		})
+	}
+}
+
+// TestSchemalessAttrMultipleWrites tests CRDT resolution for schemaless
+// attributes when multiple writes occur. Schemaless default is CardinalityOne
+// (LWW) — only the latest value should be returned.
+func TestSchemalessAttrMultipleWrites(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			// Schema exists but :test/counter is not registered
+			s, err := schema.NewBuilder().
+				Attribute(":test/name").Type(schema.TypeString).One().Add().
+				Build()
+			require.NoError(t, err)
+			db.SetSchema(s)
+
+			entityID := datalog.NewIdentity("test-entity")
+
+			// Write multiple values — each overwrites the previous (LWW)
+			for i := 0; i < 3; i++ {
+				tx := db.NewTransaction()
+				err = tx.Add(entityID, datalog.NewKeyword(":test/counter"), int64(i))
+				require.NoError(t, err)
+				_, err = tx.Commit()
+				require.NoError(t, err)
+			}
+
+			// Bound query — schemaless = CardinalityOne (LWW), only latest value
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+				entityID, datalog.NewKeyword(":test/counter"),
+			)
+			require.NoError(t, err)
+
+			require.Len(t, results, 1,
+				"[%s] Schemaless = CardinalityOne (LWW): only latest value", mode.name)
+			assert.Equal(t, int64(2), results[0][0],
+				"[%s] Latest value should be 2 (third write)", mode.name)
+
+			// Unbound query should also return only latest
+			unboundResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a ?v :where [?e ?a ?v]]`,
+			)
+			require.NoError(t, err)
+
+			var counterValues []any
+			for _, row := range unboundResults {
+				if len(row) >= 3 {
+					if kw, ok := row[1].(datalog.Keyword); ok {
+						if kw.String() == ":test/counter" {
+							counterValues = append(counterValues, row[2])
+						}
+					}
+				}
+			}
+			assert.Len(t, counterValues, 1,
+				"[%s] Unbound query should also return only latest value", mode.name)
+		})
+	}
+}
+
+// =============================================================================
+// Schemaless CardinalityOne (Default) Tests
+// =============================================================================
+//
+// These tests verify that schemaless attributes default to CardinalityOne (LWW).
+// Schemaless = no schema on the attribute (either no schema at all, or schema
+// exists but the attribute is not registered).
+//
+// See: docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md (tests 7-10)
+// =============================================================================
+
+// Test 8: Schemaless remove — tx.Add() then tx.Remove() → attribute doesn't exist
+func TestSchemalessRemove_RoundTrip(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			// Schema exists but :test/data is not registered
+			s, err := schema.NewBuilder().
+				Attribute(":test/name").Type(schema.TypeString).One().Add().
+				Build()
+			require.NoError(t, err)
+			db.SetSchema(s)
+
+			entityID := datalog.NewIdentity("test-entity")
+			attr := datalog.NewKeyword(":test/data")
+
+			// Add
+			tx := db.NewTransaction()
+			require.NoError(t, tx.Add(entityID, attr, "hello"))
+			_, err = tx.Commit()
+			require.NoError(t, err)
+
+			// Verify exists
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+				entityID, attr,
+			)
+			require.NoError(t, err)
+			require.Len(t, results, 1, "[%s] value should exist after Add", mode.name)
+
+			// Remove
+			tx2 := db.NewTransaction()
+			require.NoError(t, tx2.Remove(entityID, attr, "hello"))
+			_, err = tx2.Commit()
+			require.NoError(t, err)
+
+			// Bound query → attribute doesn't exist
+			results, err = db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+				entityID, attr,
+			)
+			require.NoError(t, err)
+			assert.Len(t, results, 0,
+				"[%s] bound query: schemaless attribute should not exist after Remove", mode.name)
+
+			// Unbound query → also doesn't exist
+			unboundResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a ?v :where [?e ?a ?v]]`,
+			)
+			require.NoError(t, err)
+			for _, row := range unboundResults {
+				if len(row) >= 3 {
+					if kw, ok := row[1].(datalog.Keyword); ok {
+						assert.NotEqual(t, ":test/data", kw.String(),
+							"[%s] unbound query should not find removed schemaless attribute", mode.name)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Test 9: Schemaless remove then re-add → latest Add wins
+func TestSchemalessRemove_ThenReAdd(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			// No schema at all — fully schemaless
+			entityID := datalog.NewIdentity("test-entity")
+			attr := datalog.NewKeyword(":test/data")
+
+			// Add
+			tx := db.NewTransaction()
+			require.NoError(t, tx.Add(entityID, attr, "first"))
+			_, err := tx.Commit()
+			require.NoError(t, err)
+
+			// Remove
+			tx2 := db.NewTransaction()
+			require.NoError(t, tx2.Remove(entityID, attr, "first"))
+			_, err = tx2.Commit()
+			require.NoError(t, err)
+
+			// Re-add with different value
+			tx3 := db.NewTransaction()
+			require.NoError(t, tx3.Add(entityID, attr, "second"))
+			_, err = tx3.Commit()
+			require.NoError(t, err)
+
+			// Latest Add wins
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+				entityID, attr,
+			)
+			require.NoError(t, err)
+			require.Len(t, results, 1, "[%s] attribute should exist after re-Add", mode.name)
+			assert.Equal(t, "second", results[0][0],
+				"[%s] re-added value should be returned", mode.name)
+		})
+	}
+}
+
+// Test 10: Schema exists, attribute not registered → defaults to CardinalityOne
+// Multiple writes return only latest. Remove works.
+func TestSchemalessAttr_UnregisteredDefaultsToCardinalityOne(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createCacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			// Schema with many attributes, but NOT :unregistered/attr
+			s, err := schema.NewBuilder().
+				Attribute(":person/name").Type(schema.TypeString).One().Add().
+				Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+				Build()
+			require.NoError(t, err)
+			db.SetSchema(s)
+
+			entityID := datalog.NewIdentity("test-entity")
+			attr := datalog.NewKeyword(":unregistered/attr")
+
+			// Multiple writes — should be LWW (CardinalityOne default)
+			tx := db.NewTransaction()
+			require.NoError(t, tx.Add(entityID, attr, "v1"))
+			_, err = tx.Commit()
+			require.NoError(t, err)
+
+			tx2 := db.NewTransaction()
+			require.NoError(t, tx2.Add(entityID, attr, "v2"))
+			_, err = tx2.Commit()
+			require.NoError(t, err)
+
+			tx3 := db.NewTransaction()
+			require.NoError(t, tx3.Add(entityID, attr, "v3"))
+			_, err = tx3.Commit()
+			require.NoError(t, err)
+
+			// Only latest value returned (LWW)
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+				entityID, attr,
+			)
+			require.NoError(t, err)
+			require.Len(t, results, 1,
+				"[%s] unregistered attr defaults to CardinalityOne: only latest", mode.name)
+			assert.Equal(t, "v3", results[0][0],
+				"[%s] should return latest value (v3)", mode.name)
+
+			// Remove works
+			tx4 := db.NewTransaction()
+			require.NoError(t, tx4.Remove(entityID, attr, "v3"))
+			_, err = tx4.Commit()
+			require.NoError(t, err)
+
+			results, err = db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+				entityID, attr,
+			)
+			require.NoError(t, err)
+			assert.Len(t, results, 0,
+				"[%s] unregistered attr Remove should work", mode.name)
+		})
+	}
+}
+
+// =============================================================================
+// Nil-Schema Matcher Test
+// =============================================================================
+//
+// Test 14: Data written with schema (tx.Set, OpNone), queried through a
+// BadgerMatcher created without schema → CardinalityOne default works.
+//
+// This exercises the code path where CRDTResolvingIterator runs with nil schema
+// and must default to CardinalityOne for all attributes.
+//
+// See: docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md (test 14)
+// =============================================================================
+
+// Test 14: Nil-schema matcher can read data written with schema
+func TestNilSchemaMatcher_ReadsSchemaData(t *testing.T) {
+	db, cleanup := createCacheTestDB(t, false)
+	defer cleanup()
+
+	// Set up schema with CardinalityOne attribute
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	e := datalog.NewIdentity("alice")
+	a := datalog.NewKeyword(":person/name")
+
+	// Write via schema-aware tx.Add() — writes OpNone
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, a, "Alice"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Overwrite — still OpNone, higher Tx
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Add(e, a, "Bob"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Create matcher WITHOUT schema
+	matcher := NewBadgerMatcher(db.Store())
+	// Deliberately NOT calling matcher.SetSchema()
+
+	// Query through nil-schema matcher using a DataPattern
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: e},
+			query.Constant{Value: a},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	// Should return data — CRDTResolvingIterator with nil schema defaults to
+	// CardinalityOne. OpNone datoms are valid CardinalityOne assertions.
+	// First entry (highest Tx) = "Bob". Should return exactly 1 result.
+	count := 0
+	var lastValue any
+	iter := results.Iterator()
+	for iter.Next() {
+		tuple := iter.Tuple()
+		if len(tuple) > 0 {
+			lastValue = tuple[0]
+		}
+		count++
+	}
+	iter.Close()
+
+	require.Equal(t, 1, count,
+		"nil-schema matcher should return exactly 1 result (CardinalityOne default, LWW)")
+	assert.Equal(t, "Bob", lastValue,
+		"nil-schema matcher should return latest value (Bob)")
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -1399,26 +1399,27 @@ func (t *Transaction) Add(e datalog.Identity, a datalog.Keyword, v interface{}) 
 			})
 		}
 	} else {
-		// Schemaless mode: store raw value for backward compatibility
-		// Queries will treat this as cardinality-one by default
+		// Schemaless mode: CardinalityOne (LWW) semantics
+		// OpNone is valid and means "CardinalityOne LWW assertion"
 		t.datoms = append(t.datoms, datalog.Datom{
 			E:  e,
 			A:  a,
 			V:  v,
 			Tx: elemID,
+			Op: datalog.OpNone,
 		})
 	}
 
 	return nil
 }
 
-// Remove removes a value from a cardinality-many set using CRDT add-wins semantics.
-// The value is wrapped in a SetEntry with OpRemove (tombstone) and stored.
+// Remove removes a value using CRDT tombstone semantics.
 //
-// This method is part of the CRDT implementation:
-// - Cardinality-Many: Value tombstoned; add-wins resolves conflicts
-// - Cardinality-One: Not applicable (use Set() to replace value)
-// - Cardinality-Vector: Not applicable (use Set() to replace entire vector)
+// Behavior by cardinality:
+// - Cardinality-One: Writes OpCRDTRemove; attribute doesn't exist if tombstone has highest Tx
+// - Cardinality-Many: Writes OpCRDTRemove; add-wins resolves per-value conflicts
+// - Cardinality-Vector: RGA LIFO tombstone; removes most recently added matching element
+// - Schemaless/undefined: Defaults to CardinalityOne
 func (t *Transaction) Remove(e datalog.Identity, a datalog.Keyword, v interface{}) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -1432,18 +1433,23 @@ func (t *Transaction) Remove(e datalog.Identity, a datalog.Keyword, v interface{
 		return fmt.Errorf("nil value not allowed for Remove on attribute %s", a.String())
 	}
 
-	// Remove requires schema with cardinality-many
+	// Determine cardinality for Remove semantics
 	s := t.db.Schema()
-	if s == nil {
-		return fmt.Errorf("Remove requires schema: attribute %s has no schema defined", a.String())
+	var def *schema.AttributeDefinition
+	if s != nil {
+		def = s.GetAttribute(a)
 	}
 
-	def := s.GetAttribute(a)
-	if def == nil {
-		return fmt.Errorf("Remove requires schema: attribute %s not defined in schema", a.String())
+	// Determine cardinality: schemaless/undefined defaults to CardinalityOne
+	var card schema.Cardinality
+	if def != nil {
+		card = def.Cardinality
+	} else {
+		// Schemaless or undefined attribute: CardinalityOne (LWW)
+		card = schema.CardinalityOne
 	}
 
-	switch def.Cardinality {
+	switch card {
 	case schema.CardinalityMany:
 		// CRDT add-wins semantics: store raw value with Op=Remove (tombstone)
 		// Op is stored in the key (between V and Tx) for proper AVET lookups
@@ -1457,7 +1463,15 @@ func (t *Transaction) Remove(e datalog.Identity, a datalog.Keyword, v interface{
 			Op: datalog.OpCRDTRemove,
 		})
 	case schema.CardinalityOne:
-		return fmt.Errorf("Remove not valid for cardinality-one attribute %s: cardinality-one values are replaced via Set()", a.String())
+		// Write tombstone — CRDTResolvingIterator checks Op on first entry
+		elemID := t.db.clock.Next()
+		t.datoms = append(t.datoms, datalog.Datom{
+			E:  e,
+			A:  a,
+			V:  v,
+			Tx: elemID,
+			Op: datalog.OpCRDTRemove,
+		})
 	case schema.CardinalityVector:
 		// RGA LIFO Remove: tombstone the most recently added element matching value
 		// O(k) via EAVT scan where k = entries for this (E, A, V) combination

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -194,12 +194,9 @@ func (m *BadgerMatcher) matchWithHashJoin(
 	}
 
 	// PHASE 3.5: Wrap with CRDT resolution
-	// This ensures we only see CRDT-resolved current values, not all historical values.
-	// The resolution is per (E, A) group based on schema cardinality.
-	var resolvedIter Iterator = storageIter
-	if m.schema != nil {
-		resolvedIter = NewCRDTResolvingIterator(storageIter, m.schema, m.txID)
-	}
+	// Always applied: CRDTResolvingIterator handles nil schema correctly
+	// (defaults to CardinalityUnknown → add-wins semantics)
+	resolvedIter := NewCRDTResolvingIterator(storageIter, m.schema, m.txID)
 
 	// PHASE 4: Create streaming hash join iterator
 	iter := &hashJoinIterator{
@@ -567,10 +564,8 @@ func (m *BadgerMatcher) matchWithMergeJoin(
 	}
 
 	// PHASE 3.5: Wrap with CRDT resolution
-	var resolvedIterMerge Iterator = storageIter
-	if m.schema != nil {
-		resolvedIterMerge = NewCRDTResolvingIterator(storageIter, m.schema, m.txID)
-	}
+	// Always applied: CRDTResolvingIterator handles nil schema correctly
+	resolvedIterMerge := NewCRDTResolvingIterator(storageIter, m.schema, m.txID)
 
 	// PHASE 4: Create streaming merge join iterator
 	iter := &mergeJoinIterator{

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -569,10 +569,10 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 			}
 
 			// Only E bound - use EATV for CRDT resolution
-		// EATV: E → A → Tx↓ → V - first entry for each (E, A) is LWW winner
-		// This is required for CRDTResolvingIterator's "first entry wins" logic
-		start, end := encoder.EncodePrefixRange(EATV, eBytes[:])
-		return EATV, start, end
+			// EATV: E → A → Tx↓ → V - first entry for each (E, A) is LWW winner
+			// This is required for CRDTResolvingIterator's "first entry wins" logic
+			start, end := encoder.EncodePrefixRange(EATV, eBytes[:])
+			return EATV, start, end
 		}
 	} else if a != nil {
 		// A is bound but not E

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -568,9 +568,11 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 				}
 			}
 
-			// Only E bound - use prefix range
-			start, end := encoder.EncodePrefixRange(EAVT, eBytes[:])
-			return EAVT, start, end
+			// Only E bound - use EATV for CRDT resolution
+		// EATV: E → A → Tx↓ → V - first entry for each (E, A) is LWW winner
+		// This is required for CRDTResolvingIterator's "first entry wins" logic
+		start, end := encoder.EncodePrefixRange(EATV, eBytes[:])
+		return EATV, start, end
 		}
 	} else if a != nil {
 		// A is bound but not E
@@ -630,7 +632,8 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 			return AETV, start, end
 		}
 	} else if v != nil {
-		// Only V bound - use VAET index
+		// Only V bound - use VAET index with per-datom cardinality resolution
+		// VAET: V → A → E → Tx↓ - groups by A, enabling efficient cardinality lookup
 		// Create dummy datom for value encoding
 		dummyDatom := &datalog.Datom{
 			E:  datalog.NewIdentity(""),
@@ -666,9 +669,11 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 		}
 	}
 
-	// Full scan on EAVT - use index prefix to avoid scanning other indices
-	start, end := encoder.EncodePrefixRange(EAVT)
-	return EAVT, start, end
+	// Full scan on EATV for CRDT resolution
+	// EATV: E → A → Tx↓ → V - first entry for each (E, A) is LWW winner
+	// This is required for CRDTResolvingIterator's "first entry wins" logic
+	start, end := encoder.EncodePrefixRange(EATV)
+	return EATV, start, end
 }
 
 // matchesDatom checks if a datom matches the pattern constraints

--- a/datalog/storage/matcher_iterator_nonreusing.go
+++ b/datalog/storage/matcher_iterator_nonreusing.go
@@ -77,11 +77,8 @@ func (it *nonReusingIterator) Next() bool {
 	}
 
 	// Wrap with CRDT resolution to ensure we only see resolved values
-	if it.matcher.schema != nil {
-		it.currentScan = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
-	} else {
-		it.currentScan = rawIter
-	}
+	// Always applied: CRDTResolvingIterator handles nil schema correctly
+	it.currentScan = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
 
 	// Try to find first match
 	return it.Next()

--- a/datalog/storage/matcher_iterator_reusing.go
+++ b/datalog/storage/matcher_iterator_reusing.go
@@ -70,11 +70,8 @@ func (it *reusingIterator) Next() bool {
 		}
 
 		// Wrap with CRDT resolution to ensure we only see resolved values
-		if it.matcher.schema != nil {
-			it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
-		} else {
-			it.storageIter = rawIter
-		}
+		// Always applied: CRDTResolvingIterator handles nil schema correctly
+		it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
 
 		// Reset to first tuple for actual processing
 		it.updateBoundPattern(firstTuple)

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -377,13 +377,10 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			return nil, fmt.Errorf("key mask scan failed: %w", err)
 		}
 
-		// Wrap with CRDT resolution when schema exists
-		// This ensures per-(E, A) group resolution regardless of bound/unbound status
-		if m.schema != nil {
-			maskIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
-		} else {
-			maskIter.storageIter = rawStorageIter
-		}
+		// Wrap with CRDT resolution for per-(E, A) group resolution
+		// Always applied: CRDTResolvingIterator handles nil schema correctly
+		// (defaults to CardinalityUnknown → add-wins semantics)
+		maskIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
 		iter = maskIter
 	} else {
 		// Use regular iterator
@@ -410,14 +407,10 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			return nil, fmt.Errorf("scan failed: %w", err)
 		}
 
-		// Wrap with CRDT resolution when schema exists
-		// This ensures per-(E, A) group resolution for ALL patterns, not just [?e :attr ?v]
-		// BUG FIX: Previously only wrapped when e == nil && a != nil, missing patterns like [?e ?a ?v]
-		if m.schema != nil {
-			regularIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
-		} else {
-			regularIter.storageIter = rawStorageIter
-		}
+		// Wrap with CRDT resolution for per-(E, A) group resolution
+		// Always applied: CRDTResolvingIterator handles nil schema correctly
+		// (defaults to CardinalityUnknown → add-wins semantics)
+		regularIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
 		iter = regularIter
 	}
 

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/codec"
 	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/query"
 	"github.com/wbrown/janus-datalog/datalog/schema"
@@ -110,16 +111,38 @@ func (m *BadgerMatcher) MatchWithConstraints(
 	// For multi-position cases, the relation may be materialized to allow cardinality counting
 	strategy, bindingRel := analyzeReuseStrategy(pattern, bindingRel)
 
+	// For V-bound queries with NeedsValidation, check cardinality
+	// Only validate when EXPLICITLY CardinalityOne
+	// CardinalityMany uses add-wins, CardinalityUnknown/schemaless emits all
+	// See docs/reference/INDEX_SELECTION_PROOF.md Theorem 3b
+	if strategy.NeedsValidation && strategy.BoundA != nil {
+		// Default: no validation (schemaless = Datascript-style = emit all)
+		strategy.NeedsValidation = false
+
+		if m.schema != nil {
+			if aKw, ok := strategy.BoundA.(datalog.Keyword); ok {
+				if def := m.schema.GetAttribute(aKw); def != nil {
+					if def.Cardinality == schema.CardinalityOne {
+						// Only explicit CardinalityOne needs validation
+						strategy.NeedsValidation = true
+					}
+				}
+			}
+		}
+	}
+
 	// Emit strategy selection event
 	if m.handler != nil {
 		m.handler(annotations.Event{
 			Name:  "storage/reuse-strategy",
 			Start: time.Now(),
 			Data: map[string]interface{}{
-				"pattern":       pattern.String(),
-				"strategy_type": strategy.Type.String(),
-				"index":         indexName(strategy.Index),
-				"position":      strategy.Position,
+				"pattern":          pattern.String(),
+				"strategy_type":    strategy.Type.String(),
+				"index":            indexName(strategy.Index),
+				"position":         strategy.Position,
+				"needs_validation": strategy.NeedsValidation,
+				"bound_a":          fmt.Sprintf("%v", strategy.BoundA),
 			},
 		})
 	}
@@ -127,6 +150,12 @@ func (m *BadgerMatcher) MatchWithConstraints(
 	// Use appropriate matching strategy
 	switch strategy.Type {
 	case SinglePositionReuse:
+		// For V-bound cardinality-one queries, use candidate + validate pattern
+		// See docs/reference/INDEX_SELECTION_PROOF.md Theorem 4
+		if strategy.NeedsValidation {
+			return m.matchWithVValidation(pattern, bindingRel, columns, strategy, constraints)
+		}
+
 		// Choose join strategy based on selectivity
 		joinStrategy := m.chooseJoinStrategy(pattern, bindingRel, strategy.Position)
 
@@ -294,8 +323,10 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			Name:  "pattern/index-selection",
 			Start: time.Now(),
 			Data: map[string]interface{}{
-				"pattern": pattern.String(),
-				"index":   indexName(index),
+				"pattern":    pattern.String(),
+				"index":      indexName(index),
+				"scan.start": codec.EncodeL85(start),
+				"scan.end":   codec.EncodeL85(end),
 			},
 		})
 	}
@@ -379,9 +410,10 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			return nil, fmt.Errorf("scan failed: %w", err)
 		}
 
-		// Wrap with CRDT resolution when E is unbound but A is bound
-		// This ensures per-(E, A) group resolution even for patterns like [?e :attr ?v]
-		if m.schema != nil && e == nil && a != nil {
+		// Wrap with CRDT resolution when schema exists
+		// This ensures per-(E, A) group resolution for ALL patterns, not just [?e :attr ?v]
+		// BUG FIX: Previously only wrapped when e == nil && a != nil, missing patterns like [?e ?a ?v]
+		if m.schema != nil {
 			regularIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
 		} else {
 			regularIter.storageIter = rawStorageIter
@@ -471,6 +503,409 @@ func (m *BadgerMatcher) matchWithIteratorReuse(
 
 	// Return streaming relation with the iterator
 	return executor.NewStreamingRelationWithOptions(columns, iter, m.options), nil
+}
+
+// matchWithVValidation implements the candidate + validate pattern for V-bound
+// cardinality-one queries. See docs/reference/INDEX_SELECTION_PROOF.md Theorem 4.
+//
+// Algorithm:
+// 1. Scan V-primary index (AVET/VAET) for candidate entities
+// 2. For each candidate E, point-lookup EATV to get CRDT winner
+// 3. If winner.V == boundV, emit; otherwise skip (stale candidate)
+func (m *BadgerMatcher) matchWithVValidation(
+	pattern *query.DataPattern,
+	bindingRel executor.Relation,
+	columns []query.Symbol,
+	strategy ReuseStrategy,
+	constraints []executor.StorageConstraint,
+) (executor.Relation, error) {
+	if m.handler != nil {
+		m.handler(annotations.Event{
+			Name:  "v-validation/entry",
+			Start: time.Now(),
+			Data: map[string]any{
+				"pattern":     pattern.String(),
+				"index":       indexName(strategy.Index),
+				"bound_a":     fmt.Sprintf("%v", strategy.BoundA),
+				"binding_rel": bindingRel.Columns(),
+			},
+		})
+	}
+	// Get sorted tuples for efficient iteration
+	sortedTuples := bindingRel.Sorted()
+
+	// Create validating iterator
+	iter := &validatingVBoundIterator{
+		matcher:          m,
+		pattern:          pattern,
+		bindingRel:       bindingRel,
+		tuples:           sortedTuples,
+		candidateIndex:   strategy.Index,           // AVET or VAET for candidates
+		validationIndex:  strategy.ValidationIndex, // EATV for validation
+		boundA:           strategy.BoundA,          // Constant A value if any
+		columns:          columns,
+		constraints:      constraints,
+		currentTupleIdx:  -1,
+		workspace:        make(executor.Tuple, len(columns)),
+		patternExtractor: query.NewPatternExtractor(pattern, bindingRel.Columns()),
+		tupleBuilder:     m.getTupleBuilder(pattern, columns),
+	}
+
+	return executor.NewStreamingRelationWithOptions(columns, iter, m.options), nil
+}
+
+// validatingVBoundIterator implements the semi-join pattern for V-bound queries.
+// It wraps a VAET scan with CRDTResolvingIterator for correct CRDT semantics,
+// then post-validates CardinalityOne emissions with EATV point lookup.
+//
+// Architecture (per proof doc):
+// 1. VAET scan wrapped with CRDTResolvingIterator
+// 2. CRDTResolvingIterator handles: group deduplication (O(1) space),
+//    add-wins with same-Tx tiebreaking, RGA for vectors
+// 3. Only CardinalityOne needs post-validation (LWW winner may have different V)
+type validatingVBoundIterator struct {
+	matcher     *BadgerMatcher
+	pattern     *query.DataPattern
+	bindingRel  executor.Relation
+	tuples      []executor.Tuple
+	columns     []query.Symbol
+	constraints []executor.StorageConstraint
+
+	// Index configuration
+	candidateIndex  IndexType // AVET or VAET
+	validationIndex IndexType // EATV
+	boundA          any       // Constant A value (nil if A is variable)
+
+	// Iterator state - CRDTResolvingIterator wraps the raw scan
+	crdtIter        *CRDTResolvingIterator // Wraps VAET/AVET scan
+	rawIter         Iterator               // Underlying raw iterator (for Close)
+	currentTupleIdx int                    // Current binding tuple index
+	currentTuple    executor.Tuple         // Current result tuple
+	workspace       executor.Tuple
+
+	// Pattern extraction
+	patternExtractor *query.PatternExtractor
+	tupleBuilder     *query.InternedTupleBuilder
+
+	// Current V value being searched
+	currentBoundV any
+}
+
+func (it *validatingVBoundIterator) Next() bool {
+	for {
+		// Try to get next CRDT-resolved result from current scan
+		if it.crdtIter != nil {
+			for it.crdtIter.Next() {
+				datom, err := it.crdtIter.Datom()
+				if err != nil {
+					continue
+				}
+
+				// Emit annotation for CRDT-resolved candidate
+				if it.matcher.handler != nil {
+					it.matcher.handler(annotations.Event{
+						Name:  "v-validation/candidate",
+						Start: time.Now(),
+						Data: map[string]any{
+							"e":     datom.E.String(),
+							"a":     datom.A.String(),
+							"v":     fmt.Sprintf("%v", datom.V),
+							"tx":    datom.Tx.String(),
+							"op":    fmt.Sprintf("%d", datom.Op),
+							"bound": fmt.Sprintf("%v", it.currentBoundV),
+						},
+					})
+				}
+
+				// CRDTResolvingIterator already handled:
+				// - CardinalityMany: add-wins with same-Tx tiebreaking
+				// - CardinalityVector: RGA resolution
+				// - CardinalityUnknown: add-wins (same as CardinalityMany)
+				//
+				// Only CardinalityOne needs post-validation because the
+				// LWW winner may have a different V than our bound V.
+				card := it.getCardinalityEnum(datom.A)
+				if card == schema.CardinalityOne {
+					if !it.validateCandidate(datom.E, datom.A) {
+						// Stale candidate - LWW winner has different V
+						continue
+					}
+				}
+
+				// Build result tuple
+				it.currentTuple = it.buildTuple(datom)
+				return true
+			}
+			it.crdtIter.Close()
+			it.crdtIter = nil
+			it.rawIter = nil
+		}
+
+		// Move to next binding tuple
+		it.currentTupleIdx++
+		if it.currentTupleIdx >= len(it.tuples) {
+			return false
+		}
+
+		// Get V value from binding tuple
+		tuple := it.tuples[it.currentTupleIdx]
+		it.currentBoundV = it.patternExtractor.ExtractV(tuple)
+		if it.currentBoundV == nil {
+			continue // V not bound in this tuple
+		}
+
+		// Open CRDT-resolving scan on V-primary index
+		var err error
+		it.crdtIter, it.rawIter, err = it.openCRDTScan()
+		if err != nil {
+			continue
+		}
+	}
+}
+
+// validateCandidate checks if the current value of (E, A) matches boundV
+func (it *validatingVBoundIterator) validateCandidate(e datalog.Identity, a datalog.Keyword) bool {
+	encoder := it.matcher.store.encoder
+
+	// Convert E to storage bytes
+	eBytes := ToStorageDatom(datalog.Datom{E: e}).E
+
+	// Convert A to storage bytes
+	aPtr := datalog.NewKeyword(a.String())
+	aStorage := ToStorageDatom(datalog.Datom{A: aPtr}).A
+
+	// Point lookup on EATV: scan (E, A) prefix, first result is CRDT winner
+	start, end := encoder.EncodePrefixRange(it.validationIndex, eBytes[:], aStorage[:])
+	rawIter, err := it.matcher.store.ScanKeysOnly(it.validationIndex, start, end)
+	if err != nil {
+		return false
+	}
+	defer rawIter.Close()
+
+	// First result is the CRDT winner (Tx descending in EATV)
+	if !rawIter.Next() {
+		if it.matcher.handler != nil {
+			it.matcher.handler(annotations.Event{
+				Name:  "v-validation/no-winner",
+				Start: time.Now(),
+				Data: map[string]any{
+					"e":     e.String(),
+					"a":     a.String(),
+					"bound": fmt.Sprintf("%v", it.currentBoundV),
+				},
+			})
+		}
+		return false // No current value
+	}
+
+	winner, err := rawIter.Datom()
+	if err != nil {
+		return false
+	}
+
+	// Check if winner's V matches our bound V
+	matches := winner.V == it.currentBoundV
+
+	if it.matcher.handler != nil {
+		it.matcher.handler(annotations.Event{
+			Name:  "v-validation/result",
+			Start: time.Now(),
+			Data: map[string]any{
+				"e":           e.String(),
+				"a":           a.String(),
+				"bound_v":     fmt.Sprintf("%v", it.currentBoundV),
+				"winner_v":    fmt.Sprintf("%v", winner.V),
+				"winner_tx":   winner.Tx.String(),
+				"winner_op":   fmt.Sprintf("%d", winner.Op),
+				"matches":     matches,
+				"will_emit":   matches,
+				"cardinality": it.getCardinality(a),
+			},
+		})
+	}
+
+	return matches
+}
+
+// getCardinality looks up the cardinality for an attribute (for annotations)
+func (it *validatingVBoundIterator) getCardinality(a datalog.Keyword) string {
+	if it.matcher.schema == nil {
+		return "unknown"
+	}
+	def := it.matcher.schema.GetAttribute(a)
+	if def == nil {
+		return "unknown"
+	}
+	switch def.Cardinality {
+	case schema.CardinalityOne:
+		return "one"
+	case schema.CardinalityMany:
+		return "many"
+	case schema.CardinalityVector:
+		return "vector"
+	default:
+		return "unknown"
+	}
+}
+
+// getCardinalityEnum looks up the cardinality enum for an attribute
+// Returns CardinalityUnknown (0) for schemaless or undefined attributes
+func (it *validatingVBoundIterator) getCardinalityEnum(a datalog.Keyword) schema.Cardinality {
+	if it.matcher.schema == nil {
+		return schema.CardinalityUnknown
+	}
+	def := it.matcher.schema.GetAttribute(a)
+	if def == nil {
+		return schema.CardinalityUnknown
+	}
+	return def.Cardinality
+}
+
+// openCRDTScan opens a CRDT-resolving scan on the V-primary index for current bound V.
+// Returns both the CRDTResolvingIterator wrapper and the raw iterator (for proper Close).
+func (it *validatingVBoundIterator) openCRDTScan() (*CRDTResolvingIterator, Iterator, error) {
+	encoder := it.matcher.store.encoder
+	var start, end []byte
+
+	if it.matcher.handler != nil {
+		it.matcher.handler(annotations.Event{
+			Name:  "v-validation/open-scan",
+			Start: time.Now(),
+			Data: map[string]any{
+				"bound_v": fmt.Sprintf("%v", it.currentBoundV),
+				"bound_a": fmt.Sprintf("%v", it.boundA),
+				"index":   indexName(it.candidateIndex),
+			},
+		})
+	}
+
+	if it.boundA != nil {
+		// A is constant: use AVET with (A, V) prefix
+		aKw, ok := it.boundA.(datalog.Keyword)
+		if !ok {
+			return nil, nil, fmt.Errorf("boundA is not a Keyword")
+		}
+
+		// Convert A to storage bytes
+		aPtr := datalog.NewKeyword(aKw.String())
+		aStorage := ToStorageDatom(datalog.Datom{A: aPtr}).A
+
+		// Encode V with type prefix
+		valueBytes := it.encodeValue(it.currentBoundV)
+
+		start, end = encoder.EncodePrefixRange(it.candidateIndex, aStorage[:], valueBytes)
+	} else {
+		// A is variable: use VAET with V prefix
+		valueBytes := it.encodeValue(it.currentBoundV)
+		start, end = encoder.EncodePrefixRange(it.candidateIndex, valueBytes)
+
+		if it.matcher.handler != nil {
+			it.matcher.handler(annotations.Event{
+				Name:  "v-validation/scan-range",
+				Start: time.Now(),
+				Data: map[string]any{
+					"value_bytes": fmt.Sprintf("%x", valueBytes),
+					"start":       fmt.Sprintf("%x", start),
+					"end":         fmt.Sprintf("%x", end),
+				},
+			})
+		}
+	}
+
+	// Raw scan on V-primary index
+	rawIter, err := it.matcher.store.ScanKeysOnly(it.candidateIndex, start, end)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Wrap with CRDTResolvingIterator for correct CRDT semantics
+	// CRDTResolvingIterator handles:
+	// - Group deduplication via contiguous comparison (O(1) space)
+	// - Add-wins with same-Tx tiebreaking for CardinalityMany
+	// - RGA for CardinalityVector
+	// - Add-wins for CardinalityUnknown (same as CardinalityMany)
+	crdtIter := NewCRDTResolvingIterator(rawIter, it.matcher.schema, 0)
+
+	if it.matcher.handler != nil {
+		it.matcher.handler(annotations.Event{
+			Name:  "v-validation/scan-opened",
+			Start: time.Now(),
+			Data: map[string]any{
+				"index":        indexName(it.candidateIndex),
+				"crdt_wrapped": true,
+			},
+		})
+	}
+
+	return crdtIter, rawIter, nil
+}
+
+// encodeValue converts a value to bytes for index prefix
+func (it *validatingVBoundIterator) encodeValue(v any) []byte {
+	encoder := it.matcher.store.encoder
+
+	// Create dummy datom for encoding
+	dummyDatom := &datalog.Datom{
+		E:  datalog.NewIdentity(""),
+		A:  datalog.NewKeyword(":dummy"),
+		V:  v,
+		Tx: datalog.ElementID{},
+	}
+	sDatom := ToStorageDatom(*dummyDatom)
+	vType := byte(datalog.Type(sDatom.V))
+
+	// Check if we're using L85 encoding and have a reference value
+	if _, isL85 := encoder.(*L85KeyEncoder); isL85 && vType == byte(datalog.TypeReference) {
+		var vArr [20]byte
+		copy(vArr[:], datalog.ValueBytes(sDatom.V))
+		return append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
+	}
+
+	// Binary encoder or non-reference values: type + raw bytes
+	vData := datalog.ValueBytes(sDatom.V)
+	return append([]byte{vType}, vData...)
+}
+
+// buildTuple creates a result tuple from a validated datom
+func (it *validatingVBoundIterator) buildTuple(datom *datalog.Datom) executor.Tuple {
+	tuple := make(executor.Tuple, len(it.columns))
+	for i, col := range it.columns {
+		// Check each pattern element - might be Variable or Constant
+		if v, ok := it.pattern.GetE().(query.Variable); ok && col == v.Name {
+			tuple[i] = datom.E
+			continue
+		}
+		if v, ok := it.pattern.GetA().(query.Variable); ok && col == v.Name {
+			tuple[i] = datom.A
+			continue
+		}
+		if v, ok := it.pattern.GetV().(query.Variable); ok && col == v.Name {
+			tuple[i] = datom.V
+			continue
+		}
+		if len(it.pattern.Elements) > 3 {
+			if v, ok := it.pattern.GetT().(query.Variable); ok && col == v.Name {
+				tuple[i] = datom.Tx
+			}
+		}
+	}
+	return tuple
+}
+
+func (it *validatingVBoundIterator) Tuple() executor.Tuple {
+	return it.currentTuple
+}
+
+func (it *validatingVBoundIterator) Close() error {
+	if it.crdtIter != nil {
+		it.crdtIter.Close()
+		it.crdtIter = nil
+	}
+	if it.rawIter != nil {
+		it.rawIter.Close()
+		it.rawIter = nil
+	}
+	return nil
 }
 
 // matchWithSimpleBatchScanning uses simplified batch scanning to process large binding sets efficiently

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -559,10 +559,10 @@ func (m *BadgerMatcher) matchWithVValidation(
 // then post-validates CardinalityOne emissions with EATV point lookup.
 //
 // Architecture (per proof doc):
-// 1. VAET scan wrapped with CRDTResolvingIterator
-// 2. CRDTResolvingIterator handles: group deduplication (O(1) space),
-//    add-wins with same-Tx tiebreaking, RGA for vectors
-// 3. Only CardinalityOne needs post-validation (LWW winner may have different V)
+//  1. VAET scan wrapped with CRDTResolvingIterator
+//  2. CRDTResolvingIterator handles: group deduplication (O(1) space),
+//     add-wins with same-Tx tiebreaking, RGA for vectors
+//  3. Only CardinalityOne needs post-validation (LWW winner may have different V)
 type validatingVBoundIterator struct {
 	matcher     *BadgerMatcher
 	pattern     *query.DataPattern

--- a/datalog/storage/matcher_strategy.go
+++ b/datalog/storage/matcher_strategy.go
@@ -144,9 +144,9 @@ func analyzeReuseStrategy(pattern *query.DataPattern, bindingRel executor.Relati
 					Type:            SinglePositionReuse,
 					Position:        position,
 					Index:           indexType,
-					NeedsValidation: true,           // Assume cardinality-one; caller clears for many
-					ValidationIndex: EATV,           // Point lookup on (E, A)
-					BoundA:          aConst.Value,   // For validation lookups
+					NeedsValidation: true,         // Assume cardinality-one; caller clears for many
+					ValidationIndex: EATV,         // Point lookup on (E, A)
+					BoundA:          aConst.Value, // For validation lookups
 				}, bindingRel
 			} else {
 				// A is variable: use VAET for V-primary scan
@@ -157,7 +157,7 @@ func analyzeReuseStrategy(pattern *query.DataPattern, bindingRel executor.Relati
 					Type:            SinglePositionReuse,
 					Position:        position,
 					Index:           indexType,
-					NeedsValidation: true,   // Must validate since A varies
+					NeedsValidation: true, // Must validate since A varies
 					ValidationIndex: EATV,
 				}, bindingRel
 			}

--- a/datalog/storage/matcher_strategy.go
+++ b/datalog/storage/matcher_strategy.go
@@ -29,9 +29,13 @@ func (rt ReuseType) String() string {
 
 // ReuseStrategy describes how iterator reuse can be applied
 type ReuseStrategy struct {
-	Type     ReuseType
-	Position int       // Which position is changing (0=E, 1=A, 2=V, 3=T)
-	Index    IndexType // Which index to use
+	Type            ReuseType
+	Position        int       // Which position is changing (0=E, 1=A, 2=V, 3=T)
+	Index           IndexType // Which index to use
+	NeedsValidation bool      // If true, V-bound query needs CRDT validation
+	ValidationIndex IndexType // Index to use for validation (EATV for point lookups)
+	BoundA          any       // The bound A value (for validation lookups)
+	BoundV          any       // The bound V value (for validation comparison)
 }
 
 // analyzeReuseStrategy determines if and how iterator reuse can be applied.
@@ -122,28 +126,40 @@ func analyzeReuseStrategy(pattern *query.DataPattern, bindingRel executor.Relati
 			canReuse = true
 
 		case 2: // V is bound
-			// Check if A is constant OR bound to a single value (not in binding relation)
-			aIsFixedValue := false
-			if _, ok := pattern.GetA().(query.Constant); ok {
-				// A is a constant in the pattern (e.g., :price/symbol)
-				aIsFixedValue = true
-			} else if v, ok := pattern.GetA().(query.Variable); ok && !bindingSet[v.Name] {
-				// A is a variable but NOT in the binding relation,
-				// so it must be bound to a scalar/constant elsewhere
-				aIsFixedValue = true
-			}
-
-			if aIsFixedValue {
-				// AVET index: A is primary, V is secondary
-				// When A is fixed, all V values for that A are contiguous
-				// We CAN efficiently seek between V values within that A range
-				indexType = AVET // A is primary, V is secondary
-				canReuse = true  // Re-enabled with fixed "moved past" logic
-			} else {
-				// A varies with the binding relation
-				// Use VAET where V is the primary sort key
-				indexType = VAET // V is primary sort key
+			// V-bound queries use candidate + validate pattern for cardinality-one.
+			// See docs/reference/INDEX_SELECTION_PROOF.md Theorem 4.
+			//
+			// Strategy: Use V-primary index for candidate discovery, then validate
+			// each candidate with EATV point lookup.
+			//
+			// For cardinality-many, validation is not needed (add-wins semantics).
+			// Caller must check cardinality and clear NeedsValidation if appropriate.
+			if aConst, ok := pattern.GetA().(query.Constant); ok {
+				// A is constant: use AVET for (A, V) prefix scan
+				indexType = AVET
 				canReuse = true
+				// Return strategy with validation setup
+				// Caller will check cardinality and may clear NeedsValidation
+				return ReuseStrategy{
+					Type:            SinglePositionReuse,
+					Position:        position,
+					Index:           indexType,
+					NeedsValidation: true,           // Assume cardinality-one; caller clears for many
+					ValidationIndex: EATV,           // Point lookup on (E, A)
+					BoundA:          aConst.Value,   // For validation lookups
+				}, bindingRel
+			} else {
+				// A is variable: use VAET for V-primary scan
+				// Validation will need to determine A from each candidate
+				indexType = VAET
+				canReuse = true
+				return ReuseStrategy{
+					Type:            SinglePositionReuse,
+					Position:        position,
+					Index:           indexType,
+					NeedsValidation: true,   // Must validate since A varies
+					ValidationIndex: EATV,
+				}, bindingRel
 			}
 
 		case 3: // T is bound

--- a/datalog/storage/query_inputs_test.go
+++ b/datalog/storage/query_inputs_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
 // TestExecuteQuery tests basic query execution without parameters
@@ -190,6 +191,20 @@ func TestExecuteQueryWithCollectionInput(t *testing.T) {
 		t.Fatalf("Failed to create database: %v", err)
 	}
 	defer db.Close()
+
+	// :person/likes is CardinalityMany — multiple values per entity
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/likes"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityMany,
+	})
+	db.SetSchema(s)
 
 	// Add test data
 	tx := db.NewTransaction()

--- a/datalog/storage/simple_batch_scanner.go
+++ b/datalog/storage/simple_batch_scanner.go
@@ -72,10 +72,8 @@ func (s *simpleBatchScanner) Scan() error {
 	}
 
 	// Wrap with CRDT resolution to ensure we only see resolved values
-	var iter Iterator = rawIter
-	if s.matcher.schema != nil {
-		iter = NewCRDTResolvingIterator(rawIter, s.matcher.schema, s.matcher.txID)
-	}
+	// Always applied: CRDTResolvingIterator handles nil schema correctly
+	iter := NewCRDTResolvingIterator(rawIter, s.matcher.schema, s.matcher.txID)
 	defer iter.Close()
 
 	// Step 4: Scan and filter

--- a/datalog/storage/store.go
+++ b/datalog/storage/store.go
@@ -18,7 +18,6 @@ const (
 )
 
 // Indices lists all indices used for queries
-// Note: AETV added for A-primary CRDT resolution. EAVT kept temporarily for migration.
 var Indices = []IndexType{EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV}
 
 // Store is the interface for datom storage

--- a/docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md
+++ b/docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md
@@ -1,0 +1,374 @@
+# BUG: Schemaless Attributes Invisible to Bound Queries When Schema Present
+
+**Status**: FIX IN PROGRESS
+**Severity**: High — data written successfully but queries silently return no results
+**Date**: 2026-02-06
+
+## Summary
+
+When a database has a schema defined, attributes NOT registered in the schema can be written successfully via `tx.Add()`, but bound queries via `:in` fail to find them. Unbound queries find the data correctly.
+
+## Reproduction
+
+```go
+// Create database WITH schema (schema does NOT include :module/input)
+db, _ := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+    Path:   dir,
+    Schema: mySchema, // has many attributes, but NOT :module/input
+})
+
+// Write schemaless attribute — succeeds, no error
+tx := db.NewTransaction()
+tx.Add(entityID, datalog.NewKeyword(":module/input"), "some text")
+tx.Commit() // succeeds
+
+// Unbound query — FINDS the data
+db.ExecuteQueryWithInputs(
+    `[:find ?e ?a ?v :where [?e ?a ?v]]`,
+) // returns row with :module/input ✓
+
+// Bound query — FAILS to find the data
+db.ExecuteQueryWithInputs(
+    `[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
+    entityID, datalog.NewKeyword(":module/input"),
+) // returns empty []  ✗
+```
+
+## Expected Behavior
+
+Bound queries should find schemaless data, same as unbound queries.
+
+## Actual Behavior
+
+- `tx.Add()` succeeds (ValidateDatom returns nil for unknown attributes — "additive schema")
+- `tx.Commit()` succeeds (data written to all 7 indices)
+- Unbound full-scan query finds the data (EATV scan, CRDTResolvingIterator works)
+- Bound query with E and A via `:in` returns empty results
+
+## Root Cause
+
+Two problems:
+
+1. **CRDTResolvingIterator gated on `m.schema != nil`**: When schema was nil on
+   the matcher, CRDTResolvingIterator was not applied at all. Raw storage scans
+   returned unresolved datoms.
+
+2. **CardinalityUnknown used add-wins (wrong default)**: When CRDTResolvingIterator
+   encountered an attribute not in schema, it defaulted to `CardinalityUnknown`
+   which routed to `processAddWins()`. Since schemaless `tx.Add()` writes `OpNone`
+   (not `OpCRDTAdd`), `processAddWins` silently dropped the datoms.
+
+## Discovery Context
+
+Found in narrative-generators scribe import workflow. The `:module/input` attribute (raw markdown text, ~36KB) was defined as a keyword constant but not registered in the schema builder. After the janus-datalog CRDT fix (v0.6.1-0.20260206164518-20348db45516), the import broke — `SetInput()` succeeded but the subsequent `HasAttribute` query returned false.
+
+Adding the attribute to the schema immediately fixed the issue.
+
+---
+
+## Resolution Plan
+
+### Design Decisions
+
+#### Schemaless default is CardinalityOne (LWW)
+
+Datomic defaults to CardinalityOne. Every database, key-value store, and user
+mental model defaults to "write an attribute twice, get the latest value."
+Add-wins as a default is surprising — writing `:name` twice returns both values.
+
+Schemaless `tx.Add()` writes `OpNone`. If you want CardinalityMany or
+CardinalityVector, declare it in schema. That's what schema is for.
+
+#### CardinalityUnknown = CardinalityOne
+
+When CRDTResolvingIterator encounters an attribute not in schema (or nil schema),
+it defaults to CardinalityOne. No Op-sniffing. Cardinality is an attribute-level
+property that belongs in schema, not something inferred from individual datoms.
+
+#### OpNone is valid and means CardinalityOne
+
+`OpNone` is not an error. It means "this is a CardinalityOne LWW assertion."
+The `processAddWins` function correctly ignores it — `OpNone` datoms are not
+add-wins operations. CardinalityOne resolution handles them: first entry wins.
+
+#### tx.Set() and tx.Add() are the same for CardinalityOne
+
+Both write `OpNone`. Both are LWW. `tx.Set()` only differs from `tx.Add()` for
+CardinalityMany (replace entire set) and CardinalityVector (replace entire vector).
+
+#### tx.Remove() works for all cardinalities
+
+Remove writes `OpCRDTRemove` regardless of cardinality. Resolution determines
+what "remove" means:
+
+- **CardinalityOne**: first entry is `OpCRDTRemove` → attribute doesn't exist
+- **CardinalityMany**: tombstone for that specific value (add-wins)
+- **CardinalityVector**: tombstone for that element (RGA)
+
+#### CRDTResolvingIterator is always applied
+
+The `m.schema != nil` guard was wrong. CRDTResolvingIterator handles nil schema
+correctly — it defaults to CardinalityOne for unknown attributes, which is the
+correct schemaless behavior.
+
+### Sequence
+
+Tests are written FIRST. All new tests should fail before any implementation
+changes are made. This validates that the tests actually catch the bugs.
+
+1. Write all new tests (expect failures)
+2. Update existing tests (expect failures)
+3. Implement changes 1-5
+4. All tests pass
+
+### Changes
+
+#### 1. Revert schemaless `tx.Add()` Op back to `OpNone`
+
+**File**: `database.go`, schemaless path of `tx.Add()` (~line 1401)
+
+Our earlier fix changed this from `OpNone` to `OpCRDTAdd`. That was wrong.
+Schemaless default is CardinalityOne. Revert to no explicit Op (zero value = `OpNone`).
+
+```go
+// CURRENT (wrong):
+Op: datalog.OpCRDTAdd,
+
+// CORRECT:
+// No Op field — defaults to OpNone (CardinalityOne LWW)
+```
+
+#### 2. CRDTResolvingIterator: CardinalityOne checks Op
+
+**File**: `crdt_resolving_iterator.go`, CardinalityOne case (~lines 134-141)
+
+Currently emits first entry unconditionally. Must check Op:
+
+```go
+case schema.CardinalityOne:
+    if isNewGroup {
+        if datom.Op == datalog.OpCRDTRemove {
+            // Value was retracted — attribute doesn't exist. Skip group.
+            continue
+        }
+        // First entry for this (E, A) — emit (LWW winner)
+        it.currentDatom = datom
+        return true
+    }
+    // Same (E, A) — skip (already emitted or skipped the winner)
+    continue
+```
+
+#### 3. CRDTResolvingIterator: CardinalityUnknown defaults to CardinalityOne
+
+**File**: `crdt_resolving_iterator.go`, `startNewGroup()` (~lines 168-197)
+
+Change CardinalityUnknown to use CardinalityOne resolution. No state needed.
+
+```go
+// CURRENT:
+case schema.CardinalityUnknown:
+    // Same as CardinalityMany - use add-wins
+    it.emitted = make(map[any]bool)
+    it.tombstones = make(map[any]uint64)
+
+// CORRECT:
+case schema.CardinalityUnknown:
+    // Default is CardinalityOne (LWW) — no state needed
+```
+
+And in the main loop, route CardinalityUnknown to CardinalityOne:
+
+```go
+// CURRENT:
+case schema.CardinalityUnknown:
+    if result := it.processAddWins(datom); result != nil {
+        ...
+    }
+
+// CORRECT:
+case schema.CardinalityUnknown:
+    // Default is CardinalityOne — same as CardinalityOne path
+    if isNewGroup {
+        if datom.Op == datalog.OpCRDTRemove {
+            continue
+        }
+        it.currentDatom = datom
+        return true
+    }
+    continue
+```
+
+#### 4. tx.Remove() accepts CardinalityOne
+
+**File**: `database.go`, `tx.Remove()` method
+
+Currently rejects CardinalityOne with an error. Should write `OpCRDTRemove`.
+
+```go
+// CURRENT:
+case schema.CardinalityOne:
+    return fmt.Errorf("Remove() not supported for cardinality-one ...")
+
+// CORRECT:
+case schema.CardinalityOne:
+    // Write tombstone — CRDTResolvingIterator checks Op on first entry
+    elemID := t.db.clock.Next()
+    t.datoms = append(t.datoms, datalog.Datom{
+        E:  e,
+        A:  a,
+        V:  v,
+        Tx: elemID,
+        Op: datalog.OpCRDTRemove,
+    })
+```
+
+#### 5. tx.Remove() schemaless default is CardinalityOne
+
+**File**: `database.go`, `tx.Remove()` schemaless/undefined path
+
+Currently defaults to CardinalityMany for schemaless removes. Should default
+to CardinalityOne, consistent with the schemaless default.
+
+```go
+// CURRENT:
+} else {
+    card = schema.CardinalityMany
+}
+
+// CORRECT:
+} else {
+    card = schema.CardinalityOne
+}
+```
+
+#### 6. CRDTResolvingIterator always applied (done)
+
+Removed `m.schema != nil` guards from all 8 wrapping sites:
+
+| # | File | Line | Context |
+|---|------|------|---------|
+| 1 | `matcher_relations.go` | 382 | Unbound mask iterator path |
+| 2 | `matcher_relations.go` | 416 | Unbound regular iterator path |
+| 3 | `hash_join_matcher.go` | 200 | Hash join scan |
+| 4 | `hash_join_matcher.go` | 571 | Merge join scan |
+| 5 | `matcher_iterator_reusing.go` | 73 | Reusing iterator (bound queries) |
+| 6 | `matcher_iterator_nonreusing.go` | 80 | Non-reusing iterator (bound queries) |
+| 7 | `simple_batch_scanner.go` | 76 | Batch scanner |
+| 8 | `batch_iterator.go` | 259 | Batch iterator |
+
+Sites NOT changed (cardinality lookups — correct as-is):
+
+| File | Line | Context |
+|------|------|---------|
+| `matcher_relations.go` | 85 | Vector cardinality intercept |
+| `matcher_relations.go` | 122 | V-bound NeedsValidation |
+| `matcher_relations.go` | 236 | Unbound cardinality determination |
+| `matcher_relations.go` | 1097 | Cardinality helper |
+| `matcher.go` | 212 | Cache cardinality lookup |
+| `matcher.go` | 555 | chooseIndex E+A bound |
+| `matcher.go` | 620 | chooseIndex A-only bound |
+| `matcher.go` | 798 | matchFromCache cardinality |
+| `matcher.go` | 952 | matchWithBindingsFromCache cardinality |
+
+### Test Changes
+
+Tests are the contract of correctness. They are written FIRST and must fail
+before implementation. Every test encodes a design decision from this plan.
+
+#### Existing tests to update
+
+**`crdt_schemaless_attr_test.go`**: Tests assumed schemaless = add-wins.
+Schemaless = CardinalityOne (LWW).
+
+- `TestSchemalessAttrMultipleWrites`: multiple writes to same (E, A) should
+  return only the latest value, not all values
+- `TestSchemalessAttrBoundQuery_BugRepro`: should continue to pass (this IS
+  the original bug reproduction — schema exists, attr not registered, bound query)
+- `TestSchemalessAttrUnboundQuery_BugRepro`: should continue to pass
+
+**`TestRemoveCardinalityValidation`**: Remove on CardinalityOne should succeed,
+not error. Remove on unknown/schemaless should still succeed (now as
+CardinalityOne, not add-wins).
+
+#### New tests: CardinalityOne Remove (schema-defined)
+
+These use a database with schema where the attribute is explicitly CardinalityOne.
+
+1. **Remove round-trip**: Add value, Remove, query → attribute doesn't exist.
+   Test with BOTH bound and unbound queries.
+2. **Remove after overwrite**: Add "Alice", Add "Bob", Remove (any V) →
+   attribute doesn't exist. V is irrelevant for CardinalityOne remove — the
+   remove has highest Tx, so the attribute is gone regardless of what V was
+   passed to Remove().
+3. **Remove then re-add**: Add "Alice", Remove, Add "Bob" → "Bob" is current.
+   The Add has higher Tx than the Remove.
+4. **Remove before any add**: Remove first, then Add → value exists. Add has
+   higher Tx, wins over pre-existing tombstone.
+5. **V is irrelevant**: Add "Alice", Remove("Bob") → attribute doesn't exist.
+   Even though "Bob" was never the value, the OpCRDTRemove at highest Tx means
+   the attribute doesn't exist. CardinalityOne has one value; Remove removes it.
+6. **Multiple entities**: Add value for entity1 and entity2. Remove entity1's
+   value. entity2's value unaffected.
+
+#### New tests: Schemaless CardinalityOne (default)
+
+These use a database WITHOUT schema (or with schema where the attribute is
+not registered). Exercises the CardinalityUnknown → CardinalityOne default.
+
+7. **Schemaless LWW**: multiple `tx.Add()` to same (E, A) → only latest
+   returned. Test with BOTH bound and unbound queries to verify both paths
+   use CardinalityOne resolution.
+8. **Schemaless remove**: `tx.Add()` then `tx.Remove()` → attribute doesn't
+   exist. Test with BOTH bound and unbound queries.
+9. **Schemaless remove then re-add**: Same as test #3 but without schema.
+10. **Schema exists, attribute not registered**: Database has schema with other
+    attributes. Unregistered attribute defaults to CardinalityOne. Multiple
+    writes return only latest. Remove works.
+
+#### New tests: Query path coverage
+
+These verify that all query paths produce consistent results after removes.
+
+11. **Bound query after remove**: E and A bound via `:in`, value was removed →
+    empty result. Exercises `matcher_iterator_reusing.go` and
+    `matcher_iterator_nonreusing.go` paths.
+12. **V-bound query after remove**: Query `[?e :name "Alice"]` after Remove →
+    empty result. Exercises `validatingVBoundIterator` path.
+13. **Unbound query after remove**: Full scan `[?e ?a ?v]` after Remove →
+    entity/attribute pair absent from results. Exercises `matcher_relations.go`
+    unbound paths.
+
+#### New tests: Nil-schema matcher
+
+14. **Nil-schema matcher**: Data written with schema (tx.Set, OpNone), queried
+    through BadgerMatcher created without schema → CardinalityOne default
+    works, returns data. Fixes `TestSchemaUniquenessValue`.
+
+#### Regression: CardinalityMany unaffected
+
+15. **CardinalityMany add-wins still works**: Schema-defined CardinalityMany
+    attribute, multiple adds → all non-tombstoned values returned. Verifies
+    CardinalityUnknown → CardinalityOne change doesn't affect schema-defined
+    CardinalityMany.
+16. **CardinalityMany remove still works**: Schema-defined CardinalityMany
+    with tombstone → tombstoned value absent, others present.
+17. **CardinalityVector still works**: Schema-defined CardinalityVector →
+    ordered vector returned correctly. Verifies no regression from
+    CRDTResolvingIterator changes.
+
+### Files Modified (summary)
+
+| File | Change |
+|------|--------|
+| `database.go` | Revert schemaless Add Op; Remove accepts CardinalityOne; schemaless Remove default |
+| `crdt_resolving_iterator.go` | CardinalityOne checks Op; CardinalityUnknown = CardinalityOne |
+| `crdt_schemaless_attr_test.go` | Update for LWW semantics |
+| `crdt_many_test.go` | Update TestRemoveCardinalityValidation |
+| New test file or additions | CardinalityOne remove tests |
+| `matcher_relations.go` | Already done (8-site change) |
+| `hash_join_matcher.go` | Already done (8-site change) |
+| `matcher_iterator_reusing.go` | Already done (8-site change) |
+| `matcher_iterator_nonreusing.go` | Already done (8-site change) |
+| `simple_batch_scanner.go` | Already done (8-site change) |
+| `batch_iterator.go` | Already done (8-site change) |

--- a/docs/bugs/TRIAGE_CARDINALITY_VECTOR_COVERAGE.md
+++ b/docs/bugs/TRIAGE_CARDINALITY_VECTOR_COVERAGE.md
@@ -1,0 +1,138 @@
+# TRIAGE: CardinalityVector Test Coverage Gaps
+
+**Date**: 2026-02-06
+**Priority**: Medium (no known bugs, but significant blind spots)
+**Related**: FIX_SCHEMALESS_CRDT_RESOLUTION.md, BUG_SCHEMALESS_ATTR_BOUND_QUERY.md
+
+## Context
+
+During the schemaless CRDT resolution fix, we identified that CardinalityVector
+is unique to Janus Datalog (not in Datomic) and easy to overlook. An audit of
+existing test coverage revealed good happy-path coverage but critical gaps in
+edge cases and integration scenarios.
+
+## Current Coverage (~59 tests)
+
+| Category | Tests | Status |
+|----------|-------|--------|
+| Basic CRUD (Add/Set/Remove) | 10 | Passing |
+| Set() backwards-diff optimization | 9 | Passing |
+| RGA encoding/decoding | 4 | Passing |
+| RGA reconstruction | 3 | Passing |
+| Schema/validation | 2 | Passing |
+| Query integration (E-bound, joins) | 4 | Passing |
+| Pull API | 1 | Passing |
+| Vector caching | 11 | Passing |
+| CRDT resolution (resolveRGAGroup) | 7 | Passing |
+| Cache matrix | 2 | Passing |
+| Bug #5 AVET/VAET index | 5 | Some failing |
+| Reflect API | 9 | Expected to fail (unimplemented) |
+| Vector functions (nth, count) | 5+ | Passing |
+
+## Gap 1: CRDTResolvingIterator with nil schema (HIGH)
+
+**Risk**: Correctness
+
+Vectors require schema to be recognized as CardinalityVector. With the
+"always apply CRDTResolvingIterator" change, a nil-schema matcher would treat
+vector datoms as CardinalityUnknown (add-wins). This would:
+
+- Treat `OpRGAInsert` as unknown Op (dropped by processAddWins)
+- Treat `OpRGATombstone` as unknown Op (dropped by processAddWins)
+- Return zero results instead of ordered vector
+
+**Mitigation**: Vectors are always schema-defined, so this only occurs if a
+matcher is created without schema for a schema-aware database. No known
+production path does this, but `NewBadgerMatcher(store)` in tests does.
+
+**Test needed**: Query vector attribute through nil-schema matcher, verify
+behavior is defined (even if degraded).
+
+## Gap 2: Time-travel queries (MEDIUM)
+
+**Risk**: Correctness
+
+No tests for `[(as-of ?tx N)]` with vectors. RGA reconstruction depends on
+seeing all inserts/tombstones up to a point in time. The `txID` filter in
+CRDTResolvingIterator (line 97-99) filters datoms before they reach
+`accumulateRGA()`. This should work but is untested.
+
+**Tests needed**:
+- Write vector across multiple transactions
+- Query at each transaction point, verify vector state matches
+
+## Gap 3: V-bound queries with vectors (MEDIUM)
+
+**Risk**: Correctness
+
+Only Bug #5 tests cover V-bound vector queries, and some are failing. The
+interaction between `validatingVBoundIterator` and CardinalityVector is unclear.
+
+**Questions**:
+- What does `[?e :skills "Go"]` mean for a vector? Membership check?
+- Should it use candidate+validate like CardinalityOne?
+- Or should it use add-wins-style Op check?
+
+**Tests needed**:
+- V-bound membership query on vector attribute
+- V-bound query after element tombstoned
+
+## Gap 4: Concurrent/distributed RGA operations (MEDIUM)
+
+**Risk**: CRDT convergence guarantees
+
+No tests verify that concurrent inserts at the same position converge to the
+same order across replicas. The RGA algorithm sorts by ElementID for
+tiebreaking, which should be deterministic, but this isn't tested with
+realistic concurrent scenarios.
+
+**Tests needed**:
+- Two "replicas" insert at same AfterRef, verify deterministic order
+- Insert + tombstone of same element, verify convergence
+- Out-of-order delivery of operations, verify same final state
+
+## Gap 5: Reflect layer — stale comments (LOW)
+
+**Risk**: Documentation accuracy
+
+9 reflect tests have "EXPECTED TO FAIL" comments but ALL PASS. The reflect
+layer for CardinalityVector works correctly. The comments are stale and
+misleading — they should be removed.
+
+**Action**: Remove stale "EXPECTED TO FAIL" comments from
+`datalog/reflect/vector_test.go`.
+
+## Gap 6: tx.Set() semantics change impact (HIGH - if we proceed)
+
+**Risk**: Regression
+
+If `tx.Set()` is changed to error on CardinalityOne (per current discussion),
+we must verify:
+
+- `tx.Set()` CardinalityVector path still works
+- `tx.Set()` CardinalityMany path still works
+- All existing tests that use `tx.Set()` for CardinalityOne are migrated to `tx.Add()`
+- No test creates CardinalityOne datoms exclusively via `tx.Set()`
+
+**Audit needed**: grep all `tx.Set(` and `\.Set(` calls in test files,
+categorize by cardinality.
+
+## Gap 7: Large-scale vectors (LOW)
+
+**Risk**: Performance
+
+No benchmarks or stress tests for vectors with 100+ elements. RGA
+reconstruction is O(n) with a hash map, but `accumulateRGA` uses linear scan
+to find tombstone targets (line 253-261 of crdt_resolving_iterator.go).
+
+**Not urgent** — performance issue, not correctness.
+
+## Recommended Priority
+
+1. **Gap 6** — Must address if proceeding with `tx.Set()` semantics change
+2. **Gap 1** — Needed for "always apply CRDTResolvingIterator" correctness
+3. **Gap 2** — Time-travel is a core feature, vectors should work with it
+4. **Gap 3** — V-bound queries are a common pattern
+5. **Gap 4** — CRDT convergence is a theoretical guarantee we should verify
+6. **Gap 7** — Performance, defer
+7. **Gap 5** — Known limitation, defer

--- a/docs/reference/INDEX_SELECTION_PROOF.md
+++ b/docs/reference/INDEX_SELECTION_PROOF.md
@@ -1,0 +1,353 @@
+# Index Selection for CRDT-Correct Queries
+
+## The Problem
+
+Given a query pattern `[?e ?a ?v ?t]` where each position may be bound or unbound, select an index that guarantees correct CRDT resolution.
+
+**Constraint**: CRDTResolvingIterator uses "first entry wins" logic. This requires indices where:
+1. (E, A) groups are contiguous in the scan
+2. Tx is in descending order within each (E, A) group
+
+## Index Anatomy
+
+An index defines a sort order for datoms. Each index name describes its key ordering:
+- **EAVT**: E → A → V → Tx↓
+- **EATV**: E → A → Tx↓ → V
+
+All indices use Tx↓ (descending via bitwise NOT). The CRDT-correctness distinction comes from **position**, not direction.
+
+**Available indices** (7 total): EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV
+
+**Removed**: VTEA (V → Tx↓ → E → A) — With V bound, effective sort is Tx↓ → E → A, making (E, A) groups non-contiguous. Same problem as T-unbound TAEV. VAET provides equivalent candidate discovery with correct (E, A) grouping.
+
+## CRDT-Correctness Definitions
+
+CRDT-correctness is cardinality-dependent:
+
+**For cardinality-one (LWW)**: An index is *CRDT-correct* if, for any prefix scan, the first datom encountered for each (E, A) group has the highest Tx value among ALL datoms for that (E, A) pair in the database.
+
+**For cardinality-many (add-wins)**: An index is *CRDT-correct* if, for any prefix scan constrained to a specific V, the first datom encountered for each (E, A, V) group has the highest Tx value for that specific (E, A, V) triple.
+
+**Critical insight**: For cardinality-one, we must see ALL V values to find the winner. For cardinality-many, we only need the history of one specific V.
+
+## Theorem 1: Valid Tx Positions for Cardinality-One
+
+An index is CRDT-correct for cardinality-one if and only if Tx↓ appears in one of two positions:
+
+**(a) Tx↓ immediately after (E, A)**: The index has form ... → E → A → Tx↓ → ... or ... → A → E → Tx↓ → ...
+- Within each contiguous (E, A) group, highest Tx comes first
+- Examples: EATV, AETV
+
+**(b) Tx↓ before E and A, with T bound**: The index has form Tx↓ → ... AND T is constrained to a single value.
+- Within a single transaction, each (E, A) appears at most once
+- Example: TAEV when querying a specific transaction
+
+**Proof of (a)**: When Tx↓ is immediately after (E, A) grouping:
+1. (E, A) groups are contiguous
+2. Within each group, datoms sorted by Tx descending
+3. First datom in group has highest Tx ∎
+
+**Proof of (b)**: When T is bound:
+1. Scan is constrained to a single transaction
+2. Each (E, A) can appear at most once per transaction
+3. CRDT resolution is trivially correct (only one entry per group) ∎
+
+**Note on T-unbound TAEV scans**: Without T bound, the same (E, A) appears at multiple Tx values interleaved with other entities. CRDTResolvingIterator detects group boundaries by comparing consecutive (E, A) pairs, so it would incorrectly treat re-encounters as new groups. Therefore, TAEV is only CRDT-correct when T is bound.
+
+## Theorem 2: V-Bound Scans for Cardinality-One
+
+**Statement**: For cardinality-one attributes, any index that filters by V cannot be CRDT-correct.
+
+**Proof by counterexample**:
+
+Consider:
+```
+Datom 1: (E=1, A=:name, V="Alice", Tx=5)
+Datom 2: (E=1, A=:name, V="Bob",   Tx=10)  -- supersedes Alice
+```
+
+CRDT-resolved value of (E=1, A=:name) is "Bob" (highest Tx wins).
+
+Query: `[?e :name "Alice"]` — V bound to "Alice".
+
+With any V-primary index (VAET, AVET):
+1. Scan prefix constrains to V="Alice"
+2. Only Datom 1 is visible in the scan
+3. CRDTResolvingIterator sees one (E=1, A=:name) entry, emits it
+4. Query returns entity 1 — **INCORRECT**
+
+The current value is "Bob", not "Alice". Entity 1 should NOT be in the results.
+
+**Root cause**: V-bound scans filter BEFORE CRDT resolution. The iterator cannot see Datom 2 because it has a different V value.
+
+**Corollary**: VAET and AVET are never CRDT-correct for cardinality-one attributes. ∎
+
+## Theorem 3: V-Bound Scans for Cardinality-Many
+
+**Statement**: For cardinality-many attributes, AVET and VAET scans with CRDTResolvingIterator are CRDT-correct.
+
+**Proof**:
+
+For cardinality-many (add-wins semantics):
+- A value V is "present" for (E, A) unless explicitly retracted
+- To check if V is current, we only need the history of the specific (E, A, V) triple
+- Check whether the highest-Tx op for (E, A, V) is an assert or retract
+- We do NOT need to see other V values
+
+With AVET scan on (A, V):
+1. All (E, A, V) groups for the bound V are contiguous
+2. Tx is descending within each group
+3. CRDTResolvingIterator correctly identifies assert/retract winner
+4. Retracted values are filtered out ∎
+
+**Important**: "Correct" here means CRDTResolvingIterator on the V-bound scan handles add-wins resolution properly. The iterator is still required to process retractions.
+
+## Theorem 3b: Schemaless Defaults to CardinalityMany (Datascript-Style)
+
+**Statement**: When no schema is defined, or an attribute has no schema definition, V-bound scans apply add-wins (CardinalityMany) semantics.
+
+**Rationale** (Datascript compatibility):
+- Datascript defaults to set semantics (add-wins) for schemaless attributes
+- `CardinalityUnknown` → treat as CardinalityMany, not CardinalityOne
+- Add-wins is safe: emits if highest-Tx op is assert, skips if retracted
+
+**Cardinality hierarchy**:
+| Condition | Cardinality | V-Bound Behavior |
+|-----------|-------------|------------------|
+| Schema defines CardinalityOne | One | Post-validate with EATV |
+| Schema defines CardinalityMany | Many | Add-wins via CRDT iterator |
+| Schema defines CardinalityVector | Vector | RGA via CRDT iterator |
+| Schema exists but attribute undefined | Unknown → Many | Add-wins via CRDT iterator |
+| No schema at all | Unknown → Many | Add-wins via CRDT iterator |
+
+**Implementation rule**: Only apply post-validation when cardinality is **explicitly CardinalityOne**. All other cases use CRDTResolvingIterator with add-wins semantics.
+
+## Theorem 4: Tx Ties Are Resolved Deterministically
+
+**Concern**: If multiple datoms exist for the same (E, A) at the same Tx, "first entry wins" becomes "arbitrary wins".
+
+**Resolution**: Our Tx is an `ElementID` with structure:
+```
+ElementID = Lamport (8 bytes) + ReplicaID (8 bytes)
+```
+
+This provides a total order:
+1. Higher Lamport wins (temporal ordering)
+2. Equal Lamport: higher ReplicaID wins (deterministic tiebreaker)
+
+Since Tx↓ sorts by the full 16-byte ElementID, ties are impossible. ∎
+
+## Index CRDT Analysis
+
+| Index | Order             | Card-One CRDT? | Card-Many CRDT? | Notes |
+|-------|-------------------|----------------|-----------------|-------|
+| EAVT  | E → A → V → Tx↓   | ✗ No           | ✓ Yes           | V before Tx breaks card-one |
+| EATV  | E → A → Tx↓ → V   | ✓ Yes          | ✓ Yes           | Tx↓ after (E, A) — Thm 1(a) |
+| AEVT  | A → E → V → Tx↓   | ✗ No           | ✓ Yes           | V before Tx breaks card-one |
+| AETV  | A → E → Tx↓ → V   | ✓ Yes          | ✓ Yes           | Tx↓ after (A, E) — Thm 1(a) |
+| AVET  | A → V → E → Tx↓   | ✗ No           | ✓ Yes           | V-bound hides other V (card-one only) |
+| VAET  | V → A → E → Tx↓   | ✗ No           | ✓ Yes           | V-bound hides other V (card-one only) |
+| TAEV  | Tx↓ → A → E → V   | T-bound only   | T-bound only    | Tx↓ primary — Thm 1(b) |
+
+**Summary**:
+- Cardinality-one: EATV, AETV always correct; TAEV when T is bound
+- Cardinality-many: All 7 indices correct with CRDTResolvingIterator
+
+## Theorem 5: Candidate + Validate (Semi-Join Pattern)
+
+**Statement**: For cardinality-one V-bound queries, use V-primary indices for candidate discovery, followed by CRDT-correct validation.
+
+**Algorithm**:
+1. AVET prefix scan on (A, V) → stream of candidate E values (if A bound)
+2. VAET prefix scan on V → stream of candidate (E, A) pairs (if A unbound)
+3. For each candidate:
+   - EATV point scan on (E, A) → first datom = CRDT winner
+4. If winner.V == bound V → emit
+   Otherwise → skip (stale candidate)
+
+**Proof of correctness**:
+- Step 1/2 finds all entities that *ever* had value V
+- Step 3 retrieves the *current* value via CRDT-correct index (EATV)
+- Step 4 filters stale candidates (entities where V was superseded)
+- Result: exactly the entities where V is the current value ∎
+
+**Complexity**: O(candidates) point lookups. The number of stale candidates is bounded by historical updates—small in practice.
+
+**Analogy**: Same pattern PostgreSQL uses: secondary index scan + visibility check against the heap.
+
+## The Selection Matrix
+
+| E | A | V | T | Card | Index | Validation | Justification |
+|---|---|---|---|------|-------|------------|---------------|
+| - | - | - | - | any | EATV | - | Full scan |
+| ✓ | - | - | - | any | EATV | - | E-primary |
+| - | ✓ | - | - | any | AETV | - | A-primary |
+| ✓ | ✓ | - | - | any | EATV | - | E+A bound |
+| - | ✓ | ✓ | - | one | AVET | EATV | Post-validate card-one emissions |
+| - | ✓ | ✓ | - | many | AVET | - | CRDT iterator (add-wins) |
+| - | ✓ | ✓ | - | vector | AVET | - | CRDT iterator (RGA) |
+| - | ✓ | ✓ | - | unknown | AVET | - | CRDT iterator (add-wins default) |
+| ✓ | ✓ | ✓ | - | any | EATV | - | Point lookup, filter by V |
+| - | - | ✓ | - | per-datom | VAET | EATV | Per-datom cardinality resolution |
+| * | * | * | ✓ | any | TAEV | varies | T bound always uses TAEV |
+
+**Resolution behavior by cardinality**:
+- **CardinalityOne**: Post-validate with EATV point lookup (LWW winner may have different V)
+- **CardinalityMany**: CRDTResolvingIterator with add-wins (handles same-Tx tiebreaking)
+- **CardinalityVector**: CRDTResolvingIterator with RGA (per-AfterRef resolution)
+- **CardinalityUnknown/schemaless**: CRDTResolvingIterator with add-wins (Datascript-compatible)
+
+## The State Machine
+
+```go
+func chooseIndex(e, a, v, t, card) (IndexType, ValidationIndex) {
+    if t != nil {
+        return TAEV, nil
+    }
+    if e != nil {
+        return EATV, nil  // V can be post-filtered
+    }
+    if a != nil {
+        if v != nil {
+            // V is bound with A constant
+            if card == CardinalityOne {
+                return AVET, EATV  // Post-validate card-one emissions
+            }
+            // CardinalityMany, CardinalityVector, CardinalityUnknown: CRDT iterator handles it
+            return AVET, nil
+        }
+        return AETV, nil
+    }
+    if v != nil {
+        // V-only bound: VAET scan with per-datom cardinality resolution
+        // CRDTResolvingIterator wraps VAET directly, handles many/vector/unknown.
+        // Post-filter validates card-one emissions with EATV point lookup.
+        // VAET sort order (V → A → E → Tx↓) groups by A first, so schema
+        // lookup is O(1) per distinct A, not per datom.
+        return VAET, EATV  // EATV available for per-datom card-one validation
+    }
+    return EATV, nil
+}
+```
+
+**Critical rule**: Only post-validate when cardinality is **explicitly CardinalityOne**.
+- CardinalityMany: CRDTResolvingIterator applies add-wins
+- CardinalityVector: CRDTResolvingIterator applies RGA
+- CardinalityUnknown/schemaless: CRDTResolvingIterator applies add-wins (Datascript-compatible)
+
+**V-only bound architecture** (CRDTResolvingIterator wraps VAET scan):
+
+VAET sort order is V → A → E → Tx↓. With V bound, effective order is A → E → Tx↓.
+Within this scan, (A, E) groups are **contiguous** — all Tx entries for the same
+(A, E) are adjacent. This is exactly what CRDTResolvingIterator requires.
+
+1. Wrap VAET scan with CRDTResolvingIterator
+2. CRDTResolvingIterator handles:
+   - Group deduplication via contiguous comparison (O(1) space)
+   - Add-wins semantics including same-Tx tiebreaking
+   - RGA for vectors
+   - CardinalityMany/Vector/Unknown all resolved correctly
+3. Post-filter: for each emission, check if `lookupCardinality(A) == CardinalityOne`
+4. If card-one: validate with EATV point lookup, skip if stale
+
+```go
+type cardinalityAwareVBoundIterator struct {
+    inner  *CRDTResolvingIterator  // wraps VAET scan
+    schema schema.SchemaProvider
+    store  *BadgerStore
+    boundV any
+}
+
+func (it *cardinalityAwareVBoundIterator) Next() bool {
+    for it.inner.Next() {
+        datom := it.inner.Datom()
+
+        if it.lookupCardinality(datom.A) == schema.CardinalityOne {
+            // CRDTResolvingIterator emitted the "winner" within the V-filtered
+            // scan, but the real LWW winner might have a different V.
+            if !it.validateWithEATV(datom.E, datom.A) {
+                continue  // stale candidate
+            }
+        }
+        // Card-many/vector/unknown: handled correctly by CRDTResolvingIterator
+        return true
+    }
+    return false
+}
+```
+
+**Why CRDTResolvingIterator?**
+- No seenCandidates map needed (deduplicates via contiguous group comparison, O(1) space)
+- No manual Op checking (handles add-wins correctly, including same-Tx tiebreaking)
+- No card-vector special casing (handles RGA)
+- Card-unknown defaults to add-wins (Datascript-compatible)
+- Only addition: card-one post-validation filter
+
+**Why not manual Op check?** A direct Op check misses add-wins-at-same-Tx:
+```
+(V="Alice", A=:tags, E=1, Tx={Lamport:10, Replica:2}, Op=Retract)
+(V="Alice", A=:tags, E=1, Tx={Lamport:10, Replica:1}, Op=Assert)
+```
+In Tx↓ ordering, Replica:2 sorts first. A naive check sees Op=Retract and skips.
+But add-wins says concurrent assert beats retract — the value should be present.
+CRDTResolvingIterator's `processAddWins` handles this correctly.
+
+## Implementation
+
+```go
+// Semi-join validation for V-bound cardinality-one queries
+func validateVBoundCandidate(store *Store, e, a, boundV interface{}) bool {
+    // Point lookup on EATV: first datom is CRDT winner
+    it := store.PrefixScan(EATV, e, a)
+    defer it.Close()
+
+    if !it.Next() {
+        return false  // No current value
+    }
+
+    winner := it.Datom()
+    return winner.V == boundV
+}
+```
+
+## Index Utility Analysis
+
+All 7 indices serve a purpose:
+
+| Index | Purpose |
+|-------|---------|
+| EATV | E-primary CRDT resolution, validation lookups |
+| AETV | A-primary CRDT resolution |
+| TAEV | T-primary queries (time-travel, single transaction) |
+| AVET | V-bound with A constant: card-many/vector resolution, card-one candidate discovery |
+| VAET | V-bound with A variable: per-datom cardinality resolution |
+| EAVT | Card-many resolution with E+A+V grouping, historical queries |
+| AEVT | Card-many resolution with A+E+V grouping, historical queries |
+
+**Note**: For card-many, EAVT and AEVT are useful because they group (E, A, V) together, allowing add-wins resolution. They're "broken" only for card-one LWW queries.
+
+## Summary
+
+| Property | Cardinality-One | Cardinality-Many/Vector |
+|----------|-----------------|-------------------------|
+| V-bound direct | ✗ Broken (LWW winner may have different V) | ✓ Works with CRDTResolvingIterator |
+| V-bound solution | CRDTResolvingIterator + post-validate | CRDTResolvingIterator directly |
+| CRDT-correct indices | EATV, AETV, TAEV* | All 7 |
+
+*TAEV only when T is bound
+
+**Key insights**:
+
+1. **Cardinality determines correctness**: Card-one requires seeing ALL V values; card-many only needs specific V history.
+
+2. **V-primary indices are useful**: For card-many/vector, they work directly. For card-one, they provide candidates that need validation.
+
+3. **Post-validation pattern**: Wrap V-bound scan with CRDTResolvingIterator, then post-validate card-one emissions with EATV point lookup.
+
+4. **V-only bound (A variable)**: VAET scan with CRDTResolvingIterator. Card-one uses EATV validation; card-many/vector/unknown handled by CRDTResolvingIterator.
+
+5. **CardinalityUnknown defaults to Many**: Schemaless attributes use add-wins semantics (Datascript-compatible).
+
+6. **TAEV is conditional**: Only CRDT-correct when T is bound (single transaction).
+
+7. **CRDTResolvingIterator handles edge cases**: Same-Tx tiebreaking for add-wins, RGA for vectors, contiguous group deduplication.

--- a/docs/reference/INDEX_SELECTION_PROOF.md
+++ b/docs/reference/INDEX_SELECTION_PROOF.md
@@ -112,13 +112,14 @@ With AVET scan on (A, V):
 - Add-wins is safe: emits if highest-Tx op is assert, skips if retracted
 
 **Cardinality hierarchy**:
-| Condition | Cardinality | V-Bound Behavior |
-|-----------|-------------|------------------|
-| Schema defines CardinalityOne | One | Post-validate with EATV |
-| Schema defines CardinalityMany | Many | Add-wins via CRDT iterator |
-| Schema defines CardinalityVector | Vector | RGA via CRDT iterator |
+
+| Condition                             | Cardinality    | V-Bound Behavior           |
+|---------------------------------------|----------------|----------------------------|
+| Schema defines CardinalityOne         | One            | Post-validate with EATV    |
+| Schema defines CardinalityMany        | Many           | Add-wins via CRDT iterator |
+| Schema defines CardinalityVector      | Vector         | RGA via CRDT iterator      |
 | Schema exists but attribute undefined | Unknown → Many | Add-wins via CRDT iterator |
-| No schema at all | Unknown → Many | Add-wins via CRDT iterator |
+| No schema at all                      | Unknown → Many | Add-wins via CRDT iterator |
 
 **Implementation rule**: Only apply post-validation when cardinality is **explicitly CardinalityOne**. All other cases use CRDTResolvingIterator with add-wins semantics.
 
@@ -139,15 +140,15 @@ Since Tx↓ sorts by the full 16-byte ElementID, ties are impossible. ∎
 
 ## Index CRDT Analysis
 
-| Index | Order             | Card-One CRDT? | Card-Many CRDT? | Notes |
-|-------|-------------------|----------------|-----------------|-------|
-| EAVT  | E → A → V → Tx↓   | ✗ No           | ✓ Yes           | V before Tx breaks card-one |
-| EATV  | E → A → Tx↓ → V   | ✓ Yes          | ✓ Yes           | Tx↓ after (E, A) — Thm 1(a) |
-| AEVT  | A → E → V → Tx↓   | ✗ No           | ✓ Yes           | V before Tx breaks card-one |
-| AETV  | A → E → Tx↓ → V   | ✓ Yes          | ✓ Yes           | Tx↓ after (A, E) — Thm 1(a) |
+| Index | Order             | Card-One CRDT? | Card-Many CRDT? | Notes                                 |
+|-------|-------------------|----------------|-----------------|---------------------------------------|
+| EAVT  | E → A → V → Tx↓   | ✗ No           | ✓ Yes           | V before Tx breaks card-one           |
+| EATV  | E → A → Tx↓ → V   | ✓ Yes          | ✓ Yes           | Tx↓ after (E, A) — Thm 1(a)           |
+| AEVT  | A → E → V → Tx↓   | ✗ No           | ✓ Yes           | V before Tx breaks card-one           |
+| AETV  | A → E → Tx↓ → V   | ✓ Yes          | ✓ Yes           | Tx↓ after (A, E) — Thm 1(a)           |
 | AVET  | A → V → E → Tx↓   | ✗ No           | ✓ Yes           | V-bound hides other V (card-one only) |
 | VAET  | V → A → E → Tx↓   | ✗ No           | ✓ Yes           | V-bound hides other V (card-one only) |
-| TAEV  | Tx↓ → A → E → V   | T-bound only   | T-bound only    | Tx↓ primary — Thm 1(b) |
+| TAEV  | Tx↓ → A → E → V   | T-bound only   | T-bound only    | Tx↓ primary — Thm 1(b)                |
 
 **Summary**:
 - Cardinality-one: EATV, AETV always correct; TAEV when T is bound
@@ -177,19 +178,19 @@ Since Tx↓ sorts by the full 16-byte ElementID, ties are impossible. ∎
 
 ## The Selection Matrix
 
-| E | A | V | T | Card | Index | Validation | Justification |
-|---|---|---|---|------|-------|------------|---------------|
-| - | - | - | - | any | EATV | - | Full scan |
-| ✓ | - | - | - | any | EATV | - | E-primary |
-| - | ✓ | - | - | any | AETV | - | A-primary |
-| ✓ | ✓ | - | - | any | EATV | - | E+A bound |
-| - | ✓ | ✓ | - | one | AVET | EATV | Post-validate card-one emissions |
-| - | ✓ | ✓ | - | many | AVET | - | CRDT iterator (add-wins) |
-| - | ✓ | ✓ | - | vector | AVET | - | CRDT iterator (RGA) |
-| - | ✓ | ✓ | - | unknown | AVET | - | CRDT iterator (add-wins default) |
-| ✓ | ✓ | ✓ | - | any | EATV | - | Point lookup, filter by V |
-| - | - | ✓ | - | per-datom | VAET | EATV | Per-datom cardinality resolution |
-| * | * | * | ✓ | any | TAEV | varies | T bound always uses TAEV |
+| E | A | V | T | Card      | Index | Validation | Justification                    |
+|---|---|---|---|-----------|-------|------------|----------------------------------|
+| - | - | - | - | any       | EATV  | -          | Full scan                        |
+| ✓ | - | - | - | any       | EATV  | -          | E-primary                        |
+| - | ✓ | - | - | any       | AETV  | -          | A-primary                        |
+| ✓ | ✓ | - | - | any       | EATV  | -          | E+A bound                        |
+| - | ✓ | ✓ | - | one       | AVET  | EATV       | Post-validate card-one emissions |
+| - | ✓ | ✓ | - | many      | AVET  | -          | CRDT iterator (add-wins)         |
+| - | ✓ | ✓ | - | vector    | AVET  | -          | CRDT iterator (RGA)              |
+| - | ✓ | ✓ | - | unknown   | AVET  | -          | CRDT iterator (add-wins default) |
+| ✓ | ✓ | ✓ | - | any       | EATV  | -          | Point lookup, filter by V        |
+| - | - | ✓ | - | per-datom | VAET  | EATV       | Per-datom cardinality resolution |
+| * | * | * | ✓ | any       | TAEV  | varies     | T bound always uses TAEV         |
 
 **Resolution behavior by cardinality**:
 - **CardinalityOne**: Post-validate with EATV point lookup (LWW winner may have different V)
@@ -314,25 +315,25 @@ func validateVBoundCandidate(store *Store, e, a, boundV interface{}) bool {
 
 All 7 indices serve a purpose:
 
-| Index | Purpose |
-|-------|---------|
-| EATV | E-primary CRDT resolution, validation lookups |
-| AETV | A-primary CRDT resolution |
-| TAEV | T-primary queries (time-travel, single transaction) |
-| AVET | V-bound with A constant: card-many/vector resolution, card-one candidate discovery |
-| VAET | V-bound with A variable: per-datom cardinality resolution |
-| EAVT | Card-many resolution with E+A+V grouping, historical queries |
-| AEVT | Card-many resolution with A+E+V grouping, historical queries |
+| Index  | Purpose                                                                            |
+|--------|------------------------------------------------------------------------------------|
+| EATV   | E-primary CRDT resolution, validation lookups                                      |
+| AETV   | A-primary CRDT resolution                                                          |
+| TAEV   | T-primary queries (time-travel, single transaction)                                |
+| AVET   | V-bound with A constant: card-many/vector resolution, card-one candidate discovery |
+| VAET   | V-bound with A variable: per-datom cardinality resolution                          |
+| EAVT   | Card-many resolution with E+A+V grouping, historical queries                       |
+| AEVT   | Card-many resolution with A+E+V grouping, historical queries                       |
 
 **Note**: For card-many, EAVT and AEVT are useful because they group (E, A, V) together, allowing add-wins resolution. They're "broken" only for card-one LWW queries.
 
 ## Summary
 
-| Property | Cardinality-One | Cardinality-Many/Vector |
-|----------|-----------------|-------------------------|
-| V-bound direct | ✗ Broken (LWW winner may have different V) | ✓ Works with CRDTResolvingIterator |
-| V-bound solution | CRDTResolvingIterator + post-validate | CRDTResolvingIterator directly |
-| CRDT-correct indices | EATV, AETV, TAEV* | All 7 |
+| Property             | Cardinality-One                            | Cardinality-Many/Vector            |
+|----------------------|--------------------------------------------|------------------------------------|
+| V-bound direct       | ✗ Broken (LWW winner may have different V) | ✓ Works with CRDTResolvingIterator |
+| V-bound solution     | CRDTResolvingIterator + post-validate      | CRDTResolvingIterator directly     |
+| CRDT-correct indices | EATV, AETV, TAEV*                          | All 7                              |
 
 *TAEV only when T is bound
 


### PR DESCRIPTION
## Summary

- V-bound queries now use CRDT-correct per-datom cardinality resolution
- Schemaless attributes default to CardinalityOne (LWW), matching Datomic
- `tx.Remove()` works for all cardinalities (was rejected for CardinalityOne)
- `CRDTResolvingIterator` always applied (was gated on `m.schema != nil`)

## Bug Fix: Schemaless Attributes Invisible to Bound Queries

When a database had a schema defined, attributes NOT registered in the schema could be written via `tx.Add()` but bound queries via `:in` silently returned empty results. Unbound queries found the data correctly.

**Root cause**: Two problems compounding:
1. `CRDTResolvingIterator` gated on `m.schema != nil` — unresolved datoms leaked through
2. `CardinalityUnknown` routed to `processAddWins()` which dropped `OpNone` datoms

**Fix**: Schemaless = CardinalityOne (LWW). `OpNone` is a valid CardinalityOne assertion. `CardinalityUnknown` defaults to CardinalityOne resolution. `CRDTResolvingIterator` always applied.

See: `docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md`

## Index Selection (`matcher.go`, `matcher_strategy.go`)

- E-only bound: EATV instead of EAVT (Tx-descending = first entry is LWW winner)
- Full scan: EATV instead of EAVT (same reason)
- V-bound queries: candidate + validate pattern per `INDEX_SELECTION_PROOF.md` Theorem 5
  - A constant: AVET scan + EATV validation for CardinalityOne
  - A variable: VAET scan + per-datom EATV validation

## CRDT Resolution (`crdt_resolving_iterator.go`)

- **CardinalityOne**: checks Op — `OpCRDTRemove` at highest Tx = attribute doesn't exist
- **CardinalityUnknown**: defaults to CardinalityOne (LWW), not add-wins
- **`startNewGroup`**: CardinalityUnknown no longer allocates add-wins maps
- Always applied: removed `m.schema != nil` guards from all 8 wrapping sites

## `tx.Remove()` for All Cardinalities (`database.go`)

- CardinalityOne: writes `OpCRDTRemove` tombstone (was: rejected with error)
- Schemaless/undefined: defaults to CardinalityOne (was: CardinalityMany)
- Schemaless `tx.Add()`: writes explicit `OpNone` (was: wrongly `OpCRDTAdd`)
- Updated docstring to reflect new behavior

## `validatingVBoundIterator` (`matcher_relations.go`)

Semi-join pattern for V-bound queries:
1. VAET/AVET scan wrapped with `CRDTResolvingIterator`
2. CardinalityOne: EATV point lookup validates LWW winner matches bound V
3. CardinalityMany: checks `OpCRDTRemove` on candidate directly

## Test Coverage

**New test files:**
- `crdt_one_remove_test.go` — 9 tests: CardinalityOne remove round-trip, overwrite, re-add, V-irrelevant, multiple entities, bound/V-bound/unbound query paths
- `crdt_schemaless_attr_test.go` — Schemaless LWW (multiple writes → latest only), schemaless remove, unregistered attr defaults to CardinalityOne, nil-schema matcher

**Updated tests:**
- `TestRemoveCardinalityValidation` — Remove on CardinalityOne now succeeds
- `TestSchemalessAttrMultipleWrites` — Expects 1 result (LWW), not 3 (add-wins)
- `TestExecuteQueryWithCollectionInput` — Added CardinalityMany schema for multi-valued `:person/likes`
- Removed 9 stale "EXPECTED TO FAIL" comments from `reflect/vector_test.go`

**Existing cache matrix tests:**
- `TestCacheMatrix_VOnlyBound`, `TestVOnlyBound_CardinalityMany_Retracted`, `TestVOnlyBound_MixedCardinality`, `TestCacheMatrix_AVBound`, `TestCacheMatrix_AllUnbound`, etc.

## Documentation

- `docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md` — Full bug report, root cause, design decisions, resolution plan, comprehensive test plan
- `docs/bugs/TRIAGE_CARDINALITY_VECTOR_COVERAGE.md` — CardinalityVector test coverage audit