### PR TITLE
fix(storage): eliminate AfterRef decode heuristic, move Op to last byte

### DIFF
--- a/datalog/storage/afterref_heuristic_bug_test.go
+++ b/datalog/storage/afterref_heuristic_bug_test.go
@@ -1,0 +1,409 @@
+package storage
+
+// Tests for the AfterRef heuristic decode bug (BUG_SHARED_DB_DATOM_LOSS).
+//
+// The bug: DecodeKey's AfterRef detection heuristic reads a byte from
+// inside value data and misinterprets it as the Op byte. For reference-
+// valued datoms (TypeReference, 21 value bytes), the key is long enough
+// to trigger the heuristic. When the 5th byte of the SHA1 hash equals 3
+// (OpRGAInsert) or 4 (OpRGATombstone), the decoder enters the wrong path,
+// truncates the value, and DatomFromKey returns an error — silently
+// dropping the datom.
+//
+// P(failure) = 2/256 ≈ 0.78% per reference-valued datom.
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// findHashWithByte4 finds an identity string whose SHA1 hash has a
+// specific byte value at position 4 (the position the heuristic reads).
+func findHashWithByte4(targetByte byte) (string, [20]byte) {
+	for i := 0; ; i++ {
+		s := fmt.Sprintf("ref-%d", i)
+		h := sha1.Sum([]byte(s))
+		if h[4] == targetByte {
+			return s, h
+		}
+	}
+}
+
+// TestAfterRefHeuristicBug_Unit demonstrates the decode bug at the
+// key encoder level. For a reference-valued datom (21 value bytes),
+// the key is 90 bytes (after prefix). The heuristic always reads
+// key[73]. Which component that lands on depends on the index layout:
+//
+//	EATV, AETV, TAEV: key[73] = hash[4]  (value data)
+//	EAVT, AEVT, AVET, VAET: key[73] = Tx↓[0]
+//
+// We craft inputs so key[73] == 3 for EVERY index, proving all 7 are broken.
+func TestAfterRefHeuristicBug_Unit(t *testing.T) {
+	encoder := &BinaryKeyEncoder{}
+
+	// For EATV/AETV/TAEV: key[73] lands in value data (hash[4]).
+	// Find a ref whose SHA1 hash has byte[4] == 3.
+	triggerStr, _ := findHashWithByte4(3)
+	triggerRef := datalog.NewIdentity(triggerStr)
+	normalTx := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+
+	// For EAVT/AEVT/AVET/VAET: key[73] lands on Tx↓[0].
+	// Tx↓[0] == 3 requires Tx[0] == ^3 == 0xFC.
+	// Lamport is big-endian uint64, so Lamport = 0xFC00000000000000.
+	txTrigger := datalog.ElementID{Lamport: 0xFC00000000000000, ReplicaID: 1}
+	// Use a safe ref (hash[4] != 3 or 4) so only the Tx triggers.
+	safeStr, _ := findHashWithByte4(0x20)
+	safeRef := datalog.NewIdentity(safeStr)
+
+	entity := datalog.NewIdentity("test-entity")
+	attr := datalog.NewKeyword(":test/ref-attr")
+
+	indices := []struct {
+		name string
+		idx  IndexType
+		ref  datalog.Identity // value that puts 3 at key[73]
+		tx   datalog.ElementID
+	}{
+		// Value-at-73 group: trigger via hash[4]==3, normal Tx
+		{"EATV", EATV, triggerRef, normalTx},
+		{"AETV", AETV, triggerRef, normalTx},
+		{"TAEV", TAEV, triggerRef, normalTx},
+		// Tx-at-73 group: trigger via Tx↓[0]==3, safe ref
+		{"EAVT", EAVT, safeRef, txTrigger},
+		{"AEVT", AEVT, safeRef, txTrigger},
+		{"AVET", AVET, safeRef, txTrigger},
+		{"VAET", VAET, safeRef, txTrigger},
+	}
+
+	for _, tc := range indices {
+		t.Run(tc.name, func(t *testing.T) {
+			datom := &datalog.Datom{
+				E: entity, A: attr, V: tc.ref, Tx: tc.tx, Op: datalog.OpNone,
+			}
+			key := encoder.EncodeKey(tc.idx, datom)
+
+			// Verify key[73] is actually 3 (the trigger byte)
+			k := key[1:] // skip prefix
+			require.Equal(t, byte(3), k[73],
+				"%s: key[73] must be 3 to trigger heuristic", tc.name)
+
+			// Decode must round-trip correctly
+			decoded, err := DatomFromKey(tc.idx, key, encoder)
+			require.NoError(t, err, "%s: decode must succeed", tc.name)
+
+			decodedRef, ok := decoded.V.(datalog.Identity)
+			require.True(t, ok, "%s: value should be Identity, got %T", tc.name, decoded.V)
+			assert.True(t, decodedRef.Equal(tc.ref),
+				"%s: decoded reference must match original", tc.name)
+			assert.Equal(t, byte(datalog.OpNone), byte(decoded.Op),
+				"%s: decoded Op must be OpNone, not %d", tc.name, decoded.Op)
+		})
+	}
+}
+
+// TestAfterRefHeuristicBug_KeyLayout prints the exact key layout for a
+// reference-valued EATV datom to show where the heuristic reads from.
+func TestAfterRefHeuristicBug_KeyLayout(t *testing.T) {
+	encoder := &BinaryKeyEncoder{}
+
+	triggerStr, triggerHash := findHashWithByte4(3)
+	triggerRef := datalog.NewIdentity(triggerStr)
+
+	datom := &datalog.Datom{
+		E:  datalog.NewIdentity("test-entity"),
+		A:  datalog.NewKeyword(":test/ref-attr"),
+		V:  triggerRef,
+		Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1},
+		Op: datalog.OpNone,
+	}
+
+	key := encoder.EncodeKey(EATV, datom)
+	k := key[1:] // skip prefix
+
+	t.Logf("EATV key layout (after prefix):")
+	t.Logf("  Total length: %d bytes", len(k))
+	t.Logf("  [0:20]   E:         %x", k[0:20])
+	t.Logf("  [20:52]  A:         %x", k[20:52])
+	t.Logf("  [52:68]  Tx↓:       %x", k[52:68])
+	t.Logf("  [68]     ValueType: %d (TypeReference=%d)", k[68], datalog.TypeReference)
+	t.Logf("  [69:89]  ValueData: %x", k[69:89])
+	t.Logf("  [89]     Op:        %d (actual)", k[89])
+
+	// Show what the heuristic reads
+	heuristicPos := len(k) - 16 - 1 // afterRefSize=16, opSize=1
+	t.Logf("")
+	t.Logf("  Heuristic reads k[%d] = %d (this is hash[%d])", heuristicPos, k[heuristicPos], heuristicPos-69)
+	t.Logf("  Actual Op at k[%d] = %d", 89, k[89])
+	t.Logf("")
+	t.Logf("  hash[4] = %d matches OpRGAInsert(3)? %v", triggerHash[4], triggerHash[4] == 3)
+
+	// Verify the positions
+	assert.Equal(t, 90, len(k), "EATV ref key should be 90 bytes (after prefix)")
+	assert.Equal(t, 73, heuristicPos, "heuristic should read from position 73")
+	assert.Equal(t, byte(3), k[heuristicPos], "heuristic position should contain hash[4]=3")
+	assert.Equal(t, byte(0), k[89], "actual Op should be 0 (OpNone)")
+}
+
+// TestAfterRefHeuristicBug_Integration tests the full write+read path
+// through BadgerDB, demonstrating that datoms are silently lost.
+func TestAfterRefHeuristicBug_Integration(t *testing.T) {
+	db, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Install schema via builder
+	refAttr := datalog.NewKeyword(":test/ref")
+	s, err := schema.NewBuilder().
+		Attribute(":test/ref").Type(schema.TypeRef).Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	// Find identities that trigger and don't trigger the bug
+	triggerStr, _ := findHashWithByte4(3)
+	safeStr, _ := findHashWithByte4(0x20)
+
+	triggerRef := datalog.NewIdentity(triggerStr)
+	safeRef := datalog.NewIdentity(safeStr)
+
+	// Write both datoms
+	entity := datalog.NewIdentity("test-entity")
+	writeTx := db.NewTransaction()
+	writeTx.Add(entity, refAttr, triggerRef)
+	_, err = writeTx.Commit()
+	require.NoError(t, err)
+
+	entity2 := datalog.NewIdentity("test-entity-2")
+	writeTx2 := db.NewTransaction()
+	writeTx2.Add(entity2, refAttr, safeRef)
+	_, err = writeTx2.Commit()
+	require.NoError(t, err)
+
+	// Read back via EATV scan (used by LookupAttribute / ResolveLWW)
+	store := db.Store()
+	encoder := store.encoder
+
+	// Build EATV prefix for entity + refAttr
+	eBytes := entity.Hash()
+	aStr := refAttr.String()
+	var aBytes [32]byte
+	copy(aBytes[:], []byte(aStr))
+
+	prefix := encoder.EncodePrefix(EATV, eBytes[:], aBytes[:])
+	end := incrementLastByte(prefix)
+	it, err := store.ScanKeysOnly(EATV, prefix, end)
+	require.NoError(t, err)
+	defer it.Close()
+
+	found := false
+	for it.Next() {
+		d, derr := it.Datom()
+		if derr != nil {
+			t.Logf("BUG: decode error during EATV scan: %v", derr)
+			continue
+		}
+		if d.E.Equal(entity) {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("BUG CONFIRMED: trigger reference datom lost in EATV scan")
+	}
+
+	// Same for the safe entity — should always be found
+	eBytes2 := entity2.Hash()
+	prefix2 := encoder.EncodePrefix(EATV, eBytes2[:], aBytes[:])
+	end2 := incrementLastByte(prefix2)
+	it2, err := store.ScanKeysOnly(EATV, prefix2, end2)
+	require.NoError(t, err)
+	defer it2.Close()
+
+	found2 := false
+	for it2.Next() {
+		d, derr := it2.Datom()
+		if derr != nil {
+			t.Logf("decode error during safe EATV scan: %v", derr)
+			continue
+		}
+		if d.E.Equal(entity2) {
+			found2 = true
+		}
+	}
+	require.True(t, found2, "safe reference datom should always be found")
+}
+
+// TestAfterRefHeuristicBug_Statistical writes many random reference-valued
+// datoms and measures the decode failure rate, confirming the ~0.78% prediction.
+func TestAfterRefHeuristicBug_Statistical(t *testing.T) {
+	encoder := &BinaryKeyEncoder{}
+
+	entity := datalog.NewIdentity("stat-entity")
+	attr := datalog.NewKeyword(":test/ref-attr")
+	tx := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+
+	const N = 10000
+	failures := 0
+	failedBytes := make(map[byte]int)
+
+	for i := 0; i < N; i++ {
+		ref := datalog.NewIdentity(fmt.Sprintf("ref-value-%d", i))
+		datom := &datalog.Datom{
+			E: entity, A: attr, V: ref, Tx: tx, Op: datalog.OpNone,
+		}
+
+		// Test EATV (the primary CRDT index used for reads)
+		key := encoder.EncodeKey(EATV, datom)
+		_, err := DatomFromKey(EATV, key, encoder)
+		if err != nil {
+			failures++
+			k := key[1:] // skip prefix
+			heuristicPos := len(k) - 16 - 1
+			if heuristicPos >= 0 && heuristicPos < len(k) {
+				failedBytes[k[heuristicPos]]++
+			}
+		}
+	}
+
+	rate := float64(failures) / float64(N) * 100
+	t.Logf("Decode failures: %d/%d = %.2f%% (expected ~0.78%%)", failures, N, rate)
+	t.Logf("Failed byte values: %v", failedBytes)
+
+	// The observed rate should be in the ballpark of 0.78%
+	// With N=10000, expected ~78 failures. Allow wide margin for this test.
+	assert.Equal(t, 0, failures,
+		"all reference-valued datoms must decode correctly; got %d/%d failures (%.2f%%)", failures, N, rate)
+}
+
+// TestAfterRefHeuristicBug_NonRefValues verifies that non-reference value
+// types are NOT affected (keyword, string, int64 all have different sizes
+// or byte patterns that don't trigger the heuristic).
+func TestAfterRefHeuristicBug_NonRefValues(t *testing.T) {
+	encoder := &BinaryKeyEncoder{}
+
+	entity := datalog.NewIdentity("test-entity")
+	tx := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+
+	testCases := []struct {
+		name string
+		attr datalog.Keyword
+		val  any
+	}{
+		// Keyword values: ASCII bytes > 0x20, never hit 3 or 4
+		{"keyword-short", datalog.NewKeyword(":test/kw"), datalog.NewKeyword(":entity.type/crawl")},
+		// String values: ASCII bytes > 0x20
+		{"string-short", datalog.NewKeyword(":test/str"), "hello"},
+		// Int64: 9 bytes (1 type + 8 data), total key < 85, heuristic won't trigger
+		{"int64", datalog.NewKeyword(":test/int"), int64(42)},
+		// Bool: 2 bytes (1 type + 1 data), total key < 85
+		{"bool", datalog.NewKeyword(":test/bool"), true},
+		// Float64: 9 bytes (1 type + 8 data), total key < 85
+		{"float64", datalog.NewKeyword(":test/float"), float64(3.14)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			datom := &datalog.Datom{
+				E: entity, A: tc.attr, V: tc.val, Tx: tx, Op: datalog.OpNone,
+			}
+			for _, idx := range Indices {
+				key := encoder.EncodeKey(idx, datom)
+				_, err := DatomFromKey(idx, key, encoder)
+				assert.NoError(t, err, "non-reference value should always decode in %v", idx)
+			}
+		})
+	}
+}
+
+// TestAfterRefHeuristicBug_FullDBRoundTrip writes N entities each with 3
+// reference fields, reads them back, and counts missing fields.
+func TestAfterRefHeuristicBug_FullDBRoundTrip(t *testing.T) {
+	db, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Install schema via builder
+	s, err := schema.NewBuilder().
+		Attribute(":test/ref-a").Type(schema.TypeRef).Add().
+		Attribute(":test/ref-b").Type(schema.TypeRef).Add().
+		Attribute(":test/ref-c").Type(schema.TypeRef).Add().
+		Attribute(":test/type").Type(schema.TypeKeyword).Add().
+		Build()
+	require.NoError(t, err)
+	db.SetSchema(s)
+
+	refAttrs := []datalog.Keyword{
+		datalog.NewKeyword(":test/ref-a"),
+		datalog.NewKeyword(":test/ref-b"),
+		datalog.NewKeyword(":test/ref-c"),
+	}
+	kwAttr := datalog.NewKeyword(":test/type")
+
+	const N = 500
+	type record struct {
+		entity datalog.Identity
+		refs   [3]datalog.Identity
+	}
+	records := make([]record, N)
+
+	// Write N entities, each with 3 ref fields + 1 keyword field
+	for i := 0; i < N; i++ {
+		entityID := datalog.NewIdentity(fmt.Sprintf("entity-%d", i))
+		refA := datalog.NewIdentity(fmt.Sprintf("ref-a-%d", i))
+		refB := datalog.NewIdentity(fmt.Sprintf("ref-b-%d", i))
+		refC := datalog.NewIdentity(fmt.Sprintf("ref-c-%d", i))
+		records[i] = record{entity: entityID, refs: [3]datalog.Identity{refA, refB, refC}}
+
+		writeTx := db.NewTransaction()
+		writeTx.Add(entityID, kwAttr, datalog.NewKeyword(":entity.type/test"))
+		writeTx.Add(entityID, refAttrs[0], refA)
+		writeTx.Add(entityID, refAttrs[1], refB)
+		writeTx.Add(entityID, refAttrs[2], refC)
+		_, err = writeTx.Commit()
+		require.NoError(t, err)
+	}
+
+	// Read back using LookupAttribute (same path as PullInto)
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(s)
+
+	fieldLosses := 0
+	entityLosses := 0
+
+	for i := 0; i < N; i++ {
+		rec := records[i]
+		anyMissing := false
+
+		for j, attr := range refAttrs {
+			val, found := matcher.LookupAttribute(rec.entity, attr)
+			if !found || val == nil {
+				fieldLosses++
+				anyMissing = true
+				t.Logf("LOSS: entity=%d attr=%s ref hash[4]=%d",
+					i, attr.String(), rec.refs[j].Hash()[4])
+			}
+		}
+
+		// Keyword field should never be lost
+		kwVal, kwFound := matcher.LookupAttribute(rec.entity, kwAttr)
+		require.True(t, kwFound, "keyword field should always be found (entity %d)", i)
+		require.NotNil(t, kwVal, "keyword value should not be nil (entity %d)", i)
+
+		if anyMissing {
+			entityLosses++
+		}
+	}
+
+	rate := float64(entityLosses) / float64(N) * 100
+	t.Logf("Entity loss: %d/%d = %.1f%% (expected ~2.3%%)", entityLosses, N, rate)
+	t.Logf("Field loss: %d/%d total ref fields", fieldLosses, N*3)
+
+	assert.Equal(t, 0, fieldLosses,
+		"all reference fields must be readable; got %d/%d losses", fieldLosses, N*3)
+}

--- a/datalog/storage/afterref_key_test.go
+++ b/datalog/storage/afterref_key_test.go
@@ -5,8 +5,8 @@ package storage
 // These tests verify that AfterRef is correctly encoded/decoded in index keys
 // when Op is OpRGAInsert or OpRGATombstone.
 //
-// Key format: [...][V][Tx↓][Op][AfterRef?]
-// AfterRef? = 16 bytes present only when Op.HasAfterRef() is true
+// Key format: [...][V][Tx↓][AfterRef?][Op]
+// Op is always the last byte. AfterRef? = 16 bytes before Op when Op.HasAfterRef()
 
 import (
 	"bytes"

--- a/datalog/storage/key_encoder_binary.go
+++ b/datalog/storage/key_encoder_binary.go
@@ -33,17 +33,18 @@ func txFromDescending(encoded []byte) [16]byte {
 
 // EncodeKey creates a binary index key from a datom
 // Tx is encoded with bitwise NOT for descending sort order (highest Tx first).
-// Op is included between V and Tx to support CRDT semantics (add-wins for cardinality-many).
+// Op is always the LAST byte of every key. This enables deterministic decoding:
+// op = key[len(key)-1]. If Op.HasAfterRef(), AfterRef is the 16 bytes before Op.
 //
-// Key formats (Bug #5 fix: Tx before Op, AfterRef at end for RGA ops):
+// Key formats (Op always last — see docs/reference/OP_POSITION_PROOF.md):
 //
-//	EAVT: [prefix][E][A][type][value][Tx↓][Op][AfterRef?]  - groups by value for add-wins
-//	EATV: [prefix][E][A][Tx↓][type][value][Op][AfterRef?]  - first entry is current (E-primary CRDT)
-//	AEVT: [prefix][A][E][type][value][Tx↓][Op][AfterRef?]  - by attribute (V before Tx)
-//	AETV: [prefix][A][E][Tx↓][type][value][Op][AfterRef?]  - first entry is current (A-primary CRDT)
-//	AVET: [prefix][A][type][value][E][Tx↓][Op][AfterRef?]  - value lookup
-//	VAET: [prefix][type][value][A][E][Tx↓][Op][AfterRef?]  - reverse refs
-//	TAEV: [prefix][Tx↓][A][E][type][value][Op][AfterRef?]  - transaction log
+//	EAVT: [prefix][E][A][type][value][Tx↓][AfterRef?][Op]  - groups by value for add-wins
+//	EATV: [prefix][E][A][Tx↓][type][value][AfterRef?][Op]  - first entry is current (E-primary CRDT)
+//	AEVT: [prefix][A][E][type][value][Tx↓][AfterRef?][Op]  - by attribute (V before Tx)
+//	AETV: [prefix][A][E][Tx↓][type][value][AfterRef?][Op]  - first entry is current (A-primary CRDT)
+//	AVET: [prefix][A][type][value][E][Tx↓][AfterRef?][Op]  - value lookup
+//	VAET: [prefix][type][value][A][E][Tx↓][AfterRef?][Op]  - reverse refs
+//	TAEV: [prefix][Tx↓][A][E][type][value][AfterRef?][Op]  - transaction log
 //
 // AfterRef? = 16 bytes present only if Op ∈ {OpRGAInsert(3), OpRGATombstone(4)}
 func (e *BinaryKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
@@ -58,70 +59,75 @@ func (e *BinaryKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 	vData := datalog.ValueBytes(sd.V)
 	vBytes := append([]byte{vType}, vData...)
 
-	// Op byte (0=none, 1=add, 2=remove)
-	opByte := []byte{byte(sd.Op)}
-
 	// Encode Tx with bitwise NOT for descending sort order
 	txDesc := txToDescending(sd.Tx)
 
-	// Build key based on index type using raw bytes
-	// Op is placed after V in all indices to preserve value grouping
+	// Build key based on index type using raw bytes.
+	// Op is always appended LAST, after AfterRef (if present).
+	// This eliminates the AfterRef length heuristic in DecodeKey.
 	switch index {
 	case EAVT:
-		// [E][A][V][Tx][Op][AfterRef?] - groups by value, Tx before Op for Bug #5 fix
-		key := concatBytes(prefix, sd.E[:], sd.A[:], vBytes, txDesc[:], opByte)
+		// [E][A][V][Tx↓][AfterRef?][Op]
+		key := concatBytes(prefix, sd.E[:], sd.A[:], vBytes, txDesc[:])
 		if sd.Op.HasAfterRef() {
 			afterRefDesc := txToDescending(sd.AfterRef)
 			key = append(key, afterRefDesc[:]...)
 		}
+		key = append(key, byte(sd.Op))
 		return key
 	case EATV:
-		// [E][A][Tx][V][Op][AfterRef?] - for cardinality-one: first entry is current
-		key := concatBytes(prefix, sd.E[:], sd.A[:], txDesc[:], vBytes, opByte)
+		// [E][A][Tx↓][V][AfterRef?][Op]
+		key := concatBytes(prefix, sd.E[:], sd.A[:], txDesc[:], vBytes)
 		if sd.Op.HasAfterRef() {
 			afterRefDesc := txToDescending(sd.AfterRef)
 			key = append(key, afterRefDesc[:]...)
 		}
+		key = append(key, byte(sd.Op))
 		return key
 	case AEVT:
-		// [A][E][V][Tx][Op][AfterRef?] - Bug #5 fix: Tx before Op
-		key := concatBytes(prefix, sd.A[:], sd.E[:], vBytes, txDesc[:], opByte)
+		// [A][E][V][Tx↓][AfterRef?][Op]
+		key := concatBytes(prefix, sd.A[:], sd.E[:], vBytes, txDesc[:])
 		if sd.Op.HasAfterRef() {
 			afterRefDesc := txToDescending(sd.AfterRef)
 			key = append(key, afterRefDesc[:]...)
 		}
+		key = append(key, byte(sd.Op))
 		return key
 	case AETV:
-		// [A][E][Tx][V][Op][AfterRef?] - A-primary CRDT: first entry is current (Tx descending)
-		key := concatBytes(prefix, sd.A[:], sd.E[:], txDesc[:], vBytes, opByte)
+		// [A][E][Tx↓][V][AfterRef?][Op]
+		key := concatBytes(prefix, sd.A[:], sd.E[:], txDesc[:], vBytes)
 		if sd.Op.HasAfterRef() {
 			afterRefDesc := txToDescending(sd.AfterRef)
 			key = append(key, afterRefDesc[:]...)
 		}
+		key = append(key, byte(sd.Op))
 		return key
 	case AVET:
-		// [A][V][E][Tx][Op][AfterRef?] - Bug #5 fix: Tx before Op, enables [A][V] prefix scans
-		key := concatBytes(prefix, sd.A[:], vBytes, sd.E[:], txDesc[:], opByte)
+		// [A][V][E][Tx↓][AfterRef?][Op]
+		key := concatBytes(prefix, sd.A[:], vBytes, sd.E[:], txDesc[:])
 		if sd.Op.HasAfterRef() {
 			afterRefDesc := txToDescending(sd.AfterRef)
 			key = append(key, afterRefDesc[:]...)
 		}
+		key = append(key, byte(sd.Op))
 		return key
 	case VAET:
-		// [V][A][E][Tx][Op][AfterRef?] - Bug #5 fix: Tx before Op, enables [V][A] prefix scans
-		key := concatBytes(prefix, vBytes, sd.A[:], sd.E[:], txDesc[:], opByte)
+		// [V][A][E][Tx↓][AfterRef?][Op]
+		key := concatBytes(prefix, vBytes, sd.A[:], sd.E[:], txDesc[:])
 		if sd.Op.HasAfterRef() {
 			afterRefDesc := txToDescending(sd.AfterRef)
 			key = append(key, afterRefDesc[:]...)
 		}
+		key = append(key, byte(sd.Op))
 		return key
 	case TAEV:
-		// [Tx][A][E][V][Op][AfterRef?]
-		key := concatBytes(prefix, txDesc[:], sd.A[:], sd.E[:], vBytes, opByte)
+		// [Tx↓][A][E][V][AfterRef?][Op]
+		key := concatBytes(prefix, txDesc[:], sd.A[:], sd.E[:], vBytes)
 		if sd.Op.HasAfterRef() {
 			afterRefDesc := txToDescending(sd.AfterRef)
 			key = append(key, afterRefDesc[:]...)
 		}
+		key = append(key, byte(sd.Op))
 		return key
 	default:
 		panic(fmt.Sprintf("unknown index type: %v", index))
@@ -132,18 +138,21 @@ func (e *BinaryKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 // Returns fixed-size arrays for entity, attr, tx, and op to avoid heap escape.
 // tx is 16 bytes: Lamport (8) + ReplicaID (8) = ElementID
 // Tx is stored with bitwise NOT for descending sort, reversed on decode.
-// Op is 1 byte: 0-4 (see CRDTOp constants).
+// Op is 1 byte: 0-4 (see CRDTOp constants). Always the LAST byte of every key.
 // AfterRef is optionally present for Op ∈ {OpRGAInsert(3), OpRGATombstone(4)}.
 //
-// Key formats (Bug #5 fix: Tx before Op, AfterRef at end for RGA ops):
+// Key formats (Op always last — see docs/reference/OP_POSITION_PROOF.md):
 //
-//	EAVT: [prefix][E][A][type][value][Tx↓][Op][AfterRef?]
-//	EATV: [prefix][E][A][Tx↓][type][value][Op][AfterRef?]
-//	AEVT: [prefix][A][E][type][value][Tx↓][Op][AfterRef?]
-//	AETV: [prefix][A][E][Tx↓][type][value][Op][AfterRef?]
-//	AVET: [prefix][A][type][value][E][Tx↓][Op][AfterRef?]
-//	VAET: [prefix][type][value][A][E][Tx↓][Op][AfterRef?]
-//	TAEV: [prefix][Tx↓][A][E][type][value][Op][AfterRef?]
+//	EAVT: [prefix][E][A][type][value][Tx↓][AfterRef?][Op]
+//	EATV: [prefix][E][A][Tx↓][type][value][AfterRef?][Op]
+//	AEVT: [prefix][A][E][type][value][Tx↓][AfterRef?][Op]
+//	AETV: [prefix][A][E][Tx↓][type][value][AfterRef?][Op]
+//	AVET: [prefix][A][type][value][E][Tx↓][AfterRef?][Op]
+//	VAET: [prefix][type][value][A][E][Tx↓][AfterRef?][Op]
+//	TAEV: [prefix][Tx↓][A][E][type][value][AfterRef?][Op]
+//
+// Decoding strategy: Op = key[len-1]. If Op.HasAfterRef(), AfterRef = key[len-17:len-1].
+// No heuristic needed. No ambiguity.
 func (e *BinaryKeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte, attr [32]byte, value []byte, tx [16]byte, op byte, afterRef [16]byte, err error) {
 	if len(key) < 1 {
 		return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("key too short")
@@ -157,205 +166,102 @@ func (e *BinaryKeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]by
 	const attrSize = 32
 	const txSize = 16 // ElementID: Lamport (8) + ReplicaID (8)
 	const opSize = 1
-
 	const afterRefSize = 16
+
+	// Op is always the last byte
+	op = key[len(key)-opSize]
+
+	// Determine tail size: AfterRef (16 bytes) + Op (1 byte), or just Op (1 byte)
+	tailSize := opSize
+	if datalog.CRDTOp(op).HasAfterRef() {
+		tailSize = afterRefSize + opSize
+		afterRef = txFromDescending(key[len(key)-opSize-afterRefSize : len(key)-opSize])
+	}
 
 	switch index {
 	case EAVT:
-		// [E][A][V][Tx][Op][AfterRef?] - Bug #5 fix: Tx before Op
-		minSize := entitySize + attrSize + txSize + opSize
+		// [E][A][V][Tx↓][AfterRef?][Op]
+		minSize := entitySize + attrSize + txSize + tailSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("EAVT key too short")
 		}
 		copy(entity[:], key[0:entitySize])
 		copy(attr[:], key[entitySize:entitySize+attrSize])
-		// Check if AfterRef is present
-		hasAfterRef := len(key) >= minSize+afterRefSize
-		if hasAfterRef {
-			op = key[len(key)-afterRefSize-opSize]
-			if datalog.CRDTOp(op).HasAfterRef() {
-				vEnd := len(key) - afterRefSize - opSize - txSize
-				value = key[entitySize+attrSize : vEnd]
-				tx = txFromDescending(key[vEnd : vEnd+txSize])
-				afterRef = txFromDescending(key[len(key)-afterRefSize:])
-			} else {
-				hasAfterRef = false
-			}
-		}
-		if !hasAfterRef {
-			op = key[len(key)-opSize]
-			vEnd := len(key) - opSize - txSize
-			value = key[entitySize+attrSize : vEnd]
-			tx = txFromDescending(key[vEnd : vEnd+txSize])
-		}
+		txStart := len(key) - tailSize - txSize
+		tx = txFromDescending(key[txStart : txStart+txSize])
+		value = key[entitySize+attrSize : txStart]
 
 	case EATV:
-		// [E][A][Tx][V][Op][AfterRef?]
-		minSize := entitySize + attrSize + txSize + opSize
+		// [E][A][Tx↓][V][AfterRef?][Op]
+		minSize := entitySize + attrSize + txSize + tailSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("EATV key too short")
 		}
 		copy(entity[:], key[0:entitySize])
 		copy(attr[:], key[entitySize:entitySize+attrSize])
 		tx = txFromDescending(key[entitySize+attrSize : entitySize+attrSize+txSize])
-		// Check if AfterRef is present
-		hasAfterRef := len(key) >= minSize+afterRefSize
-		if hasAfterRef {
-			op = key[len(key)-afterRefSize-opSize]
-			if datalog.CRDTOp(op).HasAfterRef() {
-				vStart := entitySize + attrSize + txSize
-				value = key[vStart : len(key)-afterRefSize-opSize]
-				afterRef = txFromDescending(key[len(key)-afterRefSize:])
-			} else {
-				hasAfterRef = false
-			}
-		}
-		if !hasAfterRef {
-			vStart := entitySize + attrSize + txSize
-			value = key[vStart : len(key)-opSize]
-			op = key[len(key)-opSize]
-		}
+		vStart := entitySize + attrSize + txSize
+		value = key[vStart : len(key)-tailSize]
 
 	case AEVT:
-		// [A][E][V][Tx][Op][AfterRef?] - Bug #5 fix: Tx before Op
-		minSize := attrSize + entitySize + txSize + opSize
+		// [A][E][V][Tx↓][AfterRef?][Op]
+		minSize := attrSize + entitySize + txSize + tailSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("AEVT key too short")
 		}
 		copy(attr[:], key[0:attrSize])
 		copy(entity[:], key[attrSize:attrSize+entitySize])
-		// Check if AfterRef is present
-		hasAfterRef := len(key) >= minSize+afterRefSize
-		if hasAfterRef {
-			op = key[len(key)-afterRefSize-opSize]
-			if datalog.CRDTOp(op).HasAfterRef() {
-				vEnd := len(key) - afterRefSize - opSize - txSize
-				value = key[attrSize+entitySize : vEnd]
-				tx = txFromDescending(key[vEnd : vEnd+txSize])
-				afterRef = txFromDescending(key[len(key)-afterRefSize:])
-			} else {
-				hasAfterRef = false
-			}
-		}
-		if !hasAfterRef {
-			op = key[len(key)-opSize]
-			vEnd := len(key) - opSize - txSize
-			value = key[attrSize+entitySize : vEnd]
-			tx = txFromDescending(key[vEnd : vEnd+txSize])
-		}
+		txStart := len(key) - tailSize - txSize
+		tx = txFromDescending(key[txStart : txStart+txSize])
+		value = key[attrSize+entitySize : txStart]
 
 	case AETV:
-		// [A][E][Tx][V][Op][AfterRef?] - A-primary CRDT: first entry is current (Tx descending)
-		minSize := attrSize + entitySize + txSize + opSize
+		// [A][E][Tx↓][V][AfterRef?][Op]
+		minSize := attrSize + entitySize + txSize + tailSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("AETV key too short")
 		}
 		copy(attr[:], key[0:attrSize])
 		copy(entity[:], key[attrSize:attrSize+entitySize])
 		tx = txFromDescending(key[attrSize+entitySize : attrSize+entitySize+txSize])
-		// Check if AfterRef is present
-		hasAfterRef := len(key) >= minSize+afterRefSize
-		if hasAfterRef {
-			op = key[len(key)-afterRefSize-opSize]
-			if datalog.CRDTOp(op).HasAfterRef() {
-				vStart := attrSize + entitySize + txSize
-				value = key[vStart : len(key)-afterRefSize-opSize]
-				afterRef = txFromDescending(key[len(key)-afterRefSize:])
-			} else {
-				hasAfterRef = false
-			}
-		}
-		if !hasAfterRef {
-			vStart := attrSize + entitySize + txSize
-			value = key[vStart : len(key)-opSize]
-			op = key[len(key)-opSize]
-		}
+		vStart := attrSize + entitySize + txSize
+		value = key[vStart : len(key)-tailSize]
 
 	case AVET:
-		// [A][V][E][Tx][Op][AfterRef?] - Bug #5 fix: Tx before Op
-		minSize := attrSize + entitySize + txSize + opSize
+		// [A][V][E][Tx↓][AfterRef?][Op]
+		minSize := attrSize + entitySize + txSize + tailSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("AVET key too short")
 		}
 		copy(attr[:], key[0:attrSize])
-		// Check if AfterRef is present
-		hasAfterRef := len(key) >= minSize+afterRefSize
-		if hasAfterRef {
-			op = key[len(key)-afterRefSize-opSize]
-			if datalog.CRDTOp(op).HasAfterRef() {
-				eStart := len(key) - afterRefSize - opSize - txSize - entitySize
-				copy(entity[:], key[eStart:eStart+entitySize])
-				tx = txFromDescending(key[eStart+entitySize : eStart+entitySize+txSize])
-				value = key[attrSize:eStart]
-				afterRef = txFromDescending(key[len(key)-afterRefSize:])
-			} else {
-				hasAfterRef = false
-			}
-		}
-		if !hasAfterRef {
-			op = key[len(key)-opSize]
-			eStart := len(key) - opSize - txSize - entitySize
-			copy(entity[:], key[eStart:eStart+entitySize])
-			tx = txFromDescending(key[eStart+entitySize : eStart+entitySize+txSize])
-			value = key[attrSize:eStart]
-		}
+		eStart := len(key) - tailSize - txSize - entitySize
+		copy(entity[:], key[eStart:eStart+entitySize])
+		tx = txFromDescending(key[eStart+entitySize : eStart+entitySize+txSize])
+		value = key[attrSize:eStart]
 
 	case VAET:
-		// [V][A][E][Tx][Op][AfterRef?] - Bug #5 fix: Tx before Op
-		minSize := attrSize + entitySize + txSize + opSize
+		// [V][A][E][Tx↓][AfterRef?][Op]
+		minSize := attrSize + entitySize + txSize + tailSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("VAET key too short")
 		}
-		// Check if AfterRef is present
-		hasAfterRef := len(key) >= minSize+afterRefSize
-		if hasAfterRef {
-			op = key[len(key)-afterRefSize-opSize]
-			if datalog.CRDTOp(op).HasAfterRef() {
-				eStart := len(key) - afterRefSize - opSize - txSize - entitySize
-				aStart := eStart - attrSize
-				copy(entity[:], key[eStart:eStart+entitySize])
-				copy(attr[:], key[aStart:aStart+attrSize])
-				tx = txFromDescending(key[eStart+entitySize : eStart+entitySize+txSize])
-				value = key[0:aStart]
-				afterRef = txFromDescending(key[len(key)-afterRefSize:])
-			} else {
-				hasAfterRef = false
-			}
-		}
-		if !hasAfterRef {
-			op = key[len(key)-opSize]
-			eStart := len(key) - opSize - txSize - entitySize
-			aStart := eStart - attrSize
-			copy(entity[:], key[eStart:eStart+entitySize])
-			copy(attr[:], key[aStart:aStart+attrSize])
-			tx = txFromDescending(key[eStart+entitySize : eStart+entitySize+txSize])
-			value = key[0:aStart]
-		}
+		eStart := len(key) - tailSize - txSize - entitySize
+		aStart := eStart - attrSize
+		copy(entity[:], key[eStart:eStart+entitySize])
+		copy(attr[:], key[aStart:aStart+attrSize])
+		tx = txFromDescending(key[eStart+entitySize : eStart+entitySize+txSize])
+		value = key[0:aStart]
 
 	case TAEV:
-		// [Tx][A][E][V][Op][AfterRef?]
-		minSize := txSize + attrSize + entitySize + opSize
+		// [Tx↓][A][E][V][AfterRef?][Op]
+		minSize := txSize + attrSize + entitySize + tailSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("TAEV key too short")
 		}
 		tx = txFromDescending(key[0:txSize])
 		copy(attr[:], key[txSize:txSize+attrSize])
 		copy(entity[:], key[txSize+attrSize:txSize+attrSize+entitySize])
-		// Check if AfterRef is present
-		hasAfterRef := len(key) >= minSize+afterRefSize
-		if hasAfterRef {
-			op = key[len(key)-afterRefSize-opSize]
-			if datalog.CRDTOp(op).HasAfterRef() {
-				value = key[txSize+attrSize+entitySize : len(key)-afterRefSize-opSize]
-				afterRef = txFromDescending(key[len(key)-afterRefSize:])
-			} else {
-				hasAfterRef = false
-			}
-		}
-		if !hasAfterRef {
-			value = key[txSize+attrSize+entitySize : len(key)-opSize]
-			op = key[len(key)-opSize]
-		}
+		value = key[txSize+attrSize+entitySize : len(key)-tailSize]
 
 	default:
 		return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("unknown index type: %v", index)

--- a/datalog/storage/key_encoder_l85.go
+++ b/datalog/storage/key_encoder_l85.go
@@ -11,7 +11,8 @@ import (
 type L85KeyEncoder struct{}
 
 // EncodeKey creates an L85-encoded index key from a datom
-// Op is included between V and Tx for CRDT semantics.
+// Op is always the LAST byte of every key, matching BinaryKeyEncoder convention.
+// See docs/reference/OP_POSITION_PROOF.md for the correctness proof.
 func (e *L85KeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 	sd := ToStorageDatom(*d)
 	prefix := []byte{byte(index)}
@@ -33,28 +34,28 @@ func (e *L85KeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 		vBytes = append([]byte{vType}, vData...)
 	}
 
-	// Op byte (0=none, 1=add, 2=remove)
+	// Op byte (0=none, 1=add, 2=remove, 3=rga-insert, 4=rga-tombstone)
 	opByte := []byte{byte(sd.Op)}
 
 	switch index {
 	case EAVT:
-		// [E][A][V][Op][Tx]
-		return concatBytes(prefix, []byte(eL85), []byte(aL85), vBytes, opByte, []byte(txL85))
+		// [E][A][V][Tx][Op]
+		return concatBytes(prefix, []byte(eL85), []byte(aL85), vBytes, []byte(txL85), opByte)
 	case EATV:
 		// [E][A][Tx][V][Op]
 		return concatBytes(prefix, []byte(eL85), []byte(aL85), []byte(txL85), vBytes, opByte)
 	case AEVT:
-		// [A][E][V][Op][Tx]
-		return concatBytes(prefix, []byte(aL85), []byte(eL85), vBytes, opByte, []byte(txL85))
+		// [A][E][V][Tx][Op]
+		return concatBytes(prefix, []byte(aL85), []byte(eL85), vBytes, []byte(txL85), opByte)
 	case AETV:
-		// [A][E][Tx][V][Op] - A-primary CRDT: first entry is current (Tx descending)
+		// [A][E][Tx][V][Op]
 		return concatBytes(prefix, []byte(aL85), []byte(eL85), []byte(txL85), vBytes, opByte)
 	case AVET:
-		// [A][V][E][Op][Tx] - Op before Tx for add-wins, enables [A][V] prefix scans
-		return concatBytes(prefix, []byte(aL85), vBytes, []byte(eL85), opByte, []byte(txL85))
+		// [A][V][E][Tx][Op]
+		return concatBytes(prefix, []byte(aL85), vBytes, []byte(eL85), []byte(txL85), opByte)
 	case VAET:
-		// [V][A][E][Op][Tx] - Op before Tx for add-wins, enables [V][A] prefix scans
-		return concatBytes(prefix, vBytes, []byte(aL85), []byte(eL85), opByte, []byte(txL85))
+		// [V][A][E][Tx][Op]
+		return concatBytes(prefix, vBytes, []byte(aL85), []byte(eL85), []byte(txL85), opByte)
 	case TAEV:
 		// [Tx][A][E][V][Op]
 		return concatBytes(prefix, []byte(txL85), []byte(aL85), []byte(eL85), vBytes, opByte)
@@ -65,18 +66,19 @@ func (e *L85KeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 
 // DecodeKey extracts components from an L85-encoded index key.
 // Returns fixed-size arrays for entity, attr, tx, afterRef to avoid heap escape.
-// Op is 1 byte: 0=none, 1=add, 2=remove, 3=rga-insert, 4=rga-tombstone (for CRDT semantics).
+// Op is 1 byte: 0=none, 1=add, 2=remove, 3=rga-insert, 4=rga-tombstone.
+// Op is always the LAST byte of every key: op = key[len(key)-1].
 // AfterRef is 16 bytes: present only when Op.HasAfterRef() is true, otherwise zero.
 //
-// Key formats (V before Tx, Op after Tx, AfterRef at end when present):
+// Key formats (Op always last — see docs/reference/OP_POSITION_PROOF.md):
 //
-//	EAVT: [prefix][E][A][V][Tx][Op][AfterRef?]
-//	EATV: [prefix][E][A][Tx][V][Op][AfterRef?]
-//	AEVT: [prefix][A][E][V][Tx][Op][AfterRef?]
-//	AETV: [prefix][A][E][Tx][V][Op][AfterRef?]
-//	AVET: [prefix][A][V][E][Tx][Op][AfterRef?]
-//	VAET: [prefix][V][A][E][Tx][Op][AfterRef?]
-//	TAEV: [prefix][Tx][A][E][V][Op][AfterRef?]
+//	EAVT: [prefix][E][A][V][Tx][Op]
+//	EATV: [prefix][E][A][Tx][V][Op]
+//	AEVT: [prefix][A][E][V][Tx][Op]
+//	AETV: [prefix][A][E][Tx][V][Op]
+//	AVET: [prefix][A][V][E][Tx][Op]
+//	VAET: [prefix][V][A][E][Tx][Op]
+//	TAEV: [prefix][Tx][A][E][V][Op]
 //
 // NOTE: L85 encoder does NOT yet support AfterRef - returns zero. Update pending.
 func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte, attr [32]byte, value []byte, tx [16]byte, op byte, afterRef [16]byte, err error) {
@@ -91,18 +93,23 @@ func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte,
 	const l85SizeAttr = 40 // 32-byte components (attr)
 	const opSize = 1
 
+	// Op is always the last byte
+	op = key[len(key)-opSize]
+
 	switch index {
 	case EAVT:
-		// [E][A][V][Op][Tx]
-		minSize := l85Size20 + l85SizeAttr + opSize + l85Size16
+		// [E][A][V][Tx][Op]
+		minSize := l85Size20 + l85SizeAttr + l85Size16 + opSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("EAVT key too short")
 		}
 		entity, _ = codec.DecodeFixed20(string(key[0:l85Size20]))
 		attr, _ = codec.DecodeFixed32(string(key[l85Size20 : l85Size20+l85SizeAttr]))
-		// V is between A and Op
-		vEnd := len(key) - l85Size16 - opSize
-		valueBytes := key[l85Size20+l85SizeAttr : vEnd]
+		// Tx is before Op (last l85Size16 bytes before Op)
+		txStart := len(key) - opSize - l85Size16
+		tx, _ = codec.DecodeFixed16(string(key[txStart : txStart+l85Size16]))
+		// V is between A and Tx
+		valueBytes := key[l85Size20+l85SizeAttr : txStart]
 		if len(valueBytes) == l85Size20 {
 			if decoded, decErr := codec.DecodeFixed20(string(valueBytes)); decErr == nil {
 				value = decoded[:]
@@ -112,8 +119,6 @@ func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte,
 		} else {
 			value = valueBytes
 		}
-		op = key[vEnd]
-		tx, _ = codec.DecodeFixed16(string(key[len(key)-l85Size16:]))
 
 	case EATV:
 		// [E][A][Tx][V][Op]
@@ -136,18 +141,20 @@ func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte,
 		} else {
 			value = valueBytes
 		}
-		op = key[len(key)-opSize]
 
 	case AEVT:
-		// [A][E][V][Op][Tx]
-		minSize := l85SizeAttr + l85Size20 + opSize + l85Size16
+		// [A][E][V][Tx][Op]
+		minSize := l85SizeAttr + l85Size20 + l85Size16 + opSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("AEVT key too short")
 		}
 		attr, _ = codec.DecodeFixed32(string(key[0:l85SizeAttr]))
 		entity, _ = codec.DecodeFixed20(string(key[l85SizeAttr : l85SizeAttr+l85Size20]))
-		vEnd := len(key) - l85Size16 - opSize
-		valueBytes := key[l85SizeAttr+l85Size20 : vEnd]
+		// Tx is before Op
+		txStart := len(key) - opSize - l85Size16
+		tx, _ = codec.DecodeFixed16(string(key[txStart : txStart+l85Size16]))
+		// V is between E and Tx
+		valueBytes := key[l85SizeAttr+l85Size20 : txStart]
 		if len(valueBytes) == l85Size20 {
 			if decoded, decErr := codec.DecodeFixed20(string(valueBytes)); decErr == nil {
 				value = decoded[:]
@@ -157,11 +164,9 @@ func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte,
 		} else {
 			value = valueBytes
 		}
-		op = key[vEnd]
-		tx, _ = codec.DecodeFixed16(string(key[len(key)-l85Size16:]))
 
 	case AETV:
-		// [A][E][Tx][V][Op] - A-primary CRDT: first entry is current (Tx descending)
+		// [A][E][Tx][V][Op]
 		minSize := l85SizeAttr + l85Size20 + l85Size16 + opSize
 		if len(key) < minSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("AETV key too short")
@@ -181,19 +186,19 @@ func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte,
 		} else {
 			value = valueBytes
 		}
-		op = key[len(key)-opSize]
 
 	case AVET:
-		// [A][V][E][Op][Tx] - Op before Tx
-		if len(key) < l85SizeAttr+l85Size20+opSize+l85Size16 {
+		// [A][V][E][Tx][Op]
+		if len(key) < l85SizeAttr+l85Size20+l85Size16+opSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("AVET key too short")
 		}
 		attr, _ = codec.DecodeFixed32(string(key[0:l85SizeAttr]))
-		tx, _ = codec.DecodeFixed16(string(key[len(key)-l85Size16:]))
-		op = key[len(key)-l85Size16-opSize]
-		entity, _ = codec.DecodeFixed20(string(key[len(key)-l85Size16-opSize-l85Size20 : len(key)-l85Size16-opSize]))
+		// E and Tx are at the end, before Op
+		eStart := len(key) - opSize - l85Size16 - l85Size20
+		entity, _ = codec.DecodeFixed20(string(key[eStart : eStart+l85Size20]))
+		tx, _ = codec.DecodeFixed16(string(key[eStart+l85Size20 : eStart+l85Size20+l85Size16]))
 		// V is between A and E
-		valueBytes := key[l85SizeAttr : len(key)-l85Size16-opSize-l85Size20]
+		valueBytes := key[l85SizeAttr:eStart]
 		if len(valueBytes) == l85Size20+1 && valueBytes[0] == byte(datalog.TypeReference) {
 			if decoded, decErr := codec.DecodeFixed20(string(valueBytes[1:])); decErr == nil {
 				value = append([]byte{valueBytes[0]}, decoded[:]...)
@@ -205,14 +210,16 @@ func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte,
 		}
 
 	case VAET:
-		// [V][A][E][Op][Tx] - Op before Tx
-		if len(key) < l85SizeAttr+l85Size20+opSize+l85Size16 {
+		// [V][A][E][Tx][Op]
+		if len(key) < l85SizeAttr+l85Size20+l85Size16+opSize {
 			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("VAET key too short")
 		}
-		tx, _ = codec.DecodeFixed16(string(key[len(key)-l85Size16:]))
-		op = key[len(key)-l85Size16-opSize]
-		entity, _ = codec.DecodeFixed20(string(key[len(key)-l85Size16-opSize-l85Size20 : len(key)-l85Size16-opSize]))
-		aStart := len(key) - l85Size16 - opSize - l85Size20 - l85SizeAttr
+		// E and Tx are at the end, before Op
+		eStart := len(key) - opSize - l85Size16 - l85Size20
+		entity, _ = codec.DecodeFixed20(string(key[eStart : eStart+l85Size20]))
+		tx, _ = codec.DecodeFixed16(string(key[eStart+l85Size20 : eStart+l85Size20+l85Size16]))
+		// A is before E
+		aStart := eStart - l85SizeAttr
 		attr, _ = codec.DecodeFixed32(string(key[aStart : aStart+l85SizeAttr]))
 		// V is at start, before A
 		valueBytes := key[0:aStart]
@@ -244,7 +251,6 @@ func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte,
 		} else {
 			value = valueBytes
 		}
-		op = key[len(key)-opSize]
 
 	default:
 		return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("unknown index type: %v", index)

--- a/datalog/storage/op_field_test.go
+++ b/datalog/storage/op_field_test.go
@@ -7,7 +7,7 @@ package storage
 // SetEntry wrapper approach.
 //
 // Key changes tested:
-// 1. Op field is encoded in keys between V and Tx
+// 1. Op field is always the last byte of every key
 // 2. V stores raw values (not SetEntry bytes) - enables AVET lookups
 // 3. Add-wins resolution reads Op from datom.Op, not from SetEntry
 // 4. AVET index can now match raw value types for cardinality-many

--- a/docs/bugs/BUG_SHARED_DB_DATOM_LOSS.md
+++ b/docs/bugs/BUG_SHARED_DB_DATOM_LOSS.md
@@ -1,0 +1,545 @@
+# BUG: Silent Datom Loss on Decode (AfterRef Heuristic)
+
+**Date**: 2026-02-07
+**Severity**: High — reference-valued datoms silently missing after successful Commit()
+**Status**: FIXED (2026-02-07)
+
+## Summary
+
+`BinaryKeyEncoder.DecodeKey` silently drops ~0.78% of reference-valued datoms
+due to a faulty AfterRef detection heuristic. The data is written correctly to
+BadgerDB but cannot be read back — the decoder misreads a byte from inside the
+SHA1 hash as the Op field, enters the wrong decode path, and returns an error
+that is silently swallowed by the iterator and cache layers.
+
+The bug affects any entity with `TypeReference` attributes (Identity values).
+Non-reference types (string, keyword, int64, etc.) are unaffected.
+
+The bug reproduces consistently at ~2-3% per 5-datom transaction containing
+reference-valued attributes. Earlier testing also observed failures on fresh
+per-iteration databases at lower rates (~0.5-3%), though a later independent
+run was unable to reproduce the fresh-DB failures.
+
+## Discovery
+
+Found when `PullInto` returned structs with nil Identity reference fields on
+entities that had multiple `TypeRef` attributes. Initially suspected to be a
+PullInto read-path or cache issue.
+
+Nil guards added to entity load functions caught the symptom: previously these
+nil Identity values propagated silently until they caused panics deep in
+unrelated code paths (see BUG_PULLINTO_NIL_ENTITY_PANIC.md).
+
+## Reproduction
+
+### Test Matrix
+
+The investigation used multiple test configurations to isolate the cause.
+Each test writes entities with a mix of reference and keyword attributes,
+then reads them back via both direct Datalog query and `PullInto`.
+
+**Initial results** (Windows):
+
+| Test | What it does | Failure Rate |
+|------|-------------|-------------|
+| SharedDB | `tx.Set()` per field, one DB for all 200 iterations | **~2%** |
+| SaveStruct | `SaveStruct` + `Commit`, fresh DB per iteration (100x) | **~3%** |
+| ExplicitSet | `tx.Set()` per field, fresh DB per iteration (100x) | **~1-3%** |
+| SeparateTx | Separate `tx.Set()` + `Commit` per field, fresh DB (100x) | **~3%** |
+| SingleField | One `tx.Set()` + `Commit`, one datom, fresh DB (200x) | **~0.5%** |
+
+If the per-datom loss rate is ~0.5% (from the single-datom test), then a
+5-datom transaction has roughly `1 - (1 - 0.005)^5 ~ 2.5%` chance of losing
+at least one datom. This is consistent with the observed multi-datom rates.
+
+**Independent reproduction** (macOS, Apple M4):
+
+| Test | What it does | Failure Rate |
+|------|-------------|-------------|
+| SharedDB | Same as above | **~2.5% (5/200)** |
+| SaveStruct | Same as above | 0/100 |
+| ExplicitSet | Same as above | 0/100 |
+| SeparateTx | Same as above | 0/100 |
+| SingleField | Same as above | 0/200 |
+
+Same janus-datalog version, different OS and hardware. The macOS run
+reproduced SharedDB failures but not the fresh-DB failures. The fresh-DB
+failures may be platform-dependent (filesystem behavior, memory model, I/O
+scheduling) or simply harder to trigger on macOS/ARM. The tests are
+non-deterministic (random UUIDs each run).
+
+The SharedDB variant was the most reliable reproducer across both platforms.
+
+### Minimal Failing Pattern
+
+```go
+// Single database, reused across iterations
+db, _ := storage.NewDatabase(tmpDir)
+db.SetSchema(s) // schema with TypeRef attributes
+
+for i := 0; i < 200; i++ {
+    entityID := datalog.NewIdentity(generateUUID())
+    refA := datalog.NewIdentity(generateUUID())
+    refB := datalog.NewIdentity(generateUUID())
+    refC := datalog.NewIdentity(generateUUID())
+
+    tx := db.NewTransaction()
+    tx.Set(entityID, kwAttr, datalog.NewKeyword(":entity.type/test"))
+    tx.Set(entityID, refAttrA, refA)
+    tx.Set(entityID, refAttrB, refB)
+    tx.Set(entityID, refAttrC, refC)
+    tx.Set(entityID, statusAttr, datalog.NewKeyword(":status/active"))
+    tx.Commit()  // returns nil error
+
+    // ~2.5% of the time, one reference field is missing:
+    var loaded MyEntity
+    db.Store().PullInto(entityID, &loaded)
+    // loaded.RefB == nil OR loaded.RefC == nil
+}
+```
+
+### Fresh DB Variant (fails intermittently)
+
+```go
+// Fresh database PER ITERATION — usually passes, but initial testing
+// observed ~1-3% failure rate. A later run saw 0 failures.
+for i := 0; i < 100; i++ {
+    tmpDir, _ := os.MkdirTemp("", "test_*")
+    db, _ := storage.NewDatabase(tmpDir)
+    db.SetSchema(s)
+
+    // Exact same Set+Commit logic as above
+    // ...
+    db.Close()
+    os.RemoveAll(tmpDir)
+}
+```
+
+### Single Datom Variant (minimal reproducer)
+
+```go
+// One entity, one attribute, one value. Fresh DB.
+// Initial testing: ~0.5% failure rate. Later run: 0/200.
+entityID := datalog.NewIdentity(generateUUID())
+refID := datalog.NewIdentity(generateUUID())
+
+tx := db.NewTransaction()
+tx.Set(entityID, refAttr, refID)  // returns nil error
+_, err = tx.Commit()               // returns nil error
+
+// When it fails: direct query also returns not-found
+var result datalog.Identity
+found, _ := store.QueryOneInto(&result,
+    `[:find ?v :in $ ?e :where [?e :test/ref ?v]]`, entityID)
+// found == false — the datom was never written
+```
+
+## Failure Pattern
+
+Every observed failure shows:
+
+1. **The entity exists** — keyword attributes are always found
+2. **Exactly one field is missing** from both direct query and PullInto
+3. **Which field varies** — any reference-typed attribute can be affected
+4. **Other fields are intact** — the transaction partially committed
+5. **The loss is persistent** — re-querying returns the same result
+
+Example output:
+```
+FIELD LOSS:
+  entity/type: found=true val=:entity.type/test
+  query refA=true refB=true refC=false
+  pull  refA=EXsO[NkO81Q-a`zM8Ie6 refB=h[3=pyv_ClE!K37A,eSX refC=<nil>
+```
+
+The direct Datalog query also returns not-found, confirming the data is absent
+from readable storage — not a PullInto read-path issue.
+
+## What This Rules Out
+
+### Not a PullInto / read-path bug
+
+Both direct Datalog query and PullInto miss the same datom. If the data were
+in BadgerDB but PullInto couldn't read it, the direct query would still find
+it. Both fail.
+
+### Not a SaveStruct / updateField optimization bug
+
+`SaveStruct` has an optimization in `updateField` (writer.go) that skips
+writes when the existing value matches the new value. But explicit `tx.Set()`
+calls — which bypass `SaveStruct` entirely — show the same failure in the
+shared-DB test.
+
+### Not specific to transaction size or shape
+
+The shared-DB test uses the same `tx.Set()` + `Commit()` pattern as the
+fresh-DB tests. Same number of datoms, same attributes, same value types.
+
+### Not clearly limited to accumulated state
+
+The shared-DB variant was the most reliable reproducer, and the second test
+run only saw failures there. However, the initial testing observed failures
+on fresh per-iteration databases as well (including single-datom
+transactions). This suggests the underlying cause may not be limited to
+accumulated state — it may simply be easier to trigger with a populated
+database.
+
+## Possible Causes (pre-root-cause)
+
+The following observations constrained the root cause:
+
+- **Shared-DB reproduces consistently** (~2-3% per run)
+- **Fresh-DB reproduces intermittently** (observed in initial testing, not in
+  a later run)
+- **Single-datom fresh-DB reproduces rarely** (~0.5% initially, 0% later)
+- **Both query and PullInto miss the data** — it is genuinely absent from
+  readable storage
+- **No errors from any write API** — Commit() returns nil
+
+Possible causes considered in the storage layer:
+
+- **BadgerDB compaction** — internal GC/compaction goroutines may race with
+  reads. A populated database has more compaction pressure, explaining why
+  shared-DB is more reliable to reproduce.
+- **Cache coherency** — the `BadgerMatcher` cache (`m.cache != nil` path in
+  `LookupAttribute`) accumulates entries across the DB lifetime. A stale
+  negative cache entry could mask a recently-written datom.
+- **Index iteration boundaries** — a populated database may hit LSM tree
+  level boundaries during iteration that a nearly-empty fresh DB never reaches.
+- **Write-path data loss** — if the initial fresh-DB results are accurate,
+  the bug may be in the write pipeline itself (`Assert` → `db.Update` →
+  `txn.Set`), with accumulated state merely increasing the probability.
+
+### Initial recommendations (before root cause found)
+
+These suggestions were proposed during initial investigation but turned out
+to be unrelated to the actual cause. Preserved here for completeness:
+
+- Investigate whether `DetectConflicts = false` on BadgerDB opts interacts
+  with internal compaction goroutines
+- Check whether `txn.Set(key, nil)` (nil value, keys-only indices) triggers
+  edge cases in BadgerDB's memtable
+- Consider post-commit verification in `Assert()`: scan back to confirm all
+  datoms are present
+- Evaluate `WriteBatch` API vs `db.Update()` for different atomicity
+  guarantees
+
+## Investigation Notes (2026-02-07)
+
+### Write path traced
+
+1. `tx.Set()` for CardinalityOne: appends `Datom` to `t.datoms` with unique
+   `elemID` from `t.db.clock.Next()`. No read-before-write for CardinalityOne.
+2. `Commit()` calls `t.db.store.Assert(t.datoms)` — single `db.Update()`
+   BadgerDB transaction. All datoms written atomically.
+3. Inside `Assert`: each datom written to all 7 indices via `txn.Set(key, nil)`.
+   If any index write fails, entire BadgerDB transaction rolls back.
+4. After `Assert` returns, `Commit` writes tx metadata in a **separate**
+   `Assert` call (second `db.Update` transaction).
+5. Cache invalidation: `UpdateMaxVersion` then `Invalidate` for all
+   touched (E, A) pairs.
+
+### Cache invalidation order in Commit()
+
+```go
+// 1. UpdateMaxVersion for each datom (bumps version)
+// 2. Invalidate(touched) — deletes cached entries
+```
+
+Between steps 1 and 2, `maxVersions` is updated but old cache entry still
+exists. A concurrent `GetOrResolve` at this moment would see version mismatch
+and fall through to rebuild — so this is **not** a race for stale hits.
+
+However, the reproducer tests are **single-threaded** — no goroutines. So
+concurrency races in the cache should not apply.
+
+### BadgerDB configuration
+
+```go
+opts.DetectConflicts = false    // Disabled for performance
+opts.NumCompactors = 4          // Parallel compaction
+opts.ValueThreshold = 1 << 10   // 1KB
+opts.MemTableSize = 128 << 20   // 128MB
+```
+
+`DetectConflicts = false` was initially considered suspicious. All values are
+`nil` (keys-only storage — datom info encoded in key). This means BadgerDB's
+value log is not involved; all data lives in the LSM tree.
+
+### Key observation: two separate Assert calls per Commit
+
+`Commit()` calls `Assert` twice:
+1. `t.db.store.Assert(t.datoms)` — the actual datoms
+2. `t.db.store.Assert(txMetadata)` — the `:db/txInstant` metadata
+
+These are two separate `db.Update()` transactions. The datoms are atomic
+with respect to each other (all 5 datoms in one BadgerDB txn), but the
+metadata is a separate transaction. This shouldn't cause datom loss since
+the metadata is written after the datoms, and the query reads don't depend
+on metadata.
+
+### What still needed investigation (pre-root-cause)
+
+1. **BadgerDB `db.Update` semantics with `DetectConflicts = false`**: Does
+   disabling conflict detection affect write visibility guarantees? The
+   BadgerDB docs say this only affects read-write transaction conflicts, not
+   write durability. But worth verifying.
+
+2. **`txn.Set(key, nil)` edge cases**: All datom writes use nil values
+   (keys-only). BadgerDB treats nil values as "key exists with empty value."
+   Are there edge cases in BadgerDB's memtable or LSM compaction with nil
+   values and 4 parallel compactors?
+
+3. **Read-after-write visibility**: After `db.Update()` returns, are all
+   keys immediately visible to a new `db.View()` or `db.Update()`? BadgerDB
+   guarantees this for MVCC reads, but the guarantee depends on the read
+   transaction starting after the write transaction commits.
+
+4. **Cache rebuild path**: When `GetOrResolve` falls through to `rebuild`,
+   it opens a new BadgerDB read transaction. Is there any scenario where
+   `rebuild` could see a partial view of the write?
+
+5. **`Indices` variable**: `assertDatom` iterates `Indices` to write all 7
+   index keys. If `Indices` is somehow short or corrupted, a datom could be
+   written to some indices but not all. Need to verify `Indices` is constant.
+
+6. **Key encoding determinism**: If `EncodeKey` produces different keys for
+   the same datom on write vs. read (e.g., due to keyword interning or hash
+   collision), the datom would be written but not found by queries.
+
+## Root Cause Found (2026-02-07)
+
+### AfterRef detection heuristic in `BinaryKeyEncoder.DecodeKey`
+
+**File**: `datalog/storage/key_encoder_binary.go`, `DecodeKey` method
+
+The bug is in the AfterRef detection heuristic used by all 7 index decoders.
+The decoder reads a byte from the WRONG position (inside the value data) and
+misinterprets it as the Op byte, causing key decode failure and silent datom
+loss.
+
+#### The key format (before fix)
+
+EATV keys were laid out as:
+
+```
+[prefix 1][E 20][A 32][Tx↓ 16][ValueType 1][ValueData N][Op 1][AfterRef? 16]
+```
+
+AfterRef is present only when Op ∈ {OpRGAInsert(3), OpRGATombstone(4)}.
+For normal writes (Op = 0, 1, or 2), AfterRef is absent.
+
+#### The heuristic
+
+The decoder attempts to detect AfterRef by:
+
+1. Checking if the key is long enough to contain AfterRef
+2. Reading a byte from `key[len-17]` (where AfterRef Op would be)
+3. If that byte is 3 or 4, assuming AfterRef is present
+
+```go
+// key_encoder_binary.go, DecodeKey, EATV case
+hasAfterRef := len(key) >= minSize+afterRefSize  // minSize=69, afterRefSize=16
+if hasAfterRef {
+    op = key[len(key)-afterRefSize-opSize]        // key[len-17]
+    if datalog.CRDTOp(op).HasAfterRef() {         // true if byte == 3 or 4
+        // ... treats key as having AfterRef — WRONG
+    } else {
+        hasAfterRef = false
+    }
+}
+```
+
+#### Why it fails
+
+For a CardinalityOne reference-valued datom (e.g., a `TypeRef` attribute →
+Identity), the key after the prefix byte is:
+
+```
+[E 20][A 32][Tx↓ 16][TypeRef 1][SHA1Hash 20][Op=0 1] = 90 bytes
+```
+
+The heuristic:
+- `minSize + afterRefSize = 69 + 16 = 85`
+- `90 >= 85` → **true** (key is "long enough")
+- Reads `key[90-16-1] = key[73]` — this is the **5th byte of the SHA1 hash**,
+  not the Op byte (which is at `key[89]`)
+- If `hash[4] == 3` or `hash[4] == 4`, the decoder enters the AfterRef path
+
+When the AfterRef path triggers incorrectly:
+- Value is truncated to 5 bytes: `key[68:73]` instead of `key[68:89]`
+- `DatomFromKey` tries to decode a Reference from 4 data bytes (needs 20)
+- Decode returns an error → the datom is silently treated as "not found"
+- Both the query path (`KeyOnlyIterator.Next()` returns false on decode error)
+  and the cache path (`ResolveLWW` returns error → `rebuildOne` returns nil)
+  fail identically
+
+#### Probability analysis
+
+SHA1 hash bytes are uniformly distributed.
+**P(hash[4] ∈ {3, 4}) = 2/256 ≈ 0.78% per reference-valued datom.**
+
+Keyword-valued attributes (e.g., `:entity/type`) have ASCII bytes
+(always > 0x20) at the critical position, so they never trigger the bug.
+
+Expected vs observed failure rates:
+
+| Test                 | Ref datoms | Expected              | Observed       |
+|----------------------|------------|-----------------------|----------------|
+| SingleField (1 ref)  | 1          | 0.78%                 | 0.3% (3/1000)  |
+| SharedDB (3 refs)    | 3          | 1-(1-0.0078)^3 ≈ 2.3% | 2.8% (28/1000) |
+| ExplicitSet (3 refs) | 3          | 2.3%                  | 2.6% (13/500)  |
+| SaveStruct (3 refs)  | 3          | 2.3%                  | 2.0% (10/500)  |
+| SeparateTx (3 refs)  | 3          | 2.3%                  | 2.2% (11/500)  |
+
+All observed rates fall within the statistical confidence intervals of the
+expected rates. The SingleField confidence interval for 0.78% with 1000
+trials is approximately [0.16%, 2.27%] (Wilson), which includes the observed
+0.3%.
+
+#### Why SharedDB appeared more reliable
+
+Earlier testing on macOS showed failures only for SharedDB and not for
+fresh-DB variants. This is statistical noise — the per-datom rate is constant
+regardless of database state. With 500 iterations and 2.3% expected failure
+rate, seeing 0 failures has probability (1-0.023)^500 ≈ 0.009%. But the
+earlier run used 100-200 iterations, where P(0 failures) = (1-0.023)^100 ≈
+10% — plausible. The current run with 500-1000 iterations reproduces
+failures across all variants.
+
+#### Scope
+
+The identical heuristic existed in **all 7 index decode paths** in
+`DecodeKey`. Every `case` block (EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV)
+used the same pattern:
+
+```go
+hasAfterRef := len(key) >= minSize+afterRefSize
+if hasAfterRef {
+    op = key[len(key)-afterRefSize-opSize]
+    if datalog.CRDTOp(op).HasAfterRef() { ... }
+}
+```
+
+Any index scan that decodes a key with a sufficiently long value containing
+byte 3 or 4 at the critical position will misinterpret the key.
+
+For 3 indices (EATV, AETV, TAEV), `key[73]` lands in value data (hash[4]).
+For the other 4 (EAVT, AEVT, AVET, VAET), `key[73]` lands on `Tx↓[0]`,
+which can also trigger the bug when `Tx↓[0] ∈ {3, 4}` (i.e., when
+`Lamport` has high byte `0xFC` or `0xFB`).
+
+#### Investigation items resolved
+
+| Item                                | Status                                         |
+|-------------------------------------|------------------------------------------------|
+| 1. BadgerDB `DetectConflicts=false` | Not the cause                                  |
+| 2. `txn.Set(key, nil)` edge cases   | Not the cause                                  |
+| 3. Read-after-write visibility      | Not the cause                                  |
+| 4. Cache rebuild path               | Not the cause (but propagates the error)       |
+| 5. `Indices` variable               | Confirmed constant, 7 entries                  |
+| 6. Key encoding determinism         | Encoding is deterministic; **decoding is not** |
+
+## Fix
+
+**Approach**: Move Op to always be the last byte of every key. Eliminate the
+heuristic entirely.
+
+The key format is inherently ambiguous for AfterRef detection when the value
+data is long enough. Three approaches were considered:
+
+**Approach A — Read last byte first (minimal change):**
+Read Op from `key[last]`. Op 0/1/2 never have AfterRef, so if the last byte
+is 0/1/2, we're done. Op 3/4 always have AfterRef, so if the last byte is
+3/4, it can't be the Op (it's part of AfterRef) — re-read from `key[last-16]`.
+
+This fixes 100% of non-RGA keys (the current bug) but introduces a ~1.2%
+failure rate for RGA keys where AfterRef's last byte happens to be 0, 1, or 2.
+
+**Approach B — Use value type for disambiguation (more robust):**
+After reading the value type byte (at a known fixed position), use the
+expected value size for fixed-size types (Reference=21, Int64=9, Bool=2, etc.)
+to compute the exact Op position. For variable-size types, fall back to
+approach A. This eliminates ambiguity for all fixed-size types including
+Reference.
+
+**Approach C — Key format change (complete fix) [CHOSEN]:**
+Move Op after AfterRef so Op is always the last byte. Eliminates all
+ambiguity for all key types, all value sizes, all Op values.
+
+### New key format (all 7 indices)
+
+```
+[...components...][AfterRef?][Op]
+```
+
+Op is always `key[len(key)-1]`. If `Op.HasAfterRef()`, AfterRef is the
+16 bytes before Op. No heuristic. No ambiguity.
+
+See `docs/reference/OP_POSITION_PROOF.md` for the formal proof that:
+1. Op-before-Tx breaks first-entry-wins (Theorem 1)
+2. Tx-before-Op enables O(1) CRDT resolution for all types (Theorem 2)
+3. Op does not determine sort order between distinct datoms (Theorem 3)
+4. Moving Op after AfterRef does not change scan results (Theorem 4)
+
+### Decoder change
+
+Before:
+```go
+hasAfterRef := len(key) >= minSize+afterRefSize
+if hasAfterRef {
+    op = key[len(key)-afterRefSize-opSize]  // WRONG: reads inside value data
+    if datalog.CRDTOp(op).HasAfterRef() { ... }
+}
+```
+
+After:
+```go
+op = key[len(key)-1]  // Always correct
+tailSize := opSize
+if datalog.CRDTOp(op).HasAfterRef() {
+    tailSize = afterRefSize + opSize
+    afterRef = txFromDescending(key[len(key)-opSize-afterRefSize : len(key)-opSize])
+}
+```
+
+### Binary compatibility
+
+For non-AfterRef datoms (the vast majority), the physical key layout is
+**identical** — Op was already the last byte. The change only affects keys
+with AfterRef (RGA ops), where Op and AfterRef swap positions.
+
+### Files changed
+
+- `datalog/storage/key_encoder_binary.go` — EncodeKey + DecodeKey (production)
+- `datalog/storage/key_encoder_l85.go` — EncodeKey + DecodeKey (consistency)
+- `datalog/storage/afterref_heuristic_bug_test.go` — Reproducer test suite
+
+## Reproducer Tests
+
+Reproducer tests are in `datalog/storage/afterref_heuristic_bug_test.go`:
+
+```bash
+go test -v -run TestAfterRefHeuristicBug ./datalog/storage/
+```
+
+| Test | What it verifies |
+|------|------------------|
+| `_Unit` | All 7 indices decode correctly with crafted trigger inputs |
+| `_KeyLayout` | Diagnostic: prints exact byte positions for EATV ref key |
+| `_Integration` | Full BadgerDB write+read path preserves trigger ref |
+| `_Statistical` | 10,000 random refs: 0% decode failure (was 0.78%) |
+| `_NonRefValues` | Non-reference types unaffected (keyword, string, int, etc.) |
+| `_FullDBRoundTrip` | 500 entities × 3 ref fields: 0 losses (was ~2.3%) |
+
+The `_Unit` test forces `key[73] == 3` on every index:
+- EATV/AETV/TAEV: crafted SHA1 hash with `hash[4] == 3`
+- EAVT/AEVT/AVET/VAET: crafted Tx with `Lamport=0xFC00000000000000`
+  so `Tx↓[0] == ^0xFC == 0x03`
+
+## Files
+
+- `datalog/storage/key_encoder_binary.go` — Root cause and fix
+- `datalog/storage/key_encoder_l85.go` — Consistency fix
+- `datalog/storage/afterref_heuristic_bug_test.go` — Reproducer tests
+- `docs/reference/OP_POSITION_PROOF.md` — Formal proof of Op-at-end correctness

--- a/docs/reference/OP_POSITION_PROOF.md
+++ b/docs/reference/OP_POSITION_PROOF.md
@@ -1,0 +1,369 @@
+# Op Byte Position in Index Keys: A Correctness Proof
+
+## Model
+
+### Storage model
+
+* The database is an ordered key-value store.
+* Keys are compared by **lexicographic byte order**.
+* A **prefix scan** over byte string `P` enumerates all keys `K` with prefix
+  `P` in increasing lexicographic order.
+
+### Datom
+
+A datom is a tuple:
+
+$$d = (E, A, V, T, Op, AfterRef?)$$
+
+Where:
+
+* `E` (20 bytes) entity id
+* `A` (32 bytes) attribute id
+* `V` (variable bytes) value encoding (type-tagged, not fixed length)
+* `T` (16 bytes) operation id (Lamport + replica); encoded as `T↓` so that
+  lexicographic order corresponds to **descending** logical time
+* `Op` (1 byte) operation kind: `0=None, 1=Add, 2=Remove, 3=RGAInsert,
+  4=RGATombstone`
+* `AfterRef` (16 bytes) present iff `Op ∈ {3,4}`
+
+### Invariants (required)
+
+**I1. Unique operation id.** For any two distinct datoms `d1 ≠ d2`,
+`T1 ≠ T2`.
+
+**I2. Total order.** The encoding `T↓` is strictly order-preserving for
+descending time:
+
+* If `T1 > T2` (newer), then `enc(T1↓) < enc(T2↓)` in lexicographic order.
+
+**I3. Max-T semantics for resolution groups.** For each resolution group `G`
+(defined below), the current state is determined solely by the datom in `G`
+with maximal `T` (newest). `Op` is interpreted only after that winner is
+selected.
+
+This covers:
+
+* **Scalar LWW (cardinality-one):** winner is newest write for `(E,A)`.
+* **LWW membership per value (cardinality-many):** membership of `(E,A,V)`
+  determined by newest op for that `(E,A,V)` (Add vs Remove).
+* **RGA liveness per element id (cardinality-vector):** liveness of an
+  element id determined by newest op for that element (Insert vs Tombstone).
+  Note: RGA liveness satisfies max-T semantics, but RGA **topology
+  reconstruction** (vector ordering) requires reading all entries for an
+  `(E,A)` group and building a linked-list from AfterRef pointers. First-
+  entry-wins determines alive/dead per element, not vector position.
+
+This is *not* causal add-wins (OR-Set) semantics; causal add-wins needs
+additional metadata (version vectors, observed-remove tags) and does not
+satisfy I3.
+
+**I4. AfterRef presence is a function of Op.** `AfterRef` exists iff
+`Op ∈ {3,4}`.
+
+---
+
+## Keys and resolution groups
+
+A key is a concatenation of components in some index-specific order:
+
+$$K = [\text{IndexPrefix}][\dots \text{sort components} \dots][\dots \text{payload} \dots]$$
+
+The discussion concerns two kinds of components:
+
+1. **Sort-relevant components:** those that must participate in ordering to
+   make the "winner" appear first in a scan.
+2. **Sort-irrelevant components:** those used only after reading a winner
+   (semantic tag, decoding aid).
+
+### Resolution groups
+
+Different indices support different streaming queries:
+
+* **Scalar LWW read:** resolve by scanning keys grouped by `(E,A)` and
+  taking newest `T`.
+  * A suitable index orders as: `E, A, T↓, ...`.
+
+* **Per-value membership read:** resolve by scanning keys grouped by
+  `(E,A,V)` and taking newest `T` for that value.
+  * A suitable index orders as: `E, A, V, T↓, ...`.
+
+* **RGA element liveness read:** same group shape `(E,A,V)` where `V`
+  encodes the element content.
+  * Again requires: `..., V, T↓, ...`.
+
+In all cases, I3 says "winner = argmax_T in the group".
+
+---
+
+## Property to prove
+
+### Desired property (First-entry-wins)
+
+For each resolution group `G`, scanning the keys for `G` yields the newest
+datom first, so the state can be determined with **one read per group**.
+
+Formally: for group prefix `P` (e.g., bytes of `[E][A]` or `[E][A][V]`),
+let:
+
+$$S(P) = \{ d \mid Key(d) \text{ has prefix } P \}$$
+
+First-entry-wins means:
+
+* the first key returned by prefix scan over `P` corresponds to datom `d*`
+  with maximal `T` among `S(P)`.
+
+---
+
+## Theorem 1: If Op is ordered before T, first-entry-wins fails for max-T semantics
+
+### Statement
+
+Assume I1-I3. Consider a group where the winner is the datom with maximal
+`T` among **mixed Op values** (e.g., Add vs Remove, Insert vs Tombstone).
+If keys are ordered as:
+
+$$[\dots][\text{Op}][T{\downarrow}][\dots]$$
+
+within a fixed group prefix, then first-entry-wins does not hold in general:
+the first entry in the scan need not be the global max-`T` datom of the
+group, and determining the winner requires reading from multiple `Op`
+partitions.
+
+### Proof
+
+Fix a resolution group `(E,A,V)` and assume two ops exist in that group:
+`Op=Add` and `Op=Remove`.
+
+Construct three datoms in the same group:
+
+* `d1 = (E,A,V, T=200, Op=Add)`
+* `d2 = (E,A,V, T=150, Op=Remove)`
+* `d3 = (E,A,V, T=100, Op=Add)`
+
+The global newest is `d1` (T=200).
+
+With ordering `Op` then `T↓`:
+
+* All `Add` keys appear before all `Remove` keys (because `Op` differs
+  before `T↓` in the key).
+* Inside the `Add` partition, `d1` appears before `d3` (because `T↓` is
+  descending).
+* The first key in the group is therefore the newest **Add**, i.e., `d1`.
+
+Now change only one fact: add a single remove with higher `T`:
+
+* `d4 = (E,A,V, T=250, Op=Remove)`
+
+Global newest is now `d4` (T=250), so the correct state is "removed" under
+I3.
+
+But with `Op` before `T↓`, all `Add` entries still come before all `Remove`
+entries; therefore the first entry returned by the scan is still an `Add`
+entry (specifically the newest Add). That first entry cannot determine the
+correct state, because the true max-`T` might be in the later `Remove`
+partition.
+
+Therefore, the scan's first entry is not guaranteed to be the max-`T` datom.
+First-entry-wins fails.
+
+Moreover, any correct algorithm must, in the worst case, inspect at least
+one entry from each relevant `Op` partition to compare their maxima. For
+two partitions (Add/Remove), that implies >=2 reads plus a seek (or
+equivalent) to reach the other partition.
+
+∎
+
+---
+
+## Theorem 2: If T is ordered before Op, first-entry-wins holds for all max-T semantics
+
+### Statement
+
+Assume I1-I3. For a resolution group whose winner is the max-`T` datom, if
+keys order the group as:
+
+$$[\dots \text{group prefix} \dots][T{\downarrow}][\dots]$$
+
+with `T↓` preceding any other varying fields (including `Op` and
+`AfterRef`), then the first key returned by a prefix scan over the group
+corresponds to the max-`T` datom. Hence resolution is one read per group.
+
+### Proof
+
+Fix a group prefix `P` (bytes of the group-defining components, e.g.,
+`[E][A]` or `[E][A][V]`).
+
+Within all keys sharing prefix `P`, the next compared bytes are the bytes
+of `T↓` (by hypothesis). Because `T↓` is strictly descending-order-
+preserving (I2), the lexicographically smallest `T↓` among the group
+corresponds to the largest logical `T`.
+
+Lexicographic order compares by the first differing byte. Since `T` differs
+between any two distinct datoms (I1), `T↓` differs too; thus `T↓` strictly
+determines the ordering among all keys in the group. Therefore, the first
+key in the scan over `P` is exactly the datom with maximal `T`.
+
+Under I3, the state for the group is a function only of that max-`T`
+datom's `Op` (and possibly other payload). So one read suffices.
+
+∎
+
+---
+
+## Theorem 3: Under unique T, any fields after T do not affect scan order
+
+### Statement
+
+Assume I1 and that, within any resolution group, `T↓` appears in the key
+before fields `X` and `Y`. Then rearranging `X` and `Y` (including `Op`
+and `AfterRef`) after `T↓` does not change the relative order of any two
+distinct keys in the group.
+
+### Proof
+
+Take any two distinct datoms `d1 ≠ d2` within the same group prefix `P`.
+
+By I1, `T1 ≠ T2`. Since `T↓` bytes occur before `X` and `Y`, the
+lexicographic comparison between the two keys will encounter a difference
+in the `T↓` region before it ever examines bytes in `X` or `Y`.
+
+Therefore, the relative order of the two keys depends only on `T↓` (and
+earlier group prefix), not on any later fields. Reordering bytes after `T↓`
+cannot affect which key comes first.
+
+∎
+
+**Corollary.** Once `T↓` precedes both `Op` and `AfterRef`, the choice
+`[...][Op][AfterRef?]` vs `[...][AfterRef?][Op]` is irrelevant to ordering.
+It only affects decoding.
+
+---
+
+## Theorem 4: Making Op the last byte yields an unambiguous decoder
+
+### Encoding schema
+
+For every index, place all sort-relevant components first, then optional
+`AfterRef`, then `Op` as the final byte:
+
+$$K = [\text{IndexPrefix}][\text{GroupComponents}][T{\downarrow}][\text{OtherComponents}][\text{AfterRef?}][\text{Op}]$$
+
+All 7 indices in this system:
+
+```
+EAVT: [prefix][E][A][V][T↓][AfterRef?][Op]
+EATV: [prefix][E][A][T↓][V][AfterRef?][Op]
+AEVT: [prefix][A][E][V][T↓][AfterRef?][Op]
+AETV: [prefix][A][E][T↓][V][AfterRef?][Op]
+AVET: [prefix][A][V][E][T↓][AfterRef?][Op]
+VAET: [prefix][V][A][E][T↓][AfterRef?][Op]
+TAEV: [prefix][T↓][A][E][V][AfterRef?][Op]
+```
+
+### Statement
+
+Assume fixed sizes for `E, A, T, AfterRef, Op` and I4. If `Op` is stored
+as the final byte of every key, then:
+
+1. `Op` can be read in O(1) time at `key[len-1]`,
+2. presence and location of `AfterRef` is determined without heuristics,
+3. the split between `V` and trailing fields is uniquely determined.
+
+### Proof
+
+Let `K` be any key.
+
+1. Since `Op` is last, `Op = K[len(K)-1]` is well-defined.
+
+2. By I4, `AfterRef` is present iff `Op ∈ {3,4}`. If present, it occupies
+   the 16 bytes immediately preceding `Op`, so:
+   * `AfterRef = K[len(K)-1-16 : len(K)-1]`.
+   If absent, no bytes are consumed.
+
+3. All remaining fixed-size components have predetermined offsets in each
+   index definition:
+   * In layouts like `EAVT`, `T↓` is the 16 bytes immediately preceding
+     `AfterRef?/Op`, so it is sliceable from the end once `Op` (and
+     optionally `AfterRef`) are removed.
+   * In layouts like `EATV`, `E`, `A`, `T↓` are at fixed offsets from the
+     start, leaving `V` as the remaining middle segment before the trailing
+     `AfterRef?/Op`.
+
+Thus decoding is a total function from bytes to fields with no ambiguity
+and no dependence on the contents of `V`.
+
+∎
+
+---
+
+## Theorem 5: If Op is not at a fixed position, any length-based AfterRef heuristic is unsound with variable-length V
+
+### Statement
+
+If `V` is variable-length and `AfterRef` is optional, then any decoder that
+decides "has AfterRef" by key length thresholds (or by probing bytes at a
+computed offset that is not guaranteed to be `Op`) can misclassify some
+valid keys, causing incorrect slicing and possible decode failure.
+
+### Proof (existence)
+
+Let a heuristic be any function `H(K)` that tries to infer AfterRef
+presence without reading a known-position `Op` (because `Op` is not at a
+fixed location). Because `V` is variable-length, for any fixed threshold or
+offset rule there exist keys whose `V` length makes `H` take the wrong
+branch:
+
+* keys without `AfterRef` that are long enough to satisfy the threshold, or
+* keys with `AfterRef` that are short enough to violate it (if thresholds
+  exist), or
+* keys where the probed byte lies inside `V` and coincidentally equals a
+  value interpreted as "RGA op".
+
+In any such misclassification, the decoder will interpret bytes belonging
+to `V` as either `Op` or `AfterRef`, changing boundaries and corrupting
+decoding.
+
+Therefore, heuristics are not correctness-preserving in the presence of
+variable-length `V` and optional `AfterRef`. A fixed-position tag (Op-last)
+eliminates this entire class.
+
+∎
+
+This class of bug was observed in practice: see `docs/bugs/BUG_SHARED_DB_DATOM_LOSS.md`
+for the specific instance where a length-based heuristic caused ~0.78%
+silent datom loss on reference-valued attributes.
+
+---
+
+## Final conclusion
+
+Under invariants I1-I4 (especially: unique `T` per datom and max-`T` group
+semantics), the following are correct:
+
+1. **`T↓` must precede `Op`** in any index where mixed-op groups are
+   resolved by selecting the max-`T` datom. Otherwise first-entry-wins
+   fails and additional reads are required (Theorem 1 vs Theorem 2).
+
+2. Once `T↓` is before them and `T` is unique, **`Op` and `AfterRef` do not
+   affect ordering** and can be placed in any order after `T↓` (Theorem 3).
+
+3. For decoding robustness with variable-length `V` and optional `AfterRef`,
+   **`Op` should be the last byte**, with `AfterRef` immediately before it
+   when present (Theorem 4). This makes AfterRef detection exact (I4) and
+   removes heuristic misparses (Theorem 5).
+
+### Canonical key suffix
+
+For every index:
+
+* Suffix is always `[AfterRef?][Op]`
+* `Op = key[len-1]`
+* `AfterRef` exists iff `Op ∈ {3,4}` and is the preceding 16 bytes
+
+### Required note
+
+If you ever relax I1 (multiple datoms sharing the same `T`), then some
+field **before** `Op` must provide a strict tie-breaker, or the "fields
+after T never affect order" claim no longer holds. In that case, keep `Op`
+last for decoding, but introduce a deterministic tie-breaker byte sequence
+before it.


### PR DESCRIPTION
## Summary

`BinaryKeyEncoder.DecodeKey` silently drops ~0.78% of reference-valued datoms due to a faulty AfterRef detection heuristic. Data is written correctly to BadgerDB but cannot be read back — the decoder misreads a byte from inside the SHA1 hash as the Op field, enters the wrong decode path, and returns an error that is silently swallowed by the iterator and cache layers.

This fix moves Op to always be the last byte of every key, eliminating the heuristic entirely.

## The Bug

The decoder used a length-based heuristic to detect optional AfterRef (16 bytes, present only for RGA ops):

```go
hasAfterRef := len(key) >= minSize + afterRefSize
if hasAfterRef {
    op = key[len(key)-afterRefSize-opSize]  // key[len-17]
    if CRDTOp(op).HasAfterRef() { ... }     // true if byte == 3 or 4
}
```

For reference-valued datoms (TypeReference → Identity, 21 value bytes), the key is long enough to pass the length check. Position `key[len-17]` then lands **inside the SHA1 hash** (specifically `hash[4]`), not on the actual Op byte. When `hash[4]` happens to be 3 or 4, the decoder enters the AfterRef path, truncates the value, and fails.

**P(failure) = 2/256 ≈ 0.78% per reference-valued datom.**

For a 5-datom transaction with 3 reference fields: `1-(1-0.0078)^3 ≈ 2.3%` chance of losing at least one field. This matches the observed ~2-3% failure rate.

The identical heuristic existed in **all 7 index decode paths** (EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV). The exact byte that `key[73]` lands on is index-layout-dependent:
- EATV/AETV/TAEV: lands in value data (`hash[4]`)
- EAVT/AEVT/AVET/VAET: lands on `Tx↓[0]` (triggers when Lamport high byte is `0xFC` or `0xFB`)

## The Fix

Move Op to always be the last byte of every key. AfterRef (when present) sits immediately before Op.

**Before:** `[...components...][Op][AfterRef?]` — requires heuristic to detect AfterRef
**After:** `[...components...][AfterRef?][Op]` — deterministic: `op = key[len-1]`

```go
// New decoder — no heuristic
op = key[len(key)-1]
tailSize := opSize
if CRDTOp(op).HasAfterRef() {
    tailSize = afterRefSize + opSize
    afterRef = txFromDescending(key[len(key)-opSize-afterRefSize : len(key)-opSize])
}
```

### Binary compatibility

For non-RGA datoms (the vast majority of production data), the physical key layout is **identical** — Op was already the last byte before the fix. The format change only affects keys with AfterRef (RGA ops), where Op and AfterRef swap positions. No database migration needed for non-RGA data.

## Files Changed

| File | Change |
|------|--------|
| `key_encoder_binary.go` | EncodeKey: Op appended last after optional AfterRef. DecodeKey: reads `op = key[len-1]`, computes `tailSize` from `Op.HasAfterRef()`. Removes all 7 heuristic blocks. |
| `key_encoder_l85.go` | Same Op-last convention for consistency. 4 indices (EAVT, AEVT, AVET, VAET) had Op before Tx; fixed to match binary encoder. |
| `afterref_heuristic_bug_test.go` | 6 reproducer tests: unit (all 7 indices with crafted trigger inputs), key layout diagnostic, integration (full BadgerDB round-trip), statistical (10K random refs), non-ref values (unaffected types), full DB round-trip (500 entities × 3 ref fields). |
| `afterref_key_test.go` | Comment update: key format `[...][AfterRef?][Op]` |
| `op_field_test.go` | Comment update: "Op field is always the last byte of every key" |
| `BUG_SHARED_DB_DATOM_LOSS.md` | Full investigation chain: test matrix, hypothesis elimination, write path tracing, cache analysis, root cause with probability math, fix approach comparison (A/B/C). |
| `OP_POSITION_PROOF.md` | Formal proof: Theorem 1 (Op-before-Tx breaks first-entry-wins), Theorem 2 (Tx-before-Op enables O(1) resolution), Theorem 3 (Op doesn't affect sort order given unique Tx), Theorem 4 (Op-last yields unambiguous decoder), Theorem 5 (any length-based heuristic is unsound with variable-length V). |

## Test plan

- [x] All 6 AfterRef heuristic bug tests pass (were failing before fix)
- [x] All AfterRef key encoding tests pass (RGA key format)
- [x] All Op field tests pass
- [x] Full `go test ./datalog/storage/...` passes
- [x] Full `go test ./datalog/...` passes
- [x] Verify no regressions in downstream projects