### PR TITLE
Fix EA cache bypass when attribute comes from bindings

### DIFF
--- a/datalog/storage/count_repro_test.go
+++ b/datalog/storage/count_repro_test.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+)
+
+func TestCountRepro_WithVector(t *testing.T) {
+	db, cleanup := createEACacheTestDB(t, true) // cache_disabled
+	defer cleanup()
+
+	person1 := datalog.NewIdentity("person-1")
+	nameAttr := datalog.NewKeyword(":person/name")
+	contentAttr := datalog.NewKeyword(":doc/content")
+
+	tx := db.NewTransaction()
+	tx.Set(person1, nameAttr, "Alice")
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	tx2 := db.NewTransaction()
+	tx2.Set(person1, contentAttr, []interface{}{"a", "b", "c"})
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	var events []annotations.Event
+	db.SetAnnotationHandler(func(e annotations.Event) {
+		events = append(events, e)
+	})
+
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
+		[][]any{
+			{person1, nameAttr},
+			{person1, contentAttr},
+		})
+	require.NoError(t, err)
+
+	db.SetAnnotationHandler(nil)
+
+	t.Logf("Got %d results: %v", len(results), results)
+	for _, e := range events {
+		if e.Name == "pattern/hash-join-complete" || e.Name == "matches->relations" ||
+			e.Name == "storage/reuse-strategy" || e.Name == "storage/join-strategy" {
+			t.Logf("EVENT: %s %v", e.Name, e.Data)
+		}
+	}
+	require.Len(t, results, 2, "Should get 2 results")
+}

--- a/datalog/storage/crdt_cache_matrix_test.go
+++ b/datalog/storage/crdt_cache_matrix_test.go
@@ -1249,9 +1249,9 @@ func TestCacheMatrix_CardinalityVector(t *testing.T) {
 				docID, contentAttr)
 			require.NoError(t, err)
 
-			// Should return 4 results (current vector elements)
-			// NOT 9 results (all historical elements)
-			assert.Len(t, results, 4, "[%s] CardinalityVector should return current vector only", mode.name)
+			// Should return 1 result (the resolved vector as a single value)
+			// NOT 4 individual elements or 9 historical elements
+			assert.Len(t, results, 1, "[%s] CardinalityVector should return resolved vector as single value", mode.name)
 
 			t.Logf("[%s] Results: %v", mode.name, results)
 		})

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -281,8 +281,8 @@ func (it *CRDTResolvingIterator) emitRGAGroup() bool {
 	return false
 }
 
-// resolveRGAGroup reconstructs the RGA tree and returns ordered datoms.
-// Reconstructs datoms from stored state - no datom pointer storage needed.
+// resolveRGAGroup reconstructs the RGA tree and returns a single datom
+// with V = the resolved vector ([]any), matching the cache path behavior.
 func (it *CRDTResolvingIterator) resolveRGAGroup() []*datalog.Datom {
 	if len(it.rgaElements) == 0 {
 		return nil
@@ -319,8 +319,9 @@ func (it *CRDTResolvingIterator) resolveRGAGroup() []*datalog.Datom {
 		sortRGAByID(children[k])
 	}
 
-	// DFS from HEAD, reconstruct datoms
-	var result []*datalog.Datom
+	// DFS from HEAD, collect values into a single resolved list
+	var values []any
+	var maxTx datalog.ElementID
 	visited := make(map[datalog.ElementID]bool)
 	var walk func(id datalog.ElementID)
 	walk = func(id datalog.ElementID) {
@@ -331,22 +332,26 @@ func (it *CRDTResolvingIterator) resolveRGAGroup() []*datalog.Datom {
 
 		for _, child := range children[id] {
 			if child.tombstoneID == nil && child.value != nil {
-				// Reconstruct datom from stored state
-				result = append(result, &datalog.Datom{
-					E:        it.currentE,
-					A:        it.currentA,
-					V:        child.value,
-					Tx:       child.id,
-					Op:       datalog.OpRGAInsert,
-					AfterRef: child.afterRef,
-				})
+				values = append(values, child.value)
+				if maxTx.Less(child.id) {
+					maxTx = child.id
+				}
 			}
 			walk(child.id)
 		}
 	}
 	walk(HEAD)
 
-	return result
+	if len(values) == 0 {
+		return nil
+	}
+
+	return []*datalog.Datom{{
+		E:  it.currentE,
+		A:  it.currentA,
+		V:  values,
+		Tx: maxTx,
+	}}
 }
 
 func sortRGAByID(elems []*rgaElement) {

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -40,6 +40,12 @@ type CRDTResolvingIterator struct {
 	// For detecting end of source
 	sourceExhausted bool
 
+	// Pending datom from Vector group transition: when a Vector group ends
+	// and the boundary datom starts a new group, we must emit the vector
+	// buffer first. This field saves the boundary datom so it is processed
+	// on the next call to Next() instead of being lost.
+	pendingDatom *datalog.Datom
+
 	// Current datom being yielded
 	currentDatom *datalog.Datom
 }
@@ -76,52 +82,66 @@ func (it *CRDTResolvingIterator) Next() bool {
 	}
 
 	for {
-		if !it.source.Next() {
-			// Source exhausted - emit final group if CardinalityVector
-			it.sourceExhausted = true
-			if it.hasGroup && it.card == schema.CardinalityVector {
-				return it.emitRGAGroup()
-			}
-			return false
-		}
-
-		datom, err := it.source.Datom()
-		if err != nil {
-			continue
-		}
-
-		// Apply as-of filtering
-		if it.txID > 0 && datom.Tx.Lamport > it.txID {
-			continue
-		}
-
-		// Check if (E, A) changed
+		// Check for pending datom saved from a Vector group transition.
+		// startNewGroup was already called for this datom — skip group
+		// detection and go straight to cardinality processing.
+		var datom *datalog.Datom
 		isNewGroup := false
-		if !it.hasGroup {
+
+		if it.pendingDatom != nil {
+			datom = it.pendingDatom
+			it.pendingDatom = nil
 			isNewGroup = true
 		} else {
-			eHash := datom.E.Hash()
-			currentEHash := it.currentE.Hash()
-			if eHash != currentEHash || datom.A != it.currentA {
-				isNewGroup = true
-			}
-		}
-
-		if isNewGroup {
-			// Emit pending CardinalityVector results before starting new group
-			if it.hasGroup && it.card == schema.CardinalityVector {
-				// For Vector, we need to buffer this datom and emit the old group
-				// This is the ONE place we need a copy - at group boundary for Vector
-				it.emitBuffer = it.resolveRGAGroup()
-				it.emitIdx = 0
-				it.startNewGroup(datom)
-				if len(it.emitBuffer) > 0 {
-					it.currentDatom = it.emitBuffer[it.emitIdx]
-					it.emitIdx++
-					return true
+			if !it.source.Next() {
+				// Source exhausted - emit final group if CardinalityVector
+				it.sourceExhausted = true
+				if it.hasGroup && it.card == schema.CardinalityVector {
+					return it.emitRGAGroup()
 				}
-				// Empty RGA group, continue with new group
+				return false
+			}
+
+			var err error
+			datom, err = it.source.Datom()
+			if err != nil {
+				continue
+			}
+
+			// Apply as-of filtering
+			if it.txID > 0 && datom.Tx.Lamport > it.txID {
+				continue
+			}
+
+			// Check if (E, A) changed
+			if !it.hasGroup {
+				isNewGroup = true
 			} else {
+				eHash := datom.E.Hash()
+				currentEHash := it.currentE.Hash()
+				if eHash != currentEHash || datom.A != it.currentA {
+					isNewGroup = true
+				}
+			}
+
+			if isNewGroup {
+				// Emit pending CardinalityVector results before starting new group
+				if it.hasGroup && it.card == schema.CardinalityVector {
+					it.emitBuffer = it.resolveRGAGroup()
+					it.emitIdx = 0
+					it.startNewGroup(datom)
+					// Save boundary datom — it will be processed on the next
+					// call to Next() after the emit buffer is drained.
+					it.pendingDatom = datom
+					if len(it.emitBuffer) > 0 {
+						it.currentDatom = it.emitBuffer[it.emitIdx]
+						it.emitIdx++
+						return true
+					}
+					// Empty RGA group — pendingDatom will be picked up on
+					// next loop iteration.
+					continue
+				}
 				it.startNewGroup(datom)
 			}
 		}
@@ -385,6 +405,7 @@ func (it *CRDTResolvingIterator) Seek(key []byte) {
 	it.emitBuffer = nil
 	it.emitIdx = 0
 	it.sourceExhausted = false
+	it.pendingDatom = nil
 	it.currentDatom = nil
 	it.source.Seek(key)
 }

--- a/datalog/storage/ea_cache_bypass_test.go
+++ b/datalog/storage/ea_cache_bypass_test.go
@@ -1,0 +1,520 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// =============================================================================
+// EA Cache Bypass Tests
+// =============================================================================
+//
+// These tests verify that queries with A from input bindings produce correct
+// results with cache enabled AND disabled, and that the cache path is used
+// when available.
+//
+// See: docs/bugs/BUG_EA_CACHE_BYPASS_VARIABLE_ATTRIBUTE.md
+// =============================================================================
+
+// hasReuseStrategyEvent checks if any "storage/reuse-strategy" annotation was emitted.
+// Presence of this event means the cache was bypassed and join strategies were used.
+func hasReuseStrategyEvent(events []annotations.Event) bool {
+	for _, e := range events {
+		if e.Name == "storage/reuse-strategy" {
+			return true
+		}
+	}
+	return false
+}
+
+// createEACacheTestDB creates a database with schema for cache bypass testing.
+func createEACacheTestDB(t *testing.T, disableCache bool) (*Database, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:         dir,
+		DisableCache: disableCache,
+	})
+	require.NoError(t, err)
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/age"),
+		ValueType:   schema.TypeLong,
+		Cardinality: schema.CardinalityOne,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/tags"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityMany,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":doc/content"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityVector,
+	})
+	db.SetSchema(s)
+
+	return db, func() { db.Close() }
+}
+
+// =============================================================================
+// Test 1: Reproduction — prove the cache path is taken (cache-only test)
+// =============================================================================
+
+func TestEACacheBypass_Reproduction(t *testing.T) {
+	db, cleanup := createEACacheTestDB(t, false)
+	defer cleanup()
+
+	personID := datalog.NewIdentity("person-1")
+	nameAttr := datalog.NewKeyword(":person/name")
+
+	for _, name := range []string{"Alice", "Bob", "Charlie"} {
+		tx := db.NewTransaction()
+		tx.Set(personID, nameAttr, name)
+		_, err := tx.Commit()
+		require.NoError(t, err)
+	}
+
+	t.Run("A_constant_uses_cache", func(t *testing.T) {
+		var events []annotations.Event
+		db.SetAnnotationHandler(func(e annotations.Event) {
+			events = append(events, e)
+		})
+		defer db.SetAnnotationHandler(nil)
+
+		results, err := db.ExecuteQueryWithInputs(
+			`[:find ?v :in $ ?e :where [?e :person/name ?v]]`,
+			personID)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "Charlie", results[0][0])
+
+		assert.False(t, hasReuseStrategyEvent(events),
+			"A as constant should use cache path, but storage/reuse-strategy was emitted")
+	})
+
+	t.Run("A_scalar_input_uses_cache", func(t *testing.T) {
+		var events []annotations.Event
+		db.SetAnnotationHandler(func(e annotations.Event) {
+			events = append(events, e)
+		})
+		defer db.SetAnnotationHandler(nil)
+
+		results, err := db.ExecuteQueryWithInputs(
+			`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+			personID, nameAttr)
+		require.NoError(t, err)
+		require.Len(t, results, 1, "Should return 1 result (LWW winner)")
+		assert.Equal(t, "Charlie", results[0][0])
+
+		assert.False(t, hasReuseStrategyEvent(events),
+			"A from scalar input should use cache path, not storage scans")
+	})
+}
+
+// =============================================================================
+// Tests 2-4: Correctness per cardinality (cache enabled AND disabled)
+// =============================================================================
+
+func TestEACacheBypass_CardinalityOne(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			personID := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, nameAttr, name)
+				_, err := tx.Commit()
+				require.NoError(t, err)
+			}
+
+			// A as constant
+			constantResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e :where [?e :person/name ?v]]`,
+				personID)
+			require.NoError(t, err)
+
+			// A as scalar input
+			inputResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+				personID, nameAttr)
+			require.NoError(t, err)
+
+			require.Len(t, constantResults, 1, "[%s] A-as-constant: should return 1 result", mode.name)
+			require.Len(t, inputResults, 1, "[%s] A-as-input: should return 1 result", mode.name)
+			assert.Equal(t, constantResults[0][0], inputResults[0][0],
+				"[%s] Results should be identical", mode.name)
+			assert.Equal(t, "Charlie", inputResults[0][0])
+		})
+	}
+}
+
+func TestEACacheBypass_CardinalityMany(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			personID := datalog.NewIdentity("person-1")
+			tagsAttr := datalog.NewKeyword(":person/tags")
+
+			tx := db.NewTransaction()
+			tx.Add(personID, tagsAttr, "warrior")
+			tx.Add(personID, tagsAttr, "veteran")
+			_, err := tx.Commit()
+			require.NoError(t, err)
+
+			tx2 := db.NewTransaction()
+			tx2.Remove(personID, tagsAttr, "warrior")
+			_, err = tx2.Commit()
+			require.NoError(t, err)
+
+			// A as constant
+			constantResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e :where [?e :person/tags ?v]]`,
+				personID)
+			require.NoError(t, err)
+
+			// A as scalar input
+			inputResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+				personID, tagsAttr)
+			require.NoError(t, err)
+
+			require.Len(t, constantResults, 1, "[%s] A-as-constant: should return 1 result (add-wins)", mode.name)
+			require.Len(t, inputResults, 1, "[%s] A-as-input: should return 1 result (add-wins)", mode.name)
+			assert.Equal(t, "veteran", constantResults[0][0])
+			assert.Equal(t, "veteran", inputResults[0][0])
+		})
+	}
+}
+
+func TestEACacheBypass_CardinalityVector(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			docID := datalog.NewIdentity("doc-1")
+			contentAttr := datalog.NewKeyword(":doc/content")
+
+			tx := db.NewTransaction()
+			tx.Set(docID, contentAttr, []interface{}{"a", "b", "c"})
+			_, err := tx.Commit()
+			require.NoError(t, err)
+
+			// A as constant
+			constantResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e :where [?e :doc/content ?v]]`,
+				docID)
+			require.NoError(t, err)
+
+			// A as scalar input
+			inputResults, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+				docID, contentAttr)
+			require.NoError(t, err)
+
+			require.Len(t, constantResults, 1, "[%s] A-as-constant: should return 1 result (resolved vector)", mode.name)
+			require.Len(t, inputResults, 1, "[%s] A-as-input: should return 1 result (resolved vector)", mode.name)
+			assert.Equal(t, constantResults[0][0], inputResults[0][0],
+				"[%s] Vector results should be identical", mode.name)
+		})
+	}
+}
+
+// =============================================================================
+// Tests 5-7: Input binding patterns (cache enabled AND disabled)
+// =============================================================================
+
+func TestEACacheBypass_TupleInput(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			personID := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			for _, name := range []string{"Alice", "Bob", "Charlie"} {
+				tx := db.NewTransaction()
+				tx.Set(personID, nameAttr, name)
+				_, err := tx.Commit()
+				require.NoError(t, err)
+			}
+
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ [[?e ?a]] :where [?e ?a ?v]]`,
+				[]any{personID, nameAttr})
+			require.NoError(t, err)
+			require.Len(t, results, 1, "[%s] Tuple input should return 1 result", mode.name)
+			assert.Equal(t, "Charlie", results[0][0])
+		})
+	}
+}
+
+func TestEACacheBypass_RelationInput(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			person1 := datalog.NewIdentity("person-1")
+			person2 := datalog.NewIdentity("person-2")
+			nameAttr := datalog.NewKeyword(":person/name")
+			ageAttr := datalog.NewKeyword(":person/age")
+
+			tx := db.NewTransaction()
+			tx.Set(person1, nameAttr, "Alice")
+			tx.Set(person2, ageAttr, int64(30))
+			_, err := tx.Commit()
+			require.NoError(t, err)
+
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
+				[][]any{
+					{person1, nameAttr},
+					{person2, ageAttr},
+				})
+			require.NoError(t, err)
+			require.Len(t, results, 2, "[%s] Relation input should return 2 results", mode.name)
+		})
+	}
+}
+
+func TestEACacheBypass_CollectionEWithScalarA(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			entities := make([]datalog.Identity, 3)
+			for i := 0; i < 3; i++ {
+				entities[i] = datalog.NewIdentity(fmt.Sprintf("person-%d", i))
+				for _, name := range []string{"First", "Second", fmt.Sprintf("Final-%d", i)} {
+					tx := db.NewTransaction()
+					tx.Set(entities[i], nameAttr, name)
+					_, err := tx.Commit()
+					require.NoError(t, err)
+				}
+			}
+
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?v :in $ [?e ...] ?a :where [?e ?a ?v]]`,
+				[]datalog.Identity{entities[0], entities[1], entities[2]},
+				nameAttr)
+			require.NoError(t, err)
+			require.Len(t, results, 3, "[%s] Should return 3 results (one LWW winner per entity)", mode.name)
+		})
+	}
+}
+
+// =============================================================================
+// Tests 8-10: Edge cases (cache enabled AND disabled)
+// =============================================================================
+
+func TestEACacheBypass_NonexistentAttribute(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			personID := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+			ageAttr := datalog.NewKeyword(":person/age")
+
+			tx := db.NewTransaction()
+			tx.Set(personID, nameAttr, "Alice")
+			_, err := tx.Commit()
+			require.NoError(t, err)
+
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+				personID, ageAttr)
+			require.NoError(t, err)
+			assert.Len(t, results, 0, "[%s] Nonexistent attribute should return 0 results", mode.name)
+		})
+	}
+}
+
+func TestEACacheBypass_CacheInvalidation(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			personID := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			tx := db.NewTransaction()
+			tx.Set(personID, nameAttr, "Alice")
+			_, err := tx.Commit()
+			require.NoError(t, err)
+
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+				personID, nameAttr)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.Equal(t, "Alice", results[0][0])
+
+			tx2 := db.NewTransaction()
+			tx2.Set(personID, nameAttr, "Bob")
+			_, err = tx2.Commit()
+			require.NoError(t, err)
+
+			results, err = db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
+				personID, nameAttr)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.Equal(t, "Bob", results[0][0], "[%s] Should see new value after write", mode.name)
+		})
+	}
+}
+
+func TestEACacheBypass_MixedCardinalities_RelationInput(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			person1 := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+			tagsAttr := datalog.NewKeyword(":person/tags")
+
+			tx := db.NewTransaction()
+			tx.Set(person1, nameAttr, "Alice")
+			_, err := tx.Commit()
+			require.NoError(t, err)
+
+			tx2 := db.NewTransaction()
+			tx2.Add(person1, tagsAttr, "warrior")
+			tx2.Add(person1, tagsAttr, "veteran")
+			_, err = tx2.Commit()
+			require.NoError(t, err)
+
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
+				[][]any{
+					{person1, nameAttr},
+					{person1, tagsAttr},
+				})
+			require.NoError(t, err)
+			assert.Len(t, results, 3,
+				"[%s] Mixed cardinalities: 1 name + 2 tags = 3 results, got %d", mode.name, len(results))
+		})
+	}
+}
+
+// =============================================================================
+// Benchmark (cache enabled vs cache disabled)
+// =============================================================================
+
+func BenchmarkEACacheBypass(b *testing.B) {
+	for _, mode := range []struct {
+		name         string
+		disableCache bool
+	}{
+		{"cache_enabled", false},
+		{"cache_disabled", true},
+	} {
+		b.Run(mode.name, func(b *testing.B) {
+			dir := b.TempDir()
+			db, err := NewDatabaseWithOptions(DatabaseOptions{
+				Path:         dir,
+				DisableCache: mode.disableCache,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer db.Close()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			entities := make([]datalog.Identity, 100)
+			for i := 0; i < 100; i++ {
+				entities[i] = datalog.NewIdentity(fmt.Sprintf("person-%d", i))
+				for _, name := range []string{"First", "Second", fmt.Sprintf("Final-%d", i)} {
+					tx := db.NewTransaction()
+					tx.Set(entities[i], nameAttr, name)
+					if _, err := tx.Commit(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+
+			b.Run("A_as_constant", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					e := entities[i%100]
+					results, err := db.ExecuteQueryWithInputs(
+						`[:find ?v :in $ ?e :where [?e :person/name ?v]]`, e)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(results) != 1 {
+						b.Fatalf("expected 1 result, got %d", len(results))
+					}
+				}
+			})
+
+			b.Run("A_as_scalar_input", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					e := entities[i%100]
+					results, err := db.ExecuteQueryWithInputs(
+						`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`, e, nameAttr)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(results) != 1 {
+						b.Fatalf("expected 1 result, got %d", len(results))
+					}
+				}
+			})
+
+			b.Run("A_as_tuple_input", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					e := entities[i%100]
+					results, err := db.ExecuteQueryWithInputs(
+						`[:find ?v :in $ [[?e ?a]] :where [?e ?a ?v]]`,
+						[]any{e, nameAttr})
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(results) != 1 {
+						b.Fatalf("expected 1 result, got %d", len(results))
+					}
+				}
+			})
+		})
+	}
+}

--- a/datalog/storage/ea_cache_bypass_test.go
+++ b/datalog/storage/ea_cache_bypass_test.go
@@ -426,6 +426,205 @@ func TestEACacheBypass_MixedCardinalities_RelationInput(t *testing.T) {
 }
 
 // =============================================================================
+// Phase 2 Tests: Per-row A from relation/join bindings
+// =============================================================================
+
+// TestEACacheBypass_PerRowA_UsesCache tests that the cache is used when both E and A
+// are columns in the binding relation with multiple rows (per-row A from join results).
+// This is the Phase 2 optimization target.
+//
+// Setup: Each entity has a :config/attr that names its own value attribute.
+// Pattern 1 resolves the attribute name. Pattern 2 looks up the value.
+// After pattern 1, the binding for pattern 2 has multiple rows with varying (E, A).
+func TestEACacheBypass_PerRowA_UsesCache(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":config/attr"),
+		ValueType:   schema.TypeKeyword,
+		Cardinality: schema.CardinalityOne,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/age"),
+		ValueType:   schema.TypeLong,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	configAttr := datalog.NewKeyword(":config/attr")
+	nameAttr := datalog.NewKeyword(":person/name")
+	ageAttr := datalog.NewKeyword(":person/age")
+
+	entity1 := datalog.NewIdentity("entity-1")
+	entity2 := datalog.NewIdentity("entity-2")
+
+	tx := db.NewTransaction()
+	// entity-1: config/attr = :person/name, person/name = "Alice"
+	tx.Set(entity1, configAttr, nameAttr)
+	tx.Set(entity1, nameAttr, "Alice")
+	// entity-2: config/attr = :person/age, person/age = 30
+	tx.Set(entity2, configAttr, ageAttr)
+	tx.Set(entity2, ageAttr, int64(30))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	var events []annotations.Event
+	db.SetAnnotationHandler(func(e annotations.Event) {
+		events = append(events, e)
+	})
+	defer db.SetAnnotationHandler(nil)
+
+	// Query: for each entity in the collection, look up its config/attr to get ?a,
+	// then look up [?e ?a ?v]. After pattern 1, binding has 2 rows with varying A.
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?a ?v :in $ [?e ...] :where
+		  [?e :config/attr ?a]
+		  [?e ?a ?v]]`,
+		[]interface{}{entity1, entity2})
+	require.NoError(t, err)
+	require.Len(t, results, 2, "Should get 2 results (one per entity)")
+
+	// Check that storage/reuse-strategy is NOT used for pattern 2
+	// Before Phase 2 fix: FAILS — reuse-strategy IS present (cache bypassed)
+	// After Phase 2 fix: passes — per-row A uses cache
+	assert.False(t, hasReuseStrategyEvent(events),
+		"Per-row A from join should use cache path, not storage/reuse-strategy scans")
+}
+
+func TestEACacheBypass_PerRowVector_RelationInput(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			person1 := datalog.NewIdentity("person-1")
+			nameAttr := datalog.NewKeyword(":person/name")
+			contentAttr := datalog.NewKeyword(":doc/content")
+
+			tx := db.NewTransaction()
+			tx.Set(person1, nameAttr, "Alice")
+			_, err := tx.Commit()
+			require.NoError(t, err)
+
+			tx2 := db.NewTransaction()
+			tx2.Set(person1, contentAttr, []interface{}{"a", "b", "c"})
+			_, err = tx2.Commit()
+			require.NoError(t, err)
+
+			var events []annotations.Event
+			db.SetAnnotationHandler(func(e annotations.Event) {
+				events = append(events, e)
+			})
+
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
+				[][]any{
+					{person1, nameAttr},
+					{person1, contentAttr},
+				})
+			require.NoError(t, err)
+
+			db.SetAnnotationHandler(nil)
+
+			if len(results) != 2 {
+				t.Logf("[%s] Got %d results: %v", mode.name, len(results), results)
+				for _, e := range events {
+					t.Logf("[%s] EVENT: %s %v", mode.name, e.Name, e.Data)
+				}
+			}
+			assert.Len(t, results, 2,
+				"[%s] Per-row vector: 1 name + 1 resolved vector = 2 results, got %d", mode.name, len(results))
+		})
+	}
+}
+
+func TestEACacheBypass_CacheMissFallback(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			db, cleanup := createEACacheTestDB(t, mode.disableCache)
+			defer cleanup()
+
+			person1 := datalog.NewIdentity("person-1")
+			person2 := datalog.NewIdentity("person-nonexistent")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			tx := db.NewTransaction()
+			tx.Set(person1, nameAttr, "Alice")
+			_, err := tx.Commit()
+			require.NoError(t, err)
+
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
+				[][]any{
+					{person1, nameAttr},
+					{person2, nameAttr},
+				})
+			require.NoError(t, err)
+			assert.Len(t, results, 1,
+				"[%s] Should return 1 result (Alice only, nonexistent entity skipped)", mode.name)
+		})
+	}
+}
+
+func TestEACacheBypass_JoinBoundA(t *testing.T) {
+	for _, mode := range cacheTestModes {
+		t.Run(mode.name, func(t *testing.T) {
+			dir := t.TempDir()
+			db, err := NewDatabaseWithOptions(DatabaseOptions{
+				Path:         dir,
+				DisableCache: mode.disableCache,
+			})
+			require.NoError(t, err)
+			defer db.Close()
+
+			s := schema.NewSchema()
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":meta/target-attr"),
+				ValueType:   schema.TypeKeyword,
+				Cardinality: schema.CardinalityOne,
+			})
+			s.Add(&schema.AttributeDefinition{
+				Ident:       datalog.NewKeyword(":person/name"),
+				ValueType:   schema.TypeString,
+				Cardinality: schema.CardinalityOne,
+			})
+			db.SetSchema(s)
+
+			metaID := datalog.NewIdentity("meta-1")
+			personID := datalog.NewIdentity("person-1")
+			targetAttr := datalog.NewKeyword(":meta/target-attr")
+			nameAttr := datalog.NewKeyword(":person/name")
+
+			tx := db.NewTransaction()
+			tx.Set(metaID, targetAttr, nameAttr)
+			tx.Set(personID, nameAttr, "Alice")
+			_, err = tx.Commit()
+			require.NoError(t, err)
+
+			results, err := db.ExecuteQueryWithInputs(
+				`[:find ?v :in $ ?meta :where
+				  [?meta :meta/target-attr ?a]
+				  [?person ?a ?v]]`,
+				metaID)
+			require.NoError(t, err)
+			require.Len(t, results, 1,
+				"[%s] Join-bound A should return 1 result", mode.name)
+			assert.Equal(t, "Alice", results[0][0],
+				"[%s] Join-bound A should find person's name", mode.name)
+		})
+	}
+}
+
+// =============================================================================
 // Benchmark (cache enabled vs cache disabled)
 // =============================================================================
 
@@ -512,6 +711,26 @@ func BenchmarkEACacheBypass(b *testing.B) {
 					}
 					if len(results) != 1 {
 						b.Fatalf("expected 1 result, got %d", len(results))
+					}
+				}
+			})
+
+			b.Run("A_as_relation_input", func(b *testing.B) {
+				b.ReportAllocs()
+				relInput := make([][]any, 100)
+				for i := 0; i < 100; i++ {
+					relInput[i] = []any{entities[i], nameAttr}
+				}
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					results, err := db.ExecuteQueryWithInputs(
+						`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
+						relInput)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(results) != 100 {
+						b.Fatalf("expected 100 results, got %d", len(results))
 					}
 				}
 			})

--- a/datalog/storage/eatv_vector_transition_test.go
+++ b/datalog/storage/eatv_vector_transition_test.go
@@ -1,0 +1,76 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+)
+
+// TestEATV_VectorTransitionDropsDatom reproduces the CRDT vector group
+// transition bug. When scanning EATV for an entity that has both a Vector
+// attribute and a non-Vector attribute, the CRDTResolvingIterator drops the
+// first datom of the non-Vector group at the cardinality boundary.
+//
+// Forces EATV via collection input [?e ...] with A as a free variable.
+// Single bound position (E) + A not constant → EATV (matcher_strategy.go:118-122).
+// Each entity's EATV scan crosses from :doc/content (Vector) to :person/name (One),
+// triggering the vector group transition.
+func TestEATV_VectorTransitionDropsDatom(t *testing.T) {
+	db, cleanup := createEACacheTestDB(t, true) // cache disabled
+	defer cleanup()
+
+	nameAttr := datalog.NewKeyword(":person/name")
+	contentAttr := datalog.NewKeyword(":doc/content")
+
+	entities := make([]datalog.Identity, 3)
+	for i := range entities {
+		entities[i] = datalog.NewIdentity(fmt.Sprintf("person-%d", i))
+
+		tx := db.NewTransaction()
+		tx.Set(entities[i], nameAttr, fmt.Sprintf("Name-%d", i))
+		_, err := tx.Commit()
+		require.NoError(t, err)
+
+		tx2 := db.NewTransaction()
+		tx2.Set(entities[i], contentAttr, []any{"x", "y"})
+		_, err = tx2.Commit()
+		require.NoError(t, err)
+	}
+
+	var events []annotations.Event
+	db.SetAnnotationHandler(func(e annotations.Event) {
+		events = append(events, e)
+	})
+
+	// Collection input [?e ...] — only E is bound, A is free → forces EATV
+	entitySlice := []any{entities[0], entities[1], entities[2]}
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?a ?v :in $ [?e ...] :where [?e ?a ?v]]`,
+		entitySlice)
+	require.NoError(t, err)
+
+	db.SetAnnotationHandler(nil)
+
+	// Verify EATV was selected
+	usedEATV := false
+	for _, e := range events {
+		if e.Name == "storage/reuse-strategy" {
+			t.Logf("EVENT: %s %v", e.Name, e.Data)
+			if idx, ok := e.Data["index"]; ok && fmt.Sprint(idx) == "EATV" {
+				usedEATV = true
+			}
+		}
+	}
+	require.True(t, usedEATV, "Strategy should select EATV for E-only binding with free A")
+
+	t.Logf("Got %d results:", len(results))
+	for _, r := range results {
+		t.Logf("  %v", r)
+	}
+
+	// Each entity has :person/name + :doc/content = 2 results each
+	require.Len(t, results, 6, "3 entities × 2 attributes = 6 results")
+}

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -289,7 +289,7 @@ func (m *BadgerMatcher) chooseIndexForValues(index IndexType, e, a, v, tx interf
 	encoder := m.store.encoder
 
 	switch index {
-	case EAVT: // 0
+	case EAVT, EATV: // E-primary indices: E first, then A
 		if e != nil {
 			if entity, ok := e.(datalog.Identity); ok {
 				hash := entity.Hash()

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -81,12 +81,20 @@ func (m *BadgerMatcher) MatchWithConstraints(
 
 	// Check for vector cardinality - requires special handling with bound E from bindings
 	// This intercepts BEFORE normal join paths since vectors need RGA resolution
-	if a := m.extractValue(pattern.GetA()); a != nil {
+	var aResolved interface{}
+	aResolved = m.extractValue(pattern.GetA())
+	if aResolved == nil {
+		if aVar, ok := pattern.GetA().(query.Variable); ok {
+			if kw, found := resolveKeywordFromBindings(aVar, bindings); found {
+				aResolved = kw
+			}
+		}
+	}
+	if aResolved != nil {
 		if m.schema != nil {
-			if kw, ok := a.(datalog.Keyword); ok {
+			if kw, ok := aResolved.(datalog.Keyword); ok {
 				if attr := m.schema.GetAttribute(kw); attr != nil {
 					if attr.Cardinality == schema.CardinalityVector {
-						// E is bound from bindings, A is a constant - use vector resolution
 						return m.matchVectorWithBindings(pattern, bindingRel, columns, kw)
 					}
 				}
@@ -94,15 +102,13 @@ func (m *BadgerMatcher) MatchWithConstraints(
 		}
 	}
 
-	// CACHE OPTIMIZATION: When A is a constant and E comes from bindings,
+	// CACHE OPTIMIZATION: When A is known (from pattern constant or bindings),
 	// use the cache for each E value instead of storage scans.
-	if m.cache != nil && m.txID == 0 {
-		if a := m.extractValue(pattern.GetA()); a != nil {
-			if aKw, ok := a.(datalog.Keyword); ok {
-				cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw)
-				if handled {
-					return cacheResult, nil
-				}
+	if m.cache != nil && m.txID == 0 && aResolved != nil {
+		if aKw, ok := aResolved.(datalog.Keyword); ok {
+			cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw)
+			if handled {
+				return cacheResult, nil
 			}
 		}
 	}
@@ -1083,7 +1089,41 @@ func (m *BadgerMatcher) matchFromCache(
 	return nil, false // Unknown cardinality, fallback to storage
 }
 
-// matchWithBindingsFromCache handles patterns where E comes from bindings and A is constant.
+// findVariableColumn returns the column index for a variable in a relation, or -1.
+func findVariableColumn(sym query.Symbol, rel executor.Relation) int {
+	for i, col := range rel.Columns() {
+		if col == sym {
+			return i
+		}
+	}
+	return -1
+}
+
+// resolveKeywordFromBindings searches all binding relations for a single-row relation
+// containing the given variable and returns its value as a Keyword. This covers scalar
+// inputs and single-row tuple inputs where A has exactly one known value.
+func resolveKeywordFromBindings(aVar query.Variable, bindings executor.Relations) (datalog.Keyword, bool) {
+	for _, rel := range bindings {
+		idx := findVariableColumn(aVar.Name, rel)
+		if idx < 0 {
+			continue
+		}
+		if rel.Size() != 1 {
+			return nil, false // multi-row — can't extract single value
+		}
+		iter := rel.Iterator()
+		defer iter.Close()
+		if iter.Next() {
+			if kw, ok := iter.Tuple()[idx].(datalog.Keyword); ok {
+				return kw, true
+			}
+		}
+		return nil, false
+	}
+	return nil, false
+}
+
+// matchWithBindingsFromCache handles patterns where E comes from bindings and A is known.
 // Uses cache for O(1) lookup per bound E value instead of storage scans.
 // Returns (relation, true) if cache was used, (nil, false) if fallback to storage is needed.
 func (m *BadgerMatcher) matchWithBindingsFromCache(

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -104,11 +104,28 @@ func (m *BadgerMatcher) MatchWithConstraints(
 
 	// CACHE OPTIMIZATION: When A is known (from pattern constant or bindings),
 	// use the cache for each E value instead of storage scans.
-	if m.cache != nil && m.txID == 0 && aResolved != nil {
-		if aKw, ok := aResolved.(datalog.Keyword); ok {
-			cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw)
-			if handled {
-				return cacheResult, nil
+	if m.cache != nil && m.txID == 0 {
+		if aResolved != nil {
+			// Phase 1: A has a single known value (from constant or single-row binding)
+			if aKw, ok := aResolved.(datalog.Keyword); ok {
+				cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw, -1)
+				if handled {
+					return cacheResult, nil
+				}
+			}
+		} else if aVar, ok := pattern.GetA().(query.Variable); ok {
+			// Phase 2: A varies per row in bindingRel (e.g., from join results)
+			aIdx := findVariableColumn(aVar.Name, bindingRel)
+			eVar, eIsVar := pattern.GetE().(query.Variable)
+			if aIdx >= 0 && eIsVar {
+				eIdx := findVariableColumn(eVar.Name, bindingRel)
+				if eIdx >= 0 {
+					cacheResult, handled := m.matchWithBindingsFromCache(
+						pattern, bindingRel, columns, nil, aIdx)
+					if handled {
+						return cacheResult, nil
+					}
+				}
 			}
 		}
 	}
@@ -1126,11 +1143,16 @@ func resolveKeywordFromBindings(aVar query.Variable, bindings executor.Relations
 // matchWithBindingsFromCache handles patterns where E comes from bindings and A is known.
 // Uses cache for O(1) lookup per bound E value instead of storage scans.
 // Returns (relation, true) if cache was used, (nil, false) if fallback to storage is needed.
+//
+// When aColIdx >= 0, A is extracted per-row from bindingRel[aColIdx] instead of using
+// the fixed `a` parameter. This handles the case where both E and A are columns in the
+// binding relation (e.g., from join results with varying attributes per row).
 func (m *BadgerMatcher) matchWithBindingsFromCache(
 	pattern *query.DataPattern,
 	bindingRel executor.Relation,
 	columns []query.Symbol,
 	a datalog.Keyword,
+	aColIdx int,
 ) (executor.Relation, bool) {
 	// Find which column in the binding relation has E
 	eVar, isVar := pattern.GetE().(query.Variable)
@@ -1150,12 +1172,18 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 		return nil, false // E variable not in bindings
 	}
 
-	// Determine cardinality
-	card := schema.CardinalityOne
-	if m.schema != nil {
-		if def := m.schema.GetAttribute(a); def != nil {
-			card = def.Cardinality
+	// Pre-compute fixed-A values when A is constant across all rows
+	var fixedCard schema.Cardinality
+	var fixedAAttr Attribute
+	if aColIdx < 0 {
+		fixedCard = schema.CardinalityOne
+		if m.schema != nil {
+			if def := m.schema.GetAttribute(a); def != nil {
+				fixedCard = def.Cardinality
+			}
 		}
+		aStorage := ToStorageDatom(datalog.Datom{A: a}).A
+		copy(fixedAAttr[:], aStorage[:])
 	}
 
 	// Extract V if bound
@@ -1164,17 +1192,14 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 		v = m.extractValue(elem)
 	}
 
-	// Get storage format for attribute
-	aStorage := ToStorageDatom(datalog.Datom{A: a}).A
-	var aAttr Attribute
-	copy(aAttr[:], aStorage[:])
-
 	// Get tuple builder
 	tupleBuilder := m.getTupleBuilder(pattern, columns)
 
-	// Pre-allocate datom buffer with constant A
+	// Pre-allocate datom buffer
 	var datomBuf datalog.Datom
-	datomBuf.A = a
+	if aColIdx < 0 {
+		datomBuf.A = a // constant A across all rows
+	}
 
 	buildTuple := func(e datalog.Identity, val interface{}, tx datalog.ElementID) executor.Tuple {
 		datomBuf.E = e
@@ -1206,9 +1231,35 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 			}
 		}
 
+		// Determine A and cardinality for this row
+		var rowCard schema.Cardinality
+		var rowAAttr Attribute
+		if aColIdx >= 0 {
+			// Per-row A: extract from binding tuple
+			if aColIdx >= len(tuple) {
+				continue
+			}
+			aKw, ok := tuple[aColIdx].(datalog.Keyword)
+			if !ok {
+				continue
+			}
+			rowCard = schema.CardinalityOne
+			if m.schema != nil {
+				if def := m.schema.GetAttribute(aKw); def != nil {
+					rowCard = def.Cardinality
+				}
+			}
+			aStorage := ToStorageDatom(datalog.Datom{A: aKw}).A
+			copy(rowAAttr[:], aStorage[:])
+			datomBuf.A = aKw
+		} else {
+			rowCard = fixedCard
+			rowAAttr = fixedAAttr
+		}
+
 		// Build cache key
 		eBytes := Entity(eIdent.Hash())
-		key := CacheKey{E: eBytes, A: aAttr}
+		key := CacheKey{E: eBytes, A: rowAAttr}
 
 		// Get from cache
 		entry := m.cache.GetOrResolve(key, m)
@@ -1218,7 +1269,7 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 		}
 
 		// Process based on cardinality
-		switch card {
+		switch rowCard {
 		case schema.CardinalityOne:
 			val := entry.OneValue()
 			if val == nil {

--- a/datalog/storage/matcher_strategy.go
+++ b/datalog/storage/matcher_strategy.go
@@ -211,13 +211,18 @@ func chooseBestMultiPositionStrategy(
 		bindingRel = streamRel.Materialize()
 	}
 
-	// Count distinct values for each bound position
-	positionCardinalities := make(map[int]int)
-	positionIndices := make(map[int]int) // column index in binding relation
+	// Track column index and distinct count per bound position.
+	// Uses a slice parallel to boundPositions for deterministic iteration
+	// (maps cause nondeterministic tiebreaking via random iteration order).
+	type posInfo struct {
+		pos      int // datom position (0=E, 1=A, 2=V, 3=T)
+		colIdx   int // column index in binding relation (-1 if not found)
+		distinct int // count of distinct values
+	}
+	info := make([]posInfo, 0, len(boundPositions))
 
 	// Build position-to-column-index mapping
-	for i, pos := range boundPositions {
-		_ = i // unused
+	for _, pos := range boundPositions {
 		var varName query.Symbol
 		switch pos {
 		case 0: // E
@@ -244,48 +249,56 @@ func chooseBestMultiPositionStrategy(
 			continue
 		}
 
-		// Find column index in binding relation
-		for colIdx, col := range bindingRel.Columns() {
+		colIdx := -1
+		for ci, col := range bindingRel.Columns() {
 			if col == varName {
-				positionIndices[pos] = colIdx
+				colIdx = ci
 				break
 			}
 		}
+		info = append(info, posInfo{pos: pos, colIdx: colIdx})
 	}
 
 	// Count distinct values for each position
-	distinctValues := make(map[int]map[interface{}]bool)
-	for pos := range positionIndices {
-		distinctValues[pos] = make(map[interface{}]bool)
+	sets := make([]map[interface{}]bool, len(info))
+	for i := range sets {
+		sets[i] = make(map[interface{}]bool)
 	}
 
-	// Iterate through binding relation to count distinct values
 	it := bindingRel.Iterator()
 	for it.Next() {
 		tuple := it.Tuple()
-		for pos, colIdx := range positionIndices {
-			if colIdx < len(tuple) {
-				distinctValues[pos][tuple[colIdx]] = true
+		for i, pi := range info {
+			if pi.colIdx >= 0 && pi.colIdx < len(tuple) {
+				sets[i][tuple[pi.colIdx]] = true
 			}
 		}
 	}
 	it.Close()
 
-	// Record cardinalities
-	for pos := range positionIndices {
-		positionCardinalities[pos] = len(distinctValues[pos])
+	for i := range info {
+		info[i].distinct = len(sets[i])
 	}
 
-	// Find the position with the MOST distinct values
-	// This is the position we want to use for iterator reuse (seeking)
-	// The position with fewer distinct values becomes the grouping/hash dimension
-	bestPosition := -1
+	// Find the position with the MOST distinct values.
+	// On ties, prefer A (position 1) over E (position 0) because A-primary
+	// indices (AETV) produce scans with uniform cardinality per scan — each
+	// attribute has exactly one CRDT resolution strategy. E-primary indices
+	// (EATV) mix cardinalities within a scan (one entity may have One, Many,
+	// and Vector attributes), forcing the CRDTResolvingIterator through
+	// cross-cardinality group transitions.
+	bestIdx := -1
 	maxCardinality := 0
-	for pos, card := range positionCardinalities {
-		if card > maxCardinality {
-			maxCardinality = card
-			bestPosition = pos
+	for i, pi := range info {
+		if pi.distinct > maxCardinality || (pi.distinct == maxCardinality && bestIdx >= 0 && pi.pos > info[bestIdx].pos) {
+			maxCardinality = pi.distinct
+			bestIdx = i
 		}
+	}
+
+	bestPosition := -1
+	if bestIdx >= 0 {
+		bestPosition = info[bestIdx].pos
 	}
 
 	if bestPosition == -1 {

--- a/docs/bugs/BUG_EATV_SCAN_RANGE_AND_CRDT_VECTOR_TRANSITION.md
+++ b/docs/bugs/BUG_EATV_SCAN_RANGE_AND_CRDT_VECTOR_TRANSITION.md
@@ -1,0 +1,176 @@
+# BUG: EATV Scan Range Missing + CRDT Vector Group Transition Drops Datom
+
+**Status**: Fixed
+**Severity**: Data loss (missing query results)
+**Discovered**: 2026-02-19, during EA cache bypass Phase 2 testing
+**Reproduction**: `TestCountRepro_WithVector` with `-count=2` (or any run where EATV is selected)
+
+## Symptom
+
+`TestEACacheBypass_PerRowVector_RelationInput/cache_disabled` intermittently returns 1 result instead of 2. The `:person/name "Alice"` result disappears; only the `:doc/content` vector result survives.
+
+The failure is **nondeterministic** — depends on which index `chooseBestMultiPositionStrategy` selects, which in turn depends on Go's randomized map iteration order.
+
+## Reproduction
+
+```go
+// Setup: schema with :person/name (CardinalityOne) and :doc/content (CardinalityVector)
+// Data: person-1 has :person/name = "Alice" and :doc/content = ["a", "b", "c"]
+//
+// Query:
+//   [:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]
+// Input relation:
+//   [(person-1, :person/name), (person-1, :doc/content)]
+//
+// Expected: 2 results
+// Actual (when EATV selected): 1 result (vector only, name missing)
+```
+
+Minimal repro: `datalog/storage/count_repro_test.go` — fails reliably even with `-count=1`.
+
+## Root Cause Analysis
+
+There are **two bugs** that combine to produce the failure.
+
+### Bug 1: EATV missing from `chooseIndexForValues`
+
+**File**: `datalog/storage/hash_join_matcher.go`, line 291
+
+The `chooseIndexForValues` function computes scan ranges for each index type. The switch statement handles EAVT, AEVT, AETV, AVET, VAET, and TAEV — but **not EATV** (iota value 1).
+
+```go
+switch index {
+case EAVT: // iota 0 ✓
+    ...
+// EATV (iota 1) — MISSING!
+case AEVT: // iota 2 ✓
+    ...
+case AETV: // iota 3 ✓
+    ...
+case AVET: // iota 4 ✓
+    ...
+case VAET: // iota 5 ✓
+    ...
+case TAEV: // iota 6 ✓
+    ...
+}
+```
+
+When EATV is selected, no case matches. `startParts` stays nil. `EncodePrefix(EATV)` returns just the 1-byte index prefix. The scan covers the **entire EATV index** instead of narrowing to the entity's prefix.
+
+**Impact**: Instead of scanning ~4 datoms for person-1, the hash join scans every datom in the database. In this test there's only one entity so the data is still present, but the scan range is wrong. This is a correctness issue that would also cause severe performance problems in larger databases.
+
+**Fix**: Add `case EATV:` to the switch. EATV has the same prefix structure as EAVT (E first, then A), so the logic is identical:
+
+```go
+case EATV:
+    // EATV: E-A-Tx↓-V — same prefix as EAVT (E first, then A)
+    if e != nil {
+        if entity, ok := e.(datalog.Identity); ok {
+            hash := entity.Hash()
+            startParts = append(startParts, hash[:])
+            endParts = append(endParts, hash[:])
+            if a != nil {
+                if kw, ok := a.(datalog.Keyword); ok {
+                    var attr Attribute
+                    copy(attr[:], kw.String())
+                    startParts = append(startParts, attr[:])
+                    endParts = append(endParts, attr[:])
+                }
+            }
+        }
+    }
+```
+
+### Bug 2: CRDT Vector-to-NonVector group transition drops first datom
+
+**File**: `datalog/storage/crdt_resolving_iterator.go`, lines 110-127
+
+When the `CRDTResolvingIterator` transitions from a CardinalityVector group to any other group (One, Many, or another Vector), the **first datom of the new group is consumed but never emitted**.
+
+The sequence:
+
+1. Iterator accumulates RGA elements for a Vector group (e.g., `:doc/content`)
+2. `source.Next()` returns the first datom of the NEXT group (e.g., `:person/name`)
+3. Group boundary detected → `resolveRGAGroup()` builds the vector result
+4. `startNewGroup(datom)` records the new group's E, A, cardinality
+5. Vector result is returned to caller via `emitBuffer`
+6. **On the next call to `Next()`**: `emitBuffer` is exhausted, so `source.Next()` is called — which advances **past** the already-consumed `:person/name` datom
+7. The `:person/name` datom is lost
+
+```
+Timeline:
+  source:    [v1] [v2] [v3] [name]  [EOF]
+                                ↑
+                         consumed here (step 2)
+                         used for startNewGroup (step 4)
+                         but never emitted!
+                                      ↑
+                              source.Next() lands here (step 6)
+```
+
+This bug only manifests when:
+- A Vector-cardinality group is followed by a non-Vector group in the same (E, *) scan
+- The index ordering places Vector attributes before non-Vector attributes
+
+In this test, EATV sorts by E then A. Alphabetically `:doc/content` < `:person/name`, so the vector group comes first, triggering the bug.
+
+**Why AETV doesn't hit this**: With AETV (A-primary), each per-row call scans only one attribute's datoms. There's no group transition within a single scan, so the bug never triggers.
+
+**Fix**: Save the boundary datom as a pending datom and process it before the next `source.Next()` call:
+
+```go
+type CRDTResolvingIterator struct {
+    // ... existing fields ...
+    pendingDatom *datalog.Datom // boundary datom from Vector group transition
+}
+```
+
+When emitting a Vector group at a boundary, save the boundary datom. On the next call to `Next()`, check for `pendingDatom` before calling `source.Next()` and process it through the cardinality switch.
+
+### Bug 3: Nondeterministic tiebreaker uses map iteration
+
+**File**: `datalog/storage/matcher_strategy.go`, `chooseBestMultiPositionStrategy`
+
+`chooseBestMultiPositionStrategy` iterated `positionCardinalities` (a `map[int]int`) to find the position with the most distinct values. When both E and A have equal cardinality (1 distinct value each from a single-row binding), Go's randomized map iteration determined which position "won":
+
+- Position 0 (E) wins → EATV → triggers bugs 1+2 → **FAIL**
+- Position 1 (A) wins → AETV → neither bug triggered → **PASS**
+
+**Fix (applied)**: Replaced all three maps with a deterministic slice parallel to `boundPositions`. On ties, prefer A-primary (position 1) over E-primary (position 0) because A-primary indices produce scans with **uniform cardinality** — cardinality is defined per-attribute, so every datom in an AETV scan uses the same CRDT resolution strategy (all LWW, all add-wins, or all RGA). E-primary indices (EATV) mix cardinalities within a single scan: one entity can have CardinalityOne, CardinalityMany, and CardinalityVector attributes interleaved, forcing the CRDTResolvingIterator through cross-cardinality group transitions — exactly where Bug 2 lives.
+
+## Annotation evidence
+
+With EATV selected (failing case):
+```
+storage/reuse-strategy  index:EATV position:0
+storage/join-strategy   index:EATV join_strategy:hash-join-scan
+matches->relations      binding.size:1 match.count:-1          # vector intercept (streaming)
+pattern/hash-join-complete  datoms.scanned:3 matches.found:0   # name row: 3 scanned, 0 matched
+matches->relations      binding.size:1 match.count:1           # vector result materialized
+```
+
+With AETV selected (passing case):
+```
+storage/reuse-strategy  index:AETV position:1
+storage/join-strategy   index:AETV join_strategy:hash-join-scan
+matches->relations      binding.size:1 match.count:-1          # streaming result
+matches->relations      binding.size:1 match.count:1           # materialized result
+pattern/hash-join-complete  datoms.scanned:1 matches.found:1   # 1 scanned, 1 matched
+```
+
+## Files involved
+
+| File | Issue |
+|------|-------|
+| `datalog/storage/hash_join_matcher.go:291` | Missing `case EATV` in `chooseIndexForValues` switch |
+| `datalog/storage/crdt_resolving_iterator.go:110-127` | Vector group transition loses boundary datom |
+| `datalog/storage/matcher_strategy.go:282-289` | Nondeterministic tiebreaker in `chooseBestMultiPositionStrategy` |
+
+## Interaction between the bugs
+
+Bug 1 alone (wrong scan range) would cause performance degradation but not data loss in this test — the hash join would still find all of person-1's datoms, just by scanning too broadly.
+
+Bug 2 alone (lost datom) would only manifest when a Vector group precedes a non-Vector group in the scan order, which requires a multi-attribute entity scan (E-primary index like EATV).
+
+Together: Bug 1's wide scan isn't the direct cause of the missing result. The missing result comes from Bug 2. But Bug 1 is independently wrong and must be fixed. The nondeterministic tiebreaker (choosing EATV vs AETV randomly) is what makes Bug 2 intermittent.

--- a/docs/bugs/BUG_EA_CACHE_BYPASS_VARIABLE_ATTRIBUTE.md
+++ b/docs/bugs/BUG_EA_CACHE_BYPASS_VARIABLE_ATTRIBUTE.md
@@ -1,0 +1,256 @@
+# EA Cache Bypass When Attribute Is a Variable Bound from Input
+
+**Date**: 2026-02-19
+**Severity**: Performance (Critical in write-heavy workloads)
+**Status**: Open
+**Affected**: All queries where A comes from bindings rather than being a pattern constant
+
+## Summary
+
+The EA cache is bypassed when the attribute position in a data pattern is a Variable — even when that variable's value is known from input bindings. The cache check in `MatchWithConstraints` requires A to be a Constant in the pattern itself; it does not consider values provided through binding relations. This forces every such query through a full BadgerDB storage scan with a new transaction and iterator per call.
+
+The most common query affected is the `HasAttribute` / `EntityExists` pattern:
+
+```clojure
+[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]
+```
+
+Here `?attr` is a Variable. `extractValue(pattern.GetA())` returns nil for Variables. The cache check fails. Every call creates a new BadgerDB read transaction, seeks an index, and closes the transaction.
+
+## Discovery
+
+Identified via performance profiling of a downstream application during a heavy import workload. Out of 527 existence checks, 491 (93%) took 1ms–890ms each, totaling **100.5 seconds** of pure existence-check overhead. The slow checks correlated with production writes — every `HasAttribute` call after a write to any entity took hundreds of milliseconds due to memtable/SSTable pressure in BadgerDB.
+
+126 of those checks (40%) hit the same (E, A) pair — the same entity and attribute, over and over. With the cache, these would be O(1) after the first resolution. Without it, each one creates a new BadgerDB iterator.
+
+## Root Cause
+
+### Two cache check sites, both require A as Constant
+
+The cache is checked in two places in `MatchWithConstraints` (`matcher_relations.go`):
+
+**Site 1: With bindings** (lines 97-108)
+```go
+// CACHE OPTIMIZATION: When A is a constant and E comes from bindings,
+// use the cache for each E value instead of storage scans.
+if m.cache != nil && m.txID == 0 {
+    if a := m.extractValue(pattern.GetA()); a != nil {   // ← nil for Variables
+        if aKw, ok := a.(datalog.Keyword); ok {
+            cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw)
+            if handled {
+                return cacheResult, nil
+            }
+        }
+    }
+}
+```
+
+**Site 2: Without bindings** (lines 245-256, inside `matchUnboundAsRelation`)
+```go
+// CACHE OPTIMIZATION: When E and A are bound and we're querying latest state,
+// use the cache for O(1) access instead of storage scans.
+if m.cache != nil && m.txID == 0 && e != nil && a != nil {
+    if eIdent, ok := e.(datalog.Identity); ok {
+        if aKw, ok := a.(datalog.Keyword); ok {
+            cacheResult, handled := m.matchFromCache(pattern, columns, eIdent, aKw, v, card)
+            if handled {
+                return cacheResult, nil
+            }
+        }
+    }
+}
+```
+
+Both depend on `extractValue`:
+
+```go
+// matcher.go:473-487
+func (m *BadgerMatcher) extractValue(elem query.PatternElement) interface{} {
+    switch e := elem.(type) {
+    case query.Variable:
+        return nil          // ← Variables always return nil
+    case query.Blank:
+        return nil
+    case query.Constant:
+        return e.Value      // ← Only Constants return a value
+    default:
+        return nil
+    }
+}
+```
+
+When the query is `[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`, `?attr` is a Variable in the pattern. `extractValue` returns nil. The cache check is skipped. Code falls through to join strategies (`matchWithHashJoin`, `matchWithMergeJoin`, etc.) which go directly to BadgerDB storage scans.
+
+### The gap
+
+`extractValue` only looks at the **pattern**. It does not consider whether the variable has a known value in the **binding relation**. The binding relation contains concrete values for `?e` and `?attr` — but the cache check never looks at it.
+
+| A binding type | A value known? | Cache usable? | Current behavior |
+|----------------|---------------|---------------|------------------|
+| Constant in pattern | Yes, at parse time | Yes | Cache hit |
+| Scalar input `?a` | Yes, from input | Yes | **Cache bypassed** |
+| Collection input `[?a ...]` | Yes, set from input | Yes | **Cache bypassed** |
+| Tuple input `[?e ?a]` | Yes, from input | Yes | **Cache bypassed** |
+| Relation input `[[?e ?a]]` | Yes, set of pairs | Yes | **Cache bypassed** |
+| Join-bound | Yes, after join | Yes | **Cache bypassed** |
+| Truly unbound | No | No | Correctly bypassed |
+
+## Dead Code Red Herring
+
+Note: `matchBoundPattern` (matcher.go:188-264) is **dead code**. Its only caller, `matchWithoutRelation`, has zero callers. This was the old query path before `Match` → `MatchWithConstraints` was built. Any analysis pointing to `matchBoundPattern` as the bypass location is incorrect — the actual bypass is in `MatchWithConstraints` as described above.
+
+## Impact
+
+### Performance characteristics
+
+Every bypassed query creates:
+1. A new BadgerDB read transaction
+2. An iterator seek on the chosen index (typically AEVT or EATV)
+3. Key decoding + value deserialization per matching datom
+4. Transaction close
+
+Under write pressure (concurrent writes to the same database), BadgerDB's memtable/SSTable compaction makes these seeks progressively slower. The cache would serve these as O(1) in-memory lookups with zero BadgerDB interaction.
+
+### Affected query patterns
+
+Any query where E and/or A come from `:in` parameters or bindings:
+
+```clojure
+;; HasAttribute pattern — most common
+[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]
+
+;; Entity existence check
+[:find ?e :in $ ?e ?attr :where [?e ?attr _]]
+
+;; Multiple attributes for same entity
+[:find ?v :in $ ?e [?attr ...] :where [?e ?attr ?v]]
+
+;; Batch entity lookup
+[:find ?e ?v :in $ [[?e ?attr]] :where [?e ?attr ?v]]
+```
+
+### Quantified impact (from downstream profiling)
+
+| Metric | Value |
+|--------|-------|
+| Total existence checks | 527 |
+| Checks in millisecond range | 491 (93%) |
+| Top 30 checks | 650–890ms each |
+| Total Exists overhead | **100.5 seconds** |
+| Average per check | 204.6ms |
+| Repeated (E,A) pairs | 126 (40%) hitting same pair |
+
+The 126 repeated (E,A) pairs would be a single cache miss + 125 cache hits = sub-microsecond. Instead, each one is a full BadgerDB round-trip.
+
+## Correctness Note
+
+This is a **performance bug**, not a correctness bug. The storage scan path applies CRDT resolution correctly via `CRDTResolvingIterator` (see `BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md` for the history of that fix). The results are correct — they're just obtained via an unnecessarily expensive path.
+
+The cache path (`matchWithBindingsFromCache`, `matchFromCache`) and the storage scan path return identical results. The difference is purely performance:
+- Cache path: O(1) per (E,A) pair from in-memory `sync.Map`
+- Storage scan path: O(log N) BadgerDB seek + I/O per (E,A) pair
+
+## Fix
+
+### Approach: Extract A from bindings before cache check
+
+Before falling through to join strategies, check whether A is a Variable whose value is available in the binding relation. If so, extract it and use the cache path.
+
+The existing `matchWithBindingsFromCache` already handles E-from-bindings correctly. The only missing piece is extracting A's value from bindings when it's not a pattern constant.
+
+### Where to fix
+
+`matcher_relations.go`, `MatchWithConstraints`, between lines 96 and 110 (after vector cardinality check, before join strategy selection).
+
+### Sketch
+
+```go
+// Current: only checks pattern constants
+if a := m.extractValue(pattern.GetA()); a != nil { ... }
+
+// Fixed: also check binding relation for A's value
+aValue := m.extractValue(pattern.GetA())
+if aValue == nil && bindingRel != nil {
+    // A is a Variable — check if bindings provide its value
+    if aVar, ok := pattern.GetA().(query.Variable); ok {
+        aValue = extractSingleValueFromBindings(bindingRel, aVar.Name)
+    }
+}
+if aValue != nil {
+    if aKw, ok := aValue.(datalog.Keyword); ok {
+        cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw)
+        if handled {
+            return cacheResult, nil
+        }
+    }
+}
+```
+
+For scalar inputs (single-row binding), `extractSingleValueFromBindings` returns the value directly. For collection/relation inputs (multi-row bindings), this gets more complex — each row may have a different A value. The simplest initial fix handles the single-value case (which covers the `HasAttribute` pattern) and falls through to storage scans for multi-value A bindings.
+
+### What NOT to do
+
+- Do not duplicate cache logic into the join strategies. One resolution path, not two.
+- Do not add a separate cache check inside `matchWithHashJoin` or `matchWithMergeJoin`.
+- Do not change `extractValue` to look at bindings — it's a pattern-level utility used elsewhere.
+
+### Optimization phases
+
+**Phase 1** (high impact, simple): Handle single-value A from bindings. This covers `HasAttribute` (`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`) which is the dominant pattern in downstream applications. Extract A from a single-row binding, use the existing `matchWithBindingsFromCache`.
+
+**Phase 2** (medium impact): Handle collection/relation A inputs. For each row in the binding relation, extract the (E, A) pair and do a cache lookup. This is a loop over `cache.GetOrResolve` calls with tuple building per hit.
+
+**Phase 3** (low impact, complex): Handle join-bound A. When A gets its value from a prior join (not from `:in`), the binding relation passed to the matcher already contains A's value. The same Phase 1/2 logic applies — the binding relation is the binding relation regardless of where it came from.
+
+## Test Plan
+
+### Tests needed before fix
+
+1. **Benchmark: cache hit vs cache bypass for HasAttribute pattern**
+   - Setup: database with N entities, each with a CardinalityOne attribute
+   - Measure time for N `ExecuteQueryWithInputs` calls with bound E and A
+   - Compare: A as pattern constant vs A as input parameter
+   - Expected: pattern constant is fast (cache hit), input parameter is slow (bypass)
+   - After fix: both should be equally fast
+
+2. **Functional equivalence: cache path vs bypass path**
+   - For each cardinality (one, many, vector):
+     - Query with A as pattern constant (cache path)
+     - Query with A as input parameter (currently bypass path)
+     - Assert identical results
+   - This verifies the fix doesn't change semantics
+
+3. **Cache invalidation through the new path**
+   - Write value → query via input A (cache miss → populate) → write new value → query again
+   - Assert second query returns new value (cache was invalidated and rebuilt)
+
+4. **Multi-value A inputs**
+   - Collection input: `[:find ?e ?v :in $ ?e [?attr ...] :where [?e ?attr ?v]]`
+   - Verify all attributes are resolved correctly
+   - Verify cache is consulted for each A value
+
+### Existing test coverage
+
+The `matchWithBindingsFromCache` method is well-tested for the A-as-constant case:
+- `matcher_cache_test.go`: `BenchmarkCachePathWithBindings` (100 entities)
+- `crdt_cache_matrix_test.go`: 17-pattern test matrix (cache enabled/disabled)
+
+These tests verify the cache path works correctly. The gap is that they never exercise the path where A is a Variable from bindings.
+
+## Files Involved
+
+| File | Role |
+|------|------|
+| `datalog/storage/matcher_relations.go:97-108` | Cache check that requires A as Constant (fix location) |
+| `datalog/storage/matcher.go:473-487` | `extractValue` — returns nil for Variables |
+| `datalog/storage/matcher_relations.go:1089-1223` | `matchWithBindingsFromCache` — existing cache path (reuse target) |
+| `datalog/storage/cache.go` | EA cache implementation (`GetOrResolve`) |
+| `datalog/storage/matcher_cache_test.go` | Existing cache tests (extend) |
+
+## Relationship to Other Bugs
+
+- **BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md**: That bug was about CRDT *correctness* — storage scans returning all historical values instead of resolved current values. Fixed by `CRDTResolvingIterator`. This bug is about *performance* — the storage scan path is correct but unnecessarily slow because the cache is bypassed.
+
+- **BUG_CACHE_CARDINALIY_ONE_TOMBSTONE.md**: That bug was about `ResolveLWW` not checking `datom.Op` for tombstones. Fixed. The cache path itself is correct; this bug is about the cache path not being *reached*.
+
+Both prior bugs were about the cache and storage paths producing different results. This bug is different: both paths produce the same results, but the fast path (cache) is not reached when it should be.


### PR DESCRIPTION
## Summary

The EA cache (`sync.Map` keyed by `{E, A}`) was completely bypassed whenever A arrived as a variable from input bindings rather than as a pattern constant. `extractValue(pattern.GetA())` returns nil for variables, so the cache check failed and every query fell through to BadgerDB storage scans. This caused 100+ second overhead in downstream applications using patterns like `HasAttribute` and `EntityExists` where A is passed as `:in` parameter.

- **Phase 1**: Resolve single-value A from scalar and tuple bindings via `resolveKeywordFromBindings`. Also fix `CRDTResolvingIterator.resolveRGAGroup` to return a single datom with `V = []any{...}` (resolved vector list), matching cache path behavior.
- **Phase 2**: Parameterize `matchWithBindingsFromCache` with `aColIdx` for per-row A extraction from multi-row binding relations (join results, relation inputs). Each row gets its own cache key and cardinality determination.

During Phase 2 testing, an intermittent failure in `TestEACacheBypass_PerRowVector_RelationInput/cache_disabled` uncovered **three additional bugs** that combined to produce silent data loss:

1. **EATV missing from `chooseIndexForValues` switch** — scan covered the entire EATV index instead of narrowing to the entity prefix. Added EATV to the EAVT case (same E+A prefix structure).
2. **CRDT vector group transition dropped boundary datom** — `CRDTResolvingIterator` consumed the first datom of a new group for boundary detection but never emitted it. Added `pendingDatom` field to save and reprocess it.
3. **Nondeterministic strategy selection via map iteration** — `chooseBestMultiPositionStrategy` iterated a `map[int]int` to find the best position. Go's randomized map iteration produced nondeterministic tiebreaking (sometimes EATV triggering bugs 1+2, sometimes AETV which works). Replaced with deterministic slice; tiebreaker prefers A-primary over E-primary because A-primary scans have uniform CRDT cardinality.

## Test plan

- [x] `TestEACacheBypass_*` — 10+ tests covering all input binding patterns (scalar, tuple, collection, relation), all cardinalities (One, Many, Vector), cache miss fallback, invalidation
- [x] `TestEACacheBypass_PerRowA_UsesCache` — annotation check proving per-row cache path is used
- [x] `TestEACacheBypass_PerRowVector_RelationInput` — mixed Vector + One cardinalities via relation input, both cache modes
- [x] `TestEATV_VectorTransitionDropsDatom` — reproduction test forcing EATV via collection input with free A, 3 entities x 2 attributes
- [x] `TestCountRepro_WithVector` — minimal reproduction of the intermittent EATV failure
- [x] `TestCacheMatrix` and `TestMatcherCache` — no regression in existing cache tests
- [x] `go test ./...` — full suite passes
- [x] EATV reproduction tests pass with `-count=5` (previously failed at `-count>=2`)
