### PR TITLE
Make ElementID first-class throughout stack, add datalog/db public API

### DIFF
--- a/.claude/skills/datalog/SKILL.md
+++ b/.claude/skills/datalog/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: datalog
+description: >
+  Query janus-datalog databases for debugging and data exploration.
+  Use when the user asks to inspect a .db database, explore datoms,
+  check entity attributes, debug query results, or examine CRDT storage state.
+argument-hint: <database-path>
+allowed-tools: Bash(~/go/bin/datalog *)
+---
+
+# Datalog Query
+
+Query janus-datalog databases for debugging and data exploration.
+
+The user will provide a database path and describe what they want to know. Use the `datalog` CLI to run queries against the database.
+
+## Data Model
+
+janus-datalog is a **Datomic-style EAV (Entity-Attribute-Value) store**. All data is stored as datoms: `[entity attribute value tx]`. There are no tables — entities are just collections of attribute-value pairs, connected by shared entity IDs.
+
+Attributes follow a namespaced keyword convention: `:namespace/name` (e.g., `:person/name`, `:order/total`). This means attributes cluster by namespace, which is useful when exploring unknown databases.
+
+**Storage is CRDT-backed** (Conflict-free Replicated Data Types). Every write is preserved with a unique ElementID. Attribute cardinality determines conflict resolution:
+
+| Cardinality | Behavior | Example |
+|-------------|----------|---------|
+| One | Last-Writer-Wins — only the latest value is returned by default | `:person/name`, `:person/age` |
+| Many | Add-Wins Set — all distinct values are returned | `:person/tag`, `:person/role` |
+| Vector | RGA — ordered list with deterministic merge | `:product/tags`, `:playlist/songs` |
+
+Because all writes are preserved, you can time-travel: `db.History()` returns all raw datoms (no CRDT resolution), and `db.AsOf(elementID)` queries CRDT-resolved state as of a specific transaction.
+
+## Tool
+
+Binary: `~/go/bin/datalog`
+
+Install if missing:
+```bash
+go install github.com/wbrown/janus-datalog/cmd/datalog@latest
+```
+
+## Invocation
+
+```bash
+# Run a query
+~/go/bin/datalog -db <path> -query '<EDN query>'
+
+# With input bindings (repeatable, one per :in parameter after $)
+~/go/bin/datalog -db <path> -query '<EDN query with :in>' -in '<EDN value>' [-in '<EDN value>' ...]
+
+# With performance annotations
+~/go/bin/datalog -db <path> -verbose -query '<EDN query>'
+
+# Export entire database to readable EDN (useful for small DBs)
+~/go/bin/datalog -db <path> -export <output.edn>
+```
+
+Output is a markdown table. Errors go to stderr.
+
+If the user says `/datalog <path>`, treat `$ARGUMENTS` as the database path. Start by discovering what's in the database, then ask what they want to explore.
+
+## Finding Databases
+
+- Prebuilt benchmark DB: `datalog/storage/testdata/ohlc_benchmark.db`
+- Default path when unspecified: `datalog.db` in current directory
+- Test databases are created in temp directories by tests (look for `t.TempDir()` calls)
+- Ask the user if the path is unclear
+
+## EDN Query Syntax
+
+Queries are EDN vectors. The basic form:
+
+```clojure
+[:find <find-spec>
+ :in <input-spec>       ;; optional, $ is implicit
+ :where <clauses>]
+```
+
+### Find Spec
+
+```clojure
+;; Return specific variables
+[:find ?name ?age :where ...]
+
+;; With aggregations (non-aggregated vars become group-by keys)
+[:find ?dept (sum ?salary) (count ?e) :where ...]
+
+;; Available: sum, count, avg, min, max
+```
+
+### Where Clauses
+
+**Data patterns** — match entity-attribute-value triples:
+```clojure
+[?entity :attribute ?value]          ;; basic pattern
+[?entity :attribute "literal"]       ;; match literal value
+[?entity :attribute _]               ;; wildcard (attribute exists)
+[?entity :attribute ?value ?tx]      ;; with transaction ID
+```
+
+**Predicates** — filter results:
+```clojure
+[(> ?age 25)]
+[(< ?price 100.0)]
+[(!= ?name "Alice")]
+[(< 0 ?x 100)]          ;; chained: 0 < ?x < 100
+```
+
+**Expressions** — compute values:
+```clojure
+[(+ ?age 5) ?future-age]
+[(- ?price ?discount) ?net]
+[(* ?qty ?price) ?total]
+[(str ?first " " ?last) ?fullname]
+[(ground 42) ?answer]
+[(identity ?x) ?y]                       ;; pass-through binding
+```
+
+**Time extraction** — extract components from `time.Time` values:
+```clojure
+[(year ?timestamp) ?y]
+[(month ?timestamp) ?m]
+[(day ?timestamp) ?d]
+[(hour ?timestamp) ?h]
+[(minute ?timestamp) ?min]
+[(second ?timestamp) ?sec]
+```
+
+**NOT clauses** — exclude matches:
+```clojure
+(not [?p :person/deleted true])
+(not-join [?p]
+  [?p :person/status "inactive"])
+```
+
+**OR clauses** — alternative patterns:
+```clojure
+(or [?p :person/city "New York"]
+    [?p :person/city "Boston"])
+(or-join [?p]
+  [?p :role/admin true]
+  [?p :role/superuser true])
+```
+
+**Vector functions** — operate on cardinality-vector attributes:
+```clojure
+[(nth ?vec 0) ?first-element]           ;; get element by index
+[(first ?vec) ?head]                     ;; first element
+[(last ?vec) ?tail]                      ;; last element
+[(length ?vec) ?len]                     ;; number of elements
+[(contains? ?vec "value") ?found]        ;; boolean membership test
+[(index-of ?vec "value") ?pos]           ;; index of first match
+[(subvec ?vec 1 3) ?slice]               ;; sub-vector [start, end)
+```
+
+**`enumerate`** — expands a vector into one row per element with index. This is the primary way to query vector contents:
+```clojure
+;; Given :product/tags is a vector ["electronics" "sale" "new"]
+[:find ?tag ?idx
+ :where [?e :product/label "Widget"]
+        [?e :product/tags ?vec]
+        [(enumerate ?vec) [?idx ?tag]]]
+;; Returns: [0 "electronics"], [1 "sale"], [2 "new"]
+```
+
+Important: `enumerate` produces **multiple output rows** from a single input row. The binding `[?idx ?tag]` is required — it destructures each element into an index and value. The data pattern that binds `?vec` must appear **before** the enumerate expression in the where clause, and the planner must not reorder it ahead of the pattern that provides the vector.
+
+**Database functions:**
+```clojure
+[(get-else $ ?e :person/nickname "unknown") ?nick]
+[(missing? $ ?e :person/email)]
+[(get-some $ ?e :person/nick :person/name :person/email) ?display]
+```
+
+**Subqueries** — nested queries that bind results into the outer query:
+```clojure
+;; Tuple binding — subquery returns one row, binds to variables
+[(q [:find (max ?h)
+     :in $ ?sym
+     :where [?p :price/symbol ?sym]
+            [?p :price/high ?h]]
+    $ ?s) [[?max-high]]]
+
+;; Relation binding — subquery returns multiple rows
+[(q [:find ?p ?h
+     :in $ ?sym
+     :where [?p :price/symbol ?sym]
+            [?p :price/high ?h]]
+    $ ?s) [[?price ?high] ...]]
+```
+
+The subquery `(q [...] $ ?var1 ?var2)` takes a full query, then lists the inputs to pass (matching the subquery's `:in` clause). The binding after `)` determines how results are captured: `[[?x]]` for a single row, `[[?x ?y] ...]` for multiple rows.
+
+**Tagged literals** — use typed constants directly in patterns and predicates:
+```clojure
+[#identity "L85hash..." :person/name ?name]   ;; match specific entity
+[?e :event/date #inst "2024-06-15T10:30:00Z"] ;; match timestamp
+[(> ?d #inst "2024-01-01T00:00:00Z")]          ;; compare against timestamp
+```
+
+### Input Parameters
+
+```clojure
+;; Scalar input
+[:find ?name :in $ ?target-age
+ :where [?p :person/age ?target-age]
+        [?p :person/name ?name]]
+
+;; Collection input
+[:find ?name :in $ [?city ...]
+ :where [?p :person/city ?city]
+        [?p :person/name ?name]]
+```
+
+Pass `:in` values with the `-in` flag (one per binding, order matches `:in` after `$`):
+
+```bash
+# Scalar input
+~/go/bin/datalog -db <path> \
+  -query '[:find ?name :in $ ?age :where [?p :person/age ?age] [?p :person/name ?name]]' \
+  -in 30
+
+# String input (quote in EDN)
+~/go/bin/datalog -db <path> \
+  -query '[:find ?age :in $ ?name :where [?p :person/name ?name] [?p :person/age ?age]]' \
+  -in '"Alice"'
+
+# Collection input
+~/go/bin/datalog -db <path> \
+  -query '[:find ?name :in $ [?city ...] :where [?p :person/city ?city] [?p :person/name ?name]]' \
+  -in '["New York" "Boston"]'
+
+# Multiple inputs
+~/go/bin/datalog -db <path> \
+  -query '[:find ?name :in $ ?min ?max :where [?p :person/age ?a] [(>= ?a ?min)] [(<= ?a ?max)] [?p :person/name ?name]]' \
+  -in 20 -in 30
+```
+
+Each `-in` value is parsed as EDN, so tagged literals work too: `-in '#inst "2024-01-01T00:00:00Z"'`.
+
+### Order By
+
+```clojure
+[:find ?name ?age
+ :order-by [?age :desc] [?name :asc]
+ :where [?p :person/name ?name]
+        [?p :person/age ?age]]
+```
+
+### Time-Travel
+
+```go
+// Open a database
+d, _ := db.Open("path/to/db")
+
+// History — all raw datoms, no CRDT resolution
+hist := d.History()
+hist.Query(`[:find ?name ?tx :where [?p :person/name ?name ?tx]]`)
+
+// As-of — CRDT-resolved state at a specific transaction
+txID, _ := tx.Commit()  // returns datalog.ElementID
+asOf := d.AsOf(txID)
+asOf.Query(`[:find ?name :where [?p :person/name ?name]]`)
+```
+
+## Common Debugging Patterns
+
+### 1. Explore an unknown database
+
+Start by discovering the schema shape:
+
+```bash
+# What attributes exist?
+~/go/bin/datalog -db <path> -query '[:find ?a :where [_ ?a _]]'
+
+# How many entities per attribute?
+~/go/bin/datalog -db <path> -query '[:find ?a (count ?e) :where [?e ?a _]]'
+```
+
+Then sample values for attributes that look interesting:
+
+```bash
+~/go/bin/datalog -db <path> -query '[:find ?v :where [_ :person/status ?v]]'
+```
+
+### 2. Inspect an entity through a known value
+
+Don't query for entity IDs and copy them. Instead, join through a known value to see everything about an entity:
+
+```bash
+# All attributes and values for the entity named "Alice"
+~/go/bin/datalog -db <path> -query \
+  '[:find ?a ?v :where [?e :person/name "Alice"] [?e ?a ?v]]'
+```
+
+This works for any attribute — find the entity through something you know, then fan out:
+
+```bash
+# Everything about the order with ID "ORD-1234"
+~/go/bin/datalog -db <path> -query \
+  '[:find ?a ?v :where [?e :order/id "ORD-1234"] [?e ?a ?v]]'
+```
+
+### 3. Follow references
+
+Entities reference other entities. Use variable joins to traverse:
+
+```bash
+# Who are Alice's friends, and what cities do they live in?
+~/go/bin/datalog -db <path> -query \
+  '[:find ?friend-name ?city
+    :where [?p :person/name "Alice"]
+           [?p :person/friend ?f]
+           [?f :person/name ?friend-name]
+           [?f :person/city ?city]]'
+```
+
+Chain as many hops as needed — each shared variable (`?f` above) is a join.
+
+### 4. Find missing or unexpected data
+
+```bash
+# People without an email
+~/go/bin/datalog -db <path> -query \
+  '[:find ?name
+    :where [?p :person/name ?name]
+           (not [?p :person/email _])]'
+
+# People in neither New York nor Boston
+~/go/bin/datalog -db <path> -query \
+  '[:find ?name ?city
+    :where [?p :person/name ?name]
+           [?p :person/city ?city]
+           [(!= ?city "New York")]
+           [(!= ?city "Boston")]]'
+```
+
+### 5. Aggregate to find outliers
+
+```bash
+# Which cities have the most people?
+~/go/bin/datalog -db <path> -query \
+  '[:find ?city (count ?p)
+    :where [?p :person/city ?city]]'
+
+# Average age by city
+~/go/bin/datalog -db <path> -query \
+  '[:find ?city (avg ?age)
+    :where [?p :person/city ?city]
+           [?p :person/age ?age]]'
+```
+
+### 6. For small databases, just export
+
+```bash
+~/go/bin/datalog -db <path> -export dump.edn
+```
+
+Export format is one datom per line: `[#identity "hash" :attribute value txid]`
+
+## Output Format
+
+Results are printed as markdown tables:
+
+```
+| ?name   | ?age |
+|---------|------|
+| Alice   |   30 |
+| Bob     |   25 |
+| Charlie |   35 |
+
+_3 rows (1.234ms)_
+```
+
+With `-verbose`, stderr gets annotation events showing index selection, join stats, and timing.
+
+## Entity Identity
+
+Entities are identified by an **Identity** — a SHA1 hash of a seed string, displayed as a 25-character L85-encoded string (a sort-order-preserving Base85 encoding).
+
+When you query for an entity variable like `?e`, the result column shows the L85 hash. You don't normally need to use these directly — join through known attribute values instead (see debugging patterns above).
+
+The `#identity "L85hash"` tagged literal exists for cases where you have a hash from logs or export output and need to look it up directly. This is the exception, not the normal workflow.
+
+## Notes
+
+- All attribute names are keywords starting with `:` (e.g., `:person/name`)
+- Integer literals are int64, float literals are float64
+- String literals use double quotes: `"value"`
+- The `_` wildcard matches any value without binding
+- Empty results return a table with headers but no rows
+- Tagged literals: `#identity "L85..."`, `#inst "RFC3339..."`, `#bytes "L85..."`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,10 +54,10 @@ All query paths converge on the same planner and executor. The difference is how
 The most direct path. An EDN string is parsed, planned, and executed:
 
 ```go
-results, err := db.ExecuteQuery(`[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
+results, err := d.Query(`[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
 ```
 
-**Call chain**: `ExecuteQuery` → `resolveQuery` (detects string → calls `parser.ParseQuery`) → `ExecuteQueryWithInputs` → planner → executor → `[][]interface{}`
+**Call chain**: `Query` → `resolveQuery` (detects string → calls `parser.ParseQuery`) → `ExecuteQueryWithInputs` → planner → executor → `[][]interface{}`
 
 ### Entry Point 2: Query Builder (`qb/`)
 
@@ -71,10 +71,10 @@ q := qb.Query().
         qb.Pat("?e", ":person/age", "?age"),
     ).MustBuild()
 
-results, err := db.ExecuteQuery(q)  // *query.Query passed directly
+results, err := d.Query(q)  // *query.Query passed directly
 ```
 
-**Call chain**: `ExecuteQuery` → `resolveQuery` (detects `*query.Query` → returns it as-is) → same path from there. No parsing overhead.
+**Call chain**: `Query` → `resolveQuery` (detects `*query.Query` → returns it as-is) → same path from there. No parsing overhead.
 
 ### Entry Point 3: QueryInto
 
@@ -82,7 +82,7 @@ Wraps any query path with struct-mapped result delivery:
 
 ```go
 var people []Person
-err := db.QueryInto(&people, query, inputs...)
+err := d.QueryInto(&people, query, inputs...)
 ```
 
 **Call chain**: Normal query execution → `[][]interface{}` → `reflect.QueryResultMapper.MapAll()` → populates struct slice via field tags.
@@ -94,7 +94,7 @@ For scalar types (single-column queries), extracts the first column directly wit
 Pull does **not** go through the query planner. It's direct pattern matching against storage:
 
 ```go
-result, err := db.Pull(entityID, "[:person/name :person/age {:person/friends [:person/name]}]")
+result, err := d.Pull(entityID, "[:person/name :person/age {:person/friends [:person/name]}]")
 ```
 
 **Call chain**: `parser.ParsePullPattern` → `PullExecutor.Pull` → recursive `pullWithVisited`:
@@ -109,7 +109,7 @@ result, err := db.Pull(entityID, "[:person/name :person/age {:person/friends [:p
 Any query path supports multiple data sources via `WithSources`:
 
 ```go
-results, err := db.ExecuteQueryWithInputs(query,
+results, err := d.Query(query,
     WithSources(map[Symbol]PatternMatcher{
         "$":      mainDB.Matcher(),
         "$users": userSliceSource,
@@ -264,7 +264,7 @@ For each phase in plan:
 
 ### Transaction Lifecycle
 
-1. **`db.NewTransaction()`** — Creates transaction, holds `[]Datom` buffer
+1. **`d.NewTransaction()`** — Creates transaction, holds `[]Datom` buffer
 2. **`tx.Add(entity, attr, value)`** — Per-datom:
    - Schema validation (type check against declared attribute type, skipped if no schema)
    - Lamport clock increment → `ElementID{Lamport, ReplicaID}`
@@ -285,7 +285,7 @@ For each phase in plan:
 The reflect API converts Go structs to transactions:
 
 ```go
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 id, err := tx.SaveStruct(&person)  // Person{Name: "Alice", Age: 30}
 tx.Commit()
 ```
@@ -475,6 +475,10 @@ Go struct ↔ datom bridging:
 - **Writer**: Struct tags → datoms via `tx.Add()`. Handles cardinality-many (slices), references (nested structs), update-with-diff semantics
 - **Reader**: Query results / Pull results → struct population
 - **Schema inference**: Struct tags → schema definitions (types, cardinality, uniqueness)
+
+### Public API (`datalog/db/`)
+
+The recommended entry point for consumers. Provides `db.Open()` with functional options, type aliases (`DB = storage.Database`, `Transaction = storage.Transaction`), `MustParseQuery()` for compile-time query constants, and `Querier`/`EntityReader` interfaces. All methods on `*storage.Database` (`Query`, `QueryInto`, `Pull`, `AsOf`, `History`, etc.) are available directly on the `*DB` handle. For advanced use cases (custom planner options, annotation handlers, multi-source queries with `WithSources`), consumers can still use the `storage` package directly.
 
 ### Query Builder (`datalog/qb/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ This implementation supports a hybrid approach:
 When implementing, organize code as:
 ```
 datalog/
+├── db/          # Public API package (db.Open, d.Query, d.History, d.AsOf)
 ├── parser/      # EDN and Datalog parsers
 ├── types/       # Core type definitions
 ├── query/       # Query structures and types
@@ -284,7 +285,7 @@ The storage layer connects the query engine to BadgerDB:
 10. **Storage integration** - Database and Transaction API, BadgerMatcher for pattern matching
 11. **Value encoding** - Proper serialization for all value types including entity references
 12. **Aggregation functions** - `sum`, `count`, `avg`, `min`, `max` with grouping support (with proper time.Time support)
-13. **Time-based queries** - Time-based transaction IDs and as-of queries
+13. **Temporal queries** - ElementID-based AsOf/History queries for time-travel
 14. **Time extraction functions** - `year`, `month`, `day`, `hour`, `minute`, `second` for temporal analysis
 15. **Subqueries** - Full implementation with TupleBinding and RelationBinding support
 16. **Result/Relation unification** - Eliminated redundant Result type, unified API
@@ -295,7 +296,7 @@ The storage layer connects the query engine to BadgerDB:
 21. **Relations migration** - Multi-value variable support throughout codebase
 22. **Pull API** - Declarative entity attribute retrieval with nested refs, cycle detection, wildcards (9× faster than queries)
 23. **Schema support** - Type validation, cardinality (one/many), uniqueness constraints; optional and additive
-24. **CRDT storage** - LWW for cardinality-one, add-wins for cardinality-many, RGA for cardinality-vector; all writes preserved with ElementIDs; `[(history)]` and `[(as-of ?tx N)]` predicates for time-travel queries
+24. **CRDT storage** - LWW for cardinality-one, add-wins for cardinality-many, RGA for cardinality-vector; all writes preserved with ElementIDs; `db.History()` for raw datom access, `db.AsOf(elementID)` for point-in-time queries; three-mode `*ElementID` matcher (`nil`=latest, `&ElementID{}`=history, `&ElementID{L,R}`=as-of)
 25. **NOT/OR clauses** - Full support for `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with Datomic-compatible semantics; OR supports fallback expressions for default values
 26. **QueryInto API** - Typed query results via `QueryInto()` and `QueryOneInto()` with struct tag mapping for variables and aggregates
 27. **Multi-source queries** - Named sources (`$name`), `SourceRouter`, cross-source joins, `MemoryPatternMatcher`, `SliceSource[T]`, query builder `Source()`/`PatFrom()`
@@ -447,13 +448,14 @@ handler := func(event annotations.Event) {
     // Process event (log, store, analyze, etc.)
 }
 
-// Wrap the matcher with annotation decorator
-baseMatcher := storage.NewBadgerMatcher(db.Store())
-matcher := executor.WrapMatcher(baseMatcher, handler)
+// Using the db.Open API — pass handler as an option
+d, _ := db.Open("path/to/db", db.WithAnnotationHandler(handler))
+// All queries through d.Query() will emit annotation events
 
-// Use matcher normally - annotations are transparent
-// Second parameter is EntityResolver (db) for CRDT resolution in Pull operations
-executor := executor.NewExecutor(matcher, db)
+// Internal equivalent (for advanced usage):
+// baseMatcher := storage.NewBadgerMatcher(database.Store())
+// matcher := executor.WrapMatcher(baseMatcher, handler)
+// exec := executor.NewExecutor(matcher, database)
 ```
 
 **Key Design Principles**:

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -15,7 +15,7 @@ Janus-datalog implements most of Datomic's Datalog query language. The core quer
 - ✅ Database functions: `get-else`, `missing?`, `get-some`
 - ✅ Schema: type validation, cardinality (one/many/vector), uniqueness
 - ✅ CRDT storage: LWW for cardinality-one, add-wins for cardinality-many, RGA for cardinality-vector
-- ✅ Time queries: `[(history)]`, `[(as-of ?tx N)]`, `[(tx-between ?tx low high)]`
+- ✅ Time queries: `d.AsOf(elementID).Query(...)`, `d.History().Query(...)`, `[(tx-between ?tx low high)]`
 
 **Go-Specific Ergonomics:**
 - ✅ Struct Reflection API: Go structs ↔ datoms with automatic schema generation
@@ -266,14 +266,30 @@ This differs from Datomic, where OR always uses union semantics. See [OR_FALLBAC
 
 ### 9. Time-Based Queries
 
-Query database as of specific times:
+Query database at specific points in time using database-level temporal filters:
 
 ```go
-// Query as of a timestamp
-db.AsOf(timestamp)
+// Commit() returns a full ElementID (Lamport clock + ReplicaID)
+tx := d.NewTransaction()
+tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice")
+txID, _ := tx.Commit()  // txID is datalog.ElementID
+
+// Query as of a specific transaction — CRDT-resolved state at that point
+results, _ := d.AsOf(txID).Query(myQuery)
+
+// Raw history — all datoms, no CRDT resolution
+allVersions, _ := d.History().Query(myQuery)
 ```
 
-Every datom includes a transaction ID for temporal queries.
+**Three temporal modes:**
+
+| Mode | API | CRDT resolution | Tx filtering |
+|------|-----|-----------------|--------------|
+| Latest (default) | `d.Query(...)` | Yes | No |
+| As-of | `d.AsOf(elementID).Query(...)` | Yes | Yes |
+| History (raw) | `d.History().Query(...)` | No | No |
+
+Every datom includes a full ElementID (Lamport + ReplicaID) for temporal ordering.
 
 ### 10. Storage Model
 
@@ -309,11 +325,11 @@ Declarative entity attribute retrieval with nested reference following:
 **Standalone API (Go):**
 ```go
 // Single entity
-result, err := db.Pull(entityID, `[:user/name :user/age]`)
+result, err := d.Pull(entityID, `[:user/name :user/age]`)
 // result: map[string]interface{}{"user/name": "Alice", "user/age": 30}
 
 // Multiple entities
-results, err := db.PullMany(entityIDs, `[:user/name]`)
+results, err := d.PullMany(entityIDs, `[:user/name]`)
 ```
 
 **Supported pull patterns:**
@@ -340,7 +356,10 @@ results, err := db.PullMany(entityIDs, `[:user/name]`)
 **Go-specific feature** for ergonomic struct ↔ datom conversion:
 
 ```go
-import "github.com/wbrown/janus-datalog/datalog/reflect"
+import (
+    "github.com/wbrown/janus-datalog/datalog/db"
+    "github.com/wbrown/janus-datalog/datalog/reflect"
+)
 
 // Define domain types with struct tags
 type Person struct {
@@ -353,17 +372,18 @@ type Person struct {
 
 // Generate schema from struct
 schema, _ := reflect.SchemaFromStruct(Person{})
-db, _ := storage.NewDatabaseWithSchema(path, schema)
+d, _ := db.Open(path, db.WithSchema(schema))
+defer d.Close()
 
 // Write struct as datoms
 alice := &Person{Name: "Alice", Age: 30, Tags: []string{"dev"}}
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 aliceID, _ := tx.AddStructAuto(alice)  // Auto-generate ID
 tx.Commit()
 
 // Read datoms into struct
 var loaded Person
-db.PullInto(aliceID, &loaded)
+d.PullInto(aliceID, &loaded)
 // loaded.Name == "Alice", loaded.Tags == ["dev"]
 ```
 
@@ -409,7 +429,7 @@ type TradeResult struct {
 
 // Query directly into typed slice
 var results []TradeResult
-err := db.QueryInto(&results, `
+err := d.QueryInto(&results, `
     [:find ?symbol ?price ?date
      :where [?t :trade/symbol ?symbol]
             [?t :trade/price ?price]
@@ -424,7 +444,7 @@ type DeptStats struct {
 }
 
 var stats []DeptStats
-err := db.QueryInto(&stats, `
+err := d.QueryInto(&stats, `
     [:find ?dept (sum ?salary) (count ?emp)
      :where [?e :employee/dept ?dept]
             [?e :employee/salary ?salary]]
@@ -432,7 +452,7 @@ err := db.QueryInto(&stats, `
 
 // QueryOneInto for single-result queries
 var result TradeResult
-found, err := db.QueryOneInto(&result, `
+found, err := d.QueryOneInto(&result, `
     [:find ?symbol ?price ?date
      :where [?t :trade/id ?id]
             [(= ?id 12345)]
@@ -443,10 +463,10 @@ found, err := db.QueryOneInto(&result, `
 
 // Scalar queries - single column, no struct needed
 var names []string
-db.QueryInto(&names, `[:find ?name :where [?e :person/name ?name]]`)
+d.QueryInto(&names, `[:find ?name :where [?e :person/name ?name]]`)
 
 var count int64
-found, err := db.QueryOneInto(&count, `[:find (count ?e) :where [?e :person/name _]]`)
+found, err := d.QueryOneInto(&count, `[:find (count ?e) :where [?e :person/name _]]`)
 ```
 
 **Scalar types supported:** `string`, `int64`, `float64`, `bool`, `time.Time`, `datalog.Identity`, `datalog.Keyword`, `[]byte`
@@ -468,7 +488,10 @@ See [docs/reference/QUERY_INTO.md](docs/reference/QUERY_INTO.md) for complete do
 **Go-specific feature** for compile-time safe query construction:
 
 ```go
-import "github.com/wbrown/janus-datalog/datalog/qb"
+import (
+    "github.com/wbrown/janus-datalog/datalog/db"
+    "github.com/wbrown/janus-datalog/datalog/qb"
+)
 
 // Define attributes as constants - typos caught at compile time
 var PersonName = qb.Kw(":person/name")
@@ -489,7 +512,7 @@ q := qb.Query().
     MustBuild()
 
 // Use with any query method
-results, err := db.ExecuteQuery(q)
+results, err := d.Query(q)
 ```
 
 **Key benefits:**
@@ -570,13 +593,13 @@ Schema is supported but with limitations vs Datomic:
 
 **Schema definition via Go API:**
 ```go
-schema, _ := schema.NewBuilder().
+s, _ := schema.NewBuilder().
     Attribute(":person/name").Type(schema.TypeString).Add().
     Attribute(":person/friends").Type(schema.TypeRef).Many().Add().
     Attribute(":person/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
     Build()
 
-db, _ := storage.NewDatabaseWithSchema(path, schema)
+d, _ := db.Open(path, db.WithSchema(s))
 ```
 
 **Schema behavior:**
@@ -634,32 +657,41 @@ No entity navigation:
 
 **Supported:**
 - CRDT storage inherently preserves all writes with ElementIDs (Lamport + ReplicaID)
-- `[(history)]` predicate returns all historical versions
-- `[(as-of ?tx N)]` returns value as of Lamport time N
+- `d.History()` returns a database view that exposes all raw datoms (no CRDT resolution)
+- `d.AsOf(elementID)` returns a database view with CRDT-resolved state at a specific point in causal time
+- `Commit()` returns `datalog.ElementID` (full Lamport + ReplicaID)
 - `[(tx-between ?tx low high)]` filters results to a Lamport range
 
-**History Query API:**
+**Three-Mode Temporal API:**
 ```go
-// All writes are preserved with CRDT semantics - no special mode needed
-db, _ := storage.NewDatabase("/path/to/db")
+d, _ := db.Open("/path/to/db")
+defer d.Close()
 
 // Make changes over time
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice")
-tx.Commit()  // Lamport 1
+tx1, _ := tx.Commit()  // tx1 is datalog.ElementID{Lamport: 1, ReplicaID: 42}
 
-tx2 := db.NewTransaction()
+tx2 := d.NewTransaction()
 tx2.Add(alice, datalog.NewKeyword(":person/name"), "Alicia")  // LWW: replaces "Alice"
-tx2.Commit()  // Lamport 2
+tx2ID, _ := tx2.Commit()  // tx2ID is datalog.ElementID{Lamport: 2, ReplicaID: 42}
 
-// Query current state - returns latest value
-results, _ := db.ExecuteQuery(`[:find ?name :where [?e :person/name ?name]]`)
+// Latest mode (default) - CRDT-resolved, returns latest value
+results, _ := d.Query(`[:find ?name :where [?e :person/name ?name]]`)
 // Returns: [["Alicia"]]
 
-// Query ALL historical values using [(history)] predicate
-history, _ := db.ExecuteQuery(`[:find ?name ?tx :where [?e :person/name ?name ?tx] [(history)]]`)
+// History mode - all raw datoms, no CRDT resolution
+history, _ := d.History().Query(
+    `[:find ?name ?tx :where [?e :person/name ?name ?tx]]`)
 // Returns: [["Alice" <ElementID@1>] ["Alicia" <ElementID@2>]]
+
+// As-of mode - CRDT-resolved state at tx1
+asOf, _ := d.AsOf(tx1).Query(
+    `[:find ?name :where [?e :person/name ?name]]`)
+// Returns: [["Alice"]]
 ```
+
+**Design note:** Temporal filters are applied at the database level (following Datomic's pattern), not as query predicates. `[(history)]` and `[(as-of ?tx N)]` predicates exist in the parser but are not yet wired to the executor — use `d.History().Query(...)` and `d.AsOf(elementID).Query(...)` instead.
 
 **Not supported:**
 - No `since` queries (use `[(tx-between ?tx start ∞)]` instead)
@@ -719,7 +751,7 @@ No advanced database operations:
 - NOT/OR clauses
 - Subqueries with tuple/relation bindings
 - Order-by clauses
-- Time-travel queries via `[(history)]` and `[(as-of ?tx N)]`
+- Time-travel queries via `d.History().Query(...)` and `d.AsOf(elementID).Query(...)`
 - Database functions (get-else, missing?, get-some)
 
 **Require refactoring:**
@@ -806,7 +838,7 @@ For Datomic users, the transition is straightforward:
 2. Use subqueries for complex aggregations with proper scoping
 3. Define schema for type validation and cardinality support (one/many/vector)
 4. Use Pull API for efficient entity navigation (replaces Entity API)
-5. CRDT storage preserves full history automatically - use `[(history)]` for time-travel queries
+5. CRDT storage preserves full history automatically - use `d.History().Query(...)` for raw datoms and `d.AsOf(elementID).Query(...)` for point-in-time queries
 
 **For Go developers**, additional ergonomic APIs are available:
 - **Struct Reflection API** (`datalog/reflect`): Go structs ↔ datoms with automatic schema generation

--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -45,8 +45,13 @@ The Janus Datalog engine delivers production-ready performance through architect
 
 **Key Difference**: The 2× speedup comes from QueryExecutor's clause-by-clause streaming execution, not from better plan quality. Both planners produce equivalent-quality plans.
 
-**Configuration**: Enabled by default
+**Configuration**: Enabled by default. The `db.Open` API uses these defaults automatically:
 ```go
+// Public API — uses default planner/executor configuration
+d, _ := db.Open("path/to/db")
+d.Query(`[:find ?e ?v :where [?e :price/close ?v]]`)
+
+// Advanced: direct executor construction for non-default options
 exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
     UseClauseBasedPlanner: true,  // Default
 })
@@ -300,7 +305,7 @@ During development, benchmarks showed dramatic speedups (49-4802×) comparing li
 ```go
 // For hot paths, cache the parsed pattern
 pattern, _ := parser.ParsePullPattern(`[:user/name :user/age]`)
-puller := executor.NewPullExecutor(db.Matcher())
+puller := executor.NewPullExecutor(d.Unwrap().Matcher())
 
 // Reuse pattern across calls
 for _, entity := range entities {
@@ -413,7 +418,7 @@ for _, entity := range entities {
 
 CRDT semantics add negligible overhead to writes while providing:
 - Conflict-free replication capability
-- Time-travel queries via `[(history)]` and `[(as-of ?tx N)]`
+- Time-travel queries via `d.History()` and `d.AsOf(elementID)`
 - Multi-replica merge support
 
 ### 11. CRDT Allocation Optimization (COMPLETE - February 2026)
@@ -770,13 +775,20 @@ These were **tried and measured** - data showed they're not worth the complexity
 **Production Configuration** (all settings are measured and proven):
 
 ```go
-// Use new architecture (2× faster on complex queries)
+// Public API — uses all production defaults automatically
+d, _ := db.Open("path/to/db")
+d.Query(`[:find ?e ?v :where [?e :price/close ?v]]`)
+
+// With schema:
+d, _ := db.Open("path/to/db", db.WithSchema(s))
+
+// For advanced planner tuning, use the internal packages directly:
 exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
     UseClauseBasedPlanner: true,  // ✅ DEFAULT - works with QueryExecutor
 })
 exec.SetUseQueryExecutor(true)    // ✅ Use QueryExecutor (DEFAULT - clause-by-clause streaming)
 
-// Recommended planner options
+// Recommended planner options (these are the db.Open defaults)
 PlannerOptions{
     UseClauseBasedPlanner:        true,  // ✅ DEFAULT - required for QueryExecutor
     EnablePredicatePushdown:      true,  // ✅ DEFAULT - early filtering

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ go get github.com/wbrown/janus-datalog
 **Define your schema attributes as constants:**
 
 ```go
-import "github.com/wbrown/janus-datalog/datalog/qb"
+import (
+    "github.com/wbrown/janus-datalog/datalog/db"
+    "github.com/wbrown/janus-datalog/datalog/qb"
+)
 
 var (
     UserName = qb.Kw(":user/name")
@@ -56,8 +59,8 @@ var (
 **Write data:**
 
 ```go
-db, _ := storage.NewDatabase("my.db")
-tx := db.NewTransaction()
+d, _ := db.Open("my.db")
+tx := d.NewTransaction()
 
 alice := datalog.NewIdentity("user:alice")
 tx.Add(alice, UserName.Keyword(), "Alice")
@@ -81,7 +84,7 @@ q := qb.Query().
     ).
     MustBuild()
 
-results, _ := db.ExecuteQuery(q)
+results, _ := d.Query(q)
 ```
 
 **Output:**
@@ -90,7 +93,7 @@ results, _ := db.ExecuteQuery(q)
 [["Alice" 30]]
 ```
 
-That's it. No schema required. No connection pools. No query tuning. Typos caught at compile time.
+That's it. One import, one `Open()` call, one `Query()`. No schema required. No connection pools. No query tuning. Typos caught at compile time.
 
 ## Query Builder vs EDN Strings
 
@@ -119,7 +122,7 @@ q := qb.Query().
     ).
     MustBuild()
 
-results, _ := db.ExecuteQuery(q)
+results, _ := d.Query(q)
 ```
 
 **Why use it:**
@@ -133,7 +136,7 @@ results, _ := db.ExecuteQuery(q)
 For REPL exploration, porting Datomic queries, or when you prefer Datalog syntax:
 
 ```go
-results, _ := db.ExecuteQuery(`
+results, _ := d.Query(`
     [:find ?name ?age
      :where [?e :person/name ?name]
             [?e :person/age ?age]
@@ -301,33 +304,35 @@ All writes are preserved with CRDT semantics - history is inherent:
 
 ```go
 // Make changes over time
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 tx.Add(alice, datalog.NewKeyword(":user/name"), "Alice")
 tx.Commit()  // Lamport 1
 
-tx2 := db.NewTransaction()
+tx2 := d.NewTransaction()
 tx2.Add(alice, datalog.NewKeyword(":user/name"), "Alicia")  // LWW: replaces "Alice"
-tx2.Commit()  // Lamport 2
+tx1ID, _ := tx2.Commit()  // Lamport 2
 
 // Query current state - returns latest value (LWW semantics)
-db.ExecuteQuery(`[:find ?name :where [_ :user/name ?name]]`)
+d.Query(`[:find ?name :where [_ :user/name ?name]]`)
 // Returns: [["Alicia"]]
 
-// Query ALL historical values using [(history)] predicate
-db.ExecuteQuery(`[:find ?name ?tx :where [_ :user/name ?name ?tx] [(history)]]`)
+// Query ALL historical values — no CRDT resolution
+hist := d.History()
+hist.Query(`[:find ?name ?tx :where [_ :user/name ?name ?tx]]`)
 // Returns: [["Alice" <ElementID@1>] ["Alicia" <ElementID@2>]]
 
-// Query value as of a specific Lamport time
-db.ExecuteQuery(`[:find ?name :where [_ :user/name ?name ?tx] [(as-of ?tx 1)]]`)
+// Query value as of a specific transaction
+asOf := d.AsOf(tx1ID)  // tx1ID is datalog.ElementID from Commit()
+asOf.Query(`[:find ?name :where [_ :user/name ?name]]`)
 // Returns: [["Alice"]]
 ```
 
 **Key concepts:**
 - CRDT storage preserves all writes with ElementIDs (Lamport + ReplicaID)
 - Current-state queries return resolved values (LWW for cardinality-one)
-- `[(history)]` predicate returns all historical versions
-- `[(as-of ?tx N)]` returns value as of Lamport time N
-- `[(tx-between ?tx low high)]` filters to a Lamport range
+- `d.History()` returns a new `*DB` handle — all datoms, no CRDT resolution
+- `d.AsOf(elementID)` returns a new `*DB` handle with CRDT-resolved state at a point in time
+- `Commit()` returns `datalog.ElementID` for use with `AsOf()`
 
 ### Subqueries
 
@@ -364,7 +369,7 @@ Shared variables (`?uid`) create joins across sources automatically.
 **Execution with `WithSources`:**
 
 ```go
-results, err := usersDB.ExecuteQueryWithInputs(query,
+results, err := usersDB.Query(query,
     storage.WithSources(map[query.Symbol]executor.PatternMatcher{
         query.Symbol("$users"): usersDB,
         query.Symbol("$perms"): permsDB,
@@ -397,7 +402,10 @@ See [docs/reference/MULTI_SOURCE.md](docs/reference/MULTI_SOURCE.md) for the com
 Schema is **completely optional** but provides type safety and cardinality-many support:
 
 ```go
-import "github.com/wbrown/janus-datalog/datalog/schema"
+import (
+    "github.com/wbrown/janus-datalog/datalog/db"
+    "github.com/wbrown/janus-datalog/datalog/schema"
+)
 
 // Define schema with builder API
 s, _ := schema.NewBuilder().
@@ -407,7 +415,7 @@ s, _ := schema.NewBuilder().
     Build()
 
 // Create database with schema
-db, _ := storage.NewDatabaseWithSchema("my.db", s)
+d, _ := db.Open("my.db", db.WithSchema(s))
 ```
 
 **What schema gives you:**
@@ -439,7 +447,7 @@ Retrieve entity attributes declaratively:
  :where [?user :user/active true]]
 
 // Standalone
-result, _ := db.Pull(userId, `[:user/name :user/email {:user/friends [:user/name]}]`)
+result, _ := d.Pull(userId, `[:user/name :user/email {:user/friends [:user/name]}]`)
 ```
 
 **Features:**
@@ -455,7 +463,10 @@ See [DATOMIC_COMPATIBILITY.md](DATOMIC_COMPATIBILITY.md) for Pull API details.
 For Go developers, janus-datalog provides a reflection-based API that maps structs directly to datoms:
 
 ```go
-import "github.com/wbrown/janus-datalog/datalog/reflect"
+import (
+    "github.com/wbrown/janus-datalog/datalog/db"
+    "github.com/wbrown/janus-datalog/datalog/reflect"
+)
 
 // Define your domain type with struct tags
 type Person struct {
@@ -468,18 +479,18 @@ type Person struct {
 
 // Generate schema from struct
 schema, _ := reflect.SchemaFromStruct(Person{})
-db, _ := storage.NewDatabaseWithSchema("my.db", schema)
+d, _ := db.Open("my.db", db.WithSchema(schema))
 
 // Write structs directly
 alice := &Person{Name: "Alice", Age: 30, Tags: []string{"dev", "lead"}}
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 aliceID, _ := tx.AddStructAuto(alice)  // ID auto-generated
 tx.Commit()
 // alice.ID is now populated
 
 // Read into structs
 var loaded Person
-db.PullInto(aliceID, &loaded)
+d.PullInto(aliceID, &loaded)
 fmt.Println(loaded.Name)  // "Alice"
 fmt.Println(loaded.Tags)  // ["dev", "lead"]
 ```
@@ -507,7 +518,7 @@ type TradeResult struct {
 
 // Query into typed slice
 var results []TradeResult
-err := db.QueryInto(&results, `
+err := d.QueryInto(&results, `
     [:find ?symbol ?price ?volume
      :where [?t :trade/symbol ?symbol]
             [?t :trade/price ?price]
@@ -529,7 +540,7 @@ type DeptStats struct {
 }
 
 var stats []DeptStats
-db.QueryInto(&stats, `
+d.QueryInto(&stats, `
     [:find ?dept (avg ?salary) (count ?emp)
      :where [?e :employee/dept ?dept]
             [?e :employee/salary ?salary]]
@@ -540,7 +551,7 @@ db.QueryInto(&stats, `
 
 ```go
 var result TradeResult
-err := db.QueryOneInto(&result, `[:find ?symbol ?price ?volume :where ...]`)
+err := d.QueryOneInto(&result, `[:find ?symbol ?price ?volume :where ...]`)
 // Returns ErrNotFound if no results, ErrMultipleResults if >1
 ```
 
@@ -565,7 +576,7 @@ query := q.Where(
 ).MustBuild()
 
 var results []PersonResult
-db.QueryInto(&results, query)  // tags guaranteed to match
+d.QueryInto(&results, query)  // tags guaranteed to match
 ```
 
 - `q.Find(&f.Field)` - returns `*Var` and adds to Find clause
@@ -669,29 +680,29 @@ This happens when you write a query with no join paths between patterns. Instead
 
 ```go
 // Each write gets a unique ElementID (Lamport clock + ReplicaID)
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 tx.Add(alice, UserName.Keyword(), "Alice")   // ElementID: (Lamport=1, Replica=42)
 tx.Commit()
 
-tx2 := db.NewTransaction()
+tx2 := d.NewTransaction()
 tx2.Add(alice, UserName.Keyword(), "Alicia") // ElementID: (Lamport=2, Replica=42)
 tx2.Commit()
 
 // Current value: "Alicia" (higher Lamport wins)
-// But "Alice" is preserved - query it with [(history)]
+// But "Alice" is preserved - query it with d.History()
 ```
 
 **Multi-replica scenarios:**
 - Two replicas can accept writes independently (offline-first)
-- Merge via `db.Merge(datomsFromOtherReplica)`
+- Merge via `d.Merge(datomsFromOtherReplica)`
 - Conflicts resolve deterministically - same result on all nodes
 - No coordination required, no conflict resolution callbacks
 
-**History is inherent:**
-- Every write is preserved with its ElementID
-- `[(history)]` predicate returns all versions
-- `[(as-of ?tx N)]` returns state at Lamport time N
-- No separate "history mode" to enable - it's always there
+**Three temporal modes:**
+- Every write is preserved with its ElementID (Lamport + ReplicaID)
+- `d.History()` returns a new `*DB` handle — all datoms, no CRDT resolution
+- `d.AsOf(elementID)` returns a new `*DB` handle with CRDT-resolved state at a specific point in time
+- `Commit()` returns `datalog.ElementID` for use with `AsOf()`
 
 **Why this matters:**
 - **Edge computing**: Devices work offline, sync when connected
@@ -1002,7 +1013,7 @@ Janus implements **~70% of Datomic's feature set** (weighted by typical usage), 
 - Aggregations: sum, count, avg, min, max
 - Subqueries: Full q support
 - Time queries: as-of, time functions
-- History queries: Full audit trail with `ExecuteHistoryQuery`
+- History queries: Full audit trail with `d.History().Query()`
 - Pull API: Nested references, cycle detection, wildcards
 - Schema: Type validation, cardinality, uniqueness constraints
 - Storage: Persistent BadgerDB backend

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@
 - Relation collapsing algorithm (prevents memory explosion)
 - **CRDT storage: LWW for cardinality-one, add-wins for cardinality-many, RGA for vectors**
 - **NOT/OR clauses: `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with Datomic-compatible semantics**
-- **History/time-travel queries: `[(history)]` and `[(as-of ?tx N)]` predicates**
+- **History/time-travel queries: `db.History()` and `db.AsOf(elementID)` API**
 - **Multi-source queries: named sources, SourceRouter, cross-source joins**
 - **QueryInto API: typed query results via struct tag mapping**
 - **Database export/import: EDN format for backup and migration**
@@ -92,7 +92,7 @@ These items have been completed and are preserved for historical context:
 
 These were originally listed as "out of scope" but got implemented anyway:
 
-- ~~Full history/time-travel queries~~ → ✅ **Done** via CRDT storage with `[(history)]` and `[(as-of ?tx N)]`
+- ~~Full history/time-travel queries~~ → ✅ **Done** via CRDT storage with `db.History()` and `db.AsOf(elementID)`
 - ~~Would need different storage model~~ → The CRDT refactor made it natural
 
 ### Actually Won't Do

--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -165,7 +165,7 @@ func runDemo(db *storage.Database, handler annotations.Handler, enableDecorrelat
 	if err != nil {
 		log.Fatalf("Failed to commit: %v", err)
 	}
-	fmt.Printf("Committed transaction %d\n", txID)
+	fmt.Printf("Committed transaction %v\n", txID)
 
 	// Run some queries
 	fmt.Println("\n=== Running Queries ===")
@@ -346,7 +346,7 @@ func addInteractiveData(db *storage.Database, scanner *bufio.Scanner) {
 		if err != nil {
 			fmt.Printf("Commit failed: %v\n", err)
 		} else {
-			fmt.Printf("Committed %d datoms in transaction %d\n", count, txID)
+			fmt.Printf("Committed %d datoms in transaction %v\n", count, txID)
 		}
 	} else {
 		tx.Rollback()

--- a/datalog/compare.go
+++ b/datalog/compare.go
@@ -66,12 +66,11 @@ func CompareValues(left, right interface{}) int {
 		return -1
 	}
 
-	// Handle ElementID comparison - use the Compare method
-	if eid1, ok := left.(ElementID); ok {
-		if eid2, ok := right.(ElementID); ok {
+	// Handle ElementID comparison — dereference pointers, then compare by value
+	if eid1, ok := DerefElementID(left); ok {
+		if eid2, ok := DerefElementID(right); ok {
 			return eid1.Compare(eid2)
 		}
-		// ElementID vs non-ElementID: type mismatch
 		return -1
 	}
 
@@ -293,9 +292,9 @@ func ValuesEqual(a, b interface{}) bool {
 		return false
 	}
 
-	// ElementID comparison - use the Equal method
-	if eid1, ok := a.(ElementID); ok {
-		if eid2, ok := b.(ElementID); ok {
+	// ElementID comparison — dereference pointers, then compare by value
+	if eid1, ok := DerefElementID(a); ok {
+		if eid2, ok := DerefElementID(b); ok {
 			return eid1.Equal(eid2)
 		}
 		return false
@@ -337,5 +336,20 @@ func stringValue(v interface{}) string {
 	default:
 		// Use fmt.Sprintf for other types
 		return fmt.Sprintf("%v", v)
+	}
+}
+
+// DerefElementID extracts an ElementID from either ElementID or *ElementID.
+func DerefElementID(v interface{}) (ElementID, bool) {
+	switch e := v.(type) {
+	case ElementID:
+		return e, true
+	case *ElementID:
+		if e != nil {
+			return *e, true
+		}
+		return ElementID{}, false
+	default:
+		return ElementID{}, false
 	}
 }

--- a/datalog/compare_test.go
+++ b/datalog/compare_test.go
@@ -327,6 +327,56 @@ func TestElementIDValuesEqual(t *testing.T) {
 	}
 }
 
+// TestElementIDPointerValueCrossComparison tests CompareValues and ValuesEqual
+// with *ElementID ↔ ElementID cross-type comparisons. The InternedTupleBuilder
+// stores Tx as *ElementID (pointer) while user bindings pass ElementID (value).
+// Both forms must compare correctly.
+func TestElementIDPointerValueCrossComparison(t *testing.T) {
+	a := ElementID{Lamport: 100, ReplicaID: 5}
+	b := ElementID{Lamport: 100, ReplicaID: 5} // equal to a
+	c := ElementID{Lamport: 200, ReplicaID: 5} // different from a
+
+	// CompareValues: pointer left, value right
+	if cmp := CompareValues(&a, b); cmp != 0 {
+		t.Errorf("CompareValues(&a, b) = %d, want 0", cmp)
+	}
+
+	// CompareValues: value left, pointer right
+	if cmp := CompareValues(a, &b); cmp != 0 {
+		t.Errorf("CompareValues(a, &b) = %d, want 0", cmp)
+	}
+
+	// CompareValues: both pointers, equal
+	if cmp := CompareValues(&a, &b); cmp != 0 {
+		t.Errorf("CompareValues(&a, &b) = %d, want 0", cmp)
+	}
+
+	// CompareValues: both pointers, different
+	if cmp := CompareValues(&a, &c); cmp >= 0 {
+		t.Errorf("CompareValues(&a, &c) = %d, want < 0", cmp)
+	}
+
+	// ValuesEqual: pointer/value mix
+	if !ValuesEqual(&a, b) {
+		t.Error("ValuesEqual(&a, b) should be true")
+	}
+
+	// ValuesEqual: value/pointer mix
+	if !ValuesEqual(a, &b) {
+		t.Error("ValuesEqual(a, &b) should be true")
+	}
+
+	// ValuesEqual: both pointers, different
+	if ValuesEqual(&a, &c) {
+		t.Error("ValuesEqual(&a, &c) should be false")
+	}
+
+	// ValuesEqual: nil pointer vs value
+	if ValuesEqual((*ElementID)(nil), a) {
+		t.Error("ValuesEqual(nil *ElementID, a) should be false")
+	}
+}
+
 // TestElementIDZeroValues tests comparison with zero/HEAD ElementID
 func TestElementIDZeroValues(t *testing.T) {
 	zero := ElementIDZero

--- a/datalog/db/db.go
+++ b/datalog/db/db.go
@@ -1,0 +1,66 @@
+// Package db provides the public API for janus-datalog.
+//
+// This is the primary entry point for consumers. It wraps the internal
+// storage, executor, and parser packages into a clean interface:
+//
+//	d, err := db.Open("/path/to/data")
+//	defer d.Close()
+//
+//	tx := d.NewTransaction()
+//	tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice")
+//	txID, _ := tx.Commit()
+//
+//	name, found, _ := d.GetString(alice, datalog.NewKeyword(":person/name"))
+//
+//	asOf := d.AsOf(txID)
+//	hist := d.History()
+package db
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// DB is the main database handle. It is a type alias for storage.Database;
+// all methods on *storage.Database (Query, GetString, AsOfDatabase, etc.)
+// are available directly.
+type DB = storage.Database
+
+// Transaction provides write access to the database. It is a type alias
+// for storage.Transaction; all methods (Add, Commit, Rollback, etc.)
+// are available directly.
+type Transaction = storage.Transaction
+
+// Open creates or opens a database at the given path.
+func Open(path string, opts ...Option) (*DB, error) {
+	var cfg config
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	d, err := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+		Path:              path,
+		Schema:            cfg.schema,
+		ReplicaID:         cfg.replicaID,
+		AnnotationHandler: cfg.annotationHandler,
+		DisableCache:      cfg.disableCache,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("db.Open: %w", err)
+	}
+	return d, nil
+}
+
+// MustParseQuery parses a Datalog query string, panicking on error.
+// Use this for package-level query constants known at compile time:
+//
+//	var myQuery = db.MustParseQuery(`[:find ?e :where [?e :person/name "Alice"]]`)
+func MustParseQuery(input string) *query.Query {
+	q, err := parser.ParseQuery(input)
+	if err != nil {
+		panic(fmt.Sprintf("db.MustParseQuery: %v\n%s", err, input))
+	}
+	return q
+}

--- a/datalog/db/db_test.go
+++ b/datalog/db/db_test.go
@@ -1,0 +1,434 @@
+package db_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/db"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+func tempDB(t *testing.T, opts ...db.Option) *db.DB {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "db-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	d, err := db.Open(filepath.Join(tmpDir, "test.db"), opts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func TestOpenClose(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "db-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	d, err := db.Open(filepath.Join(tmpDir, "test.db"))
+	require.NoError(t, err)
+	require.NotNil(t, d)
+
+	err = d.Close()
+	require.NoError(t, err)
+}
+
+func TestQueryRoundTrip(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	txID, err := tx.Commit()
+	require.NoError(t, err)
+	assert.NotEqual(t, datalog.ElementID{}, txID)
+
+	results, err := d.Query(`[:find ?name :where [?e :person/name ?name]]`)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Alice", results[0][0])
+}
+
+func TestQueryWithInputs(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+	age := datalog.NewKeyword(":person/age")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	require.NoError(t, tx.Add(alice, age, int64(30)))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	results, err := d.Query(
+		`[:find ?name :in $ ?min-age :where [?e :person/name ?name] [?e :person/age ?age] [(>= ?age ?min-age)]]`,
+		int64(25),
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Alice", results[0][0])
+}
+
+func TestQueryInto(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var names []string
+	err = d.QueryInto(&names, `[:find ?name :where [?e :person/name ?name]]`)
+	require.NoError(t, err)
+	require.Len(t, names, 1)
+	assert.Equal(t, "Alice", names[0])
+}
+
+func TestQueryOneInto(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var result string
+	found, err := d.QueryOneInto(&result, `[:find ?name :where [?e :person/name ?name]]`)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "Alice", result)
+
+	// Not found case
+	var missing string
+	found, err = d.QueryOneInto(&missing, `[:find ?name :where [?e :person/nonexistent ?name]]`)
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestGetString(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	val, found, err := d.GetString(alice, name)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "Alice", val)
+
+	// Missing attribute
+	val, found, err = d.GetString(alice, datalog.NewKeyword(":person/missing"))
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, "", val)
+}
+
+func TestGetInt(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	age := datalog.NewKeyword(":person/age")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, age, int64(30)))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	val, found, err := d.GetInt(alice, age)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, int64(30), val)
+
+	// Missing
+	val, found, err = d.GetInt(alice, datalog.NewKeyword(":person/missing"))
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, int64(0), val)
+}
+
+func TestGetFloat(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	score := datalog.NewKeyword(":person/score")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, score, 3.14))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	val, found, err := d.GetFloat(alice, score)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.InDelta(t, 3.14, val, 0.001)
+
+	// Missing
+	val, found, err = d.GetFloat(alice, datalog.NewKeyword(":person/missing"))
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, float64(0), val)
+}
+
+func TestGetBool(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	active := datalog.NewKeyword(":person/active")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, active, true))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	val, found, err := d.GetBool(alice, active)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.True(t, val)
+
+	// Missing
+	val, found, err = d.GetBool(alice, datalog.NewKeyword(":person/missing"))
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.False(t, val)
+}
+
+func TestGetRef(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	friend := datalog.NewKeyword(":person/friend")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, friend, bob))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	val, found, err := d.GetRef(alice, friend)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, bob, val)
+
+	// Missing
+	val, found, err = d.GetRef(alice, datalog.NewKeyword(":person/missing"))
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Nil(t, val)
+}
+
+func TestGetStrings(t *testing.T) {
+	s, err := schema.NewBuilder().
+		Attribute(":person/tag").Type(schema.TypeString).Many().Add().
+		Build()
+	require.NoError(t, err)
+	d := tempDB(t, db.WithSchema(s))
+
+	alice := datalog.NewIdentity("alice")
+	tag := datalog.NewKeyword(":person/tag")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, tag, "developer"))
+	require.NoError(t, tx.Add(alice, tag, "gopher"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	vals, err := d.GetStrings(alice, tag)
+	require.NoError(t, err)
+	assert.Len(t, vals, 2)
+	assert.Contains(t, vals, "developer")
+	assert.Contains(t, vals, "gopher")
+
+	// Missing — empty slice, no error
+	vals, err = d.GetStrings(alice, datalog.NewKeyword(":person/missing"))
+	require.NoError(t, err)
+	assert.Empty(t, vals)
+}
+
+func TestAsOf(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	tx1 := d.NewTransaction()
+	require.NoError(t, tx1.Add(alice, name, "Alice"))
+	tx1ID, err := tx1.Commit()
+	require.NoError(t, err)
+
+	tx2 := d.NewTransaction()
+	require.NoError(t, tx2.Add(alice, name, "Alicia"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Latest should be "Alicia"
+	val, found, err := d.GetString(alice, name)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "Alicia", val)
+
+	// AsOf tx1 should be "Alice"
+	asOf := d.AsOf(tx1ID)
+	val, found, err = asOf.GetString(alice, name)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "Alice", val)
+}
+
+func TestHistory(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	tx1 := d.NewTransaction()
+	require.NoError(t, tx1.Add(alice, name, "Alice"))
+	_, err := tx1.Commit()
+	require.NoError(t, err)
+
+	tx2 := d.NewTransaction()
+	require.NoError(t, tx2.Add(alice, name, "Alicia"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// History should return both values
+	hist := d.History()
+	results, err := hist.Query(`[:find ?name :where [?e :person/name ?name]]`)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	names := make([]string, len(results))
+	for i, r := range results {
+		names[i] = r[0].(string)
+	}
+	assert.Contains(t, names, "Alice")
+	assert.Contains(t, names, "Alicia")
+}
+
+func TestMustParseQuery(t *testing.T) {
+	// Valid query — should not panic
+	q := db.MustParseQuery(`[:find ?e :where [?e :person/name "Alice"]]`)
+	assert.NotNil(t, q)
+
+	// Invalid query — should panic
+	assert.Panics(t, func() {
+		db.MustParseQuery(`[:find`)
+	})
+}
+
+func TestMustParseQueryWithQuery(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Pre-parsed query works with Query
+	q := db.MustParseQuery(`[:find ?name :where [?e :person/name ?name]]`)
+	results, err := d.Query(q)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Alice", results[0][0])
+}
+
+func TestAssert(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	err := d.Assert([]datalog.Datom{{E: alice, A: name, V: "Alice"}})
+	require.NoError(t, err)
+
+	val, found, err := d.GetString(alice, name)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "Alice", val)
+}
+
+func TestPullInto(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+	age := datalog.NewKeyword(":person/age")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	require.NoError(t, tx.Add(alice, age, int64(30)))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	type Person struct {
+		Name string `datalog:"name"`
+		Age  int64  `datalog:"age"`
+	}
+	var p Person
+	err = d.PullInto(alice, &p)
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", p.Name)
+	assert.Equal(t, int64(30), p.Age)
+}
+
+func TestTransactionRollback(t *testing.T) {
+	d := tempDB(t)
+
+	alice := datalog.NewIdentity("alice")
+	name := datalog.NewKeyword(":person/name")
+
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(alice, name, "Alice"))
+	require.NoError(t, tx.Rollback())
+
+	// Should not find the data
+	results, err := d.Query(`[:find ?name :where [?e :person/name ?name]]`)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestSaveStruct(t *testing.T) {
+	d := tempDB(t)
+
+	type Person struct {
+		ID   datalog.Identity `datalog:"-,id"`
+		Name string           `datalog:"name"`
+	}
+
+	p := &Person{Name: "Alice"}
+	tx := d.NewTransaction()
+	id, err := tx.SaveStruct(p)
+	require.NoError(t, err)
+	assert.NotNil(t, id)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	val, found, err := d.GetString(id, datalog.NewKeyword(":person/name"))
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "Alice", val)
+}
+
+// Verify DB satisfies Querier interface at compile time.
+var _ db.Querier = (*db.DB)(nil)

--- a/datalog/db/interfaces.go
+++ b/datalog/db/interfaces.go
@@ -1,0 +1,25 @@
+package db
+
+import "github.com/wbrown/janus-datalog/datalog"
+
+// EntityReader provides typed attribute access for entities.
+type EntityReader interface {
+	GetString(e datalog.Identity, a datalog.Keyword) (string, bool, error)
+	GetInt(e datalog.Identity, a datalog.Keyword) (int64, bool, error)
+	GetFloat(e datalog.Identity, a datalog.Keyword) (float64, bool, error)
+	GetBool(e datalog.Identity, a datalog.Keyword) (bool, bool, error)
+	GetRef(e datalog.Identity, a datalog.Keyword) (datalog.Identity, bool, error)
+	GetStrings(e datalog.Identity, a datalog.Keyword) ([]string, error)
+}
+
+// Querier provides the core query and entity access operations.
+type Querier interface {
+	Query(q any, inputs ...any) ([][]any, error)
+	QueryInto(dest any, q any, inputs ...any) error
+	QueryOneInto(dest any, q any, inputs ...any) (bool, error)
+	PullInto(entityID datalog.Identity, v any) error
+	NewTransaction() *Transaction
+	EntityReader
+}
+
+var _ Querier = (*DB)(nil)

--- a/datalog/db/options.go
+++ b/datalog/db/options.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+type config struct {
+	schema            schema.SchemaProvider
+	replicaID         uint64
+	annotationHandler annotations.Handler
+	disableCache      bool
+}
+
+// Option configures a database opened with Open.
+type Option func(*config)
+
+// WithSchema sets the schema for type validation and cardinality handling.
+func WithSchema(s schema.SchemaProvider) Option {
+	return func(c *config) { c.schema = s }
+}
+
+// WithReplicaID sets the CRDT replica identifier.
+// Zero means auto-generate a random ID.
+func WithReplicaID(id uint64) Option {
+	return func(c *config) { c.replicaID = id }
+}
+
+// WithAnnotationHandler sets a handler for query tracing and observability.
+func WithAnnotationHandler(h annotations.Handler) Option {
+	return func(c *config) { c.annotationHandler = h }
+}
+
+// WithoutCache disables the EA cache; queries resolve directly from storage.
+func WithoutCache() Option {
+	return func(c *config) { c.disableCache = true }
+}
+
+// WithVerbose enables query tracing to stdout.
+func WithVerbose() Option {
+	return func(c *config) {
+		formatter := annotations.NewOutputFormatter(os.Stdout)
+		c.annotationHandler = func(event annotations.Event) {
+			fmt.Fprintln(os.Stdout, formatter.Format(event))
+		}
+	}
+}
+
+// WithVerboseCallback enables query tracing with a custom callback.
+// The callback receives pre-formatted human-readable strings.
+func WithVerboseCallback(fn func(string)) Option {
+	return func(c *config) {
+		formatter := annotations.NewOutputFormatter(nil)
+		c.annotationHandler = func(event annotations.Event) {
+			fn(formatter.Format(event))
+		}
+	}
+}

--- a/datalog/db/sources.go
+++ b/datalog/db/sources.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// PatternMatcher is the interface all data sources implement.
+// Database, memory sources, and slice sources all satisfy this.
+type PatternMatcher = executor.PatternMatcher
+
+// QueryOption configures query execution (e.g., adding sources).
+type QueryOption = storage.QueryOption
+
+// AttributeSchema maps keywords to accessor functions for SliceSource.
+type AttributeSchema[T any] = executor.AttributeSchema[T]
+
+// SliceSource wraps a Go slice as a queryable PatternMatcher.
+type SliceSource[T any] = executor.SliceSource[T]
+
+// WithSources adds named data sources for multi-source queries.
+// The default source ($) is always the database itself.
+//
+// Example:
+//
+//	cache := db.NewMemorySource(datoms)
+//	results, _ := d.Query(
+//	    `[:find ?name ?score
+//	      :in $ $cache
+//	      :where [?e :user/name ?name]
+//	             [$cache ?c :cache/score ?score]]`,
+//	    db.WithSources(map[datalog.Symbol]db.PatternMatcher{
+//	        datalog.NewSymbol("$cache"): cache,
+//	    }),
+//	)
+var WithSources = storage.WithSources
+
+// NewSliceSource creates a PatternMatcher from a Go slice and attribute schema.
+// Each item at index i gets entity ID "slice:i". Multi-valued attributes
+// (slices/arrays returned by accessor functions) are expanded into one datom
+// per element.
+//
+// Example:
+//
+//	type Rule struct {
+//	    Key       string
+//	    DependsOn []string
+//	}
+//
+//	source := db.NewSliceSource(rules, db.AttributeSchema[Rule]{
+//	    datalog.NewKeyword(":rule/key"):        func(r Rule) any { return r.Key },
+//	    datalog.NewKeyword(":rule/depends-on"): func(r Rule) any { return r.DependsOn },
+//	})
+func NewSliceSource[T any](items []T, schema AttributeSchema[T]) *SliceSource[T] {
+	return executor.NewSliceSource(items, schema)
+}
+
+// NewMemorySource creates a PatternMatcher from a slice of datoms.
+// Use this for ad-hoc in-memory data sources.
+//
+// Example:
+//
+//	facts := []datalog.Datom{
+//	    {E: datalog.NewIdentity("e1"), A: datalog.NewKeyword(":item/name"), V: "Sword"},
+//	}
+//	source := db.NewMemorySource(facts)
+var NewMemorySource = executor.NewMemoryPatternMatcher

--- a/datalog/executor/constraints_impl.go
+++ b/datalog/executor/constraints_impl.go
@@ -49,8 +49,8 @@ func (c *equalityConstraint) Evaluate(datom *datalog.Datom) bool {
 		}
 		return datalog.ValuesEqual(datom.V, c.value)
 	case 3: // Transaction
-		if tx, ok := c.value.(datalog.ElementID); ok {
-			return datom.Tx == tx
+		if eid, ok := datalog.DerefElementID(c.value); ok {
+			return datom.Tx == eid
 		}
 		// Backward compatibility: also support uint64 comparison by Lamport
 		if tx, ok := c.value.(uint64); ok {

--- a/datalog/executor/join.go
+++ b/datalog/executor/join.go
@@ -337,7 +337,7 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 			hasTxColumn := false
 			if txIndex < len(firstTuple) {
 				switch firstTuple[txIndex].(type) {
-				case uint64, int64, int:
+				case uint64, int64, int, datalog.ElementID, *datalog.ElementID:
 					hasTxColumn = true
 					if opts.EnableDebugLogging {
 						fmt.Printf("[HashJoin] Confirmed tx column at index %d with type %T\n", txIndex, firstTuple[txIndex])
@@ -372,6 +372,12 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 					txID = uint64(v)
 				case int:
 					txID = uint64(v)
+				case datalog.ElementID:
+					txID = v.Lamport
+				case *datalog.ElementID:
+					if v != nil {
+						txID = v.Lamport
+					}
 				}
 
 				// Keep only if this is newer than what we have
@@ -395,6 +401,12 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 						txID = uint64(v)
 					case int:
 						txID = uint64(v)
+					case datalog.ElementID:
+						txID = v.Lamport
+					case *datalog.ElementID:
+						if v != nil {
+							txID = v.Lamport
+						}
 					}
 
 					// Keep only if this is newer than what we have

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -479,7 +479,7 @@ func (r *MaterializedRelation) ProjectFromPattern(pattern *query.DataPattern) Re
 		symbolIndices[col] = i
 	}
 
-	// Check each position in the pattern
+	// Check each position in the pattern (E, A, V, T)
 	if sym, ok := pattern.GetE().(query.Variable); ok {
 		if _, exists := symbolIndices[sym.Name]; exists {
 			neededSymbols = append(neededSymbols, sym.Name)
@@ -493,6 +493,13 @@ func (r *MaterializedRelation) ProjectFromPattern(pattern *query.DataPattern) Re
 	if sym, ok := pattern.GetV().(query.Variable); ok {
 		if _, exists := symbolIndices[sym.Name]; exists && !contains(neededSymbols, sym.Name) {
 			neededSymbols = append(neededSymbols, sym.Name)
+		}
+	}
+	if len(pattern.Elements) > 3 {
+		if sym, ok := pattern.GetT().(query.Variable); ok {
+			if _, exists := symbolIndices[sym.Name]; exists && !contains(neededSymbols, sym.Name) {
+				neededSymbols = append(neededSymbols, sym.Name)
+			}
 		}
 	}
 
@@ -1006,7 +1013,7 @@ func (r *StreamingRelation) ProjectFromPattern(pattern *query.DataPattern) Relat
 		symbolIndices[col] = i
 	}
 
-	// Check each position in the pattern
+	// Check each position in the pattern (E, A, V, T)
 	if sym, ok := pattern.GetE().(query.Variable); ok {
 		if _, exists := symbolIndices[sym.Name]; exists {
 			neededSymbols = append(neededSymbols, sym.Name)
@@ -1020,6 +1027,13 @@ func (r *StreamingRelation) ProjectFromPattern(pattern *query.DataPattern) Relat
 	if sym, ok := pattern.GetV().(query.Variable); ok {
 		if _, exists := symbolIndices[sym.Name]; exists && !contains(neededSymbols, sym.Name) {
 			neededSymbols = append(neededSymbols, sym.Name)
+		}
+	}
+	if len(pattern.Elements) > 3 {
+		if sym, ok := pattern.GetT().(query.Variable); ok {
+			if _, exists := symbolIndices[sym.Name]; exists && !contains(neededSymbols, sym.Name) {
+				neededSymbols = append(neededSymbols, sym.Name)
+			}
 		}
 	}
 

--- a/datalog/executor/tuple_key.go
+++ b/datalog/executor/tuple_key.go
@@ -129,6 +129,15 @@ func hashValue(v interface{}) uint64 {
 		}
 		return 0
 
+	case datalog.ElementID:
+		return val.Lamport ^ (val.ReplicaID * 1099511628211)
+
+	case *datalog.ElementID:
+		if val == nil {
+			return 0
+		}
+		return val.Lamport ^ (val.ReplicaID * 1099511628211)
+
 	case nil:
 		return 0
 

--- a/datalog/qb/README.md
+++ b/datalog/qb/README.md
@@ -27,7 +27,7 @@ var (
 )
 
 // 2. Build queries with Go variables
-func FindAdultsInCity(db *storage.Database, city string) ([][]interface{}, error) {
+func FindAdultsInCity(d *db.DB, city string) ([][]interface{}, error) {
     e := qb.NewVar("e")
     name := qb.NewVar("name")
     age := qb.NewVar("age")
@@ -44,7 +44,7 @@ func FindAdultsInCity(db *storage.Database, city string) ([][]interface{}, error
         ).
         MustBuild()
 
-    return db.ExecuteQueryWithInputs(q, city)
+    return d.Query(q, city)
 }
 ```
 
@@ -86,13 +86,13 @@ q := qb.Query().
     ).
     MustBuild()
 
-results, err := db.ExecuteQuery(q)
+results, err := d.Query(q)
 ```
 
 ### EDN String (Fallback)
 
 ```go
-results, err := db.ExecuteQuery(`
+results, err := d.Query(`
     [:find ?name ?age
      :where
      [?e :person/name ?name]

--- a/datalog/query/history.go
+++ b/datalog/query/history.go
@@ -1,6 +1,10 @@
 package query
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
 
 // HistoryPredicateType indicates the type of history query
 type HistoryPredicateType int
@@ -125,13 +129,14 @@ func (t *TxRangePredicate) Eval(bindings map[Symbol]interface{}) (bool, error) {
 		lamport = uint64(v)
 	case int:
 		lamport = uint64(v)
-	default:
-		// Try to extract Lamport from ElementID if available
-		if elemID, ok := txVal.(interface{ GetLamport() uint64 }); ok {
-			lamport = elemID.GetLamport()
-		} else {
-			return false, fmt.Errorf("tx-between: cannot extract Lamport from %T", txVal)
+	case datalog.ElementID:
+		lamport = v.Lamport
+	case *datalog.ElementID:
+		if v != nil {
+			lamport = v.Lamport
 		}
+	default:
+		return false, fmt.Errorf("tx-between: cannot extract Lamport from %T", txVal)
 	}
 
 	return lamport >= t.Low && lamport <= t.High, nil

--- a/datalog/query/tuple_builder_interned.go
+++ b/datalog/query/tuple_builder_interned.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"sync"
+
 	"github.com/wbrown/janus-datalog/datalog"
 )
 
@@ -22,6 +24,7 @@ type InternedTupleBuilder struct {
 
 	// Cache for common ElementID values (transaction IDs)
 	txCache map[datalog.ElementID]*datalog.ElementID
+	txMu    sync.Mutex
 }
 
 // NewInternedTupleBuilder creates a tuple builder that uses interning
@@ -37,19 +40,22 @@ func NewInternedTupleBuilder(pattern *DataPattern, columns []Symbol) *InternedTu
 		tIndex:    indexer.TIndex,
 		numVars:   indexer.NumVars,
 		workspace: make(Tuple, len(columns)),
-		txCache:   make(map[datalog.ElementID]*datalog.ElementID, 128), // Pre-allocate for common tx IDs
+		txCache:   make(map[datalog.ElementID]*datalog.ElementID),
 	}
 }
 
 // getTxPtr returns a cached pointer to an ElementID value
 func (tb *InternedTupleBuilder) getTxPtr(tx datalog.ElementID) *datalog.ElementID {
+	tb.txMu.Lock()
 	if ptr, found := tb.txCache[tx]; found {
+		tb.txMu.Unlock()
 		return ptr
 	}
 	// Create new pointer and cache it
 	ptr := new(datalog.ElementID)
 	*ptr = tx
 	tb.txCache[tx] = ptr
+	tb.txMu.Unlock()
 	return ptr
 }
 

--- a/datalog/reflect/pattern.go
+++ b/datalog/reflect/pattern.go
@@ -86,6 +86,7 @@ func generatePullPatternRecursive(t reflect.Type, s schema.SchemaProvider, visit
 			elemType != timeType &&
 			elemType != identityType &&
 			elemType != keywordType &&
+			elemType != elementIDType &&
 			!isOrderedSetType(elemType) // OrderedSet is a value type, not a nested entity
 
 		if isNestedStruct {

--- a/datalog/reflect/query_reader.go
+++ b/datalog/reflect/query_reader.go
@@ -377,6 +377,17 @@ func setQueryValue(fieldVal reflect.Value, fieldType reflect.Type, value interfa
 		fieldVal.Set(reflect.ValueOf(t))
 		return nil
 
+	case elementIDType:
+		switch v := value.(type) {
+		case datalog.ElementID:
+			fieldVal.Set(reflect.ValueOf(v))
+		case *datalog.ElementID:
+			fieldVal.Set(reflect.ValueOf(*v))
+		default:
+			return fmt.Errorf("expected ElementID, got %T", value)
+		}
+		return nil
+
 	case identityType:
 		// Identity is now always a pointer type (*identity)
 		if v, ok := value.(datalog.Identity); ok {

--- a/datalog/reflect/reader.go
+++ b/datalog/reflect/reader.go
@@ -133,6 +133,20 @@ func (sr *StructReader) setFieldValue(fieldVal reflect.Value, field *FieldInfo, 
 		return fmt.Errorf("expected Keyword, got %T", value)
 	}
 
+	// Handle ElementID (value struct, not a reference)
+	if fieldType == elementIDType {
+		switch v := value.(type) {
+		case datalog.ElementID:
+			fieldVal.Set(reflect.ValueOf(v))
+			return nil
+		case *datalog.ElementID:
+			fieldVal.Set(reflect.ValueOf(*v))
+			return nil
+		default:
+			return fmt.Errorf("expected ElementID, got %T", value)
+		}
+	}
+
 	// Handle pointer fields (but not Identity/Keyword which are handled above)
 	if fieldType.Kind() == reflect.Ptr {
 		// Create new value and set pointer
@@ -282,7 +296,8 @@ func (sr *StructReader) setSingleValue(fieldVal reflect.Value, fieldType reflect
 	if fieldType.Kind() == reflect.Struct &&
 		fieldType != timeType &&
 		fieldType != identityType &&
-		fieldType != keywordType {
+		fieldType != keywordType &&
+		fieldType != elementIDType {
 
 		// Could be a map (nested pull result) or Identity (ref without nested pattern)
 		switch v := value.(type) {
@@ -331,6 +346,17 @@ func (sr *StructReader) setSingleValue(fieldVal reflect.Value, fieldType reflect
 			return fmt.Errorf("expected Keyword, got %T", value)
 		}
 		fieldVal.Set(reflect.ValueOf(kw))
+		return nil
+
+	case elementIDType:
+		switch v := value.(type) {
+		case datalog.ElementID:
+			fieldVal.Set(reflect.ValueOf(v))
+		case *datalog.ElementID:
+			fieldVal.Set(reflect.ValueOf(*v))
+		default:
+			return fmt.Errorf("expected ElementID, got %T", value)
+		}
 		return nil
 	}
 

--- a/datalog/reflect/types.go
+++ b/datalog/reflect/types.go
@@ -12,9 +12,10 @@ import (
 
 // Well-known types for comparison
 var (
-	timeType     = reflect.TypeOf(time.Time{})
-	identityType = reflect.TypeOf((datalog.Identity)(nil))
-	keywordType  = reflect.TypeOf((datalog.Keyword)(nil)) // Keyword is *keyword, no .Elem()
+	timeType      = reflect.TypeOf(time.Time{})
+	identityType  = reflect.TypeOf((datalog.Identity)(nil))
+	keywordType   = reflect.TypeOf((datalog.Keyword)(nil)) // Keyword is *keyword, no .Elem()
+	elementIDType = reflect.TypeOf(datalog.ElementID{})
 )
 
 // isOrderedSetType checks if the type is datalog.OrderedSet[T]
@@ -89,6 +90,9 @@ func GoTypeToSchemaType(t reflect.Type) (schema.ValueType, error) {
 		}
 		if t == keywordType {
 			return schema.TypeKeyword, nil
+		}
+		if t == elementIDType {
+			return schema.TypeTx, nil
 		}
 		// Check for OrderedSet[T] - get element type
 		if isOrderedSetType(t) {
@@ -169,7 +173,7 @@ func IsRefType(t reflect.Type) bool {
 
 	// Struct (other than well-known types) = nested entity reference
 	if t.Kind() == reflect.Struct {
-		if t == timeType || t == keywordType {
+		if t == timeType || t == keywordType || t == elementIDType {
 			return false
 		}
 		return true

--- a/datalog/schema/parser.go
+++ b/datalog/schema/parser.go
@@ -152,6 +152,8 @@ func parseValueType(node *edn.Node) (ValueType, error) {
 		return TypeRef, nil
 	case "db.type/keyword":
 		return TypeKeyword, nil
+	case "db.type/tx":
+		return TypeTx, nil
 	default:
 		return "", fmt.Errorf("unknown value type: %s", node.Value)
 	}

--- a/datalog/schema/types.go
+++ b/datalog/schema/types.go
@@ -17,6 +17,7 @@ const (
 	TypeBytes   ValueType = "db.type/bytes"   // []byte
 	TypeRef     ValueType = "db.type/ref"     // datalog.Identity
 	TypeKeyword ValueType = "db.type/keyword" // datalog.Keyword
+	TypeTx      ValueType = "db.type/tx"      // datalog.ElementID
 )
 
 // Cardinality represents how many values an attribute can have

--- a/datalog/schema/validation.go
+++ b/datalog/schema/validation.go
@@ -61,6 +61,15 @@ func ValidateValue(value interface{}, expected ValueType) error {
 		}
 		actualType = "Keyword"
 
+	case TypeTx:
+		switch value.(type) {
+		case datalog.ElementID:
+			ok = true
+		case *datalog.ElementID:
+			ok = true
+		}
+		actualType = "ElementID"
+
 	default:
 		// Unknown type constraint, allow anything
 		return nil

--- a/datalog/storage/batch_iterator.go
+++ b/datalog/storage/batch_iterator.go
@@ -255,9 +255,12 @@ func (it *batchScanIterator) scanRange(rg RangeGroup) {
 		return
 	}
 
-	// Wrap with CRDT resolution to ensure we only see resolved values
-	// Always applied: CRDTResolvingIterator handles nil schema correctly
-	it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
+	// Wrap with CRDT resolution unless in history mode
+	if it.matcher.isHistoryMode() {
+		it.storageIter = rawIter
+	} else {
+		it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.crdtTxID())
+	}
 	it.totalScans++
 
 	// Build a map of binding values for quick lookup
@@ -283,7 +286,7 @@ func (it *batchScanIterator) scanRange(rg RangeGroup) {
 		datomCount++
 
 		// Check transaction validity
-		if it.matcher.txID != (datalog.ElementID{}) && it.matcher.txID.Less(datom.Tx) {
+		if it.matcher.shouldFilterTx(datom.Tx) {
 			continue
 		}
 

--- a/datalog/storage/batch_iterator.go
+++ b/datalog/storage/batch_iterator.go
@@ -283,7 +283,7 @@ func (it *batchScanIterator) scanRange(rg RangeGroup) {
 		datomCount++
 
 		// Check transaction validity
-		if it.matcher.txID > 0 && datom.Tx.Lamport > it.matcher.txID {
+		if it.matcher.txID != (datalog.ElementID{}) && it.matcher.txID.Less(datom.Tx) {
 			continue
 		}
 

--- a/datalog/storage/batch_scan_performance_test.go
+++ b/datalog/storage/batch_scan_performance_test.go
@@ -57,7 +57,7 @@ func TestBatchScanPerformance(t *testing.T) {
 	// Get the matcher
 	matcher := &BadgerMatcher{
 		store: db.store,
-		txID:  0,
+		txID:  datalog.ElementID{},
 	}
 
 	// Pattern: [?bar :price/time ?time]
@@ -91,7 +91,7 @@ func TestBatchScanPerformance(t *testing.T) {
 		// We'll do this by creating a new matcher
 		matcher2 := &BadgerMatcher{
 			store: db.store,
-			txID:  0,
+			txID:  datalog.ElementID{},
 		}
 
 		start := time.Now()

--- a/datalog/storage/batch_scan_performance_test.go
+++ b/datalog/storage/batch_scan_performance_test.go
@@ -57,7 +57,7 @@ func TestBatchScanPerformance(t *testing.T) {
 	// Get the matcher
 	matcher := &BadgerMatcher{
 		store: db.store,
-		txID:  datalog.ElementID{},
+		txID:  nil,
 	}
 
 	// Pattern: [?bar :price/time ?time]
@@ -91,7 +91,7 @@ func TestBatchScanPerformance(t *testing.T) {
 		// We'll do this by creating a new matcher
 		matcher2 := &BadgerMatcher{
 			store: db.store,
-			txID:  datalog.ElementID{},
+			txID:  nil,
 		}
 
 		start := time.Now()

--- a/datalog/storage/cache_integration_test.go
+++ b/datalog/storage/cache_integration_test.go
@@ -234,7 +234,6 @@ func TestAsOfDoesNotUseCache(t *testing.T) {
 	assert.Equal(t, "Bob", val)
 
 	// As-of tx1 should still return "Alice" (bypassing cache)
-	// tx1ID is already a uint64 (Lamport timestamp)
 	asOfMatcher := db.AsOf(tx1ID).(*BadgerMatcher)
 	asOfVal, found := asOfMatcher.LookupAttribute(e, datalog.NewKeyword(":person/name"))
 	require.True(t, found)

--- a/datalog/storage/cache_integration_test.go
+++ b/datalog/storage/cache_integration_test.go
@@ -234,7 +234,7 @@ func TestAsOfDoesNotUseCache(t *testing.T) {
 	assert.Equal(t, "Bob", val)
 
 	// As-of tx1 should still return "Alice" (bypassing cache)
-	asOfMatcher := db.AsOf(tx1ID).(*BadgerMatcher)
+	asOfMatcher := db.AsOf(tx1ID).Matcher().(*BadgerMatcher)
 	asOfVal, found := asOfMatcher.LookupAttribute(e, datalog.NewKeyword(":person/name"))
 	require.True(t, found)
 	assert.Equal(t, "Alice", asOfVal, "as-of query should bypass cache and return historical value")

--- a/datalog/storage/convenience.go
+++ b/datalog/storage/convenience.go
@@ -1,0 +1,79 @@
+package storage
+
+import (
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Pre-parsed query for typed attribute accessors.
+var queryGetAttr = func() *query.Query {
+	q, err := parser.ParseQuery(`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`)
+	if err != nil {
+		panic(err)
+	}
+	return q
+}()
+
+// Query executes a Datalog query string or pre-parsed *query.Query.
+// This is a convenience alias for ExecuteQueryWithInputs.
+func (d *Database) Query(queryInput interface{}, inputs ...interface{}) ([][]interface{}, error) {
+	return d.ExecuteQueryWithInputs(queryInput, inputs...)
+}
+
+// Assert adds datoms in a single transaction.
+func (d *Database) Assert(datoms []datalog.Datom) error {
+	tx := d.NewTransaction()
+	for _, dat := range datoms {
+		if err := tx.Add(dat.E, dat.A, dat.V); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	_, err := tx.Commit()
+	return err
+}
+
+// GetString returns a string attribute value.
+func (d *Database) GetString(e datalog.Identity, a datalog.Keyword) (string, bool, error) {
+	var v string
+	found, err := d.QueryOneInto(&v, queryGetAttr, e, a)
+	return v, found, err
+}
+
+// GetInt returns an int64 attribute value.
+func (d *Database) GetInt(e datalog.Identity, a datalog.Keyword) (int64, bool, error) {
+	var v int64
+	found, err := d.QueryOneInto(&v, queryGetAttr, e, a)
+	return v, found, err
+}
+
+// GetFloat returns a float64 attribute value.
+func (d *Database) GetFloat(e datalog.Identity, a datalog.Keyword) (float64, bool, error) {
+	var v float64
+	found, err := d.QueryOneInto(&v, queryGetAttr, e, a)
+	return v, found, err
+}
+
+// GetBool returns a bool attribute value.
+func (d *Database) GetBool(e datalog.Identity, a datalog.Keyword) (bool, bool, error) {
+	var v bool
+	found, err := d.QueryOneInto(&v, queryGetAttr, e, a)
+	return v, found, err
+}
+
+// GetRef returns an entity reference attribute value.
+func (d *Database) GetRef(e datalog.Identity, a datalog.Keyword) (datalog.Identity, bool, error) {
+	var v datalog.Identity
+	found, err := d.QueryOneInto(&v, queryGetAttr, e, a)
+	return v, found, err
+}
+
+// GetStrings returns all string values for a cardinality-many attribute.
+func (d *Database) GetStrings(e datalog.Identity, a datalog.Keyword) ([]string, error) {
+	var vals []string
+	if err := d.QueryInto(&vals, queryGetAttr, e, a); err != nil {
+		return nil, err
+	}
+	return vals, nil
+}

--- a/datalog/storage/crdt_many_test.go
+++ b/datalog/storage/crdt_many_test.go
@@ -2032,3 +2032,95 @@ func TestAVETAddWinsResolution(t *testing.T) {
 		t.Error("entity3 should have 'warrior' tag (remove then add)")
 	}
 }
+
+// TestHistoryModeCardinalityMany verifies that db.History() returns raw
+// datoms including retract operations, bypassing add-wins CRDT resolution.
+func TestHistoryModeCardinalityMany(t *testing.T) {
+	dir, err := os.MkdirTemp("", "crdt-many-history-mode-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/tags"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityMany,
+	})
+	db.SetSchema(s)
+
+	entityID := datalog.NewIdentity("test-entity")
+	attr := datalog.NewKeyword(":person/tags")
+
+	// Add two tags
+	tx1 := db.NewTransaction()
+	err = tx1.Add(entityID, attr, "warrior")
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	err = tx1.Add(entityID, attr, "veteran")
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	_, err = tx1.Commit()
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	// Remove one tag
+	tx2 := db.NewTransaction()
+	err = tx2.Remove(entityID, attr, "warrior")
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	_, err = tx2.Commit()
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entityID},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?tag")},
+			query.Blank{},
+		},
+	}
+
+	// Latest mode: add-wins resolution should show only "veteran"
+	latestMatcher := db.Matcher()
+	latestResults, err := latestMatcher.Match(pattern, nil)
+	if err != nil {
+		t.Fatalf("Latest Match failed: %v", err)
+	}
+	latestCount := 0
+	latestIter := latestResults.Iterator()
+	for latestIter.Next() {
+		latestCount++
+	}
+	if latestCount != 1 {
+		t.Errorf("Latest mode: expected 1 result (add-wins resolved), got %d", latestCount)
+	}
+
+	// History mode: should return ALL raw operations (2 adds + 1 remove = 3 datoms)
+	historyMatcher := db.History()
+	historyResults, err := historyMatcher.Match(pattern, nil)
+	if err != nil {
+		t.Fatalf("History Match failed: %v", err)
+	}
+	historyCount := 0
+	historyIter := historyResults.Iterator()
+	for historyIter.Next() {
+		historyCount++
+	}
+	if historyCount != 3 {
+		t.Errorf("History mode: expected 3 results (2 adds + 1 remove), got %d", historyCount)
+	}
+}

--- a/datalog/storage/crdt_one_test.go
+++ b/datalog/storage/crdt_one_test.go
@@ -500,3 +500,117 @@ func TestSchemalessDefaultsToCardinalityOne(t *testing.T) {
 		t.Errorf("Expected 1 result (schemaless defaults to cardinality-one), got %d", resultCount)
 	}
 }
+
+// TestHistoryMode verifies that db.History() returns raw datoms without CRDT
+// resolution. For cardinality-one (LWW), this means ALL historical values are
+// returned, not just the winner.
+func TestHistoryMode(t *testing.T) {
+	dir, err := os.MkdirTemp("", "crdt-history-mode-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Create schema with cardinality-one attribute
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	entityID := datalog.NewIdentity("test-entity")
+
+	// Write 3 versions of the same attribute
+	var txIDs []datalog.ElementID
+	for i := 0; i < 3; i++ {
+		tx := db.NewTransaction()
+		err := tx.Set(entityID, datalog.NewKeyword(":person/name"), fmt.Sprintf("Name%d", i))
+		if err != nil {
+			t.Fatalf("Set failed: %v", err)
+		}
+		txID, err := tx.Commit()
+		if err != nil {
+			t.Fatalf("Commit failed: %v", err)
+		}
+		txIDs = append(txIDs, txID)
+	}
+
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entityID},
+			query.Constant{Value: datalog.NewKeyword(":person/name")},
+			query.Variable{Name: datalog.NewSymbol("?name")},
+			query.Blank{},
+		},
+	}
+
+	// Latest mode: should return only 1 result (LWW winner)
+	latestMatcher := db.Matcher()
+	latestResults, err := latestMatcher.Match(pattern, nil)
+	if err != nil {
+		t.Fatalf("Latest Match failed: %v", err)
+	}
+	latestCount := 0
+	latestIter := latestResults.Iterator()
+	for latestIter.Next() {
+		latestCount++
+	}
+	if latestCount != 1 {
+		t.Errorf("Latest mode: expected 1 result, got %d", latestCount)
+	}
+
+	// History mode: should return ALL 3 raw datoms
+	historyMatcher := db.History()
+	historyResults, err := historyMatcher.Match(pattern, nil)
+	if err != nil {
+		t.Fatalf("History Match failed: %v", err)
+	}
+	historyCount := 0
+	historyIter := historyResults.Iterator()
+	var historyNames []string
+	for historyIter.Next() {
+		historyCount++
+		tuple := historyIter.Tuple()
+		if len(tuple) > 0 {
+			if name, ok := tuple[0].(string); ok {
+				historyNames = append(historyNames, name)
+			}
+		}
+	}
+	if historyCount != 3 {
+		t.Errorf("History mode: expected 3 results (all versions), got %d", historyCount)
+	}
+
+	// As-of mode: should return 1 result (LWW winner at that point)
+	asOfMatcher := db.AsOf(txIDs[1])
+	asOfResults, err := asOfMatcher.Match(pattern, nil)
+	if err != nil {
+		t.Fatalf("AsOf Match failed: %v", err)
+	}
+	asOfCount := 0
+	asOfIter := asOfResults.Iterator()
+	var asOfName string
+	for asOfIter.Next() {
+		asOfCount++
+		tuple := asOfIter.Tuple()
+		if len(tuple) > 0 {
+			if name, ok := tuple[0].(string); ok {
+				asOfName = name
+			}
+		}
+	}
+	if asOfCount != 1 {
+		t.Errorf("AsOf mode: expected 1 result, got %d", asOfCount)
+	}
+	if asOfName != "Name1" {
+		t.Errorf("AsOf mode: expected 'Name1', got '%s'", asOfName)
+	}
+}

--- a/datalog/storage/crdt_one_test.go
+++ b/datalog/storage/crdt_one_test.go
@@ -169,16 +169,16 @@ func TestCardinalityOneAsOf(t *testing.T) {
 
 	entityID := datalog.NewIdentity("test-entity")
 
-	// Write multiple versions and track their Lamport times
-	var lamports []uint64
+	// Write multiple versions and track their transaction IDs
+	var txIDs []datalog.ElementID
 	for i := 0; i < 5; i++ {
 		tx := db.NewTransaction()
 		tx.Add(entityID, datalog.NewKeyword(":person/name"), fmt.Sprintf("Name%d", i))
-		lamport, err := tx.Commit()
+		txID, err := tx.Commit()
 		if err != nil {
 			t.Fatalf("Commit failed: %v", err)
 		}
-		lamports = append(lamports, lamport)
+		txIDs = append(txIDs, txID)
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
@@ -192,27 +192,27 @@ func TestCardinalityOneAsOf(t *testing.T) {
 		},
 	}
 
-	// Query as-of each Lamport time should return the value from that transaction
-	for i, targetLamport := range lamports {
-		results, err := matcher.MatchAsOf(pattern, targetLamport)
+	// Query as-of each transaction should return the value from that transaction
+	for i, targetTx := range txIDs {
+		results, err := matcher.MatchAsOf(pattern, targetTx)
 		if err != nil {
 			t.Fatalf("MatchAsOf failed: %v", err)
 		}
 
 		if len(results) != 1 {
-			t.Errorf("MatchAsOf(Lamport=%d): expected 1 result, got %d", targetLamport, len(results))
+			t.Errorf("MatchAsOf(Tx=%v): expected 1 result, got %d", targetTx, len(results))
 			continue
 		}
 
 		expectedName := fmt.Sprintf("Name%d", i)
 		if results[0].V.(string) != expectedName {
-			t.Errorf("MatchAsOf(Lamport=%d): expected '%s', got '%s'",
-				targetLamport, expectedName, results[0].V)
+			t.Errorf("MatchAsOf(Tx=%v): expected '%s', got '%s'",
+				targetTx, expectedName, results[0].V)
 		}
 	}
 
-	// Query as-of Lamport 0 should return no results (before any writes)
-	results, err := matcher.MatchAsOf(pattern, 0)
+	// Query as-of zero ElementID should return no results (before any writes)
+	results, err := matcher.MatchAsOf(pattern, datalog.ElementID{})
 	if err != nil {
 		t.Fatalf("MatchAsOf(0) failed: %v", err)
 	}

--- a/datalog/storage/crdt_query_resolution_test.go
+++ b/datalog/storage/crdt_query_resolution_test.go
@@ -37,7 +37,6 @@ func TestExecuteQueryWithInputs_CardinalityOne_ReturnsMultipleValues(t *testing.
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dir,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -110,7 +109,6 @@ func TestExecuteQueryWithInputs_CardinalityMany_ReturnsAllHistoricalValues(t *te
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dir,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -190,7 +188,6 @@ func TestDirectMatch_VsExecuteQuery_CRDTResolution(t *testing.T) {
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dir,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -281,7 +278,6 @@ func TestSchemaAwareness_InQueryExecution(t *testing.T) {
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dir,
-		UseTimeTx: true,
 		Schema:    s,
 	})
 	require.NoError(t, err)
@@ -313,7 +309,6 @@ func TestAllQueryMethods_CRDTResolution(t *testing.T) {
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dir,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -15,7 +15,7 @@ import (
 type CRDTResolvingIterator struct {
 	source Iterator
 	schema schema.SchemaProvider
-	txID   uint64 // For as-of queries: only consider datoms with Tx.Lamport <= txID
+	txID   datalog.ElementID // For as-of queries: only consider datoms with Tx.Lamport <= txID
 
 	// Current (E, A) group tracking
 	currentE datalog.Identity
@@ -59,7 +59,7 @@ type rgaElement struct {
 }
 
 // NewCRDTResolvingIterator creates a new CRDT-resolving iterator wrapper.
-func NewCRDTResolvingIterator(source Iterator, schema schema.SchemaProvider, txID uint64) *CRDTResolvingIterator {
+func NewCRDTResolvingIterator(source Iterator, schema schema.SchemaProvider, txID datalog.ElementID) *CRDTResolvingIterator {
 	return &CRDTResolvingIterator{
 		source: source,
 		schema: schema,
@@ -109,7 +109,7 @@ func (it *CRDTResolvingIterator) Next() bool {
 			}
 
 			// Apply as-of filtering
-			if it.txID > 0 && datom.Tx.Lamport > it.txID {
+			if it.txID != (datalog.ElementID{}) && it.txID.Less(datom.Tx) {
 				continue
 			}
 

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -402,7 +402,7 @@ func (d *Database) Match(pattern *query.DataPattern, bindings executor.Relations
 var _ executor.PatternMatcher = (*Database)(nil)
 
 // AsOf returns a PatternMatcher for a specific transaction
-func (d *Database) AsOf(txID uint64) executor.PatternMatcher {
+func (d *Database) AsOf(txID datalog.ElementID) executor.PatternMatcher {
 	// Convert default planner options to executor options
 	opts := DefaultPlannerOptions()
 	execOpts := executor.ExecutorOptions{
@@ -1951,17 +1951,17 @@ func (t *Transaction) SaveStruct(v interface{}) (datalog.Identity, error) {
 }
 
 // Commit commits the transaction
-func (t *Transaction) Commit() (uint64, error) {
+func (t *Transaction) Commit() (datalog.ElementID, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	if t.closed {
-		return 0, fmt.Errorf("transaction is closed")
+		return datalog.ElementID{}, fmt.Errorf("transaction is closed")
 	}
 
 	// Validate uniqueness constraints before committing
 	if err := t.validateUniqueness(); err != nil {
-		return 0, err
+		return datalog.ElementID{}, err
 	}
 
 	// Record transaction time for metadata
@@ -1982,14 +1982,14 @@ func (t *Transaction) Commit() (uint64, error) {
 	// Apply retractions first
 	if len(t.retracts) > 0 {
 		if err := t.db.store.Retract(t.retracts); err != nil {
-			return 0, fmt.Errorf("failed to retract datoms: %w", err)
+			return datalog.ElementID{}, fmt.Errorf("failed to retract datoms: %w", err)
 		}
 	}
 
 	// Then apply assertions
 	if len(t.datoms) > 0 {
 		if err := t.db.store.Assert(t.datoms); err != nil {
-			return 0, fmt.Errorf("failed to assert datoms: %w", err)
+			return datalog.ElementID{}, fmt.Errorf("failed to assert datoms: %w", err)
 		}
 	}
 
@@ -2056,8 +2056,9 @@ func (t *Transaction) Commit() (uint64, error) {
 	delete(t.db.activeTx, t)
 	t.db.mu.Unlock()
 
-	// Return the metadata's Lamport as the "transaction ID" - it's the highest from this tx
-	return metadataElemID.Lamport, nil
+	// Return the metadata ElementID - it has the highest Lamport in this tx,
+	// making it the correct high-water mark for as-of queries
+	return metadataElemID, nil
 }
 
 // validateUniqueness checks uniqueness constraints for all datoms in the transaction

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -38,28 +38,18 @@ type Database struct {
 	txCounter         atomic.Uint64
 	mu                sync.RWMutex
 	activeTx          map[*Transaction]bool
-	useTimeTx         bool                  // Use time-based transaction IDs
 	planCache         *planner.PlanCache    // Shared query plan cache
 	schema            schema.SchemaProvider // Optional schema for validation
 	annotationHandler annotations.Handler   // Optional handler for query tracing
 	clock             *LamportClock         // CRDT: Lamport clock for ordering (nil if not in CRDT mode)
 	replicaID         uint64                // CRDT: This database's replica identifier
 	cache             *Cache                // CRDT: Unified cache for resolved CRDT views
+	temporalTxID      *datalog.ElementID    // nil = current; set = temporal mode (AsOf/History)
 }
 
 // NewDatabase creates a new database with BadgerDB storage
 func NewDatabase(path string) (*Database, error) {
 	return NewDatabaseWithOptions(DatabaseOptions{Path: path})
-}
-
-// NewDatabaseWithTimeTx creates a database that uses time-based transaction IDs
-func NewDatabaseWithTimeTx(path string) (*Database, error) {
-	db, err := NewDatabase(path)
-	if err != nil {
-		return nil, err
-	}
-	db.useTimeTx = true
-	return db, nil
 }
 
 // NewDatabaseWithSchema creates a database with schema validation
@@ -75,7 +65,6 @@ func NewDatabaseWithSchema(path string, s schema.SchemaProvider) (*Database, err
 // DatabaseOptions configures database creation
 type DatabaseOptions struct {
 	Path              string                // Path to the database directory
-	UseTimeTx         bool                  // Use time-based transaction IDs (legacy, kept for compatibility)
 	Schema            schema.SchemaProvider // Optional schema for validation
 	AnnotationHandler annotations.Handler   // Optional handler for query tracing
 	ReplicaID         uint64                // For CRDT mode: 0 = auto-generate random; non-zero = use specified. Ignored for existing DBs.
@@ -87,7 +76,6 @@ type DatabaseOptions struct {
 //
 // Options:
 //   - Path: Required. Directory for BadgerDB storage.
-//   - UseTimeTx: Legacy option, kept for compatibility.
 //   - Schema: Optional schema for validation.
 //   - ReplicaID: For CRDT mode. 0 = auto-generate random; non-zero = use specified.
 //   - DisableCache: Disable EA cache; queries resolve directly from storage.
@@ -155,7 +143,6 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 		store:             store,
 		activeTx:          make(map[*Transaction]bool),
 		planCache:         planner.NewPlanCache(1000, 0),
-		useTimeTx:         opts.UseTimeTx,
 		schema:            opts.Schema,
 		annotationHandler: opts.AnnotationHandler,
 		clock:             clock,
@@ -389,6 +376,10 @@ func (d *Database) Matcher() executor.PatternMatcher {
 	if d.cache != nil {
 		matcher.SetCache(d.cache)
 	}
+	// Apply temporal mode if set (AsOf/History)
+	if d.temporalTxID != nil {
+		return matcher.AsOf(*d.temporalTxID)
+	}
 	return matcher
 }
 
@@ -401,32 +392,35 @@ func (d *Database) Match(pattern *query.DataPattern, bindings executor.Relations
 // Compile-time verification that Database implements PatternMatcher
 var _ executor.PatternMatcher = (*Database)(nil)
 
-// AsOf returns a PatternMatcher for a specific transaction
-func (d *Database) AsOf(txID datalog.ElementID) executor.PatternMatcher {
-	// Convert default planner options to executor options
-	opts := DefaultPlannerOptions()
-	execOpts := executor.ExecutorOptions{
-		EnableIteratorComposition:       opts.EnableIteratorComposition,
-		EnableTrueStreaming:             opts.EnableTrueStreaming,
-		EnableSymmetricHashJoin:         opts.EnableSymmetricHashJoin,
-		EnableParallelSubqueries:        opts.EnableParallelSubqueries,
-		MaxSubqueryWorkers:              opts.MaxSubqueryWorkers,
-		EnableStreamingJoins:            opts.EnableStreamingJoins,
-		EnableStreamingAggregation:      opts.EnableStreamingAggregation,
-		EnableStreamingAggregationDebug: opts.EnableStreamingAggregationDebug,
-		EnableDebugLogging:              opts.EnableDebugLogging,
-		IndexNestedLoopThreshold:        opts.IndexNestedLoopThreshold,
+// AsOf returns a new Database handle that queries state as of the given transaction.
+// The returned handle uses CRDT resolution filtered to that point in causal time.
+func (d *Database) AsOf(txID datalog.ElementID) *Database {
+	return &Database{
+		store:             d.store,
+		schema:            d.schema,
+		annotationHandler: d.annotationHandler,
+		planCache:         d.planCache,
+		cache:             d.cache,
+		clock:             d.clock,
+		replicaID:         d.replicaID,
+		temporalTxID:      &txID,
 	}
-	matcher := NewBadgerMatcherWithOptions(d.store, execOpts)
-	// Set schema for CRDT cardinality-aware resolution
-	if d.schema != nil {
-		matcher.SetSchema(d.schema)
+}
+
+// History returns a new Database handle that returns all raw datoms without
+// CRDT resolution. Every write is visible, including superseded values.
+func (d *Database) History() *Database {
+	empty := datalog.ElementID{}
+	return &Database{
+		store:             d.store,
+		schema:            d.schema,
+		annotationHandler: d.annotationHandler,
+		planCache:         d.planCache,
+		cache:             d.cache,
+		clock:             d.clock,
+		replicaID:         d.replicaID,
+		temporalTxID:      &empty,
 	}
-	// Set cache for CRDT resolution O(1) access
-	if d.cache != nil {
-		matcher.SetCache(d.cache)
-	}
-	return matcher.AsOf(txID)
 }
 
 // DefaultPlannerOptions returns the default planner and executor options for the database

--- a/datalog/storage/elementid_binding_test.go
+++ b/datalog/storage/elementid_binding_test.go
@@ -1,0 +1,431 @@
+package storage
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// extractElementID dereferences *ElementID to ElementID for test assertions.
+func extractElementID(t *testing.T, v interface{}) datalog.ElementID {
+	t.Helper()
+	switch e := v.(type) {
+	case *datalog.ElementID:
+		return *e
+	case datalog.ElementID:
+		return e
+	default:
+		t.Fatalf("expected ElementID or *ElementID, got %T", v)
+		return datalog.ElementID{}
+	}
+}
+
+// TestElementIDBinding_ScalarInput passes an ElementID value as a scalar
+// binding (:in $ ?tx) and expects the query to filter datoms to only
+// those matching that transaction.
+func TestElementIDBinding_ScalarInput(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	nameAttr := datalog.NewKeyword(":person/name")
+
+	// Write two entities in separate transactions
+	alice := datalog.NewIdentity("alice")
+	tx1 := db.NewTransaction()
+	tx1.Set(alice, nameAttr, "Alice")
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	bob := datalog.NewIdentity("bob")
+	tx2 := db.NewTransaction()
+	tx2.Set(bob, nameAttr, "Bob")
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Step 1: Query all (entity, value, tx) to discover the ElementIDs
+	allResults, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	require.NoError(t, err)
+	t.Logf("All results: %d", len(allResults))
+	require.Len(t, allResults, 2, "Should have 2 datoms (one per entity)")
+
+	// Find Alice's transaction ElementID
+	var aliceTx interface{}
+	for _, r := range allResults {
+		t.Logf("  e=%v v=%v tx=%v (txType=%T)", r[0], r[1], r[2], r[2])
+		if r[1] == "Alice" {
+			aliceTx = r[2]
+		}
+	}
+	require.NotNil(t, aliceTx, "Should find Alice's tx")
+	t.Logf("Alice's tx: %v (type %T)", aliceTx, aliceTx)
+
+	// Dereference pointer if needed
+	switch v := aliceTx.(type) {
+	case *datalog.ElementID:
+		aliceTx = *v
+	case datalog.ElementID:
+		// already a value
+	default:
+		t.Fatalf("Unexpected tx type: %T", aliceTx)
+	}
+
+	// Step 2: Use Alice's ElementID as a scalar binding to filter by tx.
+	// This should return only Alice's datom — not Bob's.
+	filteredResults, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v :in $ ?tx :where [?e :person/name ?v ?tx]]`,
+		aliceTx)
+	require.NoError(t, err)
+
+	t.Logf("Filtered results (tx=%v): %v", aliceTx, filteredResults)
+	require.Len(t, filteredResults, 1, "Should return exactly 1 result for Alice's tx")
+	assert.Equal(t, "Alice", filteredResults[0][1], "Should return Alice for her specific tx")
+}
+
+// TestElementIDBinding_CollectionInput passes a collection of ElementID values
+// as [:in $ [?tx ...]] and expects matching datoms.
+func TestElementIDBinding_CollectionInput(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	nameAttr := datalog.NewKeyword(":person/name")
+
+	// Write three entities in separate transactions
+	alice := datalog.NewIdentity("alice")
+	tx1 := db.NewTransaction()
+	tx1.Set(alice, nameAttr, "Alice")
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	bob := datalog.NewIdentity("bob")
+	tx2 := db.NewTransaction()
+	tx2.Set(bob, nameAttr, "Bob")
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	charlie := datalog.NewIdentity("charlie")
+	tx3 := db.NewTransaction()
+	tx3.Set(charlie, nameAttr, "Charlie")
+	_, err = tx3.Commit()
+	require.NoError(t, err)
+
+	// Discover all ElementIDs
+	allResults, err := db.ExecuteQueryWithInputs(
+		`[:find ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	require.NoError(t, err)
+	require.Len(t, allResults, 3)
+
+	txByName := make(map[string]datalog.ElementID)
+	for _, r := range allResults {
+		name := r[0].(string)
+		txByName[name] = extractElementID(t, r[1])
+	}
+
+	// Pass Alice's and Bob's tx as a collection — should return 2 results
+	filteredResults, err := db.ExecuteQueryWithInputs(
+		`[:find ?v :in $ [?tx ...] :where [?e :person/name ?v ?tx]]`,
+		[]datalog.ElementID{txByName["Alice"], txByName["Bob"]})
+	require.NoError(t, err)
+
+	t.Logf("Collection results: %v", filteredResults)
+	require.Len(t, filteredResults, 2, "Should return 2 results for Alice+Bob txs")
+
+	names := []string{filteredResults[0][0].(string), filteredResults[1][0].(string)}
+	sort.Strings(names)
+	assert.Equal(t, []string{"Alice", "Bob"}, names)
+}
+
+// TestElementIDBinding_RelationInput passes ElementID + Identity pairs as a
+// relation binding [:in $ [[?e ?tx] ...]].
+func TestElementIDBinding_RelationInput(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	nameAttr := datalog.NewKeyword(":person/name")
+
+	alice := datalog.NewIdentity("alice")
+	tx1 := db.NewTransaction()
+	tx1.Set(alice, nameAttr, "Alice")
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	bob := datalog.NewIdentity("bob")
+	tx2 := db.NewTransaction()
+	tx2.Set(bob, nameAttr, "Bob")
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Discover ElementIDs
+	allResults, err := db.ExecuteQueryWithInputs(
+		`[:find ?e ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	require.NoError(t, err)
+	require.Len(t, allResults, 2)
+
+	var aliceIdentity, bobIdentity interface{}
+	var aliceTx, bobTx datalog.ElementID
+	for _, r := range allResults {
+		if r[1] == "Alice" {
+			aliceIdentity = r[0]
+			aliceTx = extractElementID(t, r[2])
+		} else {
+			bobIdentity = r[0]
+			bobTx = extractElementID(t, r[2])
+		}
+	}
+
+	// Pass as relation binding [[?e ?tx] ...]
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?v :in $ [[?e ?tx] ...] :where [?e :person/name ?v ?tx]]`,
+		[][]interface{}{
+			{aliceIdentity, aliceTx},
+			{bobIdentity, bobTx},
+		})
+	require.NoError(t, err)
+
+	t.Logf("Relation results: %v", results)
+	require.Len(t, results, 2, "Should return 2 results from relation binding")
+
+	names := []string{results[0][0].(string), results[1][0].(string)}
+	sort.Strings(names)
+	assert.Equal(t, []string{"Alice", "Bob"}, names)
+}
+
+// TestElementIDBinding_TxJoin verifies that two patterns joined on ?e correctly
+// return *ElementID Tx values as distinct columns. In CRDT storage, each Set()
+// gets a unique ElementID, so ?tx1 != ?tx2 even for the same entity.
+func TestElementIDBinding_TxJoin(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/age"),
+		ValueType:   schema.TypeLong,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	nameAttr := datalog.NewKeyword(":person/name")
+	ageAttr := datalog.NewKeyword(":person/age")
+
+	// Transaction 1: Alice + age 30
+	alice := datalog.NewIdentity("alice")
+	tx1 := db.NewTransaction()
+	tx1.Set(alice, nameAttr, "Alice")
+	tx1.Set(alice, ageAttr, int64(30))
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	// Transaction 2: Bob + age 25
+	bob := datalog.NewIdentity("bob")
+	tx2 := db.NewTransaction()
+	tx2.Set(bob, nameAttr, "Bob")
+	tx2.Set(bob, ageAttr, int64(25))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Join on ?e: find name/age pairs for the same entity.
+	// Each attribute's datom has a unique Tx (CRDT per-operation Lamport),
+	// so we use separate ?tx1, ?tx2 variables.
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?name ?age ?tx1 ?tx2
+		  :where [?e :person/name ?name ?tx1]
+		         [?e :person/age ?age ?tx2]]`)
+	require.NoError(t, err)
+
+	t.Logf("TxJoin results: %v", results)
+	require.Len(t, results, 2, "Should return 2 name/age pairs joined on entity")
+
+	// Verify results contain correct name/age pairs and that Tx columns are ElementIDs
+	for _, r := range results {
+		name := r[0].(string)
+		age := r[1].(int64)
+		tx1Val := extractElementID(t, r[2])
+		tx2Val := extractElementID(t, r[3])
+
+		t.Logf("  name=%s age=%d tx1=%v tx2=%v", name, age, tx1Val, tx2Val)
+
+		// Each attribute has its own unique Tx
+		assert.NotEqual(t, tx1Val, tx2Val, "name and age should have different Tx values")
+
+		if name == "Alice" {
+			assert.Equal(t, int64(30), age)
+		} else {
+			assert.Equal(t, "Bob", name)
+			assert.Equal(t, int64(25), age)
+		}
+	}
+}
+
+// TestElementIDBinding_ComparisonPredicate uses [(= ?tx ?target-tx)] to filter
+// by a bound ElementID via predicate comparison.
+func TestElementIDBinding_ComparisonPredicate(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	nameAttr := datalog.NewKeyword(":person/name")
+
+	alice := datalog.NewIdentity("alice")
+	tx1 := db.NewTransaction()
+	tx1.Set(alice, nameAttr, "Alice")
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	bob := datalog.NewIdentity("bob")
+	tx2 := db.NewTransaction()
+	tx2.Set(bob, nameAttr, "Bob")
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Get Alice's tx
+	allResults, err := db.ExecuteQueryWithInputs(
+		`[:find ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	require.NoError(t, err)
+	require.Len(t, allResults, 2)
+
+	var aliceTx datalog.ElementID
+	for _, r := range allResults {
+		if r[0] == "Alice" {
+			aliceTx = extractElementID(t, r[1])
+		}
+	}
+
+	// Filter with equality predicate
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?v
+		  :in $ ?target-tx
+		  :where [?e :person/name ?v ?tx]
+		         [(= ?tx ?target-tx)]]`,
+		aliceTx)
+	require.NoError(t, err)
+
+	t.Logf("Comparison predicate results: %v", results)
+	require.Len(t, results, 1, "Should return exactly 1 result with equality predicate")
+	assert.Equal(t, "Alice", results[0][0])
+}
+
+// TestElementIDBinding_MultipleEntitiesSameTx verifies that each Set() gets a
+// unique ElementID (CRDT per-operation Lamport), and that filtering by a specific
+// Tx returns only the matching datom. Even within the same Commit(), Alice and
+// Bob get distinct Tx values.
+func TestElementIDBinding_MultipleEntitiesSameTx(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	db.SetSchema(s)
+
+	nameAttr := datalog.NewKeyword(":person/name")
+
+	// Write BOTH entities in the same Commit — each Set() still gets unique Tx
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	tx1 := db.NewTransaction()
+	tx1.Set(alice, nameAttr, "Alice")
+	tx1.Set(bob, nameAttr, "Bob")
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	// Write a third entity in a different Commit
+	charlie := datalog.NewIdentity("charlie")
+	tx2 := db.NewTransaction()
+	tx2.Set(charlie, nameAttr, "Charlie")
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Discover all Tx values — each entity has its own unique Tx
+	allResults, err := db.ExecuteQueryWithInputs(
+		`[:find ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	require.NoError(t, err)
+	require.Len(t, allResults, 3)
+
+	txByName := make(map[string]datalog.ElementID)
+	for _, r := range allResults {
+		name := r[0].(string)
+		txByName[name] = extractElementID(t, r[1])
+	}
+
+	// Each Set() gets unique Tx, even within the same Commit
+	assert.NotEqual(t, txByName["Alice"], txByName["Bob"],
+		"Alice and Bob should have different Tx values (per-operation Lamport)")
+	assert.NotEqual(t, txByName["Bob"], txByName["Charlie"],
+		"Bob and Charlie should have different Tx values")
+
+	// Filter by Alice's Tx — should return exactly Alice, not Bob or Charlie
+	results, err := db.ExecuteQueryWithInputs(
+		`[:find ?name :in $ ?tx :where [?e :person/name ?name ?tx]]`,
+		txByName["Alice"])
+	require.NoError(t, err)
+
+	t.Logf("Alice-tx results: %v", results)
+	require.Len(t, results, 1, "Should return exactly 1 result for Alice's Tx")
+	assert.Equal(t, "Alice", results[0][0].(string))
+
+	// Filter by Bob's Tx — should return exactly Bob
+	results, err = db.ExecuteQueryWithInputs(
+		`[:find ?name :in $ ?tx :where [?e :person/name ?name ?tx]]`,
+		txByName["Bob"])
+	require.NoError(t, err)
+
+	t.Logf("Bob-tx results: %v", results)
+	require.Len(t, results, 1, "Should return exactly 1 result for Bob's Tx")
+	assert.Equal(t, "Bob", results[0][0].(string))
+}

--- a/datalog/storage/export_test.go
+++ b/datalog/storage/export_test.go
@@ -790,10 +790,10 @@ func TestExportImport_PreservesTxIDs(t *testing.T) {
 	for _, line := range lines {
 		datom, err := ParseDatomEDN(line)
 		require.NoError(t, err)
-		if datom.Tx.Lamport == txID1 {
+		if datom.Tx == txID1 {
 			foundTx1 = true
 		}
-		if datom.Tx.Lamport == txID2 {
+		if datom.Tx == txID2 {
 			foundTx2 = true
 		}
 	}

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -193,10 +193,13 @@ func (m *BadgerMatcher) matchWithHashJoin(
 		return nil, fmt.Errorf("hash join scan failed: %w", err)
 	}
 
-	// PHASE 3.5: Wrap with CRDT resolution
-	// Always applied: CRDTResolvingIterator handles nil schema correctly
-	// (defaults to CardinalityUnknown → add-wins semantics)
-	resolvedIter := NewCRDTResolvingIterator(storageIter, m.schema, m.txID)
+	// PHASE 3.5: Wrap with CRDT resolution unless in history mode
+	var resolvedIter Iterator
+	if m.isHistoryMode() {
+		resolvedIter = storageIter
+	} else {
+		resolvedIter = NewCRDTResolvingIterator(storageIter, m.schema, m.crdtTxID())
+	}
 
 	// PHASE 4: Create streaming hash join iterator
 	iter := &hashJoinIterator{
@@ -578,9 +581,13 @@ func (m *BadgerMatcher) matchWithMergeJoin(
 		return nil, fmt.Errorf("merge join scan failed: %w", err)
 	}
 
-	// PHASE 3.5: Wrap with CRDT resolution
-	// Always applied: CRDTResolvingIterator handles nil schema correctly
-	resolvedIterMerge := NewCRDTResolvingIterator(storageIter, m.schema, m.txID)
+	// PHASE 3.5: Wrap with CRDT resolution unless in history mode
+	var resolvedIterMerge Iterator
+	if m.isHistoryMode() {
+		resolvedIterMerge = storageIter
+	} else {
+		resolvedIterMerge = NewCRDTResolvingIterator(storageIter, m.schema, m.crdtTxID())
+	}
 
 	// PHASE 4: Create streaming merge join iterator
 	iter := &mergeJoinIterator{
@@ -754,7 +761,7 @@ func (it *hashJoinIterator) Next() bool {
 		it.datomsScanned++
 
 		// Check transaction validity
-		if it.matcher.txID != (datalog.ElementID{}) && it.matcher.txID.Less(datom.Tx) {
+		if it.matcher.shouldFilterTx(datom.Tx) {
 			continue
 		}
 
@@ -842,7 +849,7 @@ func (it *mergeJoinIterator) Next() bool {
 		}
 
 		// Check transaction validity
-		if it.matcher.txID != (datalog.ElementID{}) && it.matcher.txID.Less(datom.Tx) {
+		if it.matcher.shouldFilterTx(datom.Tx) {
 			continue
 		}
 

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -393,8 +393,20 @@ func (m *BadgerMatcher) chooseIndexForValues(index IndexType, e, a, v, tx interf
 
 	case TAEV: // 4
 		// TAEV: Transaction-Attribute-Entity-Value
-		// Transaction-first index is rarely used for prefix scanning
-		// Just include the index prefix
+		// Tx must be encoded with bitwise-NOT for descending sort order
+		if tx != nil {
+			if txID, ok := tx.(uint64); ok {
+				storageTx := NewTxFromUint(txID)
+				encTx := encoder.EncodeTxForPrefix(storageTx)
+				startParts = append(startParts, encTx)
+				endParts = append(endParts, encTx)
+			} else if eid, ok := datalog.DerefElementID(tx); ok {
+				storageTx := NewTxFromElementID(eid)
+				encTx := encoder.EncodeTxForPrefix(storageTx)
+				startParts = append(startParts, encTx)
+				endParts = append(endParts, encTx)
+			}
+		}
 	}
 
 	start := encoder.EncodePrefix(index, startParts...)
@@ -454,6 +466,9 @@ func valueToHashKey(v interface{}) string {
 	// Note: Do NOT dereference *Keyword - they must stay as interned pointers
 	if ptr, ok := v.(*uint64); ok {
 		v = *ptr
+	}
+	if eid, ok := datalog.DerefElementID(v); ok {
+		return eid.String()
 	}
 
 	switch val := v.(type) {
@@ -685,6 +700,16 @@ func compareJoinKeys(a, b interface{}) int {
 				return 1
 			}
 			return 0
+		}
+	case datalog.ElementID:
+		if bEid, ok := datalog.DerefElementID(b); ok {
+			return aVal.Compare(bEid)
+		}
+	case *datalog.ElementID:
+		if aVal != nil {
+			if bEid, ok := datalog.DerefElementID(b); ok {
+				return aVal.Compare(bEid)
+			}
 		}
 	}
 

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -754,7 +754,7 @@ func (it *hashJoinIterator) Next() bool {
 		it.datomsScanned++
 
 		// Check transaction validity
-		if it.matcher.txID > 0 && datom.Tx.Lamport > it.matcher.txID {
+		if it.matcher.txID != (datalog.ElementID{}) && it.matcher.txID.Less(datom.Tx) {
 			continue
 		}
 
@@ -842,7 +842,7 @@ func (it *mergeJoinIterator) Next() bool {
 		}
 
 		// Check transaction validity
-		if it.matcher.txID > 0 && datom.Tx.Lamport > it.matcher.txID {
+		if it.matcher.txID != (datalog.ElementID{}) && it.matcher.txID.Less(datom.Tx) {
 			continue
 		}
 

--- a/datalog/storage/iterator_helpers.go
+++ b/datalog/storage/iterator_helpers.go
@@ -34,11 +34,11 @@ import (
 // (the constraint loop makes it too complex for the Go compiler's inliner).
 func validateDatomWithConstraints(
 	datom *datalog.Datom,
-	txID datalog.ElementID,
+	txID *datalog.ElementID,
 	constraints []executor.StorageConstraint,
 ) bool {
-	// Check transaction validity
-	if txID != (datalog.ElementID{}) && txID.Less(datom.Tx) {
+	// Check transaction validity (skip datoms from after the as-of target)
+	if txID != nil && *txID != (datalog.ElementID{}) && txID.Less(datom.Tx) {
 		return false
 	}
 

--- a/datalog/storage/iterator_helpers.go
+++ b/datalog/storage/iterator_helpers.go
@@ -34,11 +34,11 @@ import (
 // (the constraint loop makes it too complex for the Go compiler's inliner).
 func validateDatomWithConstraints(
 	datom *datalog.Datom,
-	txID uint64,
+	txID datalog.ElementID,
 	constraints []executor.StorageConstraint,
 ) bool {
 	// Check transaction validity
-	if txID > 0 && datom.Tx.Lamport > txID {
+	if txID != (datalog.ElementID{}) && txID.Less(datom.Tx) {
 		return false
 	}
 

--- a/datalog/storage/iterator_refactoring_bench_test.go
+++ b/datalog/storage/iterator_refactoring_bench_test.go
@@ -12,11 +12,11 @@ import (
 // validateDatomWithConstraintsHelper is the proposed helper function
 func validateDatomWithConstraintsHelper(
 	datom *datalog.Datom,
-	txID datalog.ElementID,
+	txID *datalog.ElementID,
 	constraints []executor.StorageConstraint,
 ) bool {
 	// Check transaction validity
-	if txID != (datalog.ElementID{}) && txID.Less(datom.Tx) {
+	if txID != nil && *txID != (datalog.ElementID{}) && txID.Less(datom.Tx) {
 		return false
 	}
 
@@ -32,11 +32,11 @@ func validateDatomWithConstraintsHelper(
 // Inline version (current approach)
 func validateDatomInline(
 	datom *datalog.Datom,
-	txID datalog.ElementID,
+	txID *datalog.ElementID,
 	constraints []executor.StorageConstraint,
 ) bool {
 	// Check transaction validity
-	if txID != (datalog.ElementID{}) && txID.Less(datom.Tx) {
+	if txID != nil && *txID != (datalog.ElementID{}) && txID.Less(datom.Tx) {
 		return false
 	}
 
@@ -73,18 +73,19 @@ func BenchmarkIteratorValidation(b *testing.B) {
 		Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1},
 	}
 
+	asOfTx := datalog.ElementID{Lamport: 50, ReplicaID: 1}
 	scenarios := []struct {
 		name           string
-		txID           datalog.ElementID
+		txID           *datalog.ElementID
 		constraintCnt  int
 		constraintPass bool
 	}{
-		{"no_tx_check_no_constraints", datalog.ElementID{}, 0, true},
-		{"with_tx_check_no_constraints", datalog.ElementID{Lamport: 50, ReplicaID: 1}, 0, true},
-		{"no_tx_check_1_constraint", datalog.ElementID{}, 1, true},
-		{"no_tx_check_3_constraints", datalog.ElementID{}, 3, true},
-		{"with_tx_check_3_constraints", datalog.ElementID{Lamport: 50, ReplicaID: 1}, 3, true},
-		{"with_tx_check_5_constraints", datalog.ElementID{Lamport: 50, ReplicaID: 1}, 5, true},
+		{"no_tx_check_no_constraints", nil, 0, true},
+		{"with_tx_check_no_constraints", &asOfTx, 0, true},
+		{"no_tx_check_1_constraint", nil, 1, true},
+		{"no_tx_check_3_constraints", nil, 3, true},
+		{"with_tx_check_3_constraints", &asOfTx, 3, true},
+		{"with_tx_check_5_constraints", &asOfTx, 5, true},
 	}
 
 	for _, scenario := range scenarios {
@@ -165,11 +166,12 @@ func BenchmarkIteratorLoop(b *testing.B) {
 
 	b.Run("helper", func(b *testing.B) {
 		matched := 0
+		benchTxID := datalog.ElementID{Lamport: 500, ReplicaID: 1}
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
 			for _, datom := range datoms {
 				// Helper function approach
-				if validateDatomWithConstraintsHelper(datom, datalog.ElementID{Lamport: 500, ReplicaID: 1}, constraints) {
+				if validateDatomWithConstraintsHelper(datom, &benchTxID, constraints) {
 					matched++
 				}
 			}

--- a/datalog/storage/iterator_refactoring_bench_test.go
+++ b/datalog/storage/iterator_refactoring_bench_test.go
@@ -12,11 +12,11 @@ import (
 // validateDatomWithConstraintsHelper is the proposed helper function
 func validateDatomWithConstraintsHelper(
 	datom *datalog.Datom,
-	txID uint64,
+	txID datalog.ElementID,
 	constraints []executor.StorageConstraint,
 ) bool {
 	// Check transaction validity
-	if txID > 0 && datom.Tx.Lamport > txID {
+	if txID != (datalog.ElementID{}) && txID.Less(datom.Tx) {
 		return false
 	}
 
@@ -32,11 +32,11 @@ func validateDatomWithConstraintsHelper(
 // Inline version (current approach)
 func validateDatomInline(
 	datom *datalog.Datom,
-	txID uint64,
+	txID datalog.ElementID,
 	constraints []executor.StorageConstraint,
 ) bool {
 	// Check transaction validity
-	if txID > 0 && datom.Tx.Lamport > txID {
+	if txID != (datalog.ElementID{}) && txID.Less(datom.Tx) {
 		return false
 	}
 
@@ -75,16 +75,16 @@ func BenchmarkIteratorValidation(b *testing.B) {
 
 	scenarios := []struct {
 		name           string
-		txID           uint64
+		txID           datalog.ElementID
 		constraintCnt  int
 		constraintPass bool
 	}{
-		{"no_tx_check_no_constraints", 0, 0, true},
-		{"with_tx_check_no_constraints", 50, 0, true},
-		{"no_tx_check_1_constraint", 0, 1, true},
-		{"no_tx_check_3_constraints", 0, 3, true},
-		{"with_tx_check_3_constraints", 50, 3, true},
-		{"with_tx_check_5_constraints", 50, 5, true},
+		{"no_tx_check_no_constraints", datalog.ElementID{}, 0, true},
+		{"with_tx_check_no_constraints", datalog.ElementID{Lamport: 50, ReplicaID: 1}, 0, true},
+		{"no_tx_check_1_constraint", datalog.ElementID{}, 1, true},
+		{"no_tx_check_3_constraints", datalog.ElementID{}, 3, true},
+		{"with_tx_check_3_constraints", datalog.ElementID{Lamport: 50, ReplicaID: 1}, 3, true},
+		{"with_tx_check_5_constraints", datalog.ElementID{Lamport: 50, ReplicaID: 1}, 5, true},
 	}
 
 	for _, scenario := range scenarios {
@@ -169,7 +169,7 @@ func BenchmarkIteratorLoop(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			for _, datom := range datoms {
 				// Helper function approach
-				if validateDatomWithConstraintsHelper(datom, 500, constraints) {
+				if validateDatomWithConstraintsHelper(datom, datalog.ElementID{Lamport: 500, ReplicaID: 1}, constraints) {
 					matched++
 				}
 			}

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -15,7 +15,7 @@ import (
 // BadgerMatcher implements the executor.PatternMatcher interface using BadgerStore
 type BadgerMatcher struct {
 	store             *BadgerStore
-	txID              uint64                   // For as-of queries (0 means latest)
+	txID              datalog.ElementID        // For as-of queries (zero value means latest)
 	timeRanges        []executor.TimeRange     // For time range optimization
 	builderCache      *sync.Map                // map[string]*query.InternedTupleBuilder - Thread-safe cache for tuple builders
 	builderCacheOnce  sync.Once                // Ensures builderCache is initialized exactly once
@@ -30,7 +30,7 @@ type BadgerMatcher struct {
 func NewBadgerMatcher(store *BadgerStore) *BadgerMatcher {
 	return &BadgerMatcher{
 		store:        store,
-		txID:         0,
+		txID:         datalog.ElementID{},
 		builderCache: &sync.Map{},
 		options:      executor.ExecutorOptions{}, // Default options
 	}
@@ -40,14 +40,14 @@ func NewBadgerMatcher(store *BadgerStore) *BadgerMatcher {
 func NewBadgerMatcherWithOptions(store *BadgerStore, opts executor.ExecutorOptions) *BadgerMatcher {
 	return &BadgerMatcher{
 		store:        store,
-		txID:         0,
+		txID:         datalog.ElementID{},
 		builderCache: &sync.Map{},
 		options:      opts,
 	}
 }
 
 // AsOf creates a matcher that sees the database as of a specific transaction
-func (m *BadgerMatcher) AsOf(txID uint64) *BadgerMatcher {
+func (m *BadgerMatcher) AsOf(txID datalog.ElementID) *BadgerMatcher {
 	// Ensure cache is initialized before sharing it
 	m.builderCacheOnce.Do(func() {
 		if m.builderCache == nil {
@@ -244,7 +244,7 @@ func (m *BadgerMatcher) matchBoundPattern(pattern *query.DataPattern) ([]datalog
 		}
 
 		// Check if datom is valid for our transaction view
-		if m.txID > 0 && datom.Tx.Lamport > m.txID {
+		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
 			continue
 		}
 
@@ -307,7 +307,7 @@ func (m *BadgerMatcher) MatchWithHistory(pattern *query.DataPattern) ([]datalog.
 		}
 
 		// Check if datom is valid for our transaction view (as-of still applies)
-		if m.txID > 0 && datom.Tx.Lamport > m.txID {
+		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
 			continue
 		}
 
@@ -323,7 +323,7 @@ func (m *BadgerMatcher) MatchWithHistory(pattern *query.DataPattern) ([]datalog.
 // MatchAsOf matches a pattern and returns the value as of a specific Lamport time.
 // This finds the first entry with Lamport <= targetLamport (the value that was current then).
 // If no value existed at that time, returns nil.
-func (m *BadgerMatcher) MatchAsOf(pattern *query.DataPattern, targetLamport uint64) ([]datalog.Datom, error) {
+func (m *BadgerMatcher) MatchAsOf(pattern *query.DataPattern, targetTx datalog.ElementID) ([]datalog.Datom, error) {
 	// Extract values from pattern
 	var e, a, v, tx interface{}
 
@@ -360,12 +360,12 @@ func (m *BadgerMatcher) MatchAsOf(pattern *query.DataPattern, targetLamport uint
 		}
 
 		// Skip entries newer than target time
-		if datom.Tx.Lamport > targetLamport {
+		if targetTx.Less(datom.Tx) {
 			continue
 		}
 
 		// Also apply as-of filter if set
-		if m.txID > 0 && datom.Tx.Lamport > m.txID {
+		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
 			continue
 		}
 
@@ -428,7 +428,7 @@ func (m *BadgerMatcher) scanTimeRanges(attr datalog.Keyword, tx interface{}) ([]
 			}
 
 			// Check transaction filter
-			if m.txID > 0 && datom.Tx.Lamport > m.txID {
+			if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
 				continue
 			}
 
@@ -814,7 +814,7 @@ func (m *BadgerMatcher) LookupAttribute(entity datalog.Identity, attr datalog.Ke
 	}
 
 	// Try cache first for O(1) access (only for latest state, not as-of queries)
-	if m.cache != nil && m.txID == 0 {
+	if m.cache != nil && m.txID == (datalog.ElementID{}) {
 		eEntity := Entity(eBytes)
 		var aAttr Attribute
 		copy(aAttr[:], aStorage[:])
@@ -868,7 +868,7 @@ func (m *BadgerMatcher) LookupAttribute(entity datalog.Identity, attr datalog.Ke
 			}
 
 			// Check transaction filter for as-of queries
-			if m.txID > 0 && datom.Tx.Lamport > m.txID {
+			if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
 				continue
 			}
 
@@ -912,7 +912,7 @@ func (m *BadgerMatcher) LookupAttribute(entity datalog.Identity, attr datalog.Ke
 		}
 
 		// Check transaction filter for as-of queries
-		if m.txID > 0 && datom.Tx.Lamport > m.txID {
+		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
 			continue
 		}
 
@@ -955,7 +955,7 @@ func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalo
 	aStorage := ToStorageDatom(datalog.Datom{A: attr}).A
 
 	// Try cache first for O(1) access (only for latest state, not as-of queries)
-	if m.cache != nil && m.txID == 0 {
+	if m.cache != nil && m.txID == (datalog.ElementID{}) {
 		eEntity := Entity(eBytes)
 		var aAttr Attribute
 		copy(aAttr[:], aStorage[:])
@@ -1011,7 +1011,7 @@ func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalo
 		}
 
 		// Check transaction filter for as-of queries
-		if m.txID > 0 && datom.Tx.Lamport > m.txID {
+		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
 			continue
 		}
 

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -661,10 +661,15 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 		return VAET, start, end
 	} else if tx != nil {
 		// Use TAEV index
+		var storageTx Tx
 		if txID, ok := tx.(uint64); ok {
-			// Convert to storage tx (20 bytes)
-			storageTx := NewTxFromUint(txID)
-			start, end := encoder.EncodePrefixRange(TAEV, storageTx[:])
+			storageTx = NewTxFromUint(txID)
+		} else if eid, ok := datalog.DerefElementID(tx); ok {
+			storageTx = NewTxFromElementID(eid)
+		}
+		if storageTx != (Tx{}) {
+			encTx := encoder.EncodeTxForPrefix(storageTx)
+			start, end := encoder.EncodePrefixRange(TAEV, encTx)
 			return TAEV, start, end
 		}
 	}
@@ -681,6 +686,9 @@ func (m *BadgerMatcher) matchesDatom(datom *datalog.Datom, e, a, v, tx interface
 	// Note: Identity is always a pointer type now, no dereferencing needed
 	// Note: Do NOT dereference *Keyword - they must stay as interned pointers
 	if ptr, ok := tx.(*uint64); ok {
+		tx = *ptr
+	}
+	if ptr, ok := tx.(*datalog.ElementID); ok {
 		tx = *ptr
 	}
 

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -15,7 +15,7 @@ import (
 // BadgerMatcher implements the executor.PatternMatcher interface using BadgerStore
 type BadgerMatcher struct {
 	store             *BadgerStore
-	txID              datalog.ElementID        // For as-of queries (zero value means latest)
+	txID              *datalog.ElementID       // nil=latest CRDT-resolved, &ElementID{}=raw history, &ElementID{L,R}=as-of
 	timeRanges        []executor.TimeRange     // For time range optimization
 	builderCache      *sync.Map                // map[string]*query.InternedTupleBuilder - Thread-safe cache for tuple builders
 	builderCacheOnce  sync.Once                // Ensures builderCache is initialized exactly once
@@ -26,11 +26,32 @@ type BadgerMatcher struct {
 	cache             *Cache                   // CRDT resolution cache for O(1) access to resolved views
 }
 
+// isHistoryMode returns true when raw (non-CRDT-resolved) datoms are requested.
+func (m *BadgerMatcher) isHistoryMode() bool {
+	return m.txID != nil && *m.txID == (datalog.ElementID{})
+}
+
+// shouldFilterTx returns true if a datom should be skipped because it's
+// from after the as-of target. Returns false in latest mode (nil) and
+// history mode (&ElementID{}).
+func (m *BadgerMatcher) shouldFilterTx(datomTx datalog.ElementID) bool {
+	return m.txID != nil && *m.txID != (datalog.ElementID{}) && m.txID.Less(datomTx)
+}
+
+// crdtTxID returns the ElementID to pass to CRDTResolvingIterator.
+// In latest mode returns ElementID{} (no filter). In as-of mode returns the target.
+// Must NOT be called in history mode (caller should check isHistoryMode first).
+func (m *BadgerMatcher) crdtTxID() datalog.ElementID {
+	if m.txID != nil {
+		return *m.txID
+	}
+	return datalog.ElementID{}
+}
+
 // NewBadgerMatcher creates a new pattern matcher for the BadgerStore
 func NewBadgerMatcher(store *BadgerStore) *BadgerMatcher {
 	return &BadgerMatcher{
 		store:        store,
-		txID:         datalog.ElementID{},
 		builderCache: &sync.Map{},
 		options:      executor.ExecutorOptions{}, // Default options
 	}
@@ -40,13 +61,13 @@ func NewBadgerMatcher(store *BadgerStore) *BadgerMatcher {
 func NewBadgerMatcherWithOptions(store *BadgerStore, opts executor.ExecutorOptions) *BadgerMatcher {
 	return &BadgerMatcher{
 		store:        store,
-		txID:         datalog.ElementID{},
 		builderCache: &sync.Map{},
 		options:      opts,
 	}
 }
 
-// AsOf creates a matcher that sees the database as of a specific transaction
+// AsOf creates a matcher that sees the database as of a specific transaction.
+// Passing a zero ElementID enters history mode (raw datoms, no CRDT resolution).
 func (m *BadgerMatcher) AsOf(txID datalog.ElementID) *BadgerMatcher {
 	// Ensure cache is initialized before sharing it
 	m.builderCacheOnce.Do(func() {
@@ -57,14 +78,20 @@ func (m *BadgerMatcher) AsOf(txID datalog.ElementID) *BadgerMatcher {
 
 	return &BadgerMatcher{
 		store:        m.store,
-		txID:         txID,
+		txID:         &txID,
 		timeRanges:   m.timeRanges,
 		builderCache: m.builderCache,
 		handler:      m.handler,
-		options:      m.options, // Preserve options
-		schema:       m.schema,  // Preserve schema for cardinality-aware index selection
-		cache:        m.cache,   // Preserve cache for CRDT resolution
+		options:      m.options,
+		schema:       m.schema,
+		cache:        m.cache,
 	}
+}
+
+// History creates a matcher that returns raw datoms without CRDT resolution.
+// All historical versions are visible, including retracted values.
+func (m *BadgerMatcher) History() *BadgerMatcher {
+	return m.AsOf(datalog.ElementID{})
 }
 
 // SetHandler configures the handler for detailed storage events.
@@ -244,7 +271,7 @@ func (m *BadgerMatcher) matchBoundPattern(pattern *query.DataPattern) ([]datalog
 		}
 
 		// Check if datom is valid for our transaction view
-		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
+		if m.shouldFilterTx(datom.Tx) {
 			continue
 		}
 
@@ -307,7 +334,7 @@ func (m *BadgerMatcher) MatchWithHistory(pattern *query.DataPattern) ([]datalog.
 		}
 
 		// Check if datom is valid for our transaction view (as-of still applies)
-		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
+		if m.shouldFilterTx(datom.Tx) {
 			continue
 		}
 
@@ -365,7 +392,7 @@ func (m *BadgerMatcher) MatchAsOf(pattern *query.DataPattern, targetTx datalog.E
 		}
 
 		// Also apply as-of filter if set
-		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
+		if m.shouldFilterTx(datom.Tx) {
 			continue
 		}
 
@@ -428,7 +455,7 @@ func (m *BadgerMatcher) scanTimeRanges(attr datalog.Keyword, tx interface{}) ([]
 			}
 
 			// Check transaction filter
-			if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
+			if m.shouldFilterTx(datom.Tx) {
 				continue
 			}
 
@@ -814,7 +841,7 @@ func (m *BadgerMatcher) LookupAttribute(entity datalog.Identity, attr datalog.Ke
 	}
 
 	// Try cache first for O(1) access (only for latest state, not as-of queries)
-	if m.cache != nil && m.txID == (datalog.ElementID{}) {
+	if m.cache != nil && m.txID == nil {
 		eEntity := Entity(eBytes)
 		var aAttr Attribute
 		copy(aAttr[:], aStorage[:])
@@ -868,7 +895,7 @@ func (m *BadgerMatcher) LookupAttribute(entity datalog.Identity, attr datalog.Ke
 			}
 
 			// Check transaction filter for as-of queries
-			if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
+			if m.shouldFilterTx(datom.Tx) {
 				continue
 			}
 
@@ -912,7 +939,7 @@ func (m *BadgerMatcher) LookupAttribute(entity datalog.Identity, attr datalog.Ke
 		}
 
 		// Check transaction filter for as-of queries
-		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
+		if m.shouldFilterTx(datom.Tx) {
 			continue
 		}
 
@@ -955,7 +982,7 @@ func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalo
 	aStorage := ToStorageDatom(datalog.Datom{A: attr}).A
 
 	// Try cache first for O(1) access (only for latest state, not as-of queries)
-	if m.cache != nil && m.txID == (datalog.ElementID{}) {
+	if m.cache != nil && m.txID == nil {
 		eEntity := Entity(eBytes)
 		var aAttr Attribute
 		copy(aAttr[:], aStorage[:])
@@ -1011,7 +1038,7 @@ func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalo
 		}
 
 		// Check transaction filter for as-of queries
-		if m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx) {
+		if m.shouldFilterTx(datom.Tx) {
 			continue
 		}
 

--- a/datalog/storage/matcher_concurrency_test.go
+++ b/datalog/storage/matcher_concurrency_test.go
@@ -65,7 +65,7 @@ func TestTupleBuilderCacheSharing(t *testing.T) {
 	defer db.Close()
 
 	baseMatcher := NewBadgerMatcher(db.Store())
-	asOfMatcher := baseMatcher.AsOf(100)
+	asOfMatcher := baseMatcher.AsOf(datalog.ElementID{Lamport: 100})
 
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{

--- a/datalog/storage/matcher_iterator_nonreusing.go
+++ b/datalog/storage/matcher_iterator_nonreusing.go
@@ -76,9 +76,12 @@ func (it *nonReusingIterator) Next() bool {
 		return false
 	}
 
-	// Wrap with CRDT resolution to ensure we only see resolved values
-	// Always applied: CRDTResolvingIterator handles nil schema correctly
-	it.currentScan = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
+	// Wrap with CRDT resolution unless in history mode
+	if it.matcher.isHistoryMode() {
+		it.currentScan = rawIter
+	} else {
+		it.currentScan = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.crdtTxID())
+	}
 
 	// Try to find first match
 	return it.Next()

--- a/datalog/storage/matcher_iterator_reusing.go
+++ b/datalog/storage/matcher_iterator_reusing.go
@@ -69,9 +69,12 @@ func (it *reusingIterator) Next() bool {
 			return false
 		}
 
-		// Wrap with CRDT resolution to ensure we only see resolved values
-		// Always applied: CRDTResolvingIterator handles nil schema correctly
-		it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.txID)
+		// Wrap with CRDT resolution unless in history mode
+		if it.matcher.isHistoryMode() {
+			it.storageIter = rawIter
+		} else {
+			it.storageIter = NewCRDTResolvingIterator(rawIter, it.matcher.schema, it.matcher.crdtTxID())
+		}
 
 		// Reset to first tuple for actual processing
 		it.updateBoundPattern(firstTuple)

--- a/datalog/storage/matcher_iterator_reusing.go
+++ b/datalog/storage/matcher_iterator_reusing.go
@@ -178,12 +178,12 @@ func (it *reusingIterator) Next() bool {
 					case 3: // Transaction bound (TAEV index)
 						// TAEV: Tx + Attribute + Entity + Value
 						// When transaction changes, we're past this binding
-						if expectedTx, ok := bindingTuple[0].(uint64); ok {
-							if datom.Tx.Lamport != expectedTx {
+						if eid, ok := datalog.DerefElementID(bindingTuple[0]); ok {
+							if datom.Tx != eid {
 								movedPast = true
 							}
-						} else if expectedTx, ok := bindingTuple[0].(datalog.ElementID); ok {
-							if datom.Tx != expectedTx {
+						} else if expectedTx, ok := bindingTuple[0].(uint64); ok {
+							if datom.Tx.Lamport != expectedTx {
 								movedPast = true
 							}
 						}
@@ -278,7 +278,7 @@ func (it *reusingIterator) calculateSeekKey(bindingTuple executor.Tuple) ([]byte
 	}
 
 	// Extract values based on pattern
-	var e, a, v interface{}
+	var e, a, v, tx interface{}
 
 	// Get E value
 	if c, ok := it.pattern.GetE().(query.Constant); ok {
@@ -305,8 +305,25 @@ func (it *reusingIterator) calculateSeekKey(bindingTuple executor.Tuple) ([]byte
 		}
 	}
 
-	// Use the existing chooseIndex logic but just for the key calculation
-	_, start, end := it.matcher.chooseIndex(e, a, v, nil)
+	// Get T value
+	if len(it.pattern.Elements) > 3 {
+		if c, ok := it.pattern.GetT().(query.Constant); ok {
+			tx = c.Value
+		} else if sym, ok := it.pattern.GetT().(query.Variable); ok {
+			if idx, found := colIndex[sym.Name]; found && idx < len(bindingTuple) {
+				tx = bindingTuple[idx]
+			}
+		}
+	}
+
+	// Use the existing chooseIndex logic but just for the key calculation.
+	// When the strategy chose TAEV (position 3), only pass tx to avoid
+	// chooseIndex selecting AETV due to a constant A in the pattern.
+	if it.position == 3 && it.index == TAEV {
+		_, start, end := it.matcher.chooseIndex(nil, nil, nil, tx)
+		return start, end
+	}
+	_, start, end := it.matcher.chooseIndex(e, a, v, tx)
 	return start, end
 }
 

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -104,7 +104,7 @@ func (m *BadgerMatcher) MatchWithConstraints(
 
 	// CACHE OPTIMIZATION: When A is known (from pattern constant or bindings),
 	// use the cache for each E value instead of storage scans.
-	if m.cache != nil && m.txID == 0 {
+	if m.cache != nil && m.txID == (datalog.ElementID{}) {
 		if aResolved != nil {
 			// Phase 1: A has a single known value (from constant or single-row binding)
 			if aKw, ok := aResolved.(datalog.Keyword); ok {
@@ -267,7 +267,7 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 
 	// CACHE OPTIMIZATION: When E and A are bound and we're querying latest state,
 	// use the cache for O(1) access instead of storage scans.
-	if m.cache != nil && m.txID == 0 && e != nil && a != nil {
+	if m.cache != nil && m.txID == (datalog.ElementID{}) && e != nil && a != nil {
 		if eIdent, ok := e.(datalog.Identity); ok {
 			if aKw, ok := a.(datalog.Keyword); ok {
 				cacheResult, handled := m.matchFromCache(pattern, columns, eIdent, aKw, v, card)
@@ -865,7 +865,7 @@ func (it *validatingVBoundIterator) openCRDTScan() (*CRDTResolvingIterator, Iter
 	// - Add-wins with same-Tx tiebreaking for CardinalityMany
 	// - RGA for CardinalityVector
 	// - Add-wins for CardinalityUnknown (same as CardinalityMany)
-	crdtIter := NewCRDTResolvingIterator(rawIter, it.matcher.schema, 0)
+	crdtIter := NewCRDTResolvingIterator(rawIter, it.matcher.schema, datalog.ElementID{})
 
 	if it.matcher.handler != nil {
 		it.matcher.handler(annotations.Event{

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -104,7 +104,7 @@ func (m *BadgerMatcher) MatchWithConstraints(
 
 	// CACHE OPTIMIZATION: When A is known (from pattern constant or bindings),
 	// use the cache for each E value instead of storage scans.
-	if m.cache != nil && m.txID == (datalog.ElementID{}) {
+	if m.cache != nil && m.txID == nil {
 		if aResolved != nil {
 			// Phase 1: A has a single known value (from constant or single-row binding)
 			if aKw, ok := aResolved.(datalog.Keyword); ok {
@@ -267,7 +267,7 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 
 	// CACHE OPTIMIZATION: When E and A are bound and we're querying latest state,
 	// use the cache for O(1) access instead of storage scans.
-	if m.cache != nil && m.txID == (datalog.ElementID{}) && e != nil && a != nil {
+	if m.cache != nil && m.txID == nil && e != nil && a != nil {
 		if eIdent, ok := e.(datalog.Identity); ok {
 			if aKw, ok := a.(datalog.Keyword); ok {
 				cacheResult, handled := m.matchFromCache(pattern, columns, eIdent, aKw, v, card)
@@ -329,6 +329,16 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			// V bound: find all entities where this value is in the set
 			useAddWinsScanAllEntitiesWithValue = true
 		}
+	}
+
+	// In history mode, disable all CRDT resolution flags — return raw datoms
+	if m.isHistoryMode() {
+		returnOnlyFirst = false
+		useAddWinsResolution = false
+		useMembershipCheck = false
+		useAddWinsScanAllEntities = false
+		useAddWinsScanAllEntitiesWithValue = false
+		useVectorResolution = false
 	}
 
 	// For cardinality-vector with E+A bound: use vector resolution
@@ -419,10 +429,12 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			return nil, fmt.Errorf("key mask scan failed: %w", err)
 		}
 
-		// Wrap with CRDT resolution for per-(E, A) group resolution
-		// Always applied: CRDTResolvingIterator handles nil schema correctly
-		// (defaults to CardinalityUnknown → add-wins semantics)
-		maskIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
+		// Wrap with CRDT resolution unless in history mode (raw datoms)
+		if m.isHistoryMode() {
+			maskIter.storageIter = rawStorageIter
+		} else {
+			maskIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.crdtTxID())
+		}
 		iter = maskIter
 	} else {
 		// Use regular iterator
@@ -449,10 +461,12 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			return nil, fmt.Errorf("scan failed: %w", err)
 		}
 
-		// Wrap with CRDT resolution for per-(E, A) group resolution
-		// Always applied: CRDTResolvingIterator handles nil schema correctly
-		// (defaults to CardinalityUnknown → add-wins semantics)
-		regularIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.txID)
+		// Wrap with CRDT resolution unless in history mode (raw datoms)
+		if m.isHistoryMode() {
+			regularIter.storageIter = rawStorageIter
+		} else {
+			regularIter.storageIter = NewCRDTResolvingIterator(rawStorageIter, m.schema, m.crdtTxID())
+		}
 		iter = regularIter
 	}
 

--- a/datalog/storage/merge_join_test.go
+++ b/datalog/storage/merge_join_test.go
@@ -530,6 +530,34 @@ func TestCompareJoinKeys(t *testing.T) {
 			datalog.NewKeyword(":test/a"),
 			1,
 		},
+		// ElementID value-value
+		{
+			"equal ElementID value-value",
+			datalog.ElementID{Lamport: 100, ReplicaID: 5},
+			datalog.ElementID{Lamport: 100, ReplicaID: 5},
+			0,
+		},
+		// ElementID pointer-value
+		{
+			"equal ElementID pointer-value",
+			&datalog.ElementID{Lamport: 100, ReplicaID: 5},
+			datalog.ElementID{Lamport: 100, ReplicaID: 5},
+			0,
+		},
+		// ElementID value-pointer less
+		{
+			"less ElementID value-pointer",
+			datalog.ElementID{Lamport: 100, ReplicaID: 5},
+			&datalog.ElementID{Lamport: 200, ReplicaID: 5},
+			-1,
+		},
+		// ElementID pointer-pointer greater
+		{
+			"greater ElementID pointer-pointer",
+			&datalog.ElementID{Lamport: 200, ReplicaID: 5},
+			&datalog.ElementID{Lamport: 100, ReplicaID: 5},
+			1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/datalog/storage/or_subquery_regression_test.go
+++ b/datalog/storage/or_subquery_regression_test.go
@@ -22,7 +22,6 @@ func TestOrClauseWithCorrelatedSubquery_E2E(t *testing.T) {
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dbPath,
-		UseTimeTx: true, // Same as user's code
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -92,7 +91,6 @@ func TestScenarioSummaryQuery_E2E(t *testing.T) {
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dbPath,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -207,7 +205,6 @@ func TestNestedSubqueryInOr_E2E(t *testing.T) {
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dbPath,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -270,7 +267,6 @@ func TestProductionQueryStructure_E2E(t *testing.T) {
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dbPath,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -342,7 +338,6 @@ func TestGetElseBeforeOrClause_E2E(t *testing.T) {
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dbPath,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -394,7 +389,6 @@ func TestMultipleSequentialOrClauses_E2E(t *testing.T) {
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dbPath,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -452,7 +446,6 @@ func TestOrWithGetElseInsideSubquery_E2E(t *testing.T) {
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dbPath,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -502,7 +495,6 @@ func TestOrWithMultipleAggregations_E2E(t *testing.T) {
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dbPath,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -553,7 +545,6 @@ func TestFullScenarioSummaryQuery_E2E(t *testing.T) {
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:      dbPath,
-		UseTimeTx: true,
 	})
 	require.NoError(t, err)
 	defer db.Close()

--- a/datalog/storage/queries.go
+++ b/datalog/storage/queries.go
@@ -55,11 +55,11 @@ func (q *QueryBuilder) GetAttributeValue(attr datalog.Keyword, value interface{}
 }
 
 // GetTimeRange returns all datoms within a time range
-func (q *QueryBuilder) GetTimeRange(startTx, endTx uint64) ([]*datalog.Datom, error) {
-	// Convert uint64 to bytes
+func (q *QueryBuilder) GetTimeRange(startTx, endTx datalog.ElementID) ([]*datalog.Datom, error) {
+	// Convert Lamport to bytes for TAEV index prefix
 	var startBytes, endBytes [8]byte
-	binary.BigEndian.PutUint64(startBytes[:], startTx)
-	binary.BigEndian.PutUint64(endBytes[:], endTx)
+	binary.BigEndian.PutUint64(startBytes[:], startTx.Lamport)
+	binary.BigEndian.PutUint64(endBytes[:], endTx.Lamport)
 
 	start := q.encoder.EncodePrefix(TAEV, startBytes[:])
 	end := q.encoder.EncodePrefix(TAEV, endBytes[:])
@@ -67,17 +67,17 @@ func (q *QueryBuilder) GetTimeRange(startTx, endTx uint64) ([]*datalog.Datom, er
 }
 
 // GetEntityTimeRange returns datoms for an entity within a time range
-func (q *QueryBuilder) GetEntityTimeRange(entity datalog.Identity, startTx, endTx uint64) ([]*datalog.Datom, error) {
+func (q *QueryBuilder) GetEntityTimeRange(entity datalog.Identity, startTx, endTx datalog.ElementID) ([]*datalog.Datom, error) {
 	// Need to scan EAVT and filter by time
 	allDatoms, err := q.GetEntity(entity)
 	if err != nil {
 		return nil, err
 	}
 
-	// Filter by time range (compare Lamport component)
+	// Filter by time range using full ElementID comparison
 	var result []*datalog.Datom
 	for _, d := range allDatoms {
-		if d.Tx.Lamport >= startTx && d.Tx.Lamport < endTx {
+		if !d.Tx.Less(startTx) && d.Tx.Less(endTx) {
 			result = append(result, d)
 		}
 	}

--- a/datalog/storage/simple_batch_scanner.go
+++ b/datalog/storage/simple_batch_scanner.go
@@ -280,7 +280,7 @@ func (s *simpleBatchScanner) scanAndFilter(iter Iterator, bindingSet map[string]
 		datomCount++
 
 		// Check transaction validity
-		if s.matcher.txID > 0 && datom.Tx.Lamport > s.matcher.txID {
+		if s.matcher.txID != (datalog.ElementID{}) && s.matcher.txID.Less(datom.Tx) {
 			continue
 		}
 

--- a/datalog/storage/simple_batch_scanner.go
+++ b/datalog/storage/simple_batch_scanner.go
@@ -71,9 +71,13 @@ func (s *simpleBatchScanner) Scan() error {
 		return fmt.Errorf("failed to open scan: %w", err)
 	}
 
-	// Wrap with CRDT resolution to ensure we only see resolved values
-	// Always applied: CRDTResolvingIterator handles nil schema correctly
-	iter := NewCRDTResolvingIterator(rawIter, s.matcher.schema, s.matcher.txID)
+	// Wrap with CRDT resolution unless in history mode
+	var iter Iterator
+	if s.matcher.isHistoryMode() {
+		iter = rawIter
+	} else {
+		iter = NewCRDTResolvingIterator(rawIter, s.matcher.schema, s.matcher.crdtTxID())
+	}
 	defer iter.Close()
 
 	// Step 4: Scan and filter
@@ -280,7 +284,7 @@ func (s *simpleBatchScanner) scanAndFilter(iter Iterator, bindingSet map[string]
 		datomCount++
 
 		// Check transaction validity
-		if s.matcher.txID != (datalog.ElementID{}) && s.matcher.txID.Less(datom.Tx) {
+		if s.matcher.shouldFilterTx(datom.Tx) {
 			continue
 		}
 

--- a/datalog/storage/simple_batch_scanner.go
+++ b/datalog/storage/simple_batch_scanner.go
@@ -110,6 +110,8 @@ func (s *simpleBatchScanner) valueToKey(v interface{}) string {
 		v = *ptr
 	} else if ptr, ok := v.(*uint64); ok {
 		v = *ptr
+	} else if eid, ok := datalog.DerefElementID(v); ok {
+		v = eid
 	}
 
 	switch val := v.(type) {
@@ -124,6 +126,8 @@ func (s *simpleBatchScanner) valueToKey(v interface{}) string {
 		return val.String()
 	case string:
 		return val
+	case datalog.ElementID:
+		return val.String()
 	case uint64:
 		return fmt.Sprintf("%d", val)
 	default:
@@ -247,10 +251,16 @@ func (s *simpleBatchScanner) buildKey(value interface{}, constA []byte) []byte {
 		}
 		return encoder.EncodePrefix(s.index, parts...)
 	case 4: // TAEV
-		if tx, ok := value.(uint64); ok {
-			// Convert uint64 to 20-byte Tx format
+		// Tx must be encoded with bitwise-NOT for descending sort order
+		if eid, ok := datalog.DerefElementID(value); ok {
+			txBytes := NewTxFromElementID(eid)
+			encTx := encoder.EncodeTxForPrefix(txBytes)
+			parts := [][]byte{encTx}
+			return encoder.EncodePrefix(s.index, parts...)
+		} else if tx, ok := value.(uint64); ok {
 			txBytes := NewTxFromUint(tx)
-			parts := [][]byte{txBytes[:]}
+			encTx := encoder.EncodeTxForPrefix(txBytes)
+			parts := [][]byte{encTx}
 			return encoder.EncodePrefix(s.index, parts...)
 		}
 	}

--- a/datalog/storage/vector_resolution.go
+++ b/datalog/storage/vector_resolution.go
@@ -83,6 +83,11 @@ func (m *BadgerMatcher) loadRGAElements(eBytes, aBytes []byte) ([]RGAElement, er
 			continue
 		}
 
+		// Apply temporal filtering for AsOf queries
+		if m.shouldFilterTx(datom.Tx) {
+			continue
+		}
+
 		if datom.Op == datalog.OpRGAInsert {
 			// Insert: ID is Tx, AfterRef is position reference
 			rgaElem := RGAElement{

--- a/datalog/value_encoding.go
+++ b/datalog/value_encoding.go
@@ -55,6 +55,8 @@ func Type(v Value) ValueType {
 		return TypeSymbol
 	case ElementID:
 		return TypeElementID
+	case *ElementID:
+		return TypeElementID
 	default:
 		panic(fmt.Sprintf("unknown value type: %T", val))
 	}
@@ -108,6 +110,11 @@ func ValueBytes(v Value) []byte {
 	case ElementID:
 		// Uses natural order encoding (not bitwise NOT like key encoding)
 		return val.Bytes()
+	case *ElementID:
+		if val != nil {
+			return val.Bytes()
+		}
+		return make([]byte, ElementIDSize)
 	default:
 		panic(fmt.Sprintf("cannot encode value type: %T", v))
 	}

--- a/datalog/value_encoding_test.go
+++ b/datalog/value_encoding_test.go
@@ -129,6 +129,38 @@ func TestElementIDValueType_Distinct(t *testing.T) {
 	}
 }
 
+// TestElementIDPointerValueEncoding tests that *ElementID works in Type() and
+// ValueBytes() without panicking. The InternedTupleBuilder stores Tx as
+// *ElementID, and any code path that calls Type() or ValueBytes() on tuple
+// values must handle both pointer and value forms.
+func TestElementIDPointerValueEncoding(t *testing.T) {
+	eid := ElementID{Lamport: 1234, ReplicaID: 5678}
+
+	// *ElementID should return TypeElementID
+	ptrType := Type(&eid)
+	if ptrType != TypeElementID {
+		t.Errorf("Type(&ElementID) = %d, want TypeElementID (%d)", ptrType, TypeElementID)
+	}
+
+	// *ElementID should produce same bytes as ElementID value
+	ptrBytes := ValueBytes(&eid)
+	valBytes := ValueBytes(eid)
+	if len(ptrBytes) != len(valBytes) {
+		t.Fatalf("ValueBytes(&eid) len = %d, ValueBytes(eid) len = %d", len(ptrBytes), len(valBytes))
+	}
+	for i := range ptrBytes {
+		if ptrBytes[i] != valBytes[i] {
+			t.Errorf("ValueBytes(&eid)[%d] = %d, ValueBytes(eid)[%d] = %d", i, ptrBytes[i], i, valBytes[i])
+		}
+	}
+
+	// nil *ElementID should not panic in Type()
+	var nilPtr *ElementID
+	nilType := Type(nilPtr)
+	// We don't care about the exact type for nil, just that it doesn't panic
+	_ = nilType
+}
+
 func TestElementIDValueBytes_NaturalOrder(t *testing.T) {
 	// Value encoding should use natural order (not bitwise NOT like key encoding)
 	// This means lower Lamport values should encode to smaller bytes

--- a/docs/bugs/BUG_ELEMENTID_ASOF_THROUGHOUT.md
+++ b/docs/bugs/BUG_ELEMENTID_ASOF_THROUGHOUT.md
@@ -115,12 +115,30 @@ The plan above recommended `datom.Tx.Lamport > m.txID.Lamport` for as-of filteri
 - **`datalog/storage/matcher_relations.go` line 868**: `NewCRDTResolvingIterator(rawIter, m.schema, 0)` → `datalog.ElementID{}`.
 - **`examples/*.go`**: Left unchanged — these have `//go:build example` tags and need a larger rewrite to use the Transaction API properly instead of fabricating ElementIDs from timestamps. Tracked as separate work.
 
+### Phase 3: Three-mode `*ElementID` pointer — COMPLETE
+
+Changed `BadgerMatcher.txID` from `datalog.ElementID` (value) to `*datalog.ElementID` (pointer) for three-mode semantics:
+
+| Pointer value | Mode | CRDT resolution | Tx filtering |
+|---------------|------|-----------------|--------------|
+| `nil` | Latest | Yes | No |
+| `&ElementID{}` | History (raw) | **No** | No |
+| `&ElementID{L,R}` | As-of | Yes | Yes |
+
+**Changes:**
+- Added `isHistoryMode()`, `shouldFilterTx()`, `crdtTxID()` helpers — all confirmed inlined by compiler (`go build -gcflags='-m'`)
+- Added `BadgerMatcher.History()` and `Database.History()` methods
+- All 8 `NewCRDTResolvingIterator` call sites: conditional wrapping (skip in history mode)
+- All inline filter checks replaced with `shouldFilterTx()`
+- All cache eligibility checks changed to `m.txID == nil`
+- `validateDatomWithConstraints` signature: `*datalog.ElementID`
+- History mode disables all cardinality-based CRDT flags (`returnOnlyFirst`, `useAddWinsResolution`, etc.) in `matchUnboundAsRelation`
+- New tests: `TestHistoryMode` (cardinality-one, 3 LWW versions all visible) and `TestHistoryModeCardinalityMany` (2 adds + 1 remove all visible)
+
 ### Next steps (not yet implemented)
 
-- **`BadgerMatcher.txID` should become `*datalog.ElementID`**: Currently `ElementID{}` (zero value) means "no as-of filter, latest resolved state." We want to distinguish three modes:
-  - `nil` → no AsOf called, latest CRDT-resolved state (current default)
-  - `&ElementID{}` → history mode, no CRDT resolution (raw datoms)
-  - `&ElementID{Lamport: N, ReplicaID: R}` → CRDT-resolved as-of that point
 - **`[(as-of ?tx N)]` predicate is parsed but not wired up** to the executor. The Datomic approach is to apply as-of at the database level, not in the query. A `:as-of` parameter at the EDN query root level would be the right design.
+- **`[(history)]` predicate is parsed but not wired up** — `db.History()` now provides this at the database level.
 - **`HistoryPredicate.TargetLamport` is still `uint64`** — needs to become `ElementID` if the predicate is kept.
 - **`TxRangePredicate.Low`/`.High` are still `uint64`** — same issue.
+- **`examples/*.go`** need rewrite to use Transaction API instead of fabricating ElementIDs from timestamps.

--- a/docs/bugs/BUG_ELEMENTID_ASOF_THROUGHOUT.md
+++ b/docs/bugs/BUG_ELEMENTID_ASOF_THROUGHOUT.md
@@ -1,0 +1,126 @@
+# Plan: ElementID Throughout — Commit(), AsOf(), and Internal txID
+
+## Context
+
+`Commit()` returns `uint64` (just Lamport). `BadgerMatcher.txID` is `uint64`. `AsOf()` and `MatchAsOf()` take `uint64`. All as-of filtering compares `datom.Tx.Lamport > txID` — only half the ElementID. Two replicas can share a Lamport value but have different ReplicaIDs. Filtering on Lamport alone is incorrect in a multi-replica scenario.
+
+Now that ElementID is first-class, the entire as-of path should use full ElementID comparison.
+
+## Changes
+
+### 1. `datalog/storage/database.go` — Commit() returns ElementID
+
+- `func (t *Transaction) Commit() (uint64, error)` → `(datalog.ElementID, error)`
+- Error returns: `0, err` → `datalog.ElementID{}, err`
+- Final return: `metadataElemID.Lamport, nil` → `metadataElemID, nil`
+
+**Already done in working tree.**
+
+### 2. `datalog/storage/database.go` — Database.AsOf() takes ElementID
+
+- `func (d *Database) AsOf(txID uint64)` → `AsOf(txID datalog.ElementID)`
+- Line 429: `matcher.AsOf(txID)` — passes through
+
+### 3. `datalog/storage/matcher.go` — BadgerMatcher.txID becomes ElementID
+
+- **Struct field** line 18: `txID uint64` → `txID datalog.ElementID`
+- **AsOf()** line 50: signature `uint64` → `ElementID`, field assignment direct
+- **MatchAsOf()** line 326: signature `uint64` → `ElementID`
+- **All `m.txID > 0` checks** → `m.txID != (datalog.ElementID{})` (zero-value check)
+- **All `datom.Tx.Lamport > m.txID`** → `datom.Tx.Lamport > m.txID.Lamport` (Lamport ordering is still correct for as-of — we want "datoms created before this point in causal time")
+
+Wait — actually the comparison semantics matter here. For as-of filtering, we want "include datoms whose Tx is causally before or equal to the target." Lamport ordering IS the right comparison for causal ordering within a single replica. Across replicas, same-Lamport datoms from different replicas should ALL be included if `Lamport <= target.Lamport`. The ReplicaID doesn't affect causal ordering — it's a tiebreaker for CRDT resolution, not for as-of filtering.
+
+So the filter `datom.Tx.Lamport > m.txID.Lamport` is actually correct. The field type changes to `ElementID` so the full ID flows through the API, but the filter comparison still uses `.Lamport` because that's the causal clock.
+
+### 4. `datalog/storage/crdt_resolving_iterator.go` — txID becomes ElementID
+
+- **Field** line 18: `txID uint64` → `txID datalog.ElementID`
+- **Constructor**: `NewCRDTResolvingIterator(source, schema, txID uint64)` → `ElementID`
+- **Filter** line 112: `it.txID > 0 && datom.Tx.Lamport > it.txID` → `it.txID != (datalog.ElementID{}) && datom.Tx.Lamport > it.txID.Lamport`
+
+### 5. `datalog/storage/iterator_helpers.go` — validateDatomWithConstraints
+
+- Line 37: `txID uint64` → `txID datalog.ElementID`
+- Line 41: `txID > 0 && datom.Tx.Lamport > txID` → `txID != (datalog.ElementID{}) && datom.Tx.Lamport > txID.Lamport`
+
+### 6. All `m.txID > 0` and `datom.Tx.Lamport > m.txID` sites
+
+These are mechanical — change the zero check and extract `.Lamport` for the comparison. Sites from the grep (all in `datalog/storage/`):
+
+| File | Lines | Pattern |
+|------|-------|---------|
+| `matcher.go` | 247, 310, 368, 431, 817, 871, 915, 958, 1014 | `m.txID > 0 && datom.Tx.Lamport > m.txID` |
+| `matcher_relations.go` | 107, 270 | `m.txID == 0` (cache eligibility) |
+| `hash_join_matcher.go` | 757, 845 | `it.matcher.txID > 0 && datom.Tx.Lamport > it.matcher.txID` |
+| `batch_iterator.go` | 286 | same pattern |
+| `simple_batch_scanner.go` | 283 | same pattern |
+
+### 7. Callers of AsOf/MatchAsOf
+
+| File | Line | Fix |
+|------|------|-----|
+| `cache_integration_test.go` | 238 | `db.AsOf(tx1ID)` — tx1ID is now ElementID from Commit(), just works |
+| `matcher_concurrency_test.go` | 68 | `baseMatcher.AsOf(100)` → `baseMatcher.AsOf(datalog.ElementID{Lamport: 100})` |
+| `crdt_one_test.go` | 173, 181, 197 | `var lamports []uint64` → `var txIDs []datalog.ElementID`; `MatchAsOf(pattern, txIDs[i])` |
+| `crdt_one_test.go` | 215 | `MatchAsOf(pattern, 0)` → `MatchAsOf(pattern, datalog.ElementID{})` |
+
+### 8. Commit() return value callers
+
+| File | Line | Fix |
+|------|------|-----|
+| `cmd/datalog/main.go` | 168, 349 | `%d` → `%v` |
+| `datalog/storage/export_test.go` | 793, 796 | `datom.Tx.Lamport == txID1` → `datom.Tx == txID1` |
+| `datalog/storage/crdt_cache_matrix_test.go` | 405 | No change (`%v`) |
+| `examples/*.go` | various | `%d` → `%v` |
+
+### 9. Bench test helper
+
+| File | Line | Fix |
+|------|------|-----|
+| `iterator_refactoring_bench_test.go` | 15 | `txID uint64` → `txID datalog.ElementID` |
+| `iterator_refactoring_bench_test.go` | 19 | Same pattern as iterator_helpers |
+| `iterator_refactoring_bench_test.go` | 101 | `scenario.txID` — struct field needs ElementID |
+
+## Verification
+
+```bash
+go build ./...
+go test ./datalog/storage/ -run "TestCardinalityOneAsOf|TestExport|TestCRDTCacheMatrix|TestConcurrent" -v -count=1
+go test ./...
+go test ./datalog/storage/ -count=2
+```
+
+---
+
+## Implementation Record
+
+**Status: COMPLETE** — All items implemented and verified (`go test ./... -count=2` passes).
+
+### Deviation from plan: full ElementID comparison, not Lamport extraction
+
+The plan above recommended `datom.Tx.Lamport > m.txID.Lamport` for as-of filtering — comparing only the Lamport component. This was wrong. Comparing only Lamport is comparing half the ID. Two replicas can share a Lamport value but have different ReplicaIDs.
+
+**What was actually implemented:** All as-of filter sites use `m.txID.Less(datom.Tx)` — the full `ElementID.Less()` comparison which compares Lamport first, then ReplicaID as tiebreaker. This is correct: if two datoms share a Lamport value but come from different replicas, `Less()` distinguishes them. The same pattern was applied everywhere:
+
+- `matcher.go`: `m.txID != (datalog.ElementID{}) && m.txID.Less(datom.Tx)`
+- `crdt_resolving_iterator.go`: `it.txID != (datalog.ElementID{}) && it.txID.Less(datom.Tx)`
+- `iterator_helpers.go`: `txID != (datalog.ElementID{}) && txID.Less(datom.Tx)`
+- `batch_iterator.go`, `hash_join_matcher.go`, `simple_batch_scanner.go`: same pattern via `it.matcher.txID` / `s.matcher.txID`
+- `MatchAsOf`: `targetTx.Less(datom.Tx)` for the target parameter
+
+### Additional changes not in original plan
+
+- **`datalog/storage/queries.go`**: `GetTimeRange` and `GetEntityTimeRange` changed from `uint64` to `datalog.ElementID`. `GetEntityTimeRange` filter changed from Lamport comparison to `d.Tx.Less(endTx)` / `!d.Tx.Less(startTx)`.
+- **`datalog/storage/matcher_relations.go` line 868**: `NewCRDTResolvingIterator(rawIter, m.schema, 0)` → `datalog.ElementID{}`.
+- **`examples/*.go`**: Left unchanged — these have `//go:build example` tags and need a larger rewrite to use the Transaction API properly instead of fabricating ElementIDs from timestamps. Tracked as separate work.
+
+### Next steps (not yet implemented)
+
+- **`BadgerMatcher.txID` should become `*datalog.ElementID`**: Currently `ElementID{}` (zero value) means "no as-of filter, latest resolved state." We want to distinguish three modes:
+  - `nil` → no AsOf called, latest CRDT-resolved state (current default)
+  - `&ElementID{}` → history mode, no CRDT resolution (raw datoms)
+  - `&ElementID{Lamport: N, ReplicaID: R}` → CRDT-resolved as-of that point
+- **`[(as-of ?tx N)]` predicate is parsed but not wired up** to the executor. The Datomic approach is to apply as-of at the database level, not in the query. A `:as-of` parameter at the EDN query root level would be the right design.
+- **`HistoryPredicate.TargetLamport` is still `uint64`** — needs to become `ElementID` if the predicate is kept.
+- **`TxRangePredicate.Low`/`.High` are still `uint64`** — same issue.

--- a/docs/bugs/BUG_ELEMENTID_NOT_FIRST_CLASS.md
+++ b/docs/bugs/BUG_ELEMENTID_NOT_FIRST_CLASS.md
@@ -1,0 +1,354 @@
+# Plan: Make ElementID a First-Class Value in the Query Engine
+
+## Context
+
+The `InternedTupleBuilder` stores Tx values as `*datalog.ElementID` (pointer) in tuples to avoid per-datom interface boxing allocations. User input bindings pass `datalog.ElementID` (value). Many downstream consumers only handle one form, or only handle the legacy `uint64` representation. This causes silent failures: `TestElementIDBinding_ScalarInput` passes an ElementID as a scalar binding and gets 0 results instead of 1.
+
+The pointer optimization is valid (16-byte struct boxing matters at scale) and stays. The fix is to teach all consumers about both `ElementID` and `*ElementID`.
+
+## Changes Already Made (in working tree, uncommitted)
+
+- `datalog/compare.go` — Added `derefElementID` helper (unexported); updated `CompareValues` and `ValuesEqual` to handle `*ElementID`
+- `datalog/executor/tuple_key.go` — Added `ElementID` and `*ElementID` cases to `hashValue`
+- `datalog/storage/elementid_binding_test.go` — Reproduction test (currently failing)
+
+## Files to Modify
+
+| File | Changes | Priority |
+|------|---------|----------|
+| `datalog/compare.go` | Export `derefElementID` → `DerefElementID` | Prerequisite |
+| `datalog/value_encoding.go` | Add `*ElementID` to `Type()` (line 56) and `ValueBytes()` (line 108) | Critical |
+| `datalog/storage/matcher.go` | `chooseIndex` (line 662): handle ElementID; `matchesDatom` (line 683): deref `*ElementID` | Critical |
+| `datalog/storage/hash_join_matcher.go` | `valueToHashKey` (line 452): add ElementID; `chooseIndexForValues` TAEV (line 394): fill in; `compareJoinKeys` (line 669): add ElementID | Critical |
+| `datalog/storage/matcher_iterator_reusing.go` | `calculateSeekKey` (line 281): extract T; "moved past" (line 178): handle `*ElementID` | Medium |
+| `datalog/storage/simple_batch_scanner.go` | `valueToKey` (line 106) and `buildKey` TAEV (line 249): add ElementID | Medium |
+| `datalog/executor/join.go` | Tx detection (line 339) and extraction (lines 367, 390): add ElementID types | Medium |
+| `datalog/executor/constraints_impl.go` | `equalityConstraint` (line 51): use `DerefElementID` | Medium |
+| `datalog/query/history.go` | `TxRangePredicate.Eval` (line 121): add ElementID cases, remove broken duck-type | Low |
+
+## Execution Order
+
+### Phase 1: Write ALL tests (expected to fail)
+
+Write every test listed in the "New Tests" section below. Run them to confirm they all fail. This proves the bugs exist before any fix code is written.
+
+```bash
+# Must ALL fail
+go test ./datalog/ -run "TestElementIDPointerValue" -v -count=1
+go test ./datalog/storage/ -run "TestElementIDBinding" -v -count=1
+go test ./datalog/storage/ -run "TestCompareJoinKeys" -v -count=1
+```
+
+### Phase 2: Apply fixes (tests start passing)
+
+Apply the implementation changes listed below. After each file is modified, re-run tests to see which ones start passing. Continue until all tests pass.
+
+### Phase 3: Regression verification
+
+Run the full suite to confirm no regressions.
+
+---
+
+## Implementation Details
+
+### 1. `datalog/compare.go` — Export helper
+
+Rename `derefElementID` → `DerefElementID`. Update the two call sites at lines ~70 and ~297.
+
+### 2. `datalog/value_encoding.go` — Prevent panics
+
+**`Type()`** (after line 56 `case ElementID:`): add `*ElementID` case returning `TypeElementID`. Place it near the other pointer cases at lines 30-37.
+
+**`ValueBytes()`** (after line 108 `case ElementID:`): add `*ElementID` case: dereference, return `val.Bytes()`.
+
+### 3. `datalog/storage/matcher.go` — Core matching
+
+**`chooseIndex()` lines 662-670**: Replace the uint64-only TAEV path. Use `datalog.DerefElementID` and existing `NewTxFromElementID()` (`types.go:41`):
+
+```go
+} else if tx != nil {
+    var storageTx Tx
+    if txID, ok := tx.(uint64); ok {
+        storageTx = NewTxFromUint(txID)
+    } else if eid, ok := datalog.DerefElementID(tx); ok {
+        storageTx = NewTxFromElementID(eid)
+    }
+    if storageTx != (Tx{}) {
+        start, end := encoder.EncodePrefixRange(TAEV, storageTx[:])
+        return TAEV, start, end
+    }
+}
+```
+
+**`matchesDatom()` line 683**: Add `*ElementID` dereference alongside existing `*uint64`:
+
+```go
+if ptr, ok := tx.(*datalog.ElementID); ok {
+    tx = *ptr
+}
+```
+
+### 4. `datalog/storage/hash_join_matcher.go`
+
+**`valueToHashKey()` lines 455-457**: Add ElementID deref after the existing `*uint64` deref:
+
+```go
+if eid, ok := datalog.DerefElementID(v); ok {
+    return eid.String()
+}
+```
+
+**`chooseIndexForValues()` TAEV case lines 394-398**: Fill in the empty case body:
+
+```go
+case TAEV:
+    if tx != nil {
+        if txID, ok := tx.(uint64); ok {
+            storageTx := NewTxFromUint(txID)
+            startParts = append(startParts, storageTx[:])
+            endParts = append(endParts, storageTx[:])
+        } else if eid, ok := datalog.DerefElementID(tx); ok {
+            storageTx := NewTxFromElementID(eid)
+            startParts = append(startParts, storageTx[:])
+            endParts = append(endParts, storageTx[:])
+        }
+    }
+```
+
+**`compareJoinKeys()` after line 688**: Add ElementID case:
+
+```go
+case datalog.ElementID:
+    if bEid, ok := datalog.DerefElementID(b); ok {
+        return aVal.Compare(bEid)
+    }
+case *datalog.ElementID:
+    if aVal != nil {
+        if bEid, ok := datalog.DerefElementID(b); ok {
+            return (*aVal).Compare(bEid)
+        }
+    }
+```
+
+### 5. `datalog/storage/matcher_iterator_reusing.go`
+
+**`calculateSeekKey()` lines 280-310**: Add T extraction (mirrors existing E, A, V extraction). Change `var e, a, v interface{}` to `var e, a, v, tx interface{}`. Add:
+
+```go
+// Get T value
+if c, ok := it.pattern.GetT().(query.Constant); ok {
+    tx = c.Value
+} else if sym, ok := it.pattern.GetT().(query.Variable); ok {
+    if idx, found := colIndex[sym.Name]; found && idx < len(bindingTuple) {
+        tx = bindingTuple[idx]
+    }
+}
+```
+
+Change line 309 from `it.matcher.chooseIndex(e, a, v, nil)` to `it.matcher.chooseIndex(e, a, v, tx)`.
+
+**"Moved past" case 3 lines 178-189**: Consolidate using `DerefElementID`:
+
+```go
+case 3:
+    if eid, ok := datalog.DerefElementID(bindingTuple[0]); ok {
+        if datom.Tx != eid {
+            movedPast = true
+        }
+    } else if expectedTx, ok := bindingTuple[0].(uint64); ok {
+        if datom.Tx.Lamport != expectedTx {
+            movedPast = true
+        }
+    }
+```
+
+### 6. `datalog/storage/simple_batch_scanner.go`
+
+**`valueToKey()` lines 107-113**: Add ElementID deref alongside existing `*uint64`:
+
+```go
+} else if eid, ok := datalog.DerefElementID(v); ok {
+    v = eid
+```
+
+Add `case datalog.ElementID:` in the switch at line 115: `return val.String()`.
+
+**`buildKey()` TAEV case lines 249-255**: Add ElementID path:
+
+```go
+case 4: // TAEV
+    if eid, ok := datalog.DerefElementID(value); ok {
+        txBytes := NewTxFromElementID(eid)
+        parts := [][]byte{txBytes[:]}
+        return encoder.EncodePrefix(s.index, parts...)
+    } else if tx, ok := value.(uint64); ok {
+        txBytes := NewTxFromUint(tx)
+        parts := [][]byte{txBytes[:]}
+        return encoder.EncodePrefix(s.index, parts...)
+    }
+```
+
+### 7. `datalog/executor/join.go` — Tx dedup
+
+**Tx detection line 339-340**: Add ElementID types to the type switch:
+
+```go
+case uint64, int64, int, datalog.ElementID, *datalog.ElementID:
+```
+
+**Tx extraction lines 367-375 and 390-398**: Add ElementID cases extracting `.Lamport` for the uint64-based comparison:
+
+```go
+case datalog.ElementID:
+    txID = v.Lamport
+case *datalog.ElementID:
+    if v != nil { txID = v.Lamport }
+```
+
+### 8. `datalog/executor/constraints_impl.go`
+
+**`equalityConstraint.Evaluate()` lines 51-58**: Use `DerefElementID`:
+
+```go
+case 3:
+    if eid, ok := datalog.DerefElementID(c.value); ok {
+        return datom.Tx == eid
+    }
+    if tx, ok := c.value.(uint64); ok {
+        return datom.Tx.Lamport == tx
+    }
+```
+
+### 9. `datalog/query/history.go`
+
+**`TxRangePredicate.Eval()` lines 121-135**: Add explicit ElementID cases before the `default`. Remove the broken `interface{ GetLamport() uint64 }` duck-type (ElementID has a `.Lamport` field, not a method):
+
+```go
+case datalog.ElementID:
+    lamport = v.Lamport
+case *datalog.ElementID:
+    if v != nil { lamport = v.Lamport }
+```
+
+## New Tests
+
+### Unit Tests: `datalog/compare_test.go` — Pointer/Value Cross-Comparison
+
+Add `TestElementIDPointerValueCrossComparison` covering the `*ElementID` ↔ `ElementID` gaps in existing tests (which only test value-vs-value):
+
+| Assertion | Purpose |
+|-----------|---------|
+| `CompareValues(&a, a) == 0` | Pointer left, value right |
+| `CompareValues(a, &a) == 0` | Value left, pointer right |
+| `CompareValues(&a, &b) == 0` | Both pointers, equal |
+| `CompareValues(&a, &c) < 0` | Both pointers, different |
+| `ValuesEqual(&a, a) == true` | Pointer/value mix |
+| `ValuesEqual(a, &a) == true` | Value/pointer mix |
+| `ValuesEqual(&a, &c) == false` | Both pointers, different |
+| `ValuesEqual((*ElementID)(nil), a) == false` | Nil pointer vs value |
+
+### Unit Tests: `datalog/value_encoding_test.go` — `*ElementID` Encoding
+
+Add `TestElementIDPointerValueEncoding` verifying `*ElementID` doesn't panic in `Type()` and `ValueBytes()`:
+
+| Assertion | Purpose |
+|-----------|---------|
+| `Type(&eid) == TypeElementID` | Pointer returns correct type |
+| `ValueBytes(&eid)` matches `ValueBytes(eid)` | Pointer produces same bytes as value |
+| `Type((*ElementID)(nil))` doesn't panic | Nil pointer handling |
+
+### Integration Tests: `datalog/storage/elementid_binding_test.go`
+
+All tests follow the same data setup pattern as the existing `TestElementIDBinding_ScalarInput`: write 2-3 entities in separate transactions, extract ElementIDs from query results, then use them as bindings.
+
+#### `TestElementIDBinding_CollectionInput`
+- **Purpose**: Collection binding `[:in $ [?tx ...]]` with multiple ElementIDs
+- **Query**: `[:find ?e ?v :in $ [?tx ...] :where [?e :person/name ?v ?tx]]`
+- **Input**: Slice of 2 ElementIDs (alice's tx, bob's tx)
+- **Assert**: Returns 2 results (both datoms match)
+- **Then**: Pass only alice's tx → returns 1 result
+- **Exercises**: `hashValue(ElementID)`, `ValuesEqual(*ElementID, ElementID)`, collection→relation conversion
+
+#### `TestElementIDBinding_RelationInput`
+- **Purpose**: Relation binding `[:in $ [[?e ?tx] ...]]` with ElementID + Identity pairs
+- **Query**: `[:find ?v :in $ [[?e ?tx] ...] :where [?e :person/name ?v ?tx]]`
+- **Input**: `[][]interface{}{{aliceIdentity, aliceTx}, {bobIdentity, bobTx}}`
+- **Assert**: Returns 2 results with correct names
+- **Exercises**: Multi-column hash join with ElementID, `valueToHashKey(ElementID)`, `compareJoinKeys(ElementID)`
+
+#### `TestElementIDBinding_TxJoin`
+- **Purpose**: Two patterns joined on `?tx` where Tx column holds `*ElementID`
+- **Setup**: 2 entities with 2 attributes each, written in separate transactions
+- **Query**: `[:find ?name ?age :where [?e1 :person/name ?name ?tx] [?e2 :person/age ?age ?tx]]`
+- **Assert**: Each transaction's name/age pairs are joined correctly
+- **Exercises**: Hash join on `*ElementID` column (both sides from storage), `TupleKey` hashing
+
+#### `TestElementIDBinding_ComparisonPredicate`
+- **Purpose**: `[(= ?tx ?target-tx)]` predicate with ElementID binding
+- **Query**: `[:find ?e ?v :in $ ?target-tx :where [?e :person/name ?v ?tx] [(= ?tx ?target-tx)]]`
+- **Input**: Alice's ElementID
+- **Assert**: Returns 1 result (Alice only)
+- **Exercises**: `CompareValues(*ElementID, ElementID)`, `equalityConstraint` with `DerefElementID`
+
+#### `TestElementIDBinding_HistoryQuery`
+- **Purpose**: `[(history)]` returns all writes with ElementID Tx values
+- **Setup**: Write "Alice" then overwrite with "Alice2" (CardinalityOne, LWW)
+- **Query**: `[:find ?v ?tx :where [?e :person/name ?v ?tx] [(history)]]`
+- **Assert**: Returns 2 results (both historical values), each `?tx` is an ElementID
+- **Then**: Use one of the returned ElementIDs as a scalar binding to filter
+- **Exercises**: Full round-trip — ElementID from storage → user code → binding → back to storage
+
+#### `TestElementIDBinding_MultipleEntitiesSameTx`
+- **Purpose**: Multiple entities written in the same transaction share one ElementID
+- **Setup**: Write alice and bob in the SAME transaction
+- **Query**: `[:find ?name :in $ ?tx :where [?e :person/name ?name ?tx]]`
+- **Input**: The shared transaction's ElementID
+- **Assert**: Returns 2 results (both Alice and Bob)
+- **Exercises**: TAEV index selection with ElementID (`chooseIndex`), single-tx scan efficiency
+
+### Unit Tests: `datalog/storage/merge_join_test.go` — `compareJoinKeys` with ElementID
+
+Extend existing `TestCompareJoinKeys` (line 496) with ElementID cases:
+
+| Left | Right | Expected | Purpose |
+|------|-------|----------|---------|
+| `ElementID{100,5}` | `ElementID{100,5}` | `0` | Value-value equal |
+| `&ElementID{100,5}` | `ElementID{100,5}` | `0` | Pointer-value equal |
+| `ElementID{100,5}` | `&ElementID{200,5}` | `-1` | Value-pointer less |
+| `&ElementID{200,5}` | `&ElementID{100,5}` | `1` | Pointer-pointer greater |
+
+## Verification
+
+```bash
+# New unit tests — pointer/value cross-comparison
+go test ./datalog/ -run "TestElementIDPointerValue" -v -count=1
+
+# New integration tests — all binding types
+go test ./datalog/storage/ -run "TestElementIDBinding" -v -count=1
+
+# compareJoinKeys extension
+go test ./datalog/storage/ -run "TestCompareJoinKeys" -v -count=1
+
+# Existing CRDT and cache tests — no regression
+go test ./datalog/storage/ -run "TestCacheMatrix|TestMatcherCache|TestEACacheBypass" -v
+
+# EATV vector transition tests — no regression
+go test ./datalog/storage/ -run "TestEATV_VectorTransition|TestCountRepro" -v -count=5
+
+# Full suite
+go test ./...
+```
+
+---
+
+## Implementation Record
+
+**Status: COMPLETE** — All items implemented, tested, and committed as `8577edd` on `fix/elementid-first-class` branch.
+
+### Additional fix not in original plan
+
+- `datalog/query/tuple_builder_interned.go` — Added `sync.Mutex` to protect `txCache` map. The `ProjectFromPattern` fix caused `txCache` to be accessed from parallel goroutines during execution. Fixed with manual lock/unlock (not defer) for hot-path performance.
+
+### Follow-on work
+
+See `BUG_ELEMENTID_ASOF_THROUGHOUT.md` for the next phase: changing `Commit()`, `AsOf()`, `MatchAsOf()`, and internal `txID` fields from `uint64` to `ElementID` throughout the storage layer.

--- a/docs/reference/CRDT.md
+++ b/docs/reference/CRDT.md
@@ -368,7 +368,7 @@ For databases with millions of entities, this could consume significant memory. 
 **Process Restart**: Cache is empty after restart:
 - `maxVersions` map starts empty
 - First access to each (E, A) triggers rebuild from storage
-- Use `db.WarmCache(attributes)` for performance-critical attributes
+- Use `d.WarmCache(attributes)` for performance-critical attributes
 
 ---
 
@@ -666,7 +666,7 @@ This section provides formal complexity analysis for all CRDT operations.
 | Vector | O(1) | O(n log n) | O(1) | Write-optimized, expensive rebuild |
 | OrderedSet | O(d+k) | O(n log n) | O(1) | Uniqueness costs at write time |
 
-**Key insight**: The system is write-optimized. Writes are always O(1) or O(d+k) for OrderedSet. Read performance depends on cache hit rate. For read-heavy workloads, use `db.WarmCache()` at startup.
+**Key insight**: The system is write-optimized. Writes are always O(1) or O(d+k) for OrderedSet. Read performance depends on cache hit rate. For read-heavy workloads, use `d.WarmCache()` at startup.
 
 ---
 
@@ -674,7 +674,7 @@ This section provides formal complexity analysis for all CRDT operations.
 
 ### Memory
 
-Cache entries are rebuilt on demand. After process restart, first access to each (E, A) triggers rebuild. Use `db.WarmCache(attributes)` at startup for performance-critical attributes.
+Cache entries are rebuilt on demand. After process restart, first access to each (E, A) triggers rebuild. Use `d.WarmCache(attributes)` at startup for performance-critical attributes.
 
 ---
 
@@ -725,23 +725,40 @@ See [CRDT_STREAMING_RESOLUTION.md](CRDT_STREAMING_RESOLUTION.md) for detailed de
 
 ## History and Time-Travel
 
-All writes are preserved. Use history predicates for time-travel queries:
+All writes are preserved. Use database-level temporal modes for time-travel queries:
 
-```clojure
-;; All historical values
-[:find ?name ?tx :where [?e :person/name ?name ?tx] [(history)]]
+```go
+import "github.com/wbrown/janus-datalog/datalog/db"
 
-;; Value as of specific Lamport time
-[:find ?name :where [?e :person/name ?name ?tx] [(as-of ?tx 5000)]]
+d, _ := db.Open("/path/to/data")
+defer d.Close()
+
+// History mode — all raw datoms, no CRDT resolution
+hist := d.History()
+history, _ := hist.Query(
+    `[:find ?name ?tx :where [?e :person/name ?name ?tx]]`)
+
+// As-of mode — CRDT-resolved state at a specific point in time
+asOf := d.AsOf(txID)  // txID is datalog.ElementID from Commit()
+asOfResult, _ := asOf.Query(
+    `[:find ?name :where [?e :person/name ?name]]`)
 ```
 
-The cache stores current value only. History queries bypass the cache and scan storage directly.
+**Three database modes** (controlled via `*datalog.ElementID` pointer on `BadgerMatcher.txID`):
+
+| Mode | API | `txID` value | CRDT resolution | Tx filtering |
+|------|-----|-------------|-----------------|--------------|
+| Latest | `d.Query(q)` | `nil` | Yes | No |
+| As-of | `d.AsOf(elemID).Query(q)` | `&ElementID{L,R}` | Yes | Yes |
+| History | `d.History().Query(q)` | `&ElementID{}` | No | No |
+
+The cache stores current value only. History and as-of queries bypass the cache and scan storage directly.
 
 ---
 
 ## Pull API and CRDT Resolution
 
-The Pull API (`db.Pull()`, `db.PullInto()`, and pull expressions in queries) uses CRDT resolution to return current values.
+The Pull API (`d.Pull()`, `d.PullInto()`, and pull expressions in queries) uses CRDT resolution to return current values.
 
 ### EntityResolver Interface
 
@@ -760,7 +777,7 @@ The Database implements this interface, delegating to `ResolveEntityAttributes` 
 Wildcard pulls (`[*]`) resolve all attributes for an entity:
 
 ```go
-result, _ := db.Pull(entity, "[*]")
+result, _ := d.Pull(entity, "[*]")
 // Returns CRDT-resolved values:
 // - CardinalityOne: single value (LWW)
 // - CardinalityMany: []interface{} (add-wins set)
@@ -779,7 +796,7 @@ Pull expressions in queries also use CRDT resolution:
 [:find (pull ?e [*]) :where [?e :task/name "test"]]
 ```
 
-Both standalone `db.PullInto()` and query pull expressions use the same resolution path through `EntityResolver`.
+Both standalone `d.PullInto()` and query pull expressions use the same resolution path through `EntityResolver`.
 
 ### Return Types by Cardinality
 

--- a/docs/reference/EXPORT_IMPORT.md
+++ b/docs/reference/EXPORT_IMPORT.md
@@ -89,15 +89,15 @@ diff data.edn data2.edn
 ```go
 import (
     "os"
-    "github.com/wbrown/janus-datalog/datalog/storage"
+    "github.com/wbrown/janus-datalog/datalog/db"
 )
 
 // Open database
-db, err := storage.NewDatabase("mydata.db")
+d, err := db.Open("mydata.db")
 if err != nil {
     log.Fatal(err)
 }
-defer db.Close()
+defer d.Close()
 
 // Export to file
 f, err := os.Create("backup.edn")
@@ -106,7 +106,7 @@ if err != nil {
 }
 defer f.Close()
 
-if err := db.Export(f); err != nil {
+if err := d.Export(f); err != nil {
     log.Fatal(err)
 }
 ```
@@ -115,11 +115,11 @@ if err := db.Export(f); err != nil {
 
 ```go
 // Open/create database
-db, err := storage.NewDatabase("newdata.db")
+d, err := db.Open("newdata.db")
 if err != nil {
     log.Fatal(err)
 }
-defer db.Close()
+defer d.Close()
 
 // Import from file
 f, err := os.Open("backup.edn")
@@ -128,7 +128,7 @@ if err != nil {
 }
 defer f.Close()
 
-if err := db.Import(f); err != nil {
+if err := d.Import(f); err != nil {
     log.Fatal(err)
 }
 ```
@@ -137,7 +137,7 @@ if err := db.Import(f); err != nil {
 
 ```go
 var buf bytes.Buffer
-if err := db.Export(&buf); err != nil {
+if err := d.Export(&buf); err != nil {
     log.Fatal(err)
 }
 

--- a/docs/reference/KEY_ENCODING_AND_CRDT.md
+++ b/docs/reference/KEY_ENCODING_AND_CRDT.md
@@ -506,9 +506,11 @@ Tx = (Lamport:8, ReplicaID:8) with bitwise NOT
    ```
 
 4. **Queryable history without reconstruction:**
-   ```clojure
-   ;; Get all historical values - just scan the index
-   [:find ?name ?tx :where [?e :person/name ?name ?tx] [(history)]]
+   ```go
+   // Get all historical values - just scan the index
+   histMatcher := db.History()
+   exec := executor.NewExecutor(histMatcher, db)
+   exec.ExecuteQuery(`[:find ?name ?tx :where [?e :person/name ?name ?tx]]`)
    ```
 
 5. **Scalar ElementID vs Vector Clocks:**

--- a/docs/reference/MULTI_SOURCE.md
+++ b/docs/reference/MULTI_SOURCE.md
@@ -134,15 +134,15 @@ q := qb.Query().
 
 ## Source Types
 
-### Database (`*storage.Database`)
+### Database (`*db.DB`)
 
-Any `*Database` implements `PatternMatcher`. Use this for cross-database joins:
+Any `*db.DB` implements `PatternMatcher`. Use this for cross-database joins:
 
 ```go
-usersDB, _ := storage.NewDatabase("users.db")
-permsDB, _ := storage.NewDatabase("perms.db")
+usersDB, _ := db.Open("users.db")
+permsDB, _ := db.Open("perms.db")
 
-results, err := usersDB.ExecuteQueryWithInputs(query,
+results, err := usersDB.Query(query,
     storage.WithSources(map[query.Symbol]executor.PatternMatcher{
         query.Symbol("$users"): usersDB,
         query.Symbol("$perms"): permsDB,
@@ -167,7 +167,7 @@ cache := executor.NewMemoryPatternMatcher(datoms)
 Pass as a named source:
 
 ```go
-results, err := db.ExecuteQueryWithInputs(query,
+results, err := d.Query(query,
     storage.WithSources(map[query.Symbol]executor.PatternMatcher{
         query.Symbol("$cache"): cache,
     }),
@@ -198,7 +198,7 @@ ruleSource := executor.NewSliceSource(rules, executor.AttributeSchema[Rule]{
 Query it like any other source:
 
 ```go
-results, err := db.ExecuteQueryWithInputs(
+results, err := d.Query(
     `[:find ?dep
       :in $rules ?key
       :where [$rules ?r :rule/key ?key]
@@ -215,7 +215,7 @@ results, err := db.ExecuteQueryWithInputs(
 
 ### WithSources Option
 
-`WithSources` is a functional option passed to `ExecuteQueryWithInputs`. It adds named sources to the query's execution context:
+`WithSources` is a functional option passed to `d.Query()`. It adds named sources to the query's execution context. The consumer imports `storage` for `WithSources` in multi-source scenarios:
 
 ```go
 func WithSources(sources map[query.Symbol]executor.PatternMatcher) QueryOption
@@ -224,7 +224,7 @@ func WithSources(sources map[query.Symbol]executor.PatternMatcher) QueryOption
 Sources are mixed into the variadic `inputs` parameter alongside regular query inputs (scalars, collections, relations):
 
 ```go
-results, err := db.ExecuteQueryWithInputs(query,
+results, err := d.Query(query,
     storage.WithSources(map[query.Symbol]executor.PatternMatcher{
         query.Symbol("$rules"): ruleSource,
     }),
@@ -240,7 +240,7 @@ At execution time, the engine validates that every source declared in `:in` is p
 
 ```go
 // Query declares $users but doesn't provide it
-_, err := db.ExecuteQueryWithInputs(
+_, err := d.Query(
     `[:find ?e :in $users :where [$users ?e :attr ?v]]`,
 )
 // err: "query declares source $users in :in but no PatternMatcher was provided for it"
@@ -317,7 +317,7 @@ If your source supports predicate pushdown, the `SourceRouter` will call `MatchW
 Pass your custom source via `WithSources`:
 
 ```go
-results, err := db.ExecuteQueryWithInputs(query,
+results, err := d.Query(query,
     storage.WithSources(map[query.Symbol]executor.PatternMatcher{
         query.Symbol("$custom"): myCustomSource,
     }),

--- a/docs/reference/PLANNER_COMPARISON.md
+++ b/docs/reference/PLANNER_COMPARISON.md
@@ -18,6 +18,8 @@ Both planners produce **phases** as their output format, but they differ fundame
 - Planning overhead is **negligible** (1-15 microseconds vs milliseconds of execution)
 - Combined with new executor: **2× faster on complex queries**
 
+**Note**: The `db.Open` public API uses the new clause-based planner and QueryExecutor by default. The internal planner/executor configuration shown in this document is for advanced users who need non-default planner options. Most users do not need to interact with these internals directly.
+
 ---
 
 ## Architectural Comparison
@@ -338,6 +340,14 @@ go test -bench=Benchmark -benchmem ./datalog/executor/ > benchmark_results.txt
 - Old executor still available for compatibility
 
 ### Recommended Configuration
+
+For most users, the `db.Open` API applies all recommended defaults:
+```go
+d, _ := db.Open("path/to/db")
+d.Query(`[:find ?e ?v :where [?e :price/close ?v]]`)
+```
+
+For advanced planner tuning (internal packages):
 ```go
 // Production: Use new architecture
 exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
@@ -346,7 +356,7 @@ exec := executor.NewExecutorWithOptions(matcher, planner.PlannerOptions{
 exec.SetUseQueryExecutor(true)    // Use new executor
 
 // Enable decorrelation for subquery-heavy workloads
-executor := executor.NewQueryExecutor(matcher, executor.ExecutorOptions{
+exec := executor.NewQueryExecutor(matcher, executor.ExecutorOptions{
     EnableSubqueryDecorrelation: true,
 })
 ```

--- a/docs/reference/PLANNER_OPTIONS.md
+++ b/docs/reference/PLANNER_OPTIONS.md
@@ -25,6 +25,17 @@ Janus Datalog uses a single `PlannerOptions` struct to configure both query plan
 3. **No Global State**: Configuration belongs to instances, not globals
 4. **Options Propagation**: Settings flow through entire execution pipeline
 
+### Public API vs Advanced Configuration
+
+Most users should use the `db.Open` API, which applies sensible defaults automatically:
+
+```go
+d, _ := db.Open("path/to/db")
+d.Query(`[:find ?name :where [?p :person/name ?name]]`)
+```
+
+The planner options documented below are for **advanced usage** -- tuning non-default planner behavior. To access the internal executor/planner for custom configuration, use `d.Unwrap()` or construct via the `storage` and `executor` packages directly.
+
 ---
 
 ## Unified Configuration
@@ -93,6 +104,8 @@ func DefaultPlannerOptions() planner.PlannerOptions {
 
 ### How It Works
 
+The `db.Open` API handles all of this automatically with sensible defaults. Internally:
+
 ```go
 // 1. Database creates executor with default options
 func (d *Database) NewExecutor() *executor.Executor {
@@ -116,6 +129,7 @@ func NewExecutorWithOptions(matcher PatternMatcher, opts planner.PlannerOptions)
 - Single configuration to manage
 - Streaming enabled by default
 - Clean architecture with no breaking changes
+- `db.Open` applies all defaults; advanced users can override via internal packages
 
 ---
 
@@ -395,12 +409,12 @@ The October 2025 defaults are optimized for **complex queries** and **safety**. 
 - Performance-critical path
 - Queries are well-constrained
 
-**Custom configuration for simple queries**:
+**Custom configuration for simple queries** (requires internal packages):
 ```go
 opts := storage.DefaultPlannerOptions()
 opts.EnableDynamicReordering = false
 opts.EnableFineGrainedPhases = false
-exec := db.NewExecutorWithOptions(opts)
+exec := database.NewExecutorWithOptions(opts)
 ```
 
 **Measured improvement**: 20-40% faster on simple queries (see DEFAULT_PLANNER_OPTIONS_FEEDBACK.md)
@@ -524,12 +538,18 @@ executor.EnableTrueStreaming = true
 exec := executor.NewExecutor(matcher)
 ```
 
-**✅ NEW CODE** (required):
+**✅ NEW CODE** (simplest -- uses all defaults):
+```go
+d, _ := db.Open("path/to/db")
+d.Query(queryStr)
+```
+
+**✅ NEW CODE** (advanced -- custom planner options):
 ```go
 opts := storage.DefaultPlannerOptions()
 opts.EnableIteratorComposition = true
 opts.EnableTrueStreaming = true
-exec := db.NewExecutorWithOptions(opts)
+exec := database.NewExecutorWithOptions(opts)
 ```
 
 ### From Separate ExecutorOptions (Old)
@@ -541,7 +561,12 @@ plannerOpts := planner.PlannerOptions{...}
 // Duplicated configuration
 ```
 
-**✅ NEW CODE**:
+**✅ NEW CODE** (simplest):
+```go
+d, _ := db.Open("path/to/db")  // uses sensible defaults
+```
+
+**✅ NEW CODE** (advanced -- custom planner options):
 ```go
 opts := storage.DefaultPlannerOptions()
 // Single configuration point

--- a/docs/reference/QUERY_BUILDER.md
+++ b/docs/reference/QUERY_BUILDER.md
@@ -14,7 +14,7 @@ var (
     PersonCity = qb.Kw(":person/city")
 )
 
-func FindAdults(db *storage.Database) ([][]interface{}, error) {
+func FindAdults(d *db.DB) ([][]interface{}, error) {
     // Variables are created per-query - same pointer = same logical variable
     e := qb.NewVar("e")
     name := qb.NewVar("name")
@@ -29,7 +29,7 @@ func FindAdults(db *storage.Database) ([][]interface{}, error) {
         ).
         MustBuild()
 
-    return db.ExecuteQuery(q)
+    return d.Query(q)
 }
 ```
 
@@ -376,7 +376,7 @@ q := qb.Query().
     MustBuild()
 
 // Execute with input value
-results, err := db.ExecuteQueryWithInputs(q, "Alice")
+results, err := d.Query(q, "Alice")
 ```
 
 ### Collection Input Example
@@ -395,7 +395,7 @@ q := qb.Query().
     MustBuild()
 
 // Execute with multiple values - returns results for each
-results, err := db.ExecuteQueryWithInputs(q, []string{"Alice", "Bob", "Charlie"})
+results, err := d.Query(q, []string{"Alice", "Bob", "Charlie"})
 ```
 
 ### Relation Input Example
@@ -416,7 +416,7 @@ q := qb.Query().
     MustBuild()
 
 // Execute with relation - finds matching (name, city) pairs
-results, err := db.ExecuteQueryWithInputs(q, [][]interface{}{
+results, err := d.Query(q, [][]interface{}{
     {"Alice", "NYC"},
     {"Bob", "LA"},
 })
@@ -447,7 +447,7 @@ q := qb.Query().
     MustBuild()
 
 // Execute with named sources
-results, err := db.ExecuteQueryWithInputs(q,
+results, err := d.Query(q,
     storage.WithSources(map[query.Symbol]executor.PatternMatcher{
         query.Symbol("$users"): usersDB,
         query.Symbol("$perms"): permsDB,
@@ -611,11 +611,11 @@ All database query methods accept both `*query.Query` and EDN strings:
 
 ```go
 // Basic execution
-results, err := db.ExecuteQuery(q)
-results, err := db.ExecuteQueryWithInputs(q, inputs...)
+results, err := d.Query(q)
+results, err := d.Query(q, inputs...)
 
 // Explain query plan
-plan, err := db.Explain(q)
+plan, err := d.Explain(q)
 ```
 
 ### QueryInto - Typed Results
@@ -635,7 +635,7 @@ type PersonResult struct {
     Age  int64   // maps to second Find() element
 }
 
-func FindAdults(db *storage.Database) ([]PersonResult, error) {
+func FindAdults(d *db.DB) ([]PersonResult, error) {
     e := qb.NewVar("e")
     name := qb.NewVar("name")
     age := qb.NewVar("age")
@@ -650,7 +650,7 @@ func FindAdults(db *storage.Database) ([]PersonResult, error) {
         MustBuild()
 
     var results []PersonResult
-    err := db.QueryInto(&results, q)
+    err := d.QueryInto(&results, q)
     return results, err
 }
 ```
@@ -660,7 +660,7 @@ func FindAdults(db *storage.Database) ([]PersonResult, error) {
 For queries that return exactly one result:
 
 ```go
-func FindPerson(db *storage.Database, personName string) (*PersonResult, error) {
+func FindPerson(d *db.DB, personName string) (*PersonResult, error) {
     e := qb.NewVar("e")
     name := qb.NewVar("name")
     age := qb.NewVar("age")
@@ -675,7 +675,7 @@ func FindPerson(db *storage.Database, personName string) (*PersonResult, error) 
         MustBuild()
 
     var result PersonResult
-    found, err := db.QueryOneInto(&result, q, personName)
+    found, err := d.QueryOneInto(&result, q, personName)
     if err != nil {
         return nil, err
     }
@@ -697,7 +697,7 @@ type DeptStats struct {
     Count     int64    // maps to third Find() element (count emp)
 }
 
-func GetDeptStats(db *storage.Database) ([]DeptStats, error) {
+func GetDeptStats(d *db.DB) ([]DeptStats, error) {
     emp := qb.NewVar("emp")
     dept := qb.NewVar("dept")
     salary := qb.NewVar("salary")
@@ -711,7 +711,7 @@ func GetDeptStats(db *storage.Database) ([]DeptStats, error) {
         MustBuild()
 
     var stats []DeptStats
-    err := db.QueryInto(&stats, q)
+    err := d.QueryInto(&stats, q)
     return stats, err
 }
 ```
@@ -729,7 +729,7 @@ type PersonResult struct {
     Age  int64  `datalog:"?age"`
 }
 
-func FindAdults(db *storage.Database) ([]PersonResult, error) {
+func FindAdults(d *db.DB) ([]PersonResult, error) {
     // QueryFor derives variables from struct tags
     q := qb.QueryFor[PersonResult]()
     f := &q.F
@@ -743,7 +743,7 @@ func FindAdults(db *storage.Database) ([]PersonResult, error) {
 
     // Results map directly to struct - tags guaranteed to match
     var results []PersonResult
-    err := db.QueryInto(&results, query)
+    err := d.QueryInto(&results, query)
     return results, err
 }
 ```
@@ -768,7 +768,7 @@ type DeptStats struct {
     Emp       int64   `datalog:"?emp"`     // base variable
 }
 
-func GetDeptStats(db *storage.Database) ([]DeptStats, error) {
+func GetDeptStats(d *db.DB) ([]DeptStats, error) {
     q := qb.QueryFor[DeptStats]()
     f := &q.F
     e := qb.NewVar("e")
@@ -784,7 +784,7 @@ func GetDeptStats(db *storage.Database) ([]DeptStats, error) {
         MustBuild()
 
     var stats []DeptStats
-    err := db.QueryInto(&stats, query)
+    err := d.QueryInto(&stats, query)
     return stats, err
 }
 ```
@@ -796,8 +796,8 @@ package main
 
 import (
     "fmt"
+    "github.com/wbrown/janus-datalog/datalog/db"
     "github.com/wbrown/janus-datalog/datalog/qb"
-    "github.com/wbrown/janus-datalog/datalog/storage"
 )
 
 // Define attributes once
@@ -808,8 +808,8 @@ var (
 )
 
 func main() {
-    db, _ := storage.NewDatabase("example.db")
-    defer db.Close()
+    d, _ := db.Open("example.db")
+    defer d.Close()
 
     // Find adults in specific cities
     e := qb.NewVar("e")
@@ -829,7 +829,7 @@ func main() {
         OrderBy(qb.Desc(age)).
         MustBuild()
 
-    results, err := db.ExecuteQueryWithInputs(q, []string{"NYC", "LA"})
+    results, err := d.Query(q, []string{"NYC", "LA"})
     if err != nil {
         panic(err)
     }

--- a/docs/reference/QUERY_INTO.md
+++ b/docs/reference/QUERY_INTO.md
@@ -30,7 +30,7 @@ type PersonResult struct {
 
 ```go
 var results []PersonResult
-err := db.QueryInto(&results, `
+err := d.QueryInto(&results, `
     [:find ?name ?age
      :where [?e :person/name ?name]
             [?e :person/age ?age]]
@@ -45,7 +45,7 @@ for _, r := range results {
 
 ```go
 var result PersonResult
-found, err := db.QueryOneInto(&result, `
+found, err := d.QueryOneInto(&result, `
     [:find ?name ?age
      :where [?e :person/name ?name]
             [?e :person/age ?age]
@@ -66,21 +66,21 @@ For single-column queries, use scalar slices or values directly without structs:
 ```go
 // Get all names as []string
 var names []string
-err := db.QueryInto(&names, `
+err := d.QueryInto(&names, `
     [:find ?name
      :where [?e :person/name ?name]]
 `)
 
 // Get all entity IDs as []datalog.Identity
 var entities []datalog.Identity
-err := db.QueryInto(&entities, `
+err := d.QueryInto(&entities, `
     [:find ?e
      :where [?e :person/name ?name]]
 `)
 
 // Get a single value
 var age int64
-found, err := db.QueryOneInto(&age, `
+found, err := d.QueryOneInto(&age, `
     [:find ?age
      :where [?e :person/name "Alice"]
             [?e :person/age ?age]]
@@ -147,7 +147,7 @@ Use `:in` clause with additional arguments:
 
 ```go
 var results []PersonResult
-err := db.QueryInto(&results, `
+err := d.QueryInto(&results, `
     [:find ?name ?age
      :in $ ?min-age
      :where [?e :person/name ?name]
@@ -213,7 +213,7 @@ if errors.Is(err, dlreflect.ErrSymbolNotFound) {
 var result struct {
     Count int64 `datalog:"(count ?e)"`
 }
-found, err := db.QueryOneInto(&result, `
+found, err := d.QueryOneInto(&result, `
     [:find (count ?e)
      :where [?e :person/name "NonExistent"]]
 `)
@@ -236,7 +236,7 @@ type CountResult struct {
 }
 
 var result CountResult
-found, err := db.QueryOneInto(&result, `
+found, err := d.QueryOneInto(&result, `
     [:find (count ?e)
      :where [?e :user/status "active"]]
 `)
@@ -253,11 +253,11 @@ if found {
 Or as a helper:
 
 ```go
-func countActiveUsers(db *Database) (int64, error) {
+func countActiveUsers(d *db.DB) (int64, error) {
     var result struct {
         Count int64 `datalog:"(count ?e)"`
     }
-    found, err := db.QueryOneInto(&result, `
+    found, err := d.QueryOneInto(&result, `
         [:find (count ?e)
          :where [?e :user/status "active"]]
     `)
@@ -277,13 +277,11 @@ func countActiveUsers(db *Database) (int64, error) {
 package main
 
 import (
-    "errors"
     "fmt"
     "os"
 
     "github.com/wbrown/janus-datalog/datalog"
-    dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
-    "github.com/wbrown/janus-datalog/datalog/storage"
+    "github.com/wbrown/janus-datalog/datalog/db"
 )
 
 type EmployeeStats struct {
@@ -296,11 +294,11 @@ func main() {
     tmpDir, _ := os.MkdirTemp("", "example")
     defer os.RemoveAll(tmpDir)
 
-    db, _ := storage.NewDatabase(tmpDir)
-    defer db.Close()
+    d, _ := db.Open(tmpDir)
+    defer d.Close()
 
     // Add test data
-    tx := db.NewTransaction()
+    tx := d.NewTransaction()
     for _, emp := range []struct {
         name   string
         dept   string
@@ -319,7 +317,7 @@ func main() {
 
     // Query with aggregates into typed slice
     var stats []EmployeeStats
-    err := db.QueryInto(&stats, `
+    err := d.QueryInto(&stats, `
         [:find ?dept (avg ?salary) (count ?emp)
          :where [?emp :employee/dept ?dept]
                 [?emp :employee/salary ?salary]]
@@ -345,7 +343,7 @@ Sales: 80000 avg salary, 1 employees
 
 **Before (manual):**
 ```go
-results, err := db.ExecuteQuery(`[:find ?name ?age :where ...]`)
+results, err := d.Query(`[:find ?name ?age :where ...]`)
 if err != nil {
     return err
 }
@@ -377,7 +375,7 @@ type Person struct {
 }
 
 var people []Person
-err := db.QueryInto(&people, `[:find ?name ?age :where ...]`)
+err := d.QueryInto(&people, `[:find ?name ?age :where ...]`)
 ```
 
 ## Performance
@@ -394,17 +392,17 @@ err := db.QueryInto(&people, `[:find ?name ?age :where ...]`)
 | `QueryInto` | Query results → struct slice | Typed query results |
 | `QueryOneInto` | Query results → single struct | Single-row queries |
 | `PullInto` | Entity → struct | Load entity by ID |
-| `ExecuteQuery` | Query → `[][]interface{}` | Dynamic/untyped results |
+| `Query` | Query → `[][]interface{}` | Dynamic/untyped results |
 
 ## Package Reference
 
 ```go
-import "github.com/wbrown/janus-datalog/datalog/storage"
+import "github.com/wbrown/janus-datalog/datalog/db"
 import dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
 
 // Database methods
-db.QueryInto(dest interface{}, queryStr string, inputs ...interface{}) error
-db.QueryOneInto(dest interface{}, queryStr string, inputs ...interface{}) (found bool, err error)
+d.QueryInto(dest interface{}, queryStr string, inputs ...interface{}) error
+d.QueryOneInto(dest interface{}, queryStr string, inputs ...interface{}) (found bool, err error)
 
 // Error types
 dlreflect.ErrMultipleResults

--- a/docs/reference/REFLECT.md
+++ b/docs/reference/REFLECT.md
@@ -109,7 +109,9 @@ schema, err := reflect.SchemaFromStructs(Person{}, Company{}, Order{})
 ### Using Generated Schema
 
 ```go
-db, err := storage.NewDatabaseWithSchema(path, schema)
+import "github.com/wbrown/janus-datalog/datalog/db"
+
+d, err := db.Open(path, db.WithSchema(schema))
 ```
 
 ## Writing Structs
@@ -125,7 +127,7 @@ person := &Person{
     Tags:  []string{"developer", "team-lead"},
 }
 
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 id, err := tx.SaveStruct(person)  // ID auto-generated
 tx.Commit()
 
@@ -142,7 +144,7 @@ person := &Person{
     Age:  30,
 }
 
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 id, err := tx.SaveStruct(person)  // Uses provided ID
 tx.Commit()
 ```
@@ -163,7 +165,7 @@ For single-value fields, `SaveStruct` automatically:
 alice.Name = "Alice Smith"
 alice.Age = 31
 
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 tx.SaveStruct(&alice)
 tx.Commit()
 // Now: Alice Smith, age 31 (old values retracted)
@@ -180,7 +182,7 @@ For slice fields, `SaveStruct` uses diff-based updates:
 // Original tags: ["developer", "golang"]
 alice.Tags = []string{"developer", "rust", "architect"}
 
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 tx.SaveStruct(&alice)
 tx.Commit()
 // Result: ["developer", "rust", "architect"]
@@ -200,18 +202,18 @@ For cardinality-many fields, `nil` and empty slices have different meanings:
 ```go
 // Load entity - alice has tags ["go", "rust"]
 var alice Person
-db.PullInto(aliceID, &alice)
+d.PullInto(aliceID, &alice)
 
 // Partial update - only change name, leave tags alone
 update := Person{ID: aliceID, Name: "Alice Smith", Tags: nil}
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 tx.SaveStruct(&update)
 tx.Commit()
 // tags still ["go", "rust"]
 
 // Clear all tags
 clear := Person{ID: aliceID, Name: "Alice Smith", Tags: []string{}}
-tx2 := db.NewTransaction()
+tx2 := d.NewTransaction()
 tx2.SaveStruct(&clear)
 tx2.Commit()
 // tags now empty
@@ -237,7 +239,7 @@ s, _ := schema.NewBuilder().
     Attribute(":character/skills").Type(schema.TypeString).Vector().Add().  // .Vector() !
     Build()
 
-db, _ := storage.NewDatabaseWithSchema(path, s)
+d, _ := db.Open(path, db.WithSchema(s))
 ```
 
 **Vector update semantics differ from sets:**
@@ -280,7 +282,7 @@ See [CRDT.md](CRDT.md) for detailed RGA (Replicated Growable Array) semantics.
 ```go
 // Load existing entity
 var person Person
-db.PullInto(personID, &person)
+d.PullInto(personID, &person)
 
 // Modify fields
 person.Name = "Alice Smith"
@@ -288,7 +290,7 @@ person.Age = 31
 person.Tags = []string{"senior-developer", "team-lead"}
 
 // Save with upsert semantics
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 _, err := tx.SaveStruct(&person)
 if err != nil {
     return err
@@ -302,7 +304,7 @@ tx.Commit()
 
 ```go
 var person Person
-err := db.PullInto(entityID, &person)
+err := d.PullInto(entityID, &person)
 
 fmt.Println(person.Name)  // "Alice"
 fmt.Println(person.Tags)  // ["developer", "team-lead"]
@@ -312,7 +314,7 @@ fmt.Println(person.Tags)  // ["developer", "team-lead"]
 
 ```go
 var people []Person
-err := db.PullIntoMany(entityIDs, &people)
+err := d.PullIntoMany(entityIDs, &people)
 
 for _, p := range people {
     fmt.Println(p.Name)
@@ -323,7 +325,7 @@ for _, p := range people {
 
 ```go
 var people []*Person
-err := db.PullIntoMany(entityIDs, &people)
+err := d.PullIntoMany(entityIDs, &people)
 ```
 
 ## Reference Handling
@@ -335,7 +337,7 @@ References to other entities use the `datalog.Identity` type:
 ```go
 // Create manager
 manager := &Person{Name: "Carol", Age: 35}
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 managerID, _ := tx.SaveStruct(manager)
 
 // Create employee with manager reference
@@ -359,13 +361,13 @@ When reading, reference fields contain only the ID (not full nested data) unless
 
 ```go
 var person Person
-db.PullInto(aliceID, &person)
+d.PullInto(aliceID, &person)
 
 // person.Manager has only the ID field populated
 if person.Manager != nil {
     // Load manager's data separately
     var manager Person
-    db.PullInto(person.Manager.ID, &manager)
+    d.PullInto(person.Manager.ID, &manager)
 }
 ```
 
@@ -408,8 +410,8 @@ import (
     "os"
 
     "github.com/wbrown/janus-datalog/datalog"
+    "github.com/wbrown/janus-datalog/datalog/db"
     "github.com/wbrown/janus-datalog/datalog/reflect"
-    "github.com/wbrown/janus-datalog/datalog/storage"
 )
 
 type Person struct {
@@ -425,8 +427,8 @@ func main() {
 
     // Generate schema from struct
     schema, _ := reflect.SchemaFromStruct(Person{})
-    db, _ := storage.NewDatabaseWithSchema(tmpDir, schema)
-    defer db.Close()
+    d, _ := db.Open(tmpDir, db.WithSchema(schema))
+    defer d.Close()
 
     // Create
     alice := &Person{
@@ -434,7 +436,7 @@ func main() {
         Age:  30,
         Tags: []string{"developer", "mentor"},
     }
-    tx := db.NewTransaction()
+    tx := d.NewTransaction()
     aliceID, _ := tx.SaveStruct(alice)
     tx.Commit()
 
@@ -442,7 +444,7 @@ func main() {
 
     // Read
     var loaded Person
-    db.PullInto(aliceID, &loaded)
+    d.PullInto(aliceID, &loaded)
 
     fmt.Printf("Name: %s\n", loaded.Name)
     fmt.Printf("Age: %d\n", loaded.Age)
@@ -451,13 +453,13 @@ func main() {
     // Update
     loaded.Age = 31
     loaded.Tags = []string{"developer", "mentor", "architect"}
-    tx2 := db.NewTransaction()
+    tx2 := d.NewTransaction()
     tx2.SaveStruct(&loaded)
     tx2.Commit()
 
     // Verify update
     var updated Person
-    db.PullInto(aliceID, &updated)
+    d.PullInto(aliceID, &updated)
     fmt.Printf("Updated Age: %d\n", updated.Age)
     fmt.Printf("Updated Tags: %v\n", updated.Tags)
 }
@@ -511,8 +513,8 @@ tx.SaveStruct(v interface{}) (datalog.Identity, error)
 
 ```go
 // Read entity into struct
-db.PullInto(entityID datalog.Identity, v interface{}) error
+d.PullInto(entityID datalog.Identity, v interface{}) error
 
 // Read multiple entities into slice
-db.PullIntoMany(entityIDs []datalog.Identity, v interface{}) error
+d.PullIntoMany(entityIDs []datalog.Identity, v interface{}) error
 ```

--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -45,12 +45,14 @@ s, err := schema.NewBuilder().
 ## Using Schema with Database
 
 ```go
+import "github.com/wbrown/janus-datalog/datalog/db"
+
 // Create database with schema
-db, err := storage.NewDatabaseWithSchema("/path/to/db", s)
+d, err := db.Open("/path/to/db", db.WithSchema(s))
 
 // Or add schema to existing database
-db, _ := storage.NewDatabase("/path/to/db")
-db.SetSchema(s)
+d, _ := db.Open("/path/to/db")
+d.SetSchema(s)
 ```
 
 ## Supported Attributes
@@ -112,7 +114,7 @@ Documentation string for the attribute.
 Type validation occurs at `Transaction.Add()` time:
 
 ```go
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 
 // OK - string value for string attribute
 tx.Add(alice, kw(":person/name"), "Alice")
@@ -128,12 +130,12 @@ Uniqueness validation occurs at `Transaction.Commit()` time:
 
 ```go
 // First transaction succeeds
-tx1 := db.NewTransaction()
+tx1 := d.NewTransaction()
 tx1.Add(alice, kw(":person/email"), "alice@example.com")
 tx1.Commit()
 
 // Second transaction fails - email already exists
-tx2 := db.NewTransaction()
+tx2 := d.NewTransaction()
 tx2.Add(bob, kw(":person/email"), "alice@example.com")
 _, err := tx2.Commit()
 // err: "uniqueness violation for :person/email: value alice@example.com already exists on entity ..."
@@ -142,7 +144,7 @@ _, err := tx2.Commit()
 Uniqueness is also checked within a single transaction:
 
 ```go
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 tx.Add(alice, kw(":person/email"), "shared@example.com")
 tx.Add(bob, kw(":person/email"), "shared@example.com")
 _, err := tx.Commit()
@@ -154,12 +156,12 @@ _, err := tx.Commit()
 Asserting the same value for the same entity is allowed:
 
 ```go
-tx1 := db.NewTransaction()
+tx1 := d.NewTransaction()
 tx1.Add(alice, kw(":person/email"), "alice@example.com")
 tx1.Commit()
 
 // OK - same entity, same value
-tx2 := db.NewTransaction()
+tx2 := d.NewTransaction()
 tx2.Add(alice, kw(":person/email"), "alice@example.com")
 tx2.Commit() // succeeds
 ```
@@ -180,7 +182,7 @@ result, _ := puller.Pull(alice, pattern)
 
 ```go
 // Resolve pattern with schema
-resolved := schema.ResolvePullPattern(pattern, db.Schema())
+resolved := schema.ResolvePullPattern(pattern, d.Schema())
 
 // Execute with resolved pattern
 result, _ := puller.PullResolved(alice, resolved)
@@ -190,41 +192,25 @@ result, _ := puller.PullResolved(alice, resolved)
 ### Complete Example
 
 ```go
+import "github.com/wbrown/janus-datalog/datalog/db"
+
 // Schema with cardinality-many
 s, _ := schema.NewBuilder().
     Attribute(":person/name").Type(schema.TypeString).Add().
     Attribute(":person/friends").Type(schema.TypeRef).Many().Add().
     Build()
 
-db, _ := storage.NewDatabaseWithSchema(tmpDir, s)
+d, _ := db.Open(tmpDir, db.WithSchema(s))
 
 // Add data
-tx := db.NewTransaction()
+tx := d.NewTransaction()
 tx.Add(alice, kw(":person/name"), "Alice")
 tx.Add(alice, kw(":person/friends"), bob)
 tx.Add(alice, kw(":person/friends"), carol)
 tx.Commit()
 
-// Pull pattern with nested refs
-pattern := &query.PullPattern{
-    Specs: []query.PullAttrSpec{
-        &query.PullAttribute{Attr: kw(":person/name")},
-        &query.PullMapSpec{
-            Attr: kw(":person/friends"),
-            Pattern: &query.PullPattern{
-                Specs: []query.PullAttrSpec{
-                    &query.PullAttribute{Attr: kw(":person/name")},
-                },
-            },
-        },
-    },
-}
-
-// Resolve and execute (recommended: use db.Pull() instead)
-resolved := schema.ResolvePullPattern(pattern, s)
-matcher := storage.NewBadgerMatcher(db.Store())
-puller := executor.NewPullExecutor(matcher, db) // db implements EntityResolver for CRDT resolution
-result, _ := puller.PullResolved(alice, resolved)
+// Use the high-level Pull API directly
+result, _ := d.Pull(alice, "[:person/name {:person/friends [:person/name]}]")
 
 // Result:
 // {

--- a/examples/README.md
+++ b/examples/README.md
@@ -256,16 +256,16 @@ Understand how the engine detects and prevents accidental Cartesian products.
 
 ---
 
-### Level 6: Time-Based Queries
+### Level 6: Temporal Queries
 
 Work with temporal data and historical queries.
 
 #### `financial_time_demo.go`
-**What it demonstrates:** Time-based transactions
-**Concepts:** Transaction IDs as timestamps, temporal ordering
+**What it demonstrates:** Temporal queries with ElementID ordering
+**Concepts:** Lamport clock transaction ordering, temporal queries
 **Time:** 15 minutes
 
-Use timestamps as transaction IDs for time-ordered data.
+Use ElementID-based transaction ordering for time-ordered data.
 
 #### `financial_asof_demo.go`
 **What it demonstrates:** As-of queries (point-in-time)

--- a/examples/aggregation_demo.go
+++ b/examples/aggregation_demo.go
@@ -20,7 +20,7 @@ func main() {
 	dbPath := "/tmp/datalog-aggregation"
 	os.RemoveAll(dbPath)
 
-	db, err := storage.NewDatabaseWithTimeTx(dbPath)
+	db, err := storage.NewDatabase(dbPath)
 	if err != nil {
 		log.Fatal("Failed to create database:", err)
 	}

--- a/examples/financial_asof_demo.go
+++ b/examples/financial_asof_demo.go
@@ -16,11 +16,11 @@ import (
 )
 
 func main() {
-	// Create a database with time-based transactions
+	// Create a database
 	dbPath := "/tmp/datalog-asof"
 	os.RemoveAll(dbPath)
 
-	db, err := storage.NewDatabaseWithTimeTx(dbPath)
+	db, err := storage.NewDatabase(dbPath)
 	if err != nil {
 		log.Fatal("Failed to create database:", err)
 	}
@@ -153,8 +153,8 @@ func main() {
 	fmt.Printf("Looking for transactions <= %d\n", asOfDate.UnixNano())
 
 	// Use AsOf matcher
-	asOfMatcher := db.AsOf(uint64(asOfDate.UnixNano()))
-	asOfExec := executor.NewExecutor(asOfMatcher)
+	asOfDB := db.AsOf(datalog.ElementID{Lamport: uint64(asOfDate.UnixNano())})
+	asOfExec := executor.NewExecutor(asOfDB, asOfDB)
 
 	// First check if we can find the security
 	qCheck, _ := parser.ParseQuery(`

--- a/examples/financial_time_demo.go
+++ b/examples/financial_time_demo.go
@@ -16,12 +16,12 @@ import (
 )
 
 func main() {
-	// Create a database with time-based transactions
+	// Create a database
 	dbPath := "/tmp/datalog-financial"
 	os.RemoveAll(dbPath)
 
-	// Use time-based transaction IDs for financial data
-	db, err := storage.NewDatabaseWithTimeTx(dbPath)
+	// Create database for financial data
+	db, err := storage.NewDatabase(dbPath)
 	if err != nil {
 		log.Fatal("Failed to create database:", err)
 	}

--- a/examples/gopher_street_integration.go
+++ b/examples/gopher_street_integration.go
@@ -23,7 +23,7 @@ func main() {
 	dbPath := "/tmp/gopher-street-db"
 	os.RemoveAll(dbPath)
 
-	db, err := storage.NewDatabaseWithTimeTx(dbPath)
+	db, err := storage.NewDatabase(dbPath)
 	if err != nil {
 		log.Fatal("Failed to create database:", err)
 	}
@@ -166,8 +166,8 @@ func main() {
 	fmt.Println("\n=== Example 6: Historical Position Analysis ===")
 	// Get positions as of yesterday
 	yesterday := time.Now().Add(-24 * time.Hour)
-	asOfMatcher := db.AsOf(uint64(yesterday.UnixNano()))
-	asOfExec := executor.NewExecutor(asOfMatcher)
+	asOfDB := db.AsOf(datalog.ElementID{Lamport: uint64(yesterday.UnixNano())})
+	asOfExec := executor.NewExecutor(asOfDB, asOfDB)
 
 	fmt.Printf("Positions as of %s:\n", yesterday.Format("2006-01-02"))
 	result, _ = asOfExec.Execute(positionQuery)

--- a/examples/time_functions_demo.go
+++ b/examples/time_functions_demo.go
@@ -20,7 +20,7 @@ func main() {
 	dbPath := "/tmp/datalog-timefunc"
 	os.RemoveAll(dbPath)
 
-	db, err := storage.NewDatabaseWithTimeTx(dbPath)
+	db, err := storage.NewDatabase(dbPath)
 	if err != nil {
 		log.Fatal("Failed to create database:", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/wbrown/janus-datalog
 
-go 1.22
+go 1.25
 
 require (
 	github.com/dgraph-io/badger/v4 v4.2.0
 	github.com/fatih/color v1.18.0
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/olekukonko/tablewriter v1.0.7
 	github.com/stretchr/testify v1.8.1
 )
@@ -24,7 +25,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 // indirect
 	github.com/olekukonko/ll v0.0.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect


### PR DESCRIPTION
## Summary

Make ElementID a proper first-class citizen throughout the entire stack — query engine, storage layer, schema system, reflect/struct mapping, and public API.

### ElementID as first-class query value (8577edd)

ElementID (the 16-byte CRDT transaction ID: Lamport clock + ReplicaID) was silently broken as a query binding value — passing one as an input produced 0 results. Three independent bugs:

1. **ProjectFromPattern** only checked E/A/V positions, silently dropping `?tx` bindings. Storage matcher never saw the Tx constraint → full index scans.
2. **TAEV index prefix** passed plain Tx bytes, but TAEV keys use bitwise-NOT encoding (`txToDescending`). `EncodeTxForPrefix` existed for this but was never called.
3. **`*ElementID` pointer form** not recognized. `InternedTupleBuilder` stores Tx as `*ElementID` to avoid per-datom interface boxing, but consumers only handled the value form.

Fixed across 15 files: `DerefElementID` helper, `*ElementID` support in `Type()`, `ValueBytes()`, `hashValue()`, `compareJoinKeys()`, `valueToHashKey()`, `equalityConstraint`, `TxRangePredicate`, TAEV prefix encoding in matcher/hash_join_matcher/batch_scanner, `ProjectFromPattern` T-position in both relation types, `calculateSeekKey`, and a `sync.Mutex` on `InternedTupleBuilder.txCache` (concurrent map write exposed by the fix).

### AsOf/History use full ElementID (0aaf384)

All as-of filter sites (`BadgerMatcher.txID`, `CRDTResolvingIterator.txID`) changed from `uint64` (Lamport only) to full `ElementID` comparison via `ElementID.Less()`. This is correct for multi-replica scenarios where two replicas share a Lamport value but differ in ReplicaID. `Commit()` returns `datalog.ElementID` instead of `uint64`. `AsOf()` and `MatchAsOf()` accept `ElementID`.

### Public API package: `datalog/db` (83b0d18)

New consumer-facing package reduces imports from 4-5 internal packages to 2 (`datalog` + `datalog/db`):

- **`db.Open(path, ...Option)`** with functional options (`WithSchema`, `WithReplicaID`, `WithAnnotationHandler`, `WithoutCache`, `WithVerbose`, `WithVerboseCallback`)
- **Type aliases**: `db.DB = storage.Database`, `db.Transaction = storage.Transaction`
- **Interfaces**: `db.Querier`, `db.EntityReader` define the public API surface
- **`db.MustParseQuery()`** for pre-parsed query constants
- **Convenience methods** on `*Database`: `Query()`, `Assert()`, `GetString/Int/Float/Bool/Ref/Strings()`
- **`AsOf()` / `History()` return `*Database`** instead of `PatternMatcher` — temporal handles support full query, Pull, and typed accessor operations
- **Multi-source re-exports**: `PatternMatcher`, `QueryOption`, `WithSources`, `SliceSource[T]`, `AttributeSchema[T]`, `NewSliceSource`, `NewMemorySource`

Dead code removed: `UseTimeTx` field, `NewDatabaseWithTimeTx` constructor, all test references.

### ElementID in schema and reflect (f1051d4)

- **`schema.TypeTx`** (`"db.type/tx"`) — new value type constant with validation for `ElementID` and `*ElementID`, EDN parser support
- **Reflect integration**: `GoTypeToSchemaType` mapping, `setFieldValue`/`setSingleValue`/`setQueryValue` handlers, `IsRefType` exclusion (ElementID is a value struct, not a nested entity), pull pattern generation
- **AsOf vector fix**: `loadRGAElements` now calls `shouldFilterTx`, so RGA vector resolution in AsOf queries excludes future transactions
- **go.mod bump to 1.25** for generic type alias support

### Documentation

All active docs updated to reflect `db.Open`/`d.Query`/`d.AsOf` API. Two bug investigation docs added (`BUG_ELEMENTID_NOT_FIRST_CLASS.md`, `BUG_ELEMENTID_ASOF_THROUGHOUT.md`). Time-based TX references purged from non-historical docs.

## Test plan

- [x] New `datalog/db` package: 19 tests covering Open/Close, Query round-trip, QueryInto, typed accessors, AsOf, History, MustParseQuery, Assert, PullInto, Rollback, SaveStruct
- [x] ElementID binding tests in `datalog/storage/elementid_binding_test.go`
- [x] CRDT one/many resolution tests with ElementID-based AsOf
- [x] Full `go test ./... -count=1` passes
