### PR TITLE
Streaming Query API and relational algebra terminology

### DIFF
--- a/.claude/skills/datalog/SKILL.md
+++ b/.claude/skills/datalog/SKILL.md
@@ -153,7 +153,7 @@ Queries are EDN vectors. The basic form:
 [(subvec ?vec 1 3) ?slice]               ;; sub-vector [start, end)
 ```
 
-**`enumerate`** — expands a vector into one row per element with index. This is the primary way to query vector contents:
+**`enumerate`** — expands a vector into one tuple per element with index. This is the primary way to query vector contents:
 ```clojure
 ;; Given :product/tags is a vector ["electronics" "sale" "new"]
 [:find ?tag ?idx
@@ -163,7 +163,7 @@ Queries are EDN vectors. The basic form:
 ;; Returns: [0 "electronics"], [1 "sale"], [2 "new"]
 ```
 
-Important: `enumerate` produces **multiple output rows** from a single input row. The binding `[?idx ?tag]` is required — it destructures each element into an index and value. The data pattern that binds `?vec` must appear **before** the enumerate expression in the where clause, and the planner must not reorder it ahead of the pattern that provides the vector.
+Important: `enumerate` produces **multiple output tuples** from a single input tuple. The binding `[?idx ?tag]` is required — it destructures each element into an index and value. The data pattern that binds `?vec` must appear **before** the enumerate expression in the where clause, and the planner must not reorder it ahead of the pattern that provides the vector.
 
 **Database functions:**
 ```clojure
@@ -174,14 +174,14 @@ Important: `enumerate` produces **multiple output rows** from a single input row
 
 **Subqueries** — nested queries that bind results into the outer query:
 ```clojure
-;; Tuple binding — subquery returns one row, binds to variables
+;; Tuple binding — subquery returns one tuple, binds to variables
 [(q [:find (max ?h)
      :in $ ?sym
      :where [?p :price/symbol ?sym]
             [?p :price/high ?h]]
     $ ?s) [[?max-high]]]
 
-;; Relation binding — subquery returns multiple rows
+;; Relation binding — subquery returns multiple tuples
 [(q [:find ?p ?h
      :in $ ?sym
      :where [?p :price/symbol ?sym]
@@ -189,7 +189,7 @@ Important: `enumerate` produces **multiple output rows** from a single input row
     $ ?s) [[?price ?high] ...]]
 ```
 
-The subquery `(q [...] $ ?var1 ?var2)` takes a full query, then lists the inputs to pass (matching the subquery's `:in` clause). The binding after `)` determines how results are captured: `[[?x]]` for a single row, `[[?x ?y] ...]` for multiple rows.
+The subquery `(q [...] $ ?var1 ?var2)` takes a full query, then lists the inputs to pass (matching the subquery's `:in` clause). The binding after `)` determines how results are captured: `[[?x]]` for a single tuple, `[[?x ?y] ...]` for multiple tuples.
 
 **Tagged literals** — use typed constants directly in patterns and predicates:
 ```clojure
@@ -369,7 +369,7 @@ Results are printed as markdown tables:
 | Bob     |   25 |
 | Charlie |   35 |
 
-_3 rows (1.234ms)_
+_3 tuples (1.234ms)_
 ```
 
 With `-verbose`, stderr gets annotation events showing index selection, join stats, and timing.
@@ -378,7 +378,7 @@ With `-verbose`, stderr gets annotation events showing index selection, join sta
 
 Entities are identified by an **Identity** — a SHA1 hash of a seed string, displayed as a 25-character L85-encoded string (a sort-order-preserving Base85 encoding).
 
-When you query for an entity variable like `?e`, the result column shows the L85 hash. You don't normally need to use these directly — join through known attribute values instead (see debugging patterns above).
+When you query for an entity variable like `?e`, the result symbol shows the L85 hash. You don't normally need to use these directly — join through known attribute values instead (see debugging patterns above).
 
 The `#identity "L85hash"` tagged literal exists for cases where you have a hash from logs or export output and need to look it up directly. This is the exception, not the normal workflow.
 
@@ -388,5 +388,5 @@ The `#identity "L85hash"` tagged literal exists for cases where you have a hash 
 - Integer literals are int64, float literals are float64
 - String literals use double quotes: `"value"`
 - The `_` wildcard matches any value without binding
-- Empty results return a table with headers but no rows
+- Empty results return a table with headers but no tuples
 - Tagged literals: `#identity "L85..."`, `#inst "RFC3339..."`, `#bytes "L85..."`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,7 +57,7 @@ The most direct path. An EDN string is parsed, planned, and executed:
 results, err := d.Query(`[:find ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
 ```
 
-**Call chain**: `Query` → `resolveQuery` (detects string → calls `parser.ParseQuery`) → `ExecuteQueryWithInputs` → planner → executor → `[][]interface{}`
+**Call chain**: `Query` → `resolveQuery` (detects string → calls `parser.ParseQuery`) → planner → executor → `executor.Relation` (streaming)
 
 ### Entry Point 2: Query Builder (`qb/`)
 
@@ -219,7 +219,7 @@ For each phase in plan:
     ├── DataPattern  → matcher.Match(pattern, bindings) → new StreamingRelation
     ├── Expression   → evaluate over existing relations → add symbol (lazy)
     ├── Predicate    → filter existing relations (lazy)
-    ├── Subquery     → recursive ExecuteQuery
+    ├── Subquery     → recursive Query
     ├── NOT clause   → anti-join (filter where inner query matches)
     └── OR clause    → union branches or per-tuple fallback
   After each clause: collapse relation groups (join on shared symbols)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ Janus Datalog is a Datalog query engine in Go that makes three bets most Datalog
 
 **CRDT conflict resolution instead of MVCC.** Where Datomic uses a single transactor with monotonic transaction IDs, Janus uses CRDTs — last-writer-wins for scalar attributes, add-wins sets for multi-valued attributes, and RGA for ordered vectors. Transaction IDs are ElementIDs (Lamport clock + ReplicaID), not sequential integers. This means the storage layer is designed from the ground up for a world where multiple writers exist and conflicts are resolved by data structure semantics, not coordination. The choice of cardinality *is* the choice of conflict resolution strategy.
 
-**Go structs as first-class participants in the data model.** Most Datalog engines treat the host language as a string-passing client — you construct an EDN query string, ship it to the engine, and get untyped rows back. Janus provides that path, but also: a type-safe query builder that produces query ASTs directly (no parsing), struct reflection that bridges Go types to datoms and back (struct tags define the schema, `SaveStruct` writes, `PullInto` reads), and `QueryInto` that maps query results into typed structs. The impedance mismatch between Go and Datalog is treated as an engineering problem to solve, not an inherent cost to accept.
+**Go structs as first-class participants in the data model.** Most Datalog engines treat the host language as a string-passing client — you construct an EDN query string, ship it to the engine, and get untyped tuples back. Janus provides that path, but also: a type-safe query builder that produces query ASTs directly (no parsing), struct reflection that bridges Go types to datoms and back (struct tags define the schema, `SaveStruct` writes, `PullInto` reads), and `QueryInto` that maps query results into typed structs. The impedance mismatch between Go and Datalog is treated as an engineering problem to solve, not an inherent cost to accept.
 
 These two bets reinforce each other. In traditional Datomic-style Datalog, "updating" an entity means manually retracting the old value and asserting the new one — an awkward fit for struct-level operations. CRDT semantics absorb that complexity: `SaveStruct` writes new datoms, and the storage layer resolves what's current. Cardinality-one attributes use LWW (latest Tx wins, no retraction needed). Cardinality-many attributes use add-wins sets (the reflect layer diffs and emits Add/Remove ops). Cardinality-vector attributes use RGA (positional inserts with AfterRef chains). The result is that struct-level "updates" are append-only immutable writes underneath, with conflict resolution handled by data structure semantics rather than application logic. The choice of Go type — scalar, slice, or `OrderedSet` — maps directly to the CRDT strategy.
 
@@ -87,7 +87,7 @@ err := d.QueryInto(&people, query, inputs...)
 
 **Call chain**: Normal query execution → `[][]interface{}` → `reflect.QueryResultMapper.MapAll()` → populates struct slice via field tags.
 
-For scalar types (single-column queries), extracts the first column directly without struct mapping.
+For scalar types (single-symbol queries), extracts the first symbol directly without struct mapping.
 
 ### Entry Point 4: Pull API (Separate Path)
 
@@ -176,7 +176,7 @@ This ensures cheap filtering happens early, and expensive subqueries only execut
 - **Provides**: What this phase's clauses produce
 - **Keep**: What the next phase needs (computed by scanning all remaining clauses + `:find`)
 
-The invariant `Keep ⊆ Provides` ensures the executor never tries to pass forward a symbol that doesn't exist in the relation. Columns not in `Keep` are projected away between phases, keeping intermediate results narrow.
+The invariant `Keep ⊆ Provides` ensures the executor never tries to pass forward a symbol that doesn't exist in the relation. Symbols not in `Keep` are projected away between phases, keeping intermediate results narrow.
 
 ### Streaming Execution: Relation-Centric Volcano
 
@@ -214,17 +214,17 @@ Within the executor, each phase is a mini-query. The planner decided the orderin
 
 ```
 For each phase in plan:
-  Input relations from previous phase's Keep columns
+  Input relations from previous phase's Keep symbols
   For each clause in phase.Query.Where (planner-ordered):
     ├── DataPattern  → matcher.Match(pattern, bindings) → new StreamingRelation
-    ├── Expression   → evaluate over existing relations → add column (lazy)
+    ├── Expression   → evaluate over existing relations → add symbol (lazy)
     ├── Predicate    → filter existing relations (lazy)
     ├── Subquery     → recursive ExecuteQuery
     ├── NOT clause   → anti-join (filter where inner query matches)
     └── OR clause    → union branches or per-tuple fallback
   After each clause: collapse relation groups (join on shared symbols)
   Early terminate if any group is empty
-  Project to Keep columns for next phase (lazy)
+  Project to Keep symbols for next phase (lazy)
 ```
 
 ## How Writes Work
@@ -322,18 +322,18 @@ type PatternMatcher interface {
 
 ```go
 type Relation interface {
-    Columns() []query.Symbol
+    Symbols() []query.Symbol
     Iterator() Iterator
     Size() int
     IsEmpty() bool
-    Project(columns []query.Symbol) (Relation, error)
+    Project(symbols []query.Symbol) (Relation, error)
     Join(other Relation) Relation
     HashJoin(other Relation, joinCols []query.Symbol) Relation
     // ... filtering, aggregation, materialization
 }
 ```
 
-Everything in the executor works with Relations. Pattern matches produce them, joins combine them, expressions add columns to them, predicates filter them.
+Everything in the executor works with Relations. Pattern matches produce them, joins combine them, expressions add symbols to them, predicates filter them.
 
 **Key implementations**:
 - `MaterializedRelation` — tuples in memory, supports random access and re-iteration
@@ -455,7 +455,7 @@ Single planner: `ClauseBasedPlanner`. Converts a declarative `*query.Query` (uno
 
 ### Query Execution (`datalog/executor/`)
 
-`DefaultQueryExecutor` processes clauses sequentially within each phase. After each clause, relation groups are collapsed — groups sharing columns are joined, disjoint groups are kept separate. If disjoint groups remain after all clauses, it's an error (Cartesian product prevention).
+`DefaultQueryExecutor` processes clauses sequentially within each phase. After each clause, relation groups are collapsed — groups sharing symbols are joined, disjoint groups are kept separate. If disjoint groups remain after all clauses, it's an error (Cartesian product prevention).
 
 **Streaming**: Iterator composition is the default. `FilterIterator`, `ProjectIterator`, `TransformIterator` etc. chain without materialization. `BufferedIterator` wraps any iterator for re-iteration.
 
@@ -565,7 +565,7 @@ Multi-phase: T(query) = Σ T(phase_i), executed sequentially.
 **Relational query algebra with Datalog syntax:**
 - Patterns, joins, predicates, expressions, aggregations
 - Subqueries (TupleBinding, RelationBinding)
-- Order-by (multi-column, directional)
+- Order-by (multi-symbol, directional)
 - NOT/OR clauses (`not`, `not-join`, `or`, `or-join`)
 
 **Storage and data model:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ The storage layer connects the query engine to BadgerDB:
 ### Multi-Source Query Architecture
 - **One interface**: `PatternMatcher` is the sole interface for all data sources. No separate `DataSource` type.
 - **SourceRouter**: Routes by `pattern.Source` field via `map[Symbol]PatternMatcher`. Also implements `PredicateAwareMatcher` (delegates predicate pushdown to underlying source) and `EntityLookupMatcher` (delegates to default `$` source for `get-else`, `missing?`, `get-some`).
-- **Source threading**: Sources are an execution context built once at the top level. `ExecuteQueryWithInputs` accepts `WithSources(...)` as a functional option. The `SourceRouter` becomes the executor's `PatternMatcher`, so subqueries inherit access to all sources automatically.
+- **Source threading**: Sources are an execution context built once at the top level. `Query()` accepts `WithSources(...)` as a functional option. The `SourceRouter` becomes the executor's `PatternMatcher`, so subqueries inherit access to all sources automatically.
 - **IsSourceSymbol**: Helper `strings.HasPrefix(string(sym), "$")` replacing all hardcoded `sym == "$"` checks.
 - **Adding new source types**: Implement `PatternMatcher`. Optionally implement `PredicateAwareMatcher` for predicate pushdown. Pass via `WithSources`.
 - **Key files**: `executor/source_router.go`, `executor/slice_source.go`, `storage/database.go` (`WithSources`, `buildSourceMap`, `validateQuerySources`), `qb/source.go`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ The storage layer connects the query engine to BadgerDB:
 15. **Subqueries** - Full implementation with TupleBinding and RelationBinding support
 16. **Result/Relation unification** - Eliminated redundant Result type, unified API
 17. **Table formatter** - Markdown table formatting using tablewriter library
-18. **Order-by clause** - Full implementation with multi-column sorting and direction control
+18. **Order-by clause** - Full implementation with multi-symbol sorting and direction control
 19. **Time comparison fix** - Proper time.Time comparison in aggregations and predicates
 20. **Datomic compatibility** - ~80% feature parity (see DATOMIC_COMPATIBILITY.md)
 21. **Relations migration** - Multi-value variable support throughout codebase
@@ -431,9 +431,9 @@ The query planner organizes patterns into phases based on symbol dependencies:
 
 #### 1. Progressive Join Execution
 Within each phase, multiple relations are combined using a greedy algorithm:
-- Joins relations that share columns, keeps disjoint relations separate
+- Joins relations that share symbols, keeps disjoint relations separate
 - Early termination on empty joins to avoid wasted work
-- Uses hash joins for shared columns, prevents cross products otherwise
+- Uses hash joins for shared symbols, prevents cross products otherwise
 - Note: This is a simple greedy approach without cost-based optimization
 
 #### 2. Predicate Pushdown
@@ -500,7 +500,7 @@ The implementation follows a pragmatic approach:
 The query executor has sophisticated handling for disjoint relation groups that may arise during phase execution:
 
 1. **What are Disjoint Relations?**
-   - Relations that share no common columns (symbols)
+   - Relations that share no common symbols (symbols)
    - Cannot be joined without creating a Cartesian product
    - Example: `[?person :person/name ?name]` and `[?product :product/price ?price]` share no variables
 

--- a/CLAUDE_BUGS.md
+++ b/CLAUDE_BUGS.md
@@ -88,7 +88,7 @@ This document catalogs critical bugs that have been fixed and the patterns that 
 
 2. **Executor Implementation**: Added sorting after query execution with type-aware comparison
 
-3. **Multi-column Sorting**: Supports multiple sort keys with independent directions
+3. **Multi-symbol Sorting**: Supports multiple sort keys with independent directions
 
 4. **Type-aware Comparison**: Properly handles all value types including time.Time
 
@@ -195,17 +195,17 @@ Adding input parameters to pure aggregations **changed their type** from single 
 
 **Three Related Bugs** revealed the importance of correctly handling input parameters from `:in` clauses.
 
-**Key Insight**: Input parameters are "environment" symbols (Available) not "data" columns (Provides). They're metadata ABOUT query execution, not data IN the result.
+**Key Insight**: Input parameters are "environment" symbols (Available) not "data" symbols (Provides). They're metadata ABOUT query execution, not data IN the result.
 
 **The Three-Level Type System**:
 1. **Input Parameters**: Environment symbols available in ALL phases for filtering/correlation
 2. **Pattern Variables**: Computation symbols that flow between phases via joins
-3. **Relation Columns**: Actual data in phase output relations
+3. **Relation Symbols**: Actual data in phase output relations
 
 **Critical Invariants**:
 ```
 Available = Environment symbols (inputs + previous outputs)
-Provides = Relation columns (what this phase produces)
+Provides = Relation symbols (what this phase produces)
 Keep ⊆ Provides ∩ Available  (can only keep what's in the relation)
 ```
 
@@ -217,7 +217,7 @@ Keep ⊆ Provides ∩ Available  (can only keep what's in the relation)
 
 3. **BUG_STRING_PREDICATES_CANT_USE_PARAMETERS** (Oct 13): Predicate assignment only made input parameters available in phase 0, not subsequent phases, causing "predicates could not be assigned" panic. Fixed by using phases[i].Available which includes inputs for all phases.
 
-**Analogy**: Input parameters are like SQL prepared statement parameters - they filter data but don't appear as result columns:
+**Analogy**: Input parameters are like SQL prepared statement parameters - they filter data but don't appear as result symbols:
 ```sql
 -- ?symbol filters but isn't in output
 SELECT time, close FROM prices WHERE symbol = ?
@@ -225,7 +225,7 @@ SELECT time, close FROM prices WHERE symbol = ?
 
 **See**: `docs/INPUT_PARAMETER_SEMANTICS.md` for comprehensive guide with examples and testing patterns.
 
-**Pattern**: Understand the type system. Input parameters, pattern variables, and relation columns are fundamentally different types with different semantics.
+**Pattern**: Understand the type system. Input parameters, pattern variables, and relation symbols are fundamentally different types with different semantics.
 
 ---
 
@@ -261,7 +261,7 @@ if len(phase.Patterns) == 0 && len(collapsed) == 0 {
 
 **Phase Execution Invariants**:
 1. **Input Invariant**: Every phase receives either `nil` (first phase, no inputs) or previous phase's `Keep` symbols
-2. **Output Invariant**: Every phase produces a Relation with columns matching `phase.Provides` (or subset in `Keep`)
+2. **Output Invariant**: Every phase produces a Relation with symbols matching `phase.Provides` (or subset in `Keep`)
 3. **Data Flow Invariant**: If Phase N produces K tuples with symbols S, and Phase N+1 needs S' ⊆ S, then Phase N+1 receives K tuples with S' available
 4. **Composition Invariant**: Patterns, expressions, predicates, subqueries can appear in any combination (including zero), and phase execution MUST handle all combinations
 

--- a/CLAUDE_DEBUGGING.md
+++ b/CLAUDE_DEBUGGING.md
@@ -87,7 +87,7 @@ fmt.Printf("DEBUG Phase %d: patterns=%d, expressions=%d, " +
 
 // Before/after key operations
 fmt.Printf("DEBUG before expression eval: size=%d, cols=%v\n",
-    group.Size(), group.Columns())
+    group.Size(), group.Symbols())
 ```
 
 **Strategic locations**:
@@ -128,11 +128,11 @@ if phaseIndex > 0 {
 
 // Output invariant
 assert(result != nil, "Phase returns nil result")
-assert(result.Columns() matches phase.Provides or phase.Keep)
+assert(result.Symbols() matches phase.Provides or phase.Keep)
 
 // Data flow invariant
 if phase.Available includes ?x {
-    assert(previousResult.Columns() includes ?x OR ?x is input parameter)
+    assert(previousResult.Symbols() includes ?x OR ?x is input parameter)
 }
 ```
 
@@ -141,7 +141,7 @@ if phase.Available includes ?x {
 ## Common Bug Patterns
 
 ### 1. Zero tuples from non-empty input
-- Check: Failed join (no shared columns)
+- Check: Failed join (no shared symbols)
 - Check: Predicate filtered everything
 - Check: Expression-only phase got empty relations ← **This bug**
 

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -53,7 +53,7 @@ Basic Datalog queries work as expected:
 - `:find` - with variables and aggregations
 - `:where` - pattern matching and expressions
 - `:in` - database and parameter inputs
-- `:order-by` - result ordering with multi-column and direction support
+- `:order-by` - result ordering with multi-symbol and direction support
 
 **Pattern matching:**
 - `[?e ?a ?v]` - basic triple patterns
@@ -461,7 +461,7 @@ found, err := d.QueryOneInto(&result, `
             [?t :trade/date ?date]]
 `)
 
-// Scalar queries - single column, no struct needed
+// Scalar queries - single symbol, no struct needed
 var names []string
 d.QueryInto(&names, `[:find ?name :where [?e :person/name ?name]]`)
 
@@ -474,7 +474,7 @@ found, err := d.QueryOneInto(&count, `[:find (count ?e) :where [?e :person/name 
 **Tag mapping:**
 - Variables: `datalog:"?symbol"` matches `:find ?symbol`
 - Aggregates: `datalog:"(sum ?salary)"` matches `:find (sum ?salary)` exactly
-- Positional: Omit tags entirely to use field order = result column order
+- Positional: Omit tags entirely to use field order = result symbol order
 
 **Error handling:**
 - `ErrNotFound` - QueryOneInto returns no results

--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -571,7 +571,7 @@ Transforms correlated subqueries with aggregates into single-pass conditional ag
 [(q [:find (max ?v) :in $ ?person ?day :where ...] $ ?p ?day) [[?max-value]]]
 
 ;; After: Single pass with conditional aggregate
-(max ?v :when ?__cond_?pd)  ;; Condition filters which rows contribute
+(max ?v :when ?__cond_?pd)  ;; Condition filters which tuples contribute
 ```
 
 **Benchmark Results** (Apple M4 Max, 3 people × 10 days × 20 events = 600 events):
@@ -597,7 +597,7 @@ Transforms correlated subqueries with aggregates into single-pass conditional ag
 | Medium (3000 events, 100 groups) | 11.4 ms | 12.1 ms | +6% |
 
 **Why It's Fast**:
-- **Without rewriting**: Executes N separate subqueries (one per outer row), each scanning and filtering data
+- **Without rewriting**: Executes N separate subqueries (one per outer tuple), each scanning and filtering data
 - **With rewriting**: Single pass over data with grouped conditional aggregation
 - Eliminates repeated index scans, reduces from O(N × M) to O(M)
 
@@ -1053,7 +1053,7 @@ QueryExecutor couldn't handle conditional aggregate rewriting. Tests used `UseLe
 **Root Cause**:
 1. `rewriteCorrelatedAggregates` stored conditional aggregates in `phase.Metadata["conditional_aggregates"]`
 2. Legacy executor had special code to read metadata and apply aggregation
-3. QueryExecutor treated metadata as inert data - didn't create the aggregate output column
+3. QueryExecutor treated metadata as inert data - didn't create the aggregate output symbol
 4. Find clause injection was attempted but `updatePhaseSymbols` was overwriting it
 
 **Solution**:
@@ -1267,8 +1267,8 @@ With this constraint, we evaluated the remaining consolidation candidates:
 Problem statement: `relation.go` has 5-6 types (MaterializedRelation, StreamingRelation, EmptyRelation, etc.) each implementing ~26 methods. Initial estimate: 300-500 lines savings.
 
 Analysis revealed this is **NOT real duplication**:
-- `Columns()` → one-liner returning a field
-- `Symbols()` → same as `Columns()`
+- `Symbols()` → one-liner returning a field
+- `Symbols()` → same as `Symbols()`
 - `Options()` → one-liner returning a field
 - `Join()` → one-liner calling `HashJoin()`
 
@@ -1284,7 +1284,7 @@ Analysis revealed these are **different iteration strategies**, not duplicated c
 - `reusingIterator`: Complex range calculation, single scan across all bindings
 
 Shared elements are minimal:
-- Field declarations (`tupleBuilder`, `constraints`, `columns`)
+- Field declarations (`tupleBuilder`, `constraints`, `symbols`)
 - One-liner validation calls
 - Statistics tracking
 
@@ -1296,7 +1296,7 @@ The core `Next()` logic is completely different for each strategy. Unifying them
 |---------|---------|---------------------|
 | **Real duplication** | Two identical 15-line switch statements | ✅ YES |
 | **Structural similarity** | Multiple types with same field names | ❌ NO |
-| **Trivial accessors** | One-liner `Columns()` methods | ❌ NO |
+| **Trivial accessors** | One-liner `Symbols()` methods | ❌ NO |
 | **Different algorithms** | Multiple iterator strategies | ❌ NO |
 
 **Decision Criteria for Future Consolidation**:
@@ -1316,10 +1316,10 @@ In languages like Java or C#, the typical solution would be a base class or inte
 ```go
 // Hypothetical base relation (NOT IMPLEMENTED)
 type baseRelation struct {
-    columns []query.Symbol
+    symbols []query.Symbol
     options ExecutorOptions
 }
-func (b *baseRelation) Columns() []query.Symbol { return b.columns }
+func (b *baseRelation) Symbols() []query.Symbol { return b.symbols }
 // ... 20+ more delegating methods
 ```
 

--- a/README.md
+++ b/README.md
@@ -868,13 +868,13 @@ Relations → Joins → Relations → Filters → Relations
 Relations → Aggregations → Relations → Output
 ```
 
-Every step produces a `Relation` (a set of tuples with named columns). The entire execution is just relational algebra operations composed together.
+Every step produces a `Relation` (a set of tuples with named symbols). The entire execution is just relational algebra operations composed together.
 
 **Key abstraction:**
 
 ```go
 type Relation interface {
-    Schema() []Symbol                    // Column names
+    Schema() []Symbol                    // Symbol names
     Iterator(ctx Context) Iterator       // Streaming access
     Project(cols []Symbol) Relation      // π (projection)
     Filter(filter Filter) Relation       // σ (selection)

--- a/RELATIONAL_ALGEBRA_OVERVIEW.md
+++ b/RELATIONAL_ALGEBRA_OVERVIEW.md
@@ -15,7 +15,7 @@ The `Relation` interface (in `datalog/executor/relation.go`) is the fundamental 
 ```go
 type Relation interface {
     // Core Operations (Relational Algebra)
-    Project(columns []Symbol) (Relation, error)      // π (projection)
+    Project(symbols []Symbol) (Relation, error)      // π (projection)
     Filter(filter Filter) Relation                   // σ (selection)
     Join(other Relation) Relation                    // ⋈ (natural join)
     HashJoin(other Relation, cols []Symbol) Relation // ⋈ (equi-join)
@@ -29,7 +29,7 @@ type Relation interface {
     FilterWithPredicate(pred Predicate) Relation
 
     // Metadata & Access
-    Columns() []Symbol          // Schema
+    Symbols() []Symbol          // Schema
     Iterator() Iterator         // Streaming access
     Size() int                 // Cardinality
     IsEmpty() bool             // Empty check
@@ -61,7 +61,7 @@ type Relation interface {
 // Example: Chaining operations without materialization
 result := storageRelation.
     Filter(predicate).      // Applied during iteration
-    Project(columns).       // Applied during iteration
+    Project(symbols).       // Applied during iteration
     HashJoin(other, cols)   // Only materializes hash table
 ```
 
@@ -80,7 +80,7 @@ The `Relations.Collapse()` method implements a greedy join algorithm:
 
 ```go
 func (rs Relations) Collapse(ctx Context) Relations {
-    // Groups relations by shared columns
+    // Groups relations by shared symbols
     // Joins them progressively as encountered
     // Short-circuits on empty results
     // Returns independent groups if disjoint
@@ -88,7 +88,7 @@ func (rs Relations) Collapse(ctx Context) Relations {
 ```
 
 **Algorithm Steps**:
-1. **Group by connectivity**: Relations sharing columns can join
+1. **Group by connectivity**: Relations sharing symbols can join
 2. **Progressive joining**: Add relations in the order received
 3. **Early termination**: Stop if any join produces empty result
 4. **Disjoint handling**: Keep independent groups separate
@@ -103,10 +103,10 @@ The query planner is responsible for providing relations in a sensible order.
 **Example Execution**:
 ```
 Query planner provides: R2(100 tuples), R3(10K tuples), R1(1M tuples)
-Shared columns: R1↔R3, R2↔R3
+Shared symbols: R1↔R3, R2↔R3
 
 Step 1: Start with R2
-Step 2: Join R2⋈R3 → 50 tuples (if shared columns)
+Step 2: Join R2⋈R3 → 50 tuples (if shared symbols)
 Step 3: Join (R2⋈R3)⋈R1 → 25 tuples
 Result: Single relation with 25 tuples
 ```
@@ -116,12 +116,12 @@ Result: Single relation with 25 tuples
 ## Join Algorithms
 
 ### 1. Natural Join
-Joins on ALL shared columns:
+Joins on ALL shared symbols:
 ```go
 func (r *MaterializedRelation) Join(other Relation) Relation {
     sharedCols := findSharedColumns(r, other)
     if len(sharedCols) == 0 {
-        return crossProduct(r, other) // No shared columns
+        return crossProduct(r, other) // No shared symbols
     }
     return r.HashJoin(other, sharedCols)
 }
@@ -193,8 +193,8 @@ func Aggregate(rel Relation, groupBy []Symbol, aggs []Aggregate) Relation {
 
     // Aggregate phase
     for key, group := range groups {
-        row := append(key.Values(), computeAggregates(group, aggs)...)
-        output(row)
+        tuple := append(key.Values(), computeAggregates(group, aggs)...)
+        output(tuple)
     }
 }
 ```
@@ -244,7 +244,7 @@ Phase 3: [(year ?t) ?y]                      // Uses ?t, provides ?y
 
 1. **Pattern Matching**: Storage scans produce initial relations
 2. **Progressive Joining**: Relations collapse within each phase
-3. **Expression Evaluation**: Computed columns added
+3. **Expression Evaluation**: Computed symbols added
 4. **Predicate Application**: Filtering based on conditions
 5. **Cross-Phase Joins**: Results flow between phases
 6. **Final Operations**: Sorting, aggregation, projection
@@ -300,7 +300,7 @@ func ExecutePhase(phase *Phase, input Relation) Relation {
 
 **Streaming Operations** (constant memory):
 - Filter
-- Project (column subset)
+- Project (symbol subset)
 - Scan from storage
 
 **Materializing Operations** (O(n) memory):
@@ -348,7 +348,7 @@ The implementation respects fundamental laws:
 1. **Commutativity**: `R ⋈ S = S ⋈ R`
 2. **Associativity**: `(R ⋈ S) ⋈ T = R ⋈ (S ⋈ T)`
 3. **Distributivity**: `σ(R ⋈ S) = σ(R) ⋈ S` (when predicate only references R)
-4. **Idempotence**: `π(π(R)) = π(R)` (with proper column subset)
+4. **Idempotence**: `π(π(R)) = π(R)` (with proper symbol subset)
 
 ### Set Semantics
 
@@ -362,7 +362,7 @@ Following Datalog tradition:
 The query planner applies standard optimizations:
 - **Predicate Pushdown**: Apply filters early
 - **Join Reordering**: Start with most selective
-- **Early Projection**: Remove unnecessary columns
+- **Early Projection**: Remove unnecessary symbols
 - **Join Elimination**: Remove redundant joins
 
 ## Comparison with Other Systems

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@
 - Expression clauses with arithmetic and string operations
 - Aggregations (sum, count, avg, min, max)
 - Subqueries with proper scoping (semantically correct)
-- Order-by clause with multi-column sorting
+- Order-by clause with multi-symbol sorting
 - Time extraction functions
 - **Pull API with nested references and cycle detection (9× faster than queries)**
 - **Schema support: type validation, cardinality, uniqueness (<1% write overhead)**

--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -478,7 +478,7 @@ func runSingleQuery(db *storage.Database, handler annotations.Handler, queryStr 
 	start := time.Now()
 	var result executor.Relation
 	if len(goInputs) > 0 {
-		result, err = db.ExecuteQueryRelation(q, goInputs...)
+		result, err = db.Query(q, goInputs...)
 	} else {
 		opts := storage.DefaultPlannerOptions()
 		opts.EnableSubqueryDecorrelation = enableDecorrelation

--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -499,14 +499,14 @@ func runSingleQuery(db *storage.Database, handler annotations.Handler, queryStr 
 
 	// Display results as markdown table with timing
 	table := result.Table()
-	// Replace the row count line with row count + timing
+	// Replace the tuple count line with tuple count + timing
 	lines := strings.Split(table, "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
-		if strings.HasPrefix(lines[i], "_") && strings.HasSuffix(lines[i], "rows_") {
-			// Extract row count
-			rowLine := lines[i]
-			rowLine = strings.TrimSuffix(rowLine, "_")
-			lines[i] = rowLine + fmt.Sprintf(" (%.3fms)_", float64(elapsed.Microseconds())/1000.0)
+		if strings.HasPrefix(lines[i], "_") && strings.HasSuffix(lines[i], "tuples_") {
+			// Extract tuple count
+			tupleLine := lines[i]
+			tupleLine = strings.TrimSuffix(tupleLine, "_")
+			lines[i] = tupleLine + fmt.Sprintf(" (%.3fms)_", float64(elapsed.Microseconds())/1000.0)
 			break
 		}
 	}

--- a/cmd/datalog/main_test.go
+++ b/cmd/datalog/main_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/storage"
 )
 
-// Note: We use db.ExecuteQuery() directly instead of NewExecutor() + Execute()
+// Note: We use db.Query() directly instead of NewExecutor() + Execute()
 // because Database provides a simpler API that handles parsing internally.
 
 // buildCLI builds the CLI binary for testing
@@ -156,7 +157,7 @@ func TestCLI_ImportFlag(t *testing.T) {
 	defer db.Close()
 
 	// Query to verify data exists
-	result, err := db.ExecuteQuery(`[:find ?v :where [_ :test/value ?v]]`)
+	result, err := executor.CollectTuples(db.Query(`[:find ?v :where [_ :test/value ?v]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -198,12 +199,12 @@ func TestCLI_ExportImportRoundTrip(t *testing.T) {
 	defer db2.Close()
 
 	// Query names from both
-	result1, err := db1.ExecuteQuery(`[:find ?name :where [_ :person/name ?name]]`)
+	result1, err := executor.CollectTuples(db1.Query(`[:find ?name :where [_ :person/name ?name]]`))
 	if err != nil {
 		t.Fatalf("Query db1 failed: %v", err)
 	}
 
-	result2, err := db2.ExecuteQuery(`[:find ?name :where [_ :person/name ?name]]`)
+	result2, err := executor.CollectTuples(db2.Query(`[:find ?name :where [_ :person/name ?name]]`))
 	if err != nil {
 		t.Fatalf("Query db2 failed: %v", err)
 	}

--- a/datalog/annotations/output.go
+++ b/datalog/annotations/output.go
@@ -171,13 +171,13 @@ func (f *OutputFormatter) Format(event Event) string {
 	case "pattern/multi-match":
 		pattern := event.Data["pattern"].(string)
 		bindingTuples := event.Data["binding.tuples"].(int)
-		bindingColumns := event.Data["binding.columns"].([]string)
+		bindingSymbols := event.Data["binding.symbols"].([]string)
 		totalMatches := event.Data["match.total"].(int)
 		scansPerformed := event.Data["scans.performed"].(int)
 		datomsScanned := event.Data["datoms.scanned"].(int)
 
 		// Format the binding relation
-		bindingRelStr := f.renderer.RenderRelationWithAttrs(bindingColumns, bindingTuples)
+		bindingRelStr := f.renderer.RenderRelationWithAttrs(bindingSymbols, bindingTuples)
 
 		// Format like: MultiMatch([pattern]) with binding Relation → Y tuples (Z scans, W datoms)
 		var matchStr string
@@ -249,7 +249,7 @@ func (f *OutputFormatter) Format(event Event) string {
 		pattern := event.Data["pattern"].(string)
 		matchCount := event.Data["match.count"].(int)
 
-		// Extract bound symbols from the pattern to determine output columns
+		// Extract bound symbols from the pattern to determine output symbols
 		var outputSymbols []string
 
 		// Check if we have symbol order information
@@ -420,13 +420,13 @@ func (f *OutputFormatter) Format(event Event) string {
 	case "pattern/match-with-bindings":
 		// Format pattern match that has input bindings
 		pattern := event.Data["pattern"].(string)
-		bindingCols := event.Data["binding.columns"].([]string)
+		bindingSyms := event.Data["binding.symbols"].([]string)
 		bindingSize := event.Data["binding.size"].(int)
 
 		// Format the binding relation
-		bindingRelStr := f.renderer.RenderRelationWithAttrs(bindingCols, bindingSize)
+		bindingRelStr := f.renderer.RenderRelationWithAttrs(bindingSyms, bindingSize)
 
-		// Format as Pattern(...) with binding Relation([cols], N tuples)
+		// Format as Pattern(...) with binding Relation([symbols], N tuples)
 		var patternStr string
 		if f.useColor {
 			patternStr = fmt.Sprintf("%s%s%s %s %s",

--- a/datalog/db/db_test.go
+++ b/datalog/db/db_test.go
@@ -49,10 +49,13 @@ func TestQueryRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, datalog.ElementID{}, txID)
 
-	results, err := d.Query(`[:find ?name :where [?e :person/name ?name]]`)
+	rel, err := d.Query(`[:find ?name :where [?e :person/name ?name]]`)
 	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "Alice", results[0][0])
+	iter := rel.Iterator()
+	defer iter.Close()
+	require.True(t, iter.Next())
+	assert.Equal(t, "Alice", iter.Tuple()[0])
+	assert.False(t, iter.Next())
 }
 
 func TestQueryWithInputs(t *testing.T) {
@@ -68,13 +71,16 @@ func TestQueryWithInputs(t *testing.T) {
 	_, err := tx.Commit()
 	require.NoError(t, err)
 
-	results, err := d.Query(
+	rel, err := d.Query(
 		`[:find ?name :in $ ?min-age :where [?e :person/name ?name] [?e :person/age ?age] [(>= ?age ?min-age)]]`,
 		int64(25),
 	)
 	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "Alice", results[0][0])
+	iter := rel.Iterator()
+	defer iter.Close()
+	require.True(t, iter.Next())
+	assert.Equal(t, "Alice", iter.Tuple()[0])
+	assert.False(t, iter.Next())
 }
 
 func TestQueryInto(t *testing.T) {
@@ -311,14 +317,16 @@ func TestHistory(t *testing.T) {
 
 	// History should return both values
 	hist := d.History()
-	results, err := hist.Query(`[:find ?name :where [?e :person/name ?name]]`)
+	rel, err := hist.Query(`[:find ?name :where [?e :person/name ?name]]`)
 	require.NoError(t, err)
-	assert.Len(t, results, 2)
+	iter := rel.Iterator()
+	defer iter.Close()
 
-	names := make([]string, len(results))
-	for i, r := range results {
-		names[i] = r[0].(string)
+	var names []string
+	for iter.Next() {
+		names = append(names, iter.Tuple()[0].(string))
 	}
+	assert.Len(t, names, 2)
 	assert.Contains(t, names, "Alice")
 	assert.Contains(t, names, "Alicia")
 }
@@ -347,10 +355,12 @@ func TestMustParseQueryWithQuery(t *testing.T) {
 
 	// Pre-parsed query works with Query
 	q := db.MustParseQuery(`[:find ?name :where [?e :person/name ?name]]`)
-	results, err := d.Query(q)
+	rel, err := d.Query(q)
 	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "Alice", results[0][0])
+	iter := rel.Iterator()
+	defer iter.Close()
+	require.True(t, iter.Next())
+	assert.Equal(t, "Alice", iter.Tuple()[0])
 }
 
 func TestAssert(t *testing.T) {
@@ -403,9 +413,11 @@ func TestTransactionRollback(t *testing.T) {
 	require.NoError(t, tx.Rollback())
 
 	// Should not find the data
-	results, err := d.Query(`[:find ?name :where [?e :person/name ?name]]`)
+	rel, err := d.Query(`[:find ?name :where [?e :person/name ?name]]`)
 	require.NoError(t, err)
-	assert.Empty(t, results)
+	iter := rel.Iterator()
+	defer iter.Close()
+	assert.False(t, iter.Next())
 }
 
 func TestSaveStruct(t *testing.T) {

--- a/datalog/db/interfaces.go
+++ b/datalog/db/interfaces.go
@@ -1,6 +1,9 @@
 package db
 
-import "github.com/wbrown/janus-datalog/datalog"
+import (
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+)
 
 // EntityReader provides typed attribute access for entities.
 type EntityReader interface {
@@ -14,7 +17,7 @@ type EntityReader interface {
 
 // Querier provides the core query and entity access operations.
 type Querier interface {
-	Query(q any, inputs ...any) ([][]any, error)
+	Query(q any, inputs ...any) (executor.Relation, error)
 	QueryInto(dest any, q any, inputs ...any) error
 	QueryOneInto(dest any, q any, inputs ...any) (bool, error)
 	PullInto(entityID datalog.Identity, v any) error

--- a/datalog/executor/aggregation.go
+++ b/datalog/executor/aggregation.go
@@ -27,7 +27,7 @@ func ExecuteAggregations(rel Relation, findElements []query.FindElement) Relatio
 // ExecuteAggregationsWithContext applies aggregation operations with annotation support
 func ExecuteAggregationsWithContext(ctx Context, rel Relation, findElements []query.FindElement) Relation {
 	if debugAggregation {
-		fmt.Printf("[ExecuteAggregations] Called with %d find elements, rel columns: %v\n", len(findElements), rel.Columns())
+		fmt.Printf("[ExecuteAggregations] Called with %d find elements, rel symbols: %v\n", len(findElements), rel.Symbols())
 		for i, elem := range findElements {
 			switch e := elem.(type) {
 			case query.FindAggregate:
@@ -137,7 +137,7 @@ func ExecuteAggregationsWithContext(ctx Context, rel Relation, findElements []qu
 		}
 		result := executeSingleAggregation(rel, aggregates)
 		if debugAggregation {
-			fmt.Printf("[ExecuteAggregations] executeSingleAggregation returned: Size=%d, Columns=%v\n", result.Size(), result.Columns())
+			fmt.Printf("[ExecuteAggregations] executeSingleAggregation returned: Size=%d, Symbols=%v\n", result.Size(), result.Symbols())
 			if result.Size() > 0 {
 				fmt.Printf("[ExecuteAggregations] First tuple: %v\n", result.Get(0))
 			}
@@ -192,14 +192,14 @@ func executeSingleAggregation(rel Relation, aggregates []query.FindAggregate) Re
 	it := rel.Iterator()
 	defer it.Close()
 
-	columns := rel.Columns()
+	symbols := rel.Symbols()
 
 	// Find predicate indices for conditional aggregates
 	predicateIndices := make([]int, len(aggregates))
 	for i, agg := range aggregates {
 		predicateIndices[i] = -1 // -1 means no predicate (unconditional)
 		if agg.IsConditional() {
-			for j, col := range columns {
+			for j, col := range symbols {
 				if col == agg.Predicate {
 					predicateIndices[i] = j
 					break
@@ -221,13 +221,13 @@ func executeSingleAggregation(rel Relation, aggregates []query.FindAggregate) Re
 						continue // Skip this value (predicate is false or not boolean)
 					}
 				} else {
-					continue // Predicate column missing, skip
+					continue // Predicate symbol missing, skip
 				}
 			}
 
-			// Predicate passed (or no predicate), find column index for this aggregate
+			// Predicate passed (or no predicate), find symbol index for this aggregate
 			found := false
-			for j, col := range columns {
+			for j, col := range symbols {
 				if col == agg.Arg {
 					if j < len(tuple) {
 						aggValues[i] = append(aggValues[i], tuple[j])
@@ -236,9 +236,9 @@ func executeSingleAggregation(rel Relation, aggregates []query.FindAggregate) Re
 					break
 				}
 			}
-			// DEBUG: Log when column not found
-			if !found && len(columns) > 0 {
-				fmt.Printf("AGGREGATE BUG: Column %v not found in columns %v for aggregate %d\n", agg.Arg, columns, i)
+			// DEBUG: Log when symbol not found
+			if !found && len(symbols) > 0 {
+				fmt.Printf("AGGREGATE BUG: Symbol %v not found in symbols %v for aggregate %d\n", agg.Arg, symbols, i)
 			}
 		}
 	}
@@ -253,7 +253,7 @@ func executeSingleAggregation(rel Relation, aggregates []query.FindAggregate) Re
 		results[i] = computeAggregateValues(aggValues[i], agg.Function)
 	}
 
-	// Build result columns (aggregate functions as column names)
+	// Build result symbols (aggregate functions as symbol names)
 	resultColumns := make([]query.Symbol, len(aggregates))
 	for i, agg := range aggregates {
 		// Use String() method which handles conditional vs unconditional formatting
@@ -262,7 +262,7 @@ func executeSingleAggregation(rel Relation, aggregates []query.FindAggregate) Re
 
 	// Relational theory: empty input → empty output
 	// If no aggregate has any values (all predicates failed or input was empty),
-	// return empty result set instead of a row with nil values
+	// return empty result set instead of a tuple with nil values
 	opts := rel.Options()
 	if !hasAnyValues {
 		return NewMaterializedRelationWithOptions(resultColumns, []Tuple{}, opts)
@@ -273,11 +273,11 @@ func executeSingleAggregation(rel Relation, aggregates []query.FindAggregate) Re
 
 // executeGroupedAggregation performs aggregation with grouping
 func executeGroupedAggregation(rel Relation, groupByVars []query.Symbol, aggregates []query.FindAggregate) Relation {
-	// Create column mapping
-	columns := rel.Columns()
+	// Create symbol mapping
+	symbols := rel.Symbols()
 	groupIndices := make([]int, len(groupByVars))
 	for i, groupVar := range groupByVars {
-		for j, col := range columns {
+		for j, col := range symbols {
 			if col == groupVar {
 				groupIndices[i] = j
 				break
@@ -287,7 +287,7 @@ func executeGroupedAggregation(rel Relation, groupByVars []query.Symbol, aggrega
 
 	aggIndices := make([]int, len(aggregates))
 	for i, agg := range aggregates {
-		for j, col := range columns {
+		for j, col := range symbols {
 			if col == agg.Arg {
 				aggIndices[i] = j
 				break
@@ -300,13 +300,13 @@ func executeGroupedAggregation(rel Relation, groupByVars []query.Symbol, aggrega
 	for i, agg := range aggregates {
 		predicateIndices[i] = -1 // -1 means no predicate (unconditional)
 		if agg.IsConditional() {
-			for j, col := range columns {
+			for j, col := range symbols {
 				if col == agg.Predicate {
 					predicateIndices[i] = j
 					break
 				}
 			}
-			// If predicate column not found, we'll handle it during execution
+			// If predicate symbol not found, we'll handle it during execution
 		}
 	}
 
@@ -352,7 +352,7 @@ func executeGroupedAggregation(rel Relation, groupByVars []query.Symbol, aggrega
 							continue // Skip this value (predicate is false or not boolean)
 						}
 					} else {
-						continue // Predicate column missing, skip
+						continue // Predicate symbol missing, skip
 					}
 				}
 
@@ -391,7 +391,7 @@ func executeGroupedAggregation(rel Relation, groupByVars []query.Symbol, aggrega
 		resultTuples = append(resultTuples, resultTuple)
 	}
 
-	// Build result columns
+	// Build result symbols
 	resultColumns := make([]query.Symbol, len(groupByVars)+len(aggregates))
 	copy(resultColumns, groupByVars)
 	for i, agg := range aggregates {
@@ -556,19 +556,15 @@ func NewStreamingAggregateRelation(source Relation, groupByVars []query.Symbol, 
 	}
 }
 
-// Columns returns the output columns
-func (r *StreamingAggregateRelation) Columns() []query.Symbol {
-	resultColumns := make([]query.Symbol, len(r.groupByVars)+len(r.aggregates))
-	copy(resultColumns, r.groupByVars)
+// Symbols returns the output symbols
+func (r *StreamingAggregateRelation) Symbols() []query.Symbol {
+	resultSymbols := make([]query.Symbol, len(r.groupByVars)+len(r.aggregates))
+	copy(resultSymbols, r.groupByVars)
 	for i, agg := range r.aggregates {
 		// Use String() method which handles conditional vs unconditional formatting
-		resultColumns[len(r.groupByVars)+i] = datalog.NewSymbol(agg.String())
+		resultSymbols[len(r.groupByVars)+i] = datalog.NewSymbol(agg.String())
 	}
-	return resultColumns
-}
-
-func (r *StreamingAggregateRelation) Symbols() []query.Symbol {
-	return r.Columns()
+	return resultSymbols
 }
 
 // Options returns the executor options for this streaming aggregate relation
@@ -632,10 +628,10 @@ func (r *StreamingAggregateRelation) Sorted() []Tuple {
 	return r.materialized.Sorted()
 }
 
-// Project projects specific columns (delegates to materialized result)
-func (r *StreamingAggregateRelation) Project(columns []query.Symbol) (Relation, error) {
+// Project projects specific symbols (delegates to materialized result)
+func (r *StreamingAggregateRelation) Project(symbols []query.Symbol) (Relation, error) {
 	r.Iterator()
-	return r.materialized.Project(columns)
+	return r.materialized.Project(symbols)
 }
 
 // Materialize returns the materialized relation
@@ -662,7 +658,7 @@ func (r *StreamingAggregateRelation) FilterWithPredicate(pred query.Predicate) R
 	return r.materialized.FilterWithPredicate(pred)
 }
 
-// EvaluateFunction evaluates a function and adds result as new column
+// EvaluateFunction evaluates a function and adds result as new symbol
 func (r *StreamingAggregateRelation) EvaluateFunction(fn query.Function, outputColumn query.Symbol) Relation {
 	r.Iterator()
 	return r.materialized.EvaluateFunction(fn, outputColumn)
@@ -706,11 +702,11 @@ func (r *StreamingAggregateRelation) Aggregate(findElements []query.FindElement)
 
 // materialize performs the actual streaming aggregation
 func (r *StreamingAggregateRelation) materialize() *MaterializedRelation {
-	// Build column index mappings
-	columns := r.source.Columns()
+	// Build symbol index mappings
+	symbols := r.source.Symbols()
 
 	if r.options.EnableStreamingAggregationDebug {
-		fmt.Printf("[StreamingAggregateRelation.materialize] Source columns: %v\n", columns)
+		fmt.Printf("[StreamingAggregateRelation.materialize] Source symbols: %v\n", symbols)
 		fmt.Printf("[StreamingAggregateRelation.materialize] Group-by vars: %v\n", r.groupByVars)
 		fmt.Printf("[StreamingAggregateRelation.materialize] Aggregates: %v\n", r.aggregates)
 	}
@@ -720,7 +716,7 @@ func (r *StreamingAggregateRelation) materialize() *MaterializedRelation {
 		groupIndices[i] = -1 // Initialize to -1 (not found)
 	}
 	for i, groupVar := range r.groupByVars {
-		for j, col := range columns {
+		for j, col := range symbols {
 			if col == groupVar {
 				groupIndices[i] = j
 				break
@@ -733,7 +729,7 @@ func (r *StreamingAggregateRelation) materialize() *MaterializedRelation {
 		aggIndices[i] = -1 // Initialize to -1 (not found)
 	}
 	for i, agg := range r.aggregates {
-		for j, col := range columns {
+		for j, col := range symbols {
 			if col == agg.Arg {
 				aggIndices[i] = j
 				break
@@ -751,7 +747,7 @@ func (r *StreamingAggregateRelation) materialize() *MaterializedRelation {
 	for i, agg := range r.aggregates {
 		predicateIndices[i] = -1 // -1 means no predicate (unconditional)
 		if agg.IsConditional() {
-			for j, col := range columns {
+			for j, col := range symbols {
 				if col == agg.Predicate {
 					predicateIndices[i] = j
 					break
@@ -816,7 +812,7 @@ func (r *StreamingAggregateRelation) materialize() *MaterializedRelation {
 							continue // Skip this value (predicate is false or not boolean)
 						}
 					} else {
-						continue // Predicate column missing, skip
+						continue // Predicate symbol missing, skip
 					}
 				}
 
@@ -860,5 +856,5 @@ func (r *StreamingAggregateRelation) materialize() *MaterializedRelation {
 		resultTuples = append(resultTuples, resultTuple)
 	}
 
-	return NewMaterializedRelationWithOptions(r.Columns(), resultTuples, r.options)
+	return NewMaterializedRelationWithOptions(r.Symbols(), resultTuples, r.options)
 }

--- a/datalog/executor/aggregation_test.go
+++ b/datalog/executor/aggregation_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestExecuteAggregations(t *testing.T) {
 	// Create test data
-	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?score")}
+	symbols := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?score")}
 	tuples := []Tuple{
 		{"Alice", int64(30), 85.5},
 		{"Bob", int64(25), 92.0},
 		{"Charlie", int64(35), 78.5},
 		{"Dave", int64(25), 88.0},
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	tests := []struct {
 		name         string
@@ -36,9 +36,9 @@ func TestExecuteAggregations(t *testing.T) {
 			expectedCols: []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age")},
 			expectedRows: 4,
 			validate: func(t *testing.T, result Relation) {
-				// Should have all 4 rows with just name and age
+				// Should have all 4 tuples with just name and age
 				if result.Size() != 4 {
-					t.Errorf("expected 4 rows, got %d", result.Size())
+					t.Errorf("expected 4 tuples, got %d", result.Size())
 				}
 			},
 		},
@@ -106,7 +106,7 @@ func TestExecuteAggregations(t *testing.T) {
 			expectedCols: []query.Symbol{datalog.NewSymbol("?age"), datalog.NewSymbol("(count ?name)"), datalog.NewSymbol("(avg ?score)")},
 			expectedRows: 3, // 3 unique ages: 25, 30, 35
 			validate: func(t *testing.T, result Relation) {
-				// Find the row for age 25 (should have count=2, avg=90)
+				// Find the tuple for age 25 (should have count=2, avg=90)
 				it := result.Iterator()
 				defer it.Close()
 				found25 := false
@@ -159,14 +159,14 @@ func TestExecuteAggregations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ExecuteAggregations(rel, tt.findElements)
 
-			// Check column count
-			if len(result.Columns()) != len(tt.expectedCols) {
-				t.Errorf("expected %d columns, got %d", len(tt.expectedCols), len(result.Columns()))
+			// Check symbol count
+			if len(result.Symbols()) != len(tt.expectedCols) {
+				t.Errorf("expected %d symbols, got %d", len(tt.expectedCols), len(result.Symbols()))
 			}
 
-			// Check row count
+			// Check tuple count
 			if result.Size() != tt.expectedRows {
-				t.Errorf("expected %d rows, got %d", tt.expectedRows, result.Size())
+				t.Errorf("expected %d tuples, got %d", tt.expectedRows, result.Size())
 			}
 
 			// Run custom validation
@@ -178,13 +178,13 @@ func TestExecuteAggregations(t *testing.T) {
 }
 
 func TestProjectColumns(t *testing.T) {
-	columns := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c"), datalog.NewSymbol("?d")}
+	symbols := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c"), datalog.NewSymbol("?d")}
 	tuples := []Tuple{
 		{1, 2, 3, 4},
 		{5, 6, 7, 8},
 		{9, 10, 11, 12},
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	tests := []struct {
 		name         string
@@ -231,40 +231,40 @@ func TestProjectColumns(t *testing.T) {
 				t.Fatalf("Project failed: %v", err)
 			}
 
-			// Check columns
-			resultCols := result.Columns()
+			// Check symbols
+			resultCols := result.Symbols()
 			if len(resultCols) != len(tt.expectedCols) {
-				t.Fatalf("expected %d columns, got %d", len(tt.expectedCols), len(resultCols))
+				t.Fatalf("expected %d symbols, got %d", len(tt.expectedCols), len(resultCols))
 			}
 			for i, col := range resultCols {
 				if col != tt.expectedCols[i] {
-					t.Errorf("column %d: expected %s, got %s", i, tt.expectedCols[i], col)
+					t.Errorf("symbol %d: expected %s, got %s", i, tt.expectedCols[i], col)
 				}
 			}
 
 			// Check values
 			it := result.Iterator()
 			defer it.Close()
-			row := 0
+			idx := 0
 			for it.Next() {
 				tuple := it.Tuple()
-				if row >= len(tt.expectedVals) {
-					t.Errorf("too many rows: expected %d", len(tt.expectedVals))
+				if idx >= len(tt.expectedVals) {
+					t.Errorf("too many tuples: expected %d", len(tt.expectedVals))
 					break
 				}
-				expected := tt.expectedVals[row]
+				expected := tt.expectedVals[idx]
 				if len(tuple) != len(expected) {
-					t.Errorf("row %d: expected %d values, got %d", row, len(expected), len(tuple))
+					t.Errorf("tuple %d: expected %d values, got %d", idx, len(expected), len(tuple))
 				}
 				for i, val := range tuple {
 					if val != expected[i] {
-						t.Errorf("row %d col %d: expected %v, got %v", row, i, expected[i], val)
+						t.Errorf("tuple %d col %d: expected %v, got %v", idx, i, expected[i], val)
 					}
 				}
-				row++
+				idx++
 			}
-			if row != len(tt.expectedVals) {
-				t.Errorf("expected %d rows, got %d", len(tt.expectedVals), row)
+			if idx != len(tt.expectedVals) {
+				t.Errorf("expected %d tuples, got %d", len(tt.expectedVals), idx)
 			}
 		})
 	}
@@ -276,13 +276,13 @@ func TestAggregationWithTimeValues(t *testing.T) {
 	date2 := time.Date(2023, 6, 10, 0, 0, 0, 0, time.UTC)
 	date3 := time.Date(2023, 3, 20, 0, 0, 0, 0, time.UTC)
 
-	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?date")}
+	symbols := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?date")}
 	tuples := []Tuple{
 		{"Alice", date1},
 		{"Bob", date2},
 		{"Charlie", date3},
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// Test min/max with dates
 	result := ExecuteAggregations(rel, []query.FindElement{
@@ -291,7 +291,7 @@ func TestAggregationWithTimeValues(t *testing.T) {
 	})
 
 	if result.Size() != 1 {
-		t.Fatalf("expected 1 row, got %d", result.Size())
+		t.Fatalf("expected 1 tuple, got %d", result.Size())
 	}
 
 	it := result.Iterator()
@@ -340,7 +340,7 @@ func TestEmptyRelationAggregation(t *testing.T) {
 	})
 
 	if result.Size() != 0 {
-		t.Fatalf("expected 0 rows (empty result), got %d", result.Size())
+		t.Fatalf("expected 0 tuples (empty result), got %d", result.Size())
 	}
 
 	// Other aggregates on empty also return empty results
@@ -352,6 +352,6 @@ func TestEmptyRelationAggregation(t *testing.T) {
 	})
 
 	if result.Size() != 0 {
-		t.Fatalf("expected 0 rows (empty result), got %d", result.Size())
+		t.Fatalf("expected 0 tuples (empty result), got %d", result.Size())
 	}
 }

--- a/datalog/executor/annotated_matcher.go
+++ b/datalog/executor/annotated_matcher.go
@@ -49,17 +49,17 @@ func (m *AnnotatedMatcher) Match(pattern *query.DataPattern, bindings Relations)
 	start := time.Now()
 
 	// Collect binding information if present
-	var bindingColumns []string
+	var bindingSymbols []string
 	var bindingSize int
 
 	if bindings != nil && len(bindings) > 0 {
 		// Find best binding relation for context
 		bindingRel := bindings.FindBestForPattern(pattern)
 		if bindingRel != nil {
-			bindingCols := bindingRel.Columns()
-			bindingColumns = make([]string, len(bindingCols))
-			for i, col := range bindingCols {
-				bindingColumns[i] = col.String()
+			bindingSyms := bindingRel.Symbols()
+			bindingSymbols = make([]string, len(bindingSyms))
+			for i, col := range bindingSyms {
+				bindingSymbols[i] = col.String()
 			}
 			bindingSize = bindingRel.Size()
 		}
@@ -75,8 +75,8 @@ func (m *AnnotatedMatcher) Match(pattern *query.DataPattern, bindings Relations)
 	data["success"] = err == nil
 
 	// Add binding information if it was present
-	if len(bindingColumns) > 0 {
-		data["binding.columns"] = bindingColumns
+	if len(bindingSymbols) > 0 {
+		data["binding.symbols"] = bindingSymbols
 		data["binding.size"] = bindingSize
 	}
 
@@ -84,8 +84,8 @@ func (m *AnnotatedMatcher) Match(pattern *query.DataPattern, bindings Relations)
 		data["match.count"] = result.Size()
 
 		// Add symbol order information for rendering
-		symbolOrder := make([]string, len(result.Columns()))
-		for i, col := range result.Columns() {
+		symbolOrder := make([]string, len(result.Symbols()))
+		for i, col := range result.Symbols() {
 			symbolOrder[i] = col.String()
 		}
 		data["symbol.order"] = symbolOrder
@@ -112,16 +112,16 @@ func (m *AnnotatedMatcher) MatchWithConstraints(
 		start := time.Now()
 
 		// Collect binding information if present
-		var bindingColumns []string
+		var bindingSymbols []string
 		var bindingSize int
 
 		if bindings != nil && len(bindings) > 0 {
 			bindingRel := bindings.FindBestForPattern(pattern)
 			if bindingRel != nil {
-				bindingCols := bindingRel.Columns()
-				bindingColumns = make([]string, len(bindingCols))
-				for i, col := range bindingCols {
-					bindingColumns[i] = col.String()
+				bindingSyms := bindingRel.Symbols()
+				bindingSymbols = make([]string, len(bindingSyms))
+				for i, col := range bindingSyms {
+					bindingSymbols[i] = col.String()
 				}
 				bindingSize = bindingRel.Size()
 			}
@@ -138,16 +138,16 @@ func (m *AnnotatedMatcher) MatchWithConstraints(
 		data["success"] = err == nil
 
 		// Add binding information if it was present
-		if len(bindingColumns) > 0 {
-			data["binding.columns"] = bindingColumns
+		if len(bindingSymbols) > 0 {
+			data["binding.symbols"] = bindingSymbols
 			data["binding.size"] = bindingSize
 		}
 
 		if result != nil {
 			data["match.count"] = result.Size()
 
-			symbolOrder := make([]string, len(result.Columns()))
-			for i, col := range result.Columns() {
+			symbolOrder := make([]string, len(result.Symbols()))
+			for i, col := range result.Symbols() {
 				symbolOrder[i] = col.String()
 			}
 			data["symbol.order"] = symbolOrder

--- a/datalog/executor/annotated_matcher_test.go
+++ b/datalog/executor/annotated_matcher_test.go
@@ -269,9 +269,9 @@ func TestWrapMatcher_WithBindings(t *testing.T) {
 
 	event := capturedEvents[0]
 
-	bindingCols, ok := event.Data["binding.columns"].([]string)
+	bindingCols, ok := event.Data["binding.symbols"].([]string)
 	if !ok || len(bindingCols) != 1 || bindingCols[0] != "?x" {
-		t.Errorf("Expected binding.columns=[?x], got %v", event.Data["binding.columns"])
+		t.Errorf("Expected binding.symbols=[?x], got %v", event.Data["binding.symbols"])
 	}
 
 	if event.Data["binding.size"] != 3 {

--- a/datalog/executor/benchmark_test.go
+++ b/datalog/executor/benchmark_test.go
@@ -12,12 +12,12 @@ import (
 // Benchmark expression evaluation
 func BenchmarkExpressionEvaluation(b *testing.B) {
 	// Create test data
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 	tuples := make([]Tuple, 1000)
 	for i := 0; i < 1000; i++ {
 		tuples[i] = Tuple{int64(i), int64(i * 2), float64(i) * 1.5}
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	expr := &query.Expression{
 		Function: &query.ArithmeticFunction{
@@ -38,12 +38,12 @@ func BenchmarkExpressionEvaluation(b *testing.B) {
 // Benchmark aggregation operations
 func BenchmarkAggregation(b *testing.B) {
 	// Create test data with groups
-	columns := []query.Symbol{datalog.NewSymbol("?group"), datalog.NewSymbol("?value")}
+	symbols := []query.Symbol{datalog.NewSymbol("?group"), datalog.NewSymbol("?value")}
 	tuples := make([]Tuple, 10000)
 	for i := 0; i < 10000; i++ {
 		tuples[i] = Tuple{int64(i % 100), float64(i)}
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	b.Run("single_aggregation", func(b *testing.B) {
 		findElements := []query.FindElement{
@@ -128,7 +128,7 @@ func BenchmarkFullQuery(b *testing.B) {
 
 // Benchmark time-based aggregations
 func BenchmarkTimeAggregation(b *testing.B) {
-	columns := []query.Symbol{datalog.NewSymbol("?date"), datalog.NewSymbol("?value")}
+	symbols := []query.Symbol{datalog.NewSymbol("?date"), datalog.NewSymbol("?value")}
 	tuples := make([]Tuple, 1000)
 	baseTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 
@@ -138,7 +138,7 @@ func BenchmarkTimeAggregation(b *testing.B) {
 			float64(i * 10),
 		}
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	findElements := []query.FindElement{
 		query.FindAggregate{Function: "min", Arg: datalog.NewSymbol("?date")},

--- a/datalog/executor/bind_query_inputs_test.go
+++ b/datalog/executor/bind_query_inputs_test.go
@@ -47,14 +47,14 @@ func TestBindQueryInputs_TwoCollectionsCrossProduct(t *testing.T) {
 		attrTuples,
 	)
 
-	t.Logf("Entity relation - columns: %v, size: %d", entityRel.Columns(), entityRel.Size())
+	t.Logf("Entity relation - symbols: %v, size: %d", entityRel.Symbols(), entityRel.Size())
 	it := entityRel.Iterator()
 	for it.Next() {
 		t.Logf("  Entity tuple: %v", it.Tuple())
 	}
 	it.Close()
 
-	t.Logf("Attr relation - columns: %v, size: %d", attrRel.Columns(), attrRel.Size())
+	t.Logf("Attr relation - symbols: %v, size: %d", attrRel.Symbols(), attrRel.Size())
 	it = attrRel.Iterator()
 	for it.Next() {
 		t.Logf("  Attr tuple: %v", it.Tuple())
@@ -65,7 +65,7 @@ func TestBindQueryInputs_TwoCollectionsCrossProduct(t *testing.T) {
 	inputRelations := []Relation{entityRel, attrRel}
 	bound := BindQueryInputs(q, inputRelations)
 
-	t.Logf("Bound relation - columns: %v, size: %d", bound.Columns(), bound.Size())
+	t.Logf("Bound relation - symbols: %v, size: %d", bound.Symbols(), bound.Size())
 	it = bound.Iterator()
 	var tuples []Tuple
 	for it.Next() {
@@ -79,11 +79,11 @@ func TestBindQueryInputs_TwoCollectionsCrossProduct(t *testing.T) {
 	// Should have cross-product: 2 entities × 2 attrs = 4 tuples
 	assert.Len(t, tuples, 4, "should produce cross-product of 2×2=4 tuples")
 
-	// Verify columns
+	// Verify symbols
 	assert.Equal(t, []query.Symbol{
 		datalog.NewSymbol("?e"),
 		datalog.NewSymbol("?a"),
-	}, bound.Columns())
+	}, bound.Symbols())
 }
 
 // TestBindQueryInputs_EmptyCollectionReturnsEmpty verifies that an empty
@@ -103,7 +103,7 @@ func TestBindQueryInputs_EmptyCollectionReturnsEmpty(t *testing.T) {
 	inputRelations := []Relation{entityRel}
 	bound := BindQueryInputs(q, inputRelations)
 
-	t.Logf("Bound relation - columns: %v, size: %d", bound.Columns(), bound.Size())
+	t.Logf("Bound relation - symbols: %v, size: %d", bound.Symbols(), bound.Size())
 
 	// An empty collection should result in empty bound relation (0 results)
 	// because there are no values to match against
@@ -133,8 +133,8 @@ func TestBindQueryInputs_SingleCollection(t *testing.T) {
 	inputRelations := []Relation{entityRel}
 	bound := BindQueryInputs(q, inputRelations)
 
-	t.Logf("Bound relation - columns: %v, size: %d", bound.Columns(), bound.Size())
+	t.Logf("Bound relation - symbols: %v, size: %d", bound.Symbols(), bound.Size())
 
 	assert.Equal(t, 3, bound.Size(), "should have 3 tuples for 3 entities")
-	assert.Equal(t, []query.Symbol{datalog.NewSymbol("?e")}, bound.Columns())
+	assert.Equal(t, []query.Symbol{datalog.NewSymbol("?e")}, bound.Symbols())
 }

--- a/datalog/executor/buffered_iterator_test.go
+++ b/datalog/executor/buffered_iterator_test.go
@@ -270,10 +270,10 @@ func TestStreamingRelationWithBuffering(t *testing.T) {
 			{1, "alice", 100},
 			{2, "bob", 200},
 		}
-		columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score")}
+		symbols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score")}
 
 		source := newMockIterator(tuples)
-		rel := NewStreamingRelationWithOptions(columns, source, opts)
+		rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 		// Call Materialize() to enable multiple iterations
 		_ = rel.Materialize()
@@ -308,13 +308,13 @@ func TestStreamingRelationWithBuffering(t *testing.T) {
 
 	t.Run("EfficientIsEmpty", func(t *testing.T) {
 		tuples := []Tuple{{1, "alice"}}
-		columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name")}
+		symbols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name")}
 
 		source := newMockIterator(tuples)
 		// Use EnableTrueStreaming=true for this test since we're testing that IsEmpty() is efficient
 		// With true streaming, IsEmpty() returns false without consuming the iterator
 		streamingOpts := ExecutorOptions{EnableTrueStreaming: true}
-		rel := NewStreamingRelationWithOptions(columns, source, streamingOpts)
+		rel := NewStreamingRelationWithOptions(symbols, source, streamingOpts)
 
 		// IsEmpty should not trigger full materialization
 		assert.False(t, rel.IsEmpty())

--- a/datalog/executor/componentized_subquery_bench_test.go
+++ b/datalog/executor/componentized_subquery_bench_test.go
@@ -154,7 +154,7 @@ func BenchmarkSubqueryExecution(b *testing.B) {
 				b.Fatalf("Failed to execute query: %v", err)
 			}
 			if result.Size() != 10 {
-				b.Errorf("Expected 10 rows, got %d", result.Size())
+				b.Errorf("Expected 10 tuples, got %d", result.Size())
 			}
 		}
 	})
@@ -175,7 +175,7 @@ func BenchmarkSubqueryExecution(b *testing.B) {
 				b.Fatalf("Failed to execute query: %v", err)
 			}
 			if result.Size() != 10 {
-				b.Errorf("Expected 10 rows, got %d", result.Size())
+				b.Errorf("Expected 10 tuples, got %d", result.Size())
 			}
 		}
 	})
@@ -198,7 +198,7 @@ func BenchmarkSubqueryExecution(b *testing.B) {
 				b.Fatalf("Failed to execute query: %v", err)
 			}
 			if result.Size() != 10 {
-				b.Errorf("Expected 10 rows, got %d", result.Size())
+				b.Errorf("Expected 10 tuples, got %d", result.Size())
 			}
 		}
 	})
@@ -303,9 +303,9 @@ func BenchmarkSubqueryExecutionLarge(b *testing.B) {
 			if err != nil {
 				b.Fatalf("Failed to execute query: %v", err)
 			}
-			// Query groups by day, should have 50 rows (50 days) or less
+			// Query groups by day, should have 50 tuples (50 days) or less
 			if result.Size() < 1 {
-				b.Errorf("Expected at least 1 row, got %d", result.Size())
+				b.Errorf("Expected at least 1 tuple, got %d", result.Size())
 			}
 		}
 	})
@@ -326,9 +326,9 @@ func BenchmarkSubqueryExecutionLarge(b *testing.B) {
 			if err != nil {
 				b.Fatalf("Failed to execute query: %v", err)
 			}
-			// Query groups by day, should have 50 rows (50 days) or less
+			// Query groups by day, should have 50 tuples (50 days) or less
 			if result.Size() < 1 {
-				b.Errorf("Expected at least 1 row, got %d", result.Size())
+				b.Errorf("Expected at least 1 tuple, got %d", result.Size())
 			}
 		}
 	})

--- a/datalog/executor/conditional_aggregate_internal_test.go
+++ b/datalog/executor/conditional_aggregate_internal_test.go
@@ -12,15 +12,15 @@ import (
 // TestConditionalAggregateInternalInfrastructure tests the internal conditional aggregate
 // execution infrastructure (used by query rewriter, NOT exposed to users)
 func TestConditionalAggregateInternalInfrastructure(t *testing.T) {
-	// Create a simple relation with hour, filter, and value columns
-	columns := []query.Symbol{datalog.NewSymbol("?hour"), datalog.NewSymbol("?filter"), datalog.NewSymbol("?value")}
+	// Create a simple relation with hour, filter, and value symbols
+	symbols := []query.Symbol{datalog.NewSymbol("?hour"), datalog.NewSymbol("?filter"), datalog.NewSymbol("?value")}
 	tuples := []Tuple{
 		{int64(10), true, 100.0},
 		{int64(10), true, 102.0},
 		{int64(10), false, 105.0},
 		{int64(10), false, 103.0},
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// Create find elements with conditional aggregate (internal use only)
 	findElements := []query.FindElement{
@@ -28,7 +28,7 @@ func TestConditionalAggregateInternalInfrastructure(t *testing.T) {
 		query.FindAggregate{
 			Function:  "min",
 			Arg:       datalog.NewSymbol("?value"),
-			Predicate: datalog.NewSymbol("?filter"), // Internal: filter on this column
+			Predicate: datalog.NewSymbol("?filter"), // Internal: filter on this symbol
 		},
 	}
 
@@ -43,7 +43,7 @@ func TestConditionalAggregateInternalInfrastructure(t *testing.T) {
 
 	assert.True(t, it.Next())
 	tuple := it.Tuple()
-	assert.Equal(t, 2, len(tuple), "should have 2 columns: hour and min")
+	assert.Equal(t, 2, len(tuple), "should have 2 symbols: hour and min")
 	assert.Equal(t, int64(10), tuple[0], "hour should be 10")
 	assert.Equal(t, 100.0, tuple[1], "min should be 100.0 (only values where filter=true)")
 
@@ -54,13 +54,13 @@ func TestConditionalAggregateInternalInfrastructure(t *testing.T) {
 // empty result set when no tuples match the filter predicate (relational theory)
 func TestConditionalAggregateEmptyResult(t *testing.T) {
 	// Create relation where all filter values are false
-	columns := []query.Symbol{datalog.NewSymbol("?filter"), datalog.NewSymbol("?value")}
+	symbols := []query.Symbol{datalog.NewSymbol("?filter"), datalog.NewSymbol("?value")}
 	tuples := []Tuple{
 		{false, 10.0},
 		{false, 20.0},
 		{false, 30.0},
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// Conditional aggregate with filter that matches nothing
 	findElements := []query.FindElement{
@@ -74,21 +74,21 @@ func TestConditionalAggregateEmptyResult(t *testing.T) {
 	result := ExecuteAggregations(rel, findElements)
 
 	// Relational theory: empty input → empty output
-	// Should get zero rows (not one row with NULL)
+	// Should get zero tuples (not one tuple with NULL)
 	assert.Equal(t, 0, result.Size(), "expected empty result set when no tuples match filter")
 }
 
 // TestConditionalAggregateMixedTypes tests multiple aggregates with different predicates
 func TestConditionalAggregateMixedTypes(t *testing.T) {
-	// Create relation with multiple filter columns
-	columns := []query.Symbol{datalog.NewSymbol("?early"), datalog.NewSymbol("?late"), datalog.NewSymbol("?price")}
+	// Create relation with multiple filter symbols
+	symbols := []query.Symbol{datalog.NewSymbol("?early"), datalog.NewSymbol("?late"), datalog.NewSymbol("?price")}
 	tuples := []Tuple{
 		{true, false, 100.0}, // Early
 		{true, false, 102.0}, // Early
 		{false, true, 105.0}, // Late
 		{false, true, 103.0}, // Late
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// Two conditional aggregates with different predicates
 	findElements := []query.FindElement{

--- a/datalog/executor/context.go
+++ b/datalog/executor/context.go
@@ -400,30 +400,30 @@ func (c *AnnotatedContext) JoinRelations(left, right Relation, fn func() Relatio
 		data["amplification"] = float64(resultSize) / float64(leftSize+rightSize)
 	}
 
-	// Add columns being joined
+	// Add symbols being joined
 	if left != nil && right != nil {
-		data["left.columns"] = left.Columns()
-		data["right.columns"] = right.Columns()
+		data["left.symbols"] = left.Symbols()
+		data["right.symbols"] = right.Symbols()
 	}
 
 	// Add relation attributes for rendering
 	if left != nil {
-		leftAttrs := make([]string, len(left.Columns()))
-		for i, col := range left.Columns() {
+		leftAttrs := make([]string, len(left.Symbols()))
+		for i, col := range left.Symbols() {
 			leftAttrs[i] = col.String()
 		}
 		data["left.attrs"] = leftAttrs
 	}
 	if right != nil {
-		rightAttrs := make([]string, len(right.Columns()))
-		for i, col := range right.Columns() {
+		rightAttrs := make([]string, len(right.Symbols()))
+		for i, col := range right.Symbols() {
 			rightAttrs[i] = col.String()
 		}
 		data["right.attrs"] = rightAttrs
 	}
 	if result != nil {
-		resultAttrs := make([]string, len(result.Columns()))
-		for i, col := range result.Columns() {
+		resultAttrs := make([]string, len(result.Symbols()))
+		for i, col := range result.Symbols() {
 			resultAttrs[i] = col.String()
 		}
 		data["result.attrs"] = resultAttrs

--- a/datalog/executor/cse_test.go
+++ b/datalog/executor/cse_test.go
@@ -120,35 +120,35 @@ func TestCSEOpportunity(t *testing.T) {
 		t.Errorf("Expected 0 merged queries (pure aggregations not decorrelated), got %d", mergedQueryCount)
 	}
 
-	// Log columns for debugging
-	t.Logf("Result columns: %v", result.Columns())
+	// Log symbols for debugging
+	t.Logf("Result symbols: %v", result.Symbols())
 
 	// Verify actual result values
 	for i := 0; i < result.Size(); i++ {
-		row := result.Get(i)
+		tuple := result.Get(i)
 		if i == 0 {
-			t.Logf("First row: %v", row)
+			t.Logf("First tuple: %v", tuple)
 		}
 
-		name := row[0].(string)
+		name := tuple[0].(string)
 
 		// Aggregates return float64 for sum/count/avg
 		var val1, val2 float64
-		switch v := row[1].(type) {
+		switch v := tuple[1].(type) {
 		case int64:
 			val1 = float64(v)
 		case float64:
 			val1 = v
 		default:
-			t.Fatalf("Unexpected type for row[1]: %T", v)
+			t.Fatalf("Unexpected type for tuple[1]: %T", v)
 		}
-		switch v := row[2].(type) {
+		switch v := tuple[2].(type) {
 		case int64:
 			val2 = float64(v)
 		case float64:
 			val2 = v
 		default:
-			t.Fatalf("Unexpected type for row[2]: %T", v)
+			t.Fatalf("Unexpected type for tuple[2]: %T", v)
 		}
 
 		// Category A (0): products 0-9, prices 100-109, stock 0,5,10,15,20,25,30,35,40,45
@@ -161,7 +161,7 @@ func TestCSEOpportunity(t *testing.T) {
 
 		// Check which order they're in
 		if val1 == expectedTotalStock && val2 == expectedMaxPrice {
-			t.Logf("NOTE: Columns appear to be swapped (got stock, price instead of price, stock)")
+			t.Logf("NOTE: Symbols appear to be swapped (got stock, price instead of price, stock)")
 		}
 	}
 }

--- a/datalog/executor/datom_relation.go
+++ b/datalog/executor/datom_relation.go
@@ -9,31 +9,31 @@ import (
 type DatomIterator struct {
 	datoms  []datalog.Datom
 	pos     int
-	columns []query.Symbol
+	symbols []query.Symbol
 	pattern PatternBinding
 	current Tuple
 }
 
 func NewDatomIterator(datoms []datalog.Datom, binding PatternBinding) *DatomIterator {
-	// Build columns from binding
-	var columns []query.Symbol
+	// Build symbols from binding
+	var symbols []query.Symbol
 	if binding.EntitySym != nil {
-		columns = append(columns, *binding.EntitySym)
+		symbols = append(symbols, *binding.EntitySym)
 	}
 	if binding.AttributeSym != nil {
-		columns = append(columns, *binding.AttributeSym)
+		symbols = append(symbols, *binding.AttributeSym)
 	}
 	if binding.ValueSym != nil {
-		columns = append(columns, *binding.ValueSym)
+		symbols = append(symbols, *binding.ValueSym)
 	}
 	if binding.TxSym != nil {
-		columns = append(columns, *binding.TxSym)
+		symbols = append(symbols, *binding.TxSym)
 	}
 
 	return &DatomIterator{
 		datoms:  datoms,
 		pos:     -1,
-		columns: columns,
+		symbols: symbols,
 		pattern: binding,
 	}
 }
@@ -75,24 +75,24 @@ func (it *DatomIterator) Close() error {
 
 // NewDatomRelation creates a relation from datoms
 func NewDatomRelation(datoms []datalog.Datom, binding PatternBinding) Relation {
-	// Build columns from binding
-	var columns []query.Symbol
-	columnCount := 0
+	// Build symbols from binding
+	var symbols []query.Symbol
+	symbolCount := 0
 	if binding.EntitySym != nil {
-		columns = append(columns, *binding.EntitySym)
-		columnCount++
+		symbols = append(symbols, *binding.EntitySym)
+		symbolCount++
 	}
 	if binding.AttributeSym != nil {
-		columns = append(columns, *binding.AttributeSym)
-		columnCount++
+		symbols = append(symbols, *binding.AttributeSym)
+		symbolCount++
 	}
 	if binding.ValueSym != nil {
-		columns = append(columns, *binding.ValueSym)
-		columnCount++
+		symbols = append(symbols, *binding.ValueSym)
+		symbolCount++
 	}
 	if binding.TxSym != nil {
-		columns = append(columns, *binding.TxSym)
-		columnCount++
+		symbols = append(symbols, *binding.TxSym)
+		symbolCount++
 	}
 
 	// Pre-allocate tuples slice with exact capacity
@@ -101,7 +101,7 @@ func NewDatomRelation(datoms []datalog.Datom, binding PatternBinding) Relation {
 	// Build tuples directly without iterator overhead
 	for _, datom := range datoms {
 		// Pre-allocate tuple with exact size
-		tuple := make(Tuple, 0, columnCount)
+		tuple := make(Tuple, 0, symbolCount)
 
 		if binding.EntitySym != nil {
 			tuple = append(tuple, datom.E)
@@ -119,5 +119,5 @@ func NewDatomRelation(datoms []datalog.Datom, binding PatternBinding) Relation {
 		tuples = append(tuples, tuple)
 	}
 
-	return NewMaterializedRelation(columns, tuples)
+	return NewMaterializedRelation(symbols, tuples)
 }

--- a/datalog/executor/datom_test.go
+++ b/datalog/executor/datom_test.go
@@ -32,12 +32,12 @@ func TestDatomIterator(t *testing.T) {
 
 	it := NewDatomIterator(datoms, binding)
 
-	// Check columns
-	if len(it.columns) != 2 {
-		t.Errorf("expected 2 columns, got %d", len(it.columns))
+	// Check symbols
+	if len(it.symbols) != 2 {
+		t.Errorf("expected 2 symbols, got %d", len(it.symbols))
 	}
-	if it.columns[0] != userSym || it.columns[1] != valueSym {
-		t.Errorf("unexpected columns: %v", it.columns)
+	if it.symbols[0] != userSym || it.symbols[1] != valueSym {
+		t.Errorf("unexpected symbols: %v", it.symbols)
 	}
 
 	// Iterate and check tuples
@@ -97,10 +97,10 @@ func TestDatomRelation(t *testing.T) {
 
 	rel := NewDatomRelation(datoms, binding)
 
-	// Check columns
-	cols := rel.Columns()
+	// Check symbols
+	cols := rel.Symbols()
 	if len(cols) != 4 {
-		t.Errorf("expected 4 columns, got %d", len(cols))
+		t.Errorf("expected 4 symbols, got %d", len(cols))
 	}
 
 	// Check data
@@ -185,11 +185,11 @@ func TestDatomJoinScenario(t *testing.T) {
 		it.Close()
 	}
 
-	// Verify columns
-	cols := joined.Columns()
+	// Verify symbols
+	cols := joined.Symbols()
 	expectedCols := []query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age")}
 	if len(cols) != len(expectedCols) {
-		t.Errorf("expected %d columns, got %d", len(expectedCols), len(cols))
+		t.Errorf("expected %d symbols, got %d", len(expectedCols), len(cols))
 	}
 
 	// Check actual data

--- a/datalog/executor/decorrelation_end_to_end_test.go
+++ b/datalog/executor/decorrelation_end_to_end_test.go
@@ -87,11 +87,11 @@ func TestDecorrelationEndToEnd(t *testing.T) {
 		t.Fatalf("query execution failed: %v", err)
 	}
 
-	// Check columns
+	// Check symbols
 	expectedCols := []query.Symbol{datalog.NewSymbol("?hour"), datalog.NewSymbol("?high"), datalog.NewSymbol("?low")}
-	if !columnsEqualTest(result.Columns(), expectedCols) {
-		t.Errorf("column mismatch:\n  got=%v\n  want=%v",
-			result.Columns(), expectedCols)
+	if !columnsEqualTest(result.Symbols(), expectedCols) {
+		t.Errorf("symbol mismatch:\n  got=%v\n  want=%v",
+			result.Symbols(), expectedCols)
 	}
 
 	// Check results
@@ -182,7 +182,7 @@ func columnsEqualTest(a, b []query.Symbol) bool {
 }
 
 func dumpRelationTest(t *testing.T, rel Relation) {
-	t.Logf("Relation columns: %v", rel.Columns())
+	t.Logf("Relation symbols: %v", rel.Symbols())
 	it := rel.Iterator()
 	defer it.Close()
 	count := 0

--- a/datalog/executor/decorrelation_executor.go
+++ b/datalog/executor/decorrelation_executor.go
@@ -375,7 +375,7 @@ func (e *DefaultQueryExecutor) executeWithDecorrelation(ctx Context, q *query.Qu
 	groupsHaveSymbols := make([][]bool, len(groups))
 	for i, group := range groups {
 		groupsHaveSymbols[i] = make([]bool, len(findVars))
-		cols := group.Columns()
+		cols := group.Symbols()
 		for j, sym := range findVars {
 			for _, col := range cols {
 				if col == sym {
@@ -456,8 +456,8 @@ func (e *DefaultQueryExecutor) executeBatchedGroup(
 		results := make(map[int]Relation)
 		for _, subqIdx := range batchGroup.Indices {
 			subq := subqueries[subqIdx]
-			columns := extractBindingSymbols(subq.Binding)
-			results[subqIdx] = NewMaterializedRelation(columns, []Tuple{})
+			symbols := extractBindingSymbols(subq.Binding)
+			results[subqIdx] = NewMaterializedRelation(symbols, []Tuple{})
 		}
 		return results, nil
 	}
@@ -526,19 +526,19 @@ func combineGroups(groups []Relation) Relation {
 
 // createBatchedInputRelation creates a relation containing all input combinations
 func createBatchedInputRelation(inputSymbols []query.Symbol, combinations []map[query.Symbol]interface{}) Relation {
-	// Filter out source markers from columns
-	var columns []query.Symbol
+	// Filter out source markers from symbols
+	var symbols []query.Symbol
 	for _, sym := range inputSymbols {
 		if !sym.IsSource() {
-			columns = append(columns, sym)
+			symbols = append(symbols, sym)
 		}
 	}
 
 	// Build tuples from all combinations
 	var tuples []Tuple
 	for _, values := range combinations {
-		tuple := make(Tuple, len(columns))
-		for i, col := range columns {
+		tuple := make(Tuple, len(symbols))
+		for i, col := range symbols {
 			if val, ok := values[col]; ok {
 				tuple[i] = val
 			}
@@ -546,7 +546,7 @@ func createBatchedInputRelation(inputSymbols []query.Symbol, combinations []map[
 		tuples = append(tuples, tuple)
 	}
 
-	return NewMaterializedRelation(columns, tuples)
+	return NewMaterializedRelation(symbols, tuples)
 }
 
 // canUseBatchedInput checks if a subquery can accept batched RelationInput
@@ -596,9 +596,9 @@ func (e *DefaultQueryExecutor) executeBatchedSubquery(
 
 	// For batched execution, we expect a single result group
 	if len(nestedGroups) == 0 {
-		// Empty result - return empty relation with appropriate columns
-		columns := extractBindingSymbols(subq.Binding)
-		return NewMaterializedRelation(columns, []Tuple{}), nil
+		// Empty result - return empty relation with appropriate symbols
+		symbols := extractBindingSymbols(subq.Binding)
+		return NewMaterializedRelation(symbols, []Tuple{}), nil
 	}
 	if len(nestedGroups) > 1 {
 		return nil, fmt.Errorf("batched subquery returned %d disjoint groups - expected 1", len(nestedGroups))
@@ -607,7 +607,7 @@ func (e *DefaultQueryExecutor) executeBatchedSubquery(
 	nestedResult := nestedGroups[0]
 
 	// For batched execution, apply binding form with empty input values
-	// The result should already have all rows with correlation columns
+	// The result should already have all tuples with correlation symbols
 	boundResult, err := applyBindingFormBatched(nestedResult, subq.Binding, inputSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("batched binding form application failed: %w", err)
@@ -618,8 +618,8 @@ func (e *DefaultQueryExecutor) executeBatchedSubquery(
 
 // applyBindingFormBatched applies binding form to batched subquery results
 func applyBindingFormBatched(result Relation, binding query.BindingForm, inputSymbols []query.Symbol) (Relation, error) {
-	// For batched execution, the result already contains correlation columns
-	// We just need to ensure column ordering is correct
+	// For batched execution, the result already contains correlation symbols
+	// We just need to ensure symbol ordering is correct
 	switch binding.(type) {
 	case query.TupleBinding:
 		// For batched TupleBinding, result should have [correlation_vars..., binding_vars...]

--- a/datalog/executor/decorrelation_integration_test.go
+++ b/datalog/executor/decorrelation_integration_test.go
@@ -181,7 +181,7 @@ func TestHourlyOHLCDecorrelation(t *testing.T) {
 
 	t.Logf("Sequential execution: %d results", resultNoDecor.Size())
 	for i := 0; i < resultNoDecor.Size(); i++ {
-		t.Logf("  Row %d: %v", i, resultNoDecor.Get(i))
+		t.Logf("  Tuple %d: %v", i, resultNoDecor.Get(i))
 	}
 
 	// Execute with decorrelation ENABLED (with parallel execution)
@@ -211,20 +211,20 @@ func TestHourlyOHLCDecorrelation(t *testing.T) {
 		t.Errorf("Expected 3 hours, got %d", resultWithDecor.Size())
 	}
 
-	// Verify each row matches
+	// Verify each tuple matches
 	for i := 0; i < resultWithDecor.Size(); i++ {
 		rowDecor := resultWithDecor.Get(i)
 		rowNoDecor := resultNoDecor.Get(i)
 
 		if len(rowDecor) != len(rowNoDecor) {
-			t.Errorf("Row %d column count mismatch: decorrelated=%d, sequential=%d",
+			t.Errorf("Tuple %d symbol count mismatch: decorrelated=%d, sequential=%d",
 				i, len(rowDecor), len(rowNoDecor))
 			continue
 		}
 
 		for j := range rowDecor {
 			if rowDecor[j] != rowNoDecor[j] {
-				t.Errorf("Row %d, col %d mismatch: decorrelated=%v, sequential=%v",
+				t.Errorf("Tuple %d, col %d mismatch: decorrelated=%v, sequential=%v",
 					i, j, rowDecor[j], rowNoDecor[j])
 			}
 		}

--- a/datalog/executor/decorrelation_ohlc_symbol_order_test.go
+++ b/datalog/executor/decorrelation_ohlc_symbol_order_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/planner"
 )
 
-// TestOHLCColumnOrderBug reproduces the gopher-street column ordering bug
+// TestOHLCColumnOrderBug reproduces the gopher-street symbol ordering bug
 // with a realistic OHLC query pattern
 func TestOHLCColumnOrderBug(t *testing.T) {
 	// Create realistic OHLC data: 3 bars for one day
@@ -181,7 +181,7 @@ func TestOHLCColumnOrderBug(t *testing.T) {
 		}
 
 		if len(tuple) != 6 {
-			t.Fatalf("Expected 6 columns, got %d", len(tuple))
+			t.Fatalf("Expected 6 symbols, got %d", len(tuple))
 		}
 
 		// Verify :find clause order: ?date ?open-price ?daily-high ?daily-low ?close-price ?total-volume
@@ -266,7 +266,7 @@ func TestOHLCColumnOrderBug(t *testing.T) {
 
 		// Just verify it returns the same values as parallel (in correct order)
 		if len(tuple) != 6 {
-			t.Fatalf("Expected 6 columns, got %d", len(tuple))
+			t.Fatalf("Expected 6 symbols, got %d", len(tuple))
 		}
 
 		// Should match parallel results exactly

--- a/datalog/executor/decorrelation_symbol_order_test.go
+++ b/datalog/executor/decorrelation_symbol_order_test.go
@@ -130,7 +130,7 @@ func TestParallelDecorrelationColumnOrder(t *testing.T) {
 		// Which should be: [date_string, 101.50 (max high), 99.50 (min low), 1000000 (sum volume)]
 
 		if len(tuple) != 4 {
-			t.Fatalf("Expected 4 columns, got %d: %v", len(tuple), tuple)
+			t.Fatalf("Expected 4 symbols, got %d: %v", len(tuple), tuple)
 		}
 
 		// Log what we actually got
@@ -202,7 +202,7 @@ func TestParallelDecorrelationColumnOrder(t *testing.T) {
 
 		// Verify tuple order matches :find clause
 		if len(tuple) != 4 {
-			t.Fatalf("Expected 4 columns, got %d: %v", len(tuple), tuple)
+			t.Fatalf("Expected 4 symbols, got %d: %v", len(tuple), tuple)
 		}
 
 		// Log what we actually got

--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -190,7 +190,7 @@ func (e *Executor) ExecuteWithRelations(ctx Context, q *query.Query, inputRelati
 //
 // Key semantics:
 // - Each phase executes as independent Query returning []Relation (disjoint groups)
-// - Groups are projected to Keep columns and passed to next phase
+// - Groups are projected to Keep symbols and passed to next phase
 // - Final phase must collapse to single relation or error on Cartesian product
 func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inputRelations []Relation) (Relation, error) {
 	// Check if we need to iterate over a RelationInput
@@ -232,9 +232,9 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 		if len(allConstBindable) > 0 {
 			// Extract constant values from the bound input relation
 			boundRel := currentGroups[0]
-			cols := boundRel.Columns()
+			cols := boundRel.Symbols()
 
-			// Find column indices for constant-bindable symbols
+			// Find symbol indices for constant-bindable symbols
 			constValues := make(map[query.Symbol]interface{})
 			constColIndices := make(map[int]bool)
 			for i, col := range cols {
@@ -243,7 +243,7 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 				}
 			}
 
-			// Read first tuple to get the constant values (scalar inputs have exactly 1 row)
+			// Read first tuple to get the constant values (scalar inputs have exactly 1 tuple)
 			if len(constColIndices) > 0 {
 				it := boundRel.Iterator()
 				if it.Next() {
@@ -259,7 +259,7 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 				if len(constValues) > 0 {
 					queryExecutor.constantBindings = constValues
 
-					// Project out constant columns from the bound relation
+					// Project out constant symbols from the bound relation
 					var keepCols []query.Symbol
 					for i, col := range cols {
 						if !constColIndices[i] {
@@ -268,16 +268,16 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 					}
 
 					if len(keepCols) == 0 {
-						// All columns were constants — no input relation needed
+						// All symbols were constants — no input relation needed
 						currentGroups = nil
 					} else if len(keepCols) < len(cols) {
-						// Re-materialize without constant columns
+						// Re-materialize without constant symbols
 						projected, err := boundRel.Materialize().Project(keepCols)
 						if err == nil {
 							currentGroups = []Relation{projected}
 						}
 					}
-					// else: no constant columns to remove (shouldn't happen but safe)
+					// else: no constant symbols to remove (shouldn't happen but safe)
 				}
 			}
 		}
@@ -343,7 +343,7 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 			})
 		}
 
-		// Project each group to Keep columns (what passes to next phase)
+		// Project each group to Keep symbols (what passes to next phase)
 		// Skip for last phase - QueryExecutor already projected to :find symbols
 		if !isLastPhase && len(phase.Keep) > 0 {
 			for i, group := range groups {
@@ -353,7 +353,7 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 				collectTuplesInto(&tuples, group)
 
 				opts := group.Options()
-				materialized := NewMaterializedRelationWithOptions(group.Columns(), tuples, opts)
+				materialized := NewMaterializedRelationWithOptions(group.Symbols(), tuples, opts)
 
 				projected, err := materialized.Project(phase.Keep)
 				if err != nil {
@@ -429,7 +429,7 @@ func (e *Executor) executeRealizedWithRelationInputIteration(ctx Context, plan *
 
 	if iterationRelation == nil || iterationRelation.Size() == 0 {
 		// No iteration needed or empty input
-		return NewMaterializedRelation(extractFindColumns(plan.Query.Find), []Tuple{}), nil
+		return NewMaterializedRelation(extractFindSymbols(plan.Query.Find), []Tuple{}), nil
 	}
 
 	// Dispatch to parallel or sequential implementation
@@ -482,18 +482,18 @@ func (e *Executor) executeRealizedWithRelationInputIterationSequential(
 
 	// Combine all results
 	if len(allResults) == 0 {
-		return NewMaterializedRelation(extractFindColumns(plan.Query.Find), []Tuple{}), nil
+		return NewMaterializedRelation(extractFindSymbols(plan.Query.Find), []Tuple{}), nil
 	}
 
 	// Union all results
 	var allTuples []Tuple
-	columns := allResults[0].Columns()
+	symbols := allResults[0].Symbols()
 
 	for _, rel := range allResults {
 		collectTuplesInto(&allTuples, rel)
 	}
 
-	return NewMaterializedRelation(columns, allTuples), nil
+	return NewMaterializedRelation(symbols, allTuples), nil
 }
 
 // executeRealizedWithRelationInputIterationParallel executes QueryExecutor path in parallel for RelationInput
@@ -515,7 +515,7 @@ func (e *Executor) executeRealizedWithRelationInputIterationParallel(
 	collectTuplesInto(&tuples, iterationRelation)
 
 	if len(tuples) == 0 {
-		return NewMaterializedRelation(extractFindColumns(plan.Query.Find), []Tuple{}), nil
+		return NewMaterializedRelation(extractFindSymbols(plan.Query.Find), []Tuple{}), nil
 	}
 
 	// Result collection with mutex for thread safety
@@ -575,18 +575,18 @@ func (e *Executor) executeRealizedWithRelationInputIterationParallel(
 
 	// Combine all results
 	if len(allResults) == 0 {
-		return NewMaterializedRelation(extractFindColumns(plan.Query.Find), []Tuple{}), nil
+		return NewMaterializedRelation(extractFindSymbols(plan.Query.Find), []Tuple{}), nil
 	}
 
 	// Union all results
 	var allTuples []Tuple
-	columns := allResults[0].Columns()
+	symbols := allResults[0].Symbols()
 
 	for _, rel := range allResults {
 		collectTuplesInto(&allTuples, rel)
 	}
 
-	return NewMaterializedRelation(columns, allTuples), nil
+	return NewMaterializedRelation(symbols, allTuples), nil
 }
 
 // executeRealizedNonIterating executes a RealizedPlan without RelationInput iteration
@@ -636,7 +636,7 @@ func (e *Executor) executeRealizedNonIterating(
 			return nil, fmt.Errorf("phase %d failed: %w", phaseIndex+1, err)
 		}
 
-		// Project each group to Keep columns (what passes to next phase)
+		// Project each group to Keep symbols (what passes to next phase)
 		// Skip for last phase - QueryExecutor already projected to :find symbols
 		if !isLastPhase && len(phase.Keep) > 0 {
 			for i, group := range groups {
@@ -645,7 +645,7 @@ func (e *Executor) executeRealizedNonIterating(
 				collectTuplesInto(&tuples, group)
 
 				opts := group.Options()
-				materialized := NewMaterializedRelationWithOptions(group.Columns(), tuples, opts)
+				materialized := NewMaterializedRelationWithOptions(group.Symbols(), tuples, opts)
 
 				projected, err := materialized.Project(phase.Keep)
 				if err != nil {

--- a/datalog/executor/executor_aggregate_test.go
+++ b/datalog/executor/executor_aggregate_test.go
@@ -193,7 +193,7 @@ func TestAggregateMixedWithNonAggregated(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
-	// Should have 2 rows (Electronics and Books)
+	// Should have 2 tuples (Electronics and Books)
 	assert.Equal(t, 2, result.Size())
 
 	// Check results

--- a/datalog/executor/executor_sorting_test.go
+++ b/datalog/executor/executor_sorting_test.go
@@ -54,7 +54,7 @@ func TestQueryWithOrderBy(t *testing.T) {
 	tests := []struct {
 		name     string
 		query    string
-		expected []string // Expected first column values in order
+		expected []string // Expected first symbol values in order
 	}{
 		{
 			name: "Sort by name ascending",
@@ -97,7 +97,7 @@ func TestQueryWithOrderBy(t *testing.T) {
 			expected: []string{"Bob", "Alice", "Charlie", "Dave"},
 		},
 		{
-			name: "Multi-column sort: age then name",
+			name: "Multi-symbol sort: age then name",
 			query: `[:find ?name ?age ?score
 			         :where [?e :user/name ?name]
 			                [?e :user/age ?age]
@@ -131,7 +131,7 @@ func TestQueryWithOrderBy(t *testing.T) {
 				tuple := result.Get(i)
 				name := tuple[0].(string)
 				if name != tt.expected[i] {
-					t.Errorf("row %d: expected %s, got %s", i, tt.expected[i], name)
+					t.Errorf("tuple %d: expected %s, got %s", i, tt.expected[i], name)
 				}
 			}
 		})
@@ -157,7 +157,7 @@ func TestSortingEdgeCases(t *testing.T) {
 			},
 		},
 		{
-			name: "Sort with missing sort column",
+			name: "Sort with missing sort symbol",
 			query: `[:find ?name
 			         :where [?e :user/name ?name]
 			         :order-by [[?age :asc]]]`, // ?age not in find
@@ -166,7 +166,7 @@ func TestSortingEdgeCases(t *testing.T) {
 			},
 		},
 		{
-			name: "Sort single row",
+			name: "Sort single tuple",
 			query: `[:find ?name ?age
 			         :where [?e :user/name ?name]
 			                [?e :user/age ?age]
@@ -186,7 +186,7 @@ func TestSortingEdgeCases(t *testing.T) {
 			// Parse query
 			q, err := parser.ParseQuery(tt.query)
 			if err != nil {
-				// Some edge cases might have parse errors (like missing sort column)
+				// Some edge cases might have parse errors (like missing sort symbol)
 				// That's OK for testing error handling
 				return
 			}

--- a/datalog/executor/executor_subquery_comprehensive_test.go
+++ b/datalog/executor/executor_subquery_comprehensive_test.go
@@ -51,7 +51,7 @@ func TestSubqueryWithNoResults(t *testing.T) {
 	}
 }
 
-// TestSubqueryWithRelationBinding tests subquery that returns multiple rows
+// TestSubqueryWithRelationBinding tests subquery that returns multiple tuples
 func TestSubqueryWithRelationBinding(t *testing.T) {
 	matcher := &MockPatternMatcher{
 		data: map[string][]datalog.Datom{
@@ -116,7 +116,7 @@ func TestSubqueryWithRelationBinding(t *testing.T) {
 	}
 }
 
-// TestSubqueryWithMultipleOuterRows tests subquery executed for multiple outer rows
+// TestSubqueryWithMultipleOuterRows tests subquery executed for multiple outer tuples
 func TestSubqueryWithMultipleOuterRows(t *testing.T) {
 	matcher := &MockPatternMatcher{
 		data: map[string][]datalog.Datom{
@@ -420,8 +420,8 @@ func TestSubqueryErrorHandling(t *testing.T) {
 			           [(q [:find ?salary
 			                :in $ ?emp
 			                :where [?emp :employee/salary ?salary]]
-			               $ ?e) [[?a ?b ?c] ...]]]`, // Expects 3 columns but query returns 1
-			wantErr: "relation binding expects 3 columns, got 1",
+			               $ ?e) [[?a ?b ?c] ...]]]`, // Expects 3 symbols but query returns 1
+			wantErr: "relation binding expects 3 symbols, got 1",
 		},
 	}
 

--- a/datalog/executor/executor_test.go
+++ b/datalog/executor/executor_test.go
@@ -384,14 +384,14 @@ func TestResultMethods(t *testing.T) {
 	}
 
 	// Test ColumnIndex
-	if idx := result.ColumnIndex(datalog.NewSymbol("?name")); idx != 0 {
+	if idx := result.SymbolIndex(datalog.NewSymbol("?name")); idx != 0 {
 		t.Errorf("expected index 0 for ?name, got %d", idx)
 	}
-	if idx := result.ColumnIndex(datalog.NewSymbol("?age")); idx != 1 {
+	if idx := result.SymbolIndex(datalog.NewSymbol("?age")); idx != 1 {
 		t.Errorf("expected index 1 for ?age, got %d", idx)
 	}
-	if idx := result.ColumnIndex(datalog.NewSymbol("?missing")); idx != -1 {
-		t.Errorf("expected index -1 for missing column, got %d", idx)
+	if idx := result.SymbolIndex(datalog.NewSymbol("?missing")); idx != -1 {
+		t.Errorf("expected index -1 for missing symbol, got %d", idx)
 	}
 
 	// Test GetValue
@@ -402,9 +402,9 @@ func TestResultMethods(t *testing.T) {
 		t.Errorf("expected 25, got %v", val)
 	}
 	if _, ok := result.GetValue(0, datalog.NewSymbol("?missing")); ok {
-		t.Error("expected false for missing column")
+		t.Error("expected false for missing symbol")
 	}
 	if _, ok := result.GetValue(2, datalog.NewSymbol("?name")); ok {
-		t.Error("expected false for out of bounds row")
+		t.Error("expected false for out of bounds tuple")
 	}
 }

--- a/datalog/executor/executor_utils.go
+++ b/datalog/executor/executor_utils.go
@@ -54,22 +54,24 @@ func injectConditionalAggregates(findClause []query.FindElement, condAggs []plan
 	return result
 }
 
-func extractFindColumns(findElements []query.FindElement) []query.Symbol {
-	var columns []query.Symbol
+func extractFindSymbols(findElements []query.FindElement) []query.Symbol {
+	var symbols []query.Symbol
 	for _, elem := range findElements {
 		switch e := elem.(type) {
 		case query.FindVariable:
-			columns = append(columns, e.Symbol)
+			symbols = append(symbols, e.Symbol)
 		case query.FindAggregate:
-			columns = append(columns, datalog.NewSymbol(e.String()))
+			symbols = append(symbols, datalog.NewSymbol(e.String()))
+		case query.FindPull:
+			symbols = append(symbols, e.Variable)
 		}
 	}
-	return columns
+	return symbols
 }
 
-// MaterializeResult converts a streaming relation to a materialized result with the specified columns.
+// MaterializeResult converts a streaming relation to a materialized result with the specified symbols.
 // This is a pure function that collects all tuples from the iterator into memory.
-func MaterializeResult(rel Relation, columns []query.Symbol) Relation {
+func MaterializeResult(rel Relation, symbols []query.Symbol) Relation {
 	var tuples []Tuple
 	collectTuplesInto(&tuples, rel)
 
@@ -91,7 +93,7 @@ func MaterializeResult(rel Relation, columns []query.Symbol) Relation {
 
 	// Extract options from source relation to preserve configuration
 	opts := rel.Options()
-	return NewMaterializedRelationWithOptions(columns, tuples, opts)
+	return NewMaterializedRelationWithOptions(symbols, tuples, opts)
 }
 
 // Result is deprecated - use Relation instead.
@@ -99,20 +101,20 @@ func MaterializeResult(rel Relation, columns []query.Symbol) Relation {
 type Result = MaterializedRelation
 
 // SortRelation sorts a relation according to the order-by clauses.
-// This is a pure function that performs multi-column sorting with configurable direction.
+// This is a pure function that performs multi-symbol sorting with configurable direction.
 // It materializes the relation if not already materialized.
 func SortRelation(rel Relation, orderBy []query.OrderByClause) Relation {
 	// Materialize if not already materialized
 	var tuples []Tuple
 	collectTuplesInto(&tuples, rel)
 
-	// Get column indices for sort variables
-	columns := rel.Columns()
+	// Get symbol indices for sort variables
+	symbols := rel.Symbols()
 	sortIndices := make([]int, len(orderBy))
 	for i, clause := range orderBy {
 		idx := -1
-		for j, col := range columns {
-			if col == clause.Variable {
+		for j, sym := range symbols {
+			if sym == clause.Variable {
 				idx = j
 				break
 			}
@@ -144,10 +146,10 @@ func SortRelation(rel Relation, orderBy []query.OrderByClause) Relation {
 	})
 
 	opts := rel.Options()
-	return NewMaterializedRelationWithOptions(columns, tuples, opts)
+	return NewMaterializedRelationWithOptions(symbols, tuples, opts)
 }
 
-// computeAggregate computes an aggregate over all values in a column
+// computeAggregate computes an aggregate over all values in a symbol
 func computeAggregate(rel Relation, colIdx int, function string) interface{} {
 	var values []interface{}
 
@@ -273,12 +275,12 @@ func BindQueryInputs(q *query.Query, inputRelations []Relation) Relation {
 			continue
 
 		case query.ScalarInput:
-			// Single value input - expect a relation with one column and one row
+			// Single value input - expect a relation with one symbol and one tuple
 			if relationIndex < len(inputRelations) {
 				rel := inputRelations[relationIndex]
 				if rel.Size() > 0 {
-					// Create a new relation with the input symbol as column name
-					columns := []query.Symbol{inp.Symbol}
+					// Create a new relation with the input symbol as symbol name
+					symbols := []query.Symbol{inp.Symbol}
 					tuples := make([]Tuple, 0, rel.Size())
 
 					it := rel.Iterator()
@@ -292,17 +294,17 @@ func BindQueryInputs(q *query.Query, inputRelations []Relation) Relation {
 					it.Close()
 
 					opts := rel.Options()
-					boundRelations = append(boundRelations, NewMaterializedRelationWithOptions(columns, tuples, opts))
+					boundRelations = append(boundRelations, NewMaterializedRelationWithOptions(symbols, tuples, opts))
 				}
 				relationIndex++
 			}
 
 		case query.RelationInput:
-			// Multiple tuples input - use the relation directly with renamed columns
+			// Multiple tuples input - use the relation directly with renamed symbols
 			if relationIndex < len(inputRelations) {
 				rel := inputRelations[relationIndex]
-				if rel.Size() > 0 && len(inp.Symbols) == len(rel.Columns()) {
-					// Create a new relation with the input variables as column names
+				if rel.Size() > 0 && len(inp.Symbols) == len(rel.Symbols()) {
+					// Create a new relation with the input variables as symbol names
 					tuples := make([]Tuple, 0, rel.Size())
 					collectTuplesInto(&tuples, rel)
 
@@ -313,10 +315,10 @@ func BindQueryInputs(q *query.Query, inputRelations []Relation) Relation {
 			}
 
 		case query.TupleInput:
-			// Single tuple input - expect a relation with one row
+			// Single tuple input - expect a relation with one tuple
 			if relationIndex < len(inputRelations) {
 				rel := inputRelations[relationIndex]
-				if rel.Size() > 0 && len(inp.Symbols) == len(rel.Columns()) {
+				if rel.Size() > 0 && len(inp.Symbols) == len(rel.Symbols()) {
 					// Take the first tuple and bind to variables
 					it := rel.Iterator()
 					if it.Next() {
@@ -331,12 +333,12 @@ func BindQueryInputs(q *query.Query, inputRelations []Relation) Relation {
 			}
 
 		case query.CollectionInput:
-			// Collection input - all values in one column
+			// Collection input - all values in one symbol
 			// IMPORTANT: Always add the collection relation, even if empty.
 			// An empty collection should produce 0 results when joined.
 			if relationIndex < len(inputRelations) {
 				rel := inputRelations[relationIndex]
-				columns := []query.Symbol{inp.Symbol}
+				symbols := []query.Symbol{inp.Symbol}
 				tuples := make([]Tuple, 0, rel.Size())
 
 				it := rel.Iterator()
@@ -350,7 +352,7 @@ func BindQueryInputs(q *query.Query, inputRelations []Relation) Relation {
 				it.Close()
 
 				opts := rel.Options()
-				boundRelations = append(boundRelations, NewMaterializedRelationWithOptions(columns, tuples, opts))
+				boundRelations = append(boundRelations, NewMaterializedRelationWithOptions(symbols, tuples, opts))
 				relationIndex++
 			}
 		}

--- a/datalog/executor/filter.go
+++ b/datalog/executor/filter.go
@@ -13,7 +13,7 @@ type Filter interface {
 	RequiredSymbols() []query.Symbol
 
 	// Evaluate returns true if the tuple passes the filter
-	Evaluate(tuple Tuple, columns []query.Symbol) bool
+	Evaluate(tuple Tuple, symbols []query.Symbol) bool
 
 	// String returns a string representation of the filter
 	String() string
@@ -30,11 +30,11 @@ func (f ComparisonFilter) RequiredSymbols() []query.Symbol {
 	return []query.Symbol{f.Symbol}
 }
 
-func (f ComparisonFilter) Evaluate(tuple Tuple, columns []query.Symbol) bool {
-	// Find the column index
+func (f ComparisonFilter) Evaluate(tuple Tuple, symbols []query.Symbol) bool {
+	// Find the symbol index
 	idx := -1
-	for i, col := range columns {
-		if col == f.Symbol {
+	for i, sym := range symbols {
+		if sym == f.Symbol {
 			idx = i
 			break
 		}
@@ -62,16 +62,16 @@ func (f BinaryFilter) RequiredSymbols() []query.Symbol {
 	return []query.Symbol{f.Left, f.Right}
 }
 
-func (f BinaryFilter) Evaluate(tuple Tuple, columns []query.Symbol) bool {
-	// Find column indices
+func (f BinaryFilter) Evaluate(tuple Tuple, symbols []query.Symbol) bool {
+	// Find symbol indices
 	leftIdx := -1
 	rightIdx := -1
 
-	for i, col := range columns {
-		if col == f.Left {
+	for i, sym := range symbols {
+		if sym == f.Left {
 			leftIdx = i
 		}
-		if col == f.Right {
+		if sym == f.Right {
 			rightIdx = i
 		}
 	}
@@ -94,25 +94,25 @@ type VariadicFilter struct {
 }
 
 func (f VariadicFilter) RequiredSymbols() []query.Symbol {
-	var symbols []query.Symbol
+	var syms []query.Symbol
 	for _, arg := range f.Args {
 		if v, ok := arg.(query.Variable); ok {
-			symbols = append(symbols, v.Name)
+			syms = append(syms, v.Name)
 		}
 	}
-	return symbols
+	return syms
 }
 
-func (f VariadicFilter) Evaluate(tuple Tuple, columns []query.Symbol) bool {
+func (f VariadicFilter) Evaluate(tuple Tuple, symbols []query.Symbol) bool {
 	// Resolve all arguments to values
 	values := make([]interface{}, len(f.Args))
 	for i, arg := range f.Args {
 		switch a := arg.(type) {
 		case query.Variable:
-			// Find the column index
+			// Find the symbol index
 			idx := -1
-			for j, col := range columns {
-				if col == a.Name {
+			for j, sym := range symbols {
+				if sym == a.Name {
 					idx = j
 					break
 				}
@@ -149,24 +149,24 @@ func (f VariadicFilter) String() string {
 // FilterRelation applies a filter to a relation
 func FilterRelation(rel Relation, filter Filter) Relation {
 	// Check if all required symbols are present
-	cols := rel.Columns()
+	syms := rel.Symbols()
 	for _, sym := range filter.RequiredSymbols() {
 		found := false
-		for _, col := range cols {
-			if col == sym {
+		for _, s := range syms {
+			if s == sym {
 				found = true
 				break
 			}
 		}
 		if !found {
 			// Missing required symbol - return empty relation
-			return NewMaterializedRelation(cols, nil)
+			return NewMaterializedRelation(syms, nil)
 		}
 	}
 
 	// Apply filter
 	predFunc := func(tuple Tuple) bool {
-		return filter.Evaluate(tuple, cols)
+		return filter.Evaluate(tuple, syms)
 	}
 
 	return Select(rel, predFunc)

--- a/datalog/executor/filter_test.go
+++ b/datalog/executor/filter_test.go
@@ -12,7 +12,7 @@ func TestComparisonFilter(t *testing.T) {
 		name     string
 		filter   ComparisonFilter
 		tuple    Tuple
-		columns  []query.Symbol
+		symbols  []query.Symbol
 		expected bool
 	}{
 		{
@@ -23,7 +23,7 @@ func TestComparisonFilter(t *testing.T) {
 				Value:    int64(30),
 			},
 			tuple:    Tuple{int64(25)},
-			columns:  []query.Symbol{datalog.NewSymbol("?age")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?age")},
 			expected: true,
 		},
 		{
@@ -34,7 +34,7 @@ func TestComparisonFilter(t *testing.T) {
 				Value:    int64(30),
 			},
 			tuple:    Tuple{int64(35)},
-			columns:  []query.Symbol{datalog.NewSymbol("?age")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?age")},
 			expected: false,
 		},
 		{
@@ -45,7 +45,7 @@ func TestComparisonFilter(t *testing.T) {
 				Value:    "Alice",
 			},
 			tuple:    Tuple{"Alice"},
-			columns:  []query.Symbol{datalog.NewSymbol("?name")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?name")},
 			expected: true,
 		},
 		{
@@ -56,36 +56,36 @@ func TestComparisonFilter(t *testing.T) {
 				Value:    "Alice",
 			},
 			tuple:    Tuple{"Bob"},
-			columns:  []query.Symbol{datalog.NewSymbol("?name")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?name")},
 			expected: true,
 		},
 		{
-			name: "symbol not in columns",
+			name: "symbol not in symbols",
 			filter: ComparisonFilter{
 				Function: "<",
 				Symbol:   datalog.NewSymbol("?missing"),
 				Value:    int64(30),
 			},
 			tuple:    Tuple{int64(25)},
-			columns:  []query.Symbol{datalog.NewSymbol("?age")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?age")},
 			expected: false,
 		},
 		{
-			name: "multiple columns",
+			name: "multiple symbols",
 			filter: ComparisonFilter{
 				Function: ">=",
 				Symbol:   datalog.NewSymbol("?score"),
 				Value:    3.5,
 			},
 			tuple:    Tuple{"Alice", 4.0},
-			columns:  []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?score")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?score")},
 			expected: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.filter.Evaluate(tt.tuple, tt.columns)
+			result := tt.filter.Evaluate(tt.tuple, tt.symbols)
 			if result != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 			}
@@ -98,7 +98,7 @@ func TestBinaryFilterEvaluate(t *testing.T) {
 		name     string
 		filter   BinaryFilter
 		tuple    Tuple
-		columns  []query.Symbol
+		symbols  []query.Symbol
 		expected bool
 	}{
 		{
@@ -109,7 +109,7 @@ func TestBinaryFilterEvaluate(t *testing.T) {
 				Right:    datalog.NewSymbol("?y"),
 			},
 			tuple:    Tuple{int64(10), int64(20)},
-			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: true,
 		},
 		{
@@ -120,7 +120,7 @@ func TestBinaryFilterEvaluate(t *testing.T) {
 				Right:    datalog.NewSymbol("?y"),
 			},
 			tuple:    Tuple{int64(10), int64(20)},
-			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: false,
 		},
 		{
@@ -131,7 +131,7 @@ func TestBinaryFilterEvaluate(t *testing.T) {
 				Right:    datalog.NewSymbol("?b"),
 			},
 			tuple:    Tuple{"test", "test"},
-			columns:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			expected: true,
 		},
 		{
@@ -142,7 +142,7 @@ func TestBinaryFilterEvaluate(t *testing.T) {
 				Right:    datalog.NewSymbol("?y"),
 			},
 			tuple:    Tuple{int64(10), 20.5},
-			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: true,
 		},
 		{
@@ -153,14 +153,14 @@ func TestBinaryFilterEvaluate(t *testing.T) {
 				Right:    datalog.NewSymbol("?y"),
 			},
 			tuple:    Tuple{int64(10)},
-			columns:  []query.Symbol{datalog.NewSymbol("?x")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x")},
 			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.filter.Evaluate(tt.tuple, tt.columns)
+			result := tt.filter.Evaluate(tt.tuple, tt.symbols)
 			if result != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 			}

--- a/datalog/executor/hash_join_bench_test.go
+++ b/datalog/executor/hash_join_bench_test.go
@@ -45,7 +45,7 @@ func BenchmarkHashJoinBuildSize(b *testing.B) {
 					// BOTH relations must be streaming to trigger DefaultHashTableSize
 					// If one is materialized, it will be chosen as build (known size)
 					left := &StreamingRelation{
-						columns:  leftCols,
+						symbols:  leftCols,
 						iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 						size:     -1,
 						options: ExecutorOptions{
@@ -55,7 +55,7 @@ func BenchmarkHashJoinBuildSize(b *testing.B) {
 					}
 
 					right := &StreamingRelation{
-						columns:  rightCols,
+						symbols:  rightCols,
 						iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 						size:     -1,
 						options: ExecutorOptions{
@@ -105,7 +105,7 @@ func BenchmarkHashJoinBuildSizeOptimal(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					// BOTH streaming to trigger DefaultHashTableSize
 					left := &StreamingRelation{
-						columns:  leftCols,
+						symbols:  leftCols,
 						iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 						size:     -1,
 						options: ExecutorOptions{
@@ -115,7 +115,7 @@ func BenchmarkHashJoinBuildSizeOptimal(b *testing.B) {
 					}
 
 					right := &StreamingRelation{
-						columns:  rightCols,
+						symbols:  rightCols,
 						iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 						size:     -1,
 						options: ExecutorOptions{
@@ -186,7 +186,7 @@ func BenchmarkHashJoinInputTypes(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options:  ExecutorOptions{EnableStreamingJoins: true},
@@ -211,7 +211,7 @@ func BenchmarkHashJoinInputTypes(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				left := NewMaterializedRelation(leftCols, leftTuples)
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options:  ExecutorOptions{EnableStreamingJoins: true},
@@ -234,7 +234,7 @@ func BenchmarkHashJoinInputTypes(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -243,7 +243,7 @@ func BenchmarkHashJoinInputTypes(b *testing.B) {
 					},
 				}
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -312,7 +312,7 @@ func BenchmarkHashJoinMaterializedVsStreaming(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			left := &StreamingRelation{
-				columns:  leftCols,
+				symbols:  leftCols,
 				iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 				size:     -1,
 				options:  ExecutorOptions{EnableStreamingJoins: true},
@@ -342,7 +342,7 @@ func BenchmarkHashJoinStreaming(b *testing.B) {
 
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
-			// Create two relations with common column
+			// Create two relations with common symbol
 			leftCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?name")}
 			rightCols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?value")}
 
@@ -438,7 +438,7 @@ func BenchmarkHashJoinStreamingInput(b *testing.B) {
 				// Create streaming left relation (Size() = -1)
 				// This triggers DefaultHashTableSize
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options:  ExecutorOptions{EnableStreamingJoins: true},

--- a/datalog/executor/helpers.go
+++ b/datalog/executor/helpers.go
@@ -58,9 +58,9 @@ func materializeRelationsForPattern(pattern *query.DataPattern, relations Relati
 }
 
 // filterWithPredicateAndLookup filters a relation using a predicate with optional database lookup.
-// constantBindings are pre-resolved scalar values that are not present as relation columns.
+// constantBindings are pre-resolved scalar values that are not present as relation symbols.
 func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup query.EntityLookup, constantBindings map[query.Symbol]interface{}) Relation {
-	columns := rel.Columns()
+	symbols := rel.Symbols()
 	needsCopy := rel.RequiresCopy()
 
 	// Pre-allocate filtered only for materialized relations to avoid forcing materialization
@@ -72,7 +72,7 @@ func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup que
 	}
 
 	// Reuse single bindings map to avoid repeated allocations
-	bindings := make(map[query.Symbol]interface{}, len(columns)+len(constantBindings))
+	bindings := make(map[query.Symbol]interface{}, len(symbols)+len(constantBindings))
 
 	// Check if this is a DatabaseFunctionPredicate that needs lookup
 	dbFuncPred, isDbFuncPred := pred.(*query.DatabaseFunctionPredicate)
@@ -90,7 +90,7 @@ func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup que
 		for sym, val := range constantBindings {
 			bindings[sym] = val
 		}
-		for i, col := range columns {
+		for i, col := range symbols {
 			bindings[col] = tuple[i]
 		}
 
@@ -117,15 +117,15 @@ func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup que
 
 	// Extract options from source relation to preserve configuration
 	opts := rel.Options()
-	return NewMaterializedRelationWithOptions(columns, filtered, opts)
+	return NewMaterializedRelationWithOptions(symbols, filtered, opts)
 }
 
 // evaluateExpressionWithLookup evaluates an expression with optional database lookup support.
 // If lookup is non-nil and the expression is a DatabaseFunction, it uses EvalWithLookup.
 // Otherwise, it falls back to the standard Eval method.
-// constantBindings are pre-resolved scalar values that are not present as relation columns.
+// constantBindings are pre-resolved scalar values that are not present as relation symbols.
 func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup query.EntityLookup, constantBindings map[query.Symbol]interface{}) Relation {
-	columns := rel.Columns()
+	symbols := rel.Symbols()
 
 	// Determine binding symbols and whether they already exist
 	var bindingSymbols []query.Symbol
@@ -138,12 +138,12 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 		bindingSymbols = b.Variables
 	}
 
-	// Check which binding columns already exist
+	// Check which binding symbols already exist
 	hasAllBindings := len(bindingSymbols) > 0
 	existingBindingIndices := make(map[query.Symbol]int)
 	for _, bindSym := range bindingSymbols {
 		found := false
-		for i, col := range columns {
+		for i, col := range symbols {
 			if col == bindSym {
 				existingBindingIndices[bindSym] = i
 				found = true
@@ -155,9 +155,9 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 		}
 	}
 
-	newColumns := columns
+	newColumns := symbols
 	if !hasAllBindings && len(bindingSymbols) > 0 {
-		newColumns = append([]query.Symbol{}, columns...)
+		newColumns = append([]query.Symbol{}, symbols...)
 		for _, bindSym := range bindingSymbols {
 			if _, exists := existingBindingIndices[bindSym]; !exists {
 				newColumns = append(newColumns, bindSym)
@@ -166,7 +166,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 	}
 
 	// Reuse single bindings map to avoid repeated allocations
-	bindings := make(map[query.Symbol]interface{}, len(columns)+len(constantBindings))
+	bindings := make(map[query.Symbol]interface{}, len(symbols)+len(constantBindings))
 
 	// Pre-allocate newTuples only for materialized relations to avoid forcing materialization
 	var newTuples []Tuple
@@ -189,7 +189,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 		for sym, val := range constantBindings {
 			bindings[sym] = val
 		}
-		for i, col := range columns {
+		for i, col := range symbols {
 			bindings[col] = tuple[i]
 		}
 
@@ -213,7 +213,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 			result = gsr.Value
 		}
 
-		// Handle multi-row expansion (e.g., enumerate returns [][]interface{})
+		// Handle multi-tuple expansion (e.g., enumerate returns [][]interface{})
 		if multiRows, ok := result.([][]interface{}); ok {
 			if tb, ok := expr.Binding.(query.TupleBinding); ok {
 				for _, subTuple := range multiRows {
@@ -233,7 +233,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 						newTuple := make(Tuple, len(newColumns))
 						copy(newTuple, tuple)
 						for i, bindSym := range tb.Variables {
-							for j := len(columns); j < len(newColumns); j++ {
+							for j := len(symbols); j < len(newColumns); j++ {
 								if newColumns[j] == bindSym {
 									newTuple[j] = subTuple[i]
 									break
@@ -252,7 +252,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 			// No binding, just keep original tuple
 			newTuples = append(newTuples, tuple)
 		} else if hasAllBindings {
-			// Update existing columns
+			// Update existing symbols
 			newTuple := make(Tuple, len(tuple))
 			copy(newTuple, tuple)
 			// Handle tuple binding - result should be []interface{}
@@ -267,7 +267,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 				}
 			} else {
 				// Scalar binding
-				for i, col := range columns {
+				for i, col := range symbols {
 					if bindSym, ok := expr.Binding.(query.Symbol); ok && col == bindSym {
 						newTuple[i] = result
 						break
@@ -276,7 +276,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 			}
 			newTuples = append(newTuples, newTuple)
 		} else {
-			// Add new columns
+			// Add new symbols
 			newTuple := make(Tuple, len(newColumns))
 			copy(newTuple, tuple)
 			// Handle tuple binding - result should be []interface{}
@@ -285,7 +285,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 				if ok && len(values) == len(tb.Variables) {
 					for i, bindSym := range tb.Variables {
 						// Find position of this symbol in newColumns
-						for j := len(columns); j < len(newColumns); j++ {
+						for j := len(symbols); j < len(newColumns); j++ {
 							if newColumns[j] == bindSym {
 								newTuple[j] = values[i]
 								break
@@ -306,11 +306,11 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 	return NewMaterializedRelationWithOptions(newColumns, newTuples, opts)
 }
 
-// projectToColumns projects a relation to the specified columns
+// projectToColumns projects a relation to the specified symbols
 func projectToColumns(rel Relation, cols []query.Symbol, opts ExecutorOptions) Relation {
-	relCols := rel.Columns()
+	relCols := rel.Symbols()
 
-	// Build column index mapping
+	// Build symbol index mapping
 	colIndices := make([]int, len(cols))
 	for i, col := range cols {
 		found := false
@@ -322,7 +322,7 @@ func projectToColumns(rel Relation, cols []query.Symbol, opts ExecutorOptions) R
 			}
 		}
 		if !found {
-			// Column not found - return empty relation
+			// Symbol not found - return empty relation
 			return NewMaterializedRelationWithOptions(cols, nil, opts)
 		}
 	}
@@ -378,13 +378,13 @@ func collectInnerVars(clauses []query.Clause) []query.Symbol {
 	return vars
 }
 
-// getUniqueCombinations extracts unique value combinations for the given columns
+// getUniqueCombinations extracts unique value combinations for the given symbols
 func getUniqueCombinations(rel Relation, cols []query.Symbol) []Tuple {
 	if rel == nil || len(cols) == 0 {
 		return nil
 	}
 
-	relCols := rel.Columns()
+	relCols := rel.Symbols()
 	colIndices := make([]int, len(cols))
 	for i, col := range cols {
 		found := false
@@ -448,7 +448,7 @@ func countOverlap(cols, syms []query.Symbol) int {
 	return count
 }
 
-// unionRelations creates a union of multiple relations, projecting to common columns
+// unionRelations creates a union of multiple relations, projecting to common symbols
 func unionRelations(relations []Relation, cols []query.Symbol, opts ExecutorOptions) Relation {
 	if len(relations) == 0 {
 		return NewMaterializedRelationWithOptions(cols, nil, opts)
@@ -458,8 +458,8 @@ func unionRelations(relations []Relation, cols []query.Symbol, opts ExecutorOpti
 	var allTuples []Tuple
 
 	for _, rel := range relations {
-		// Build column index mapping
-		relCols := rel.Columns()
+		// Build symbol index mapping
+		relCols := rel.Symbols()
 		colIndices := make([]int, len(cols))
 		valid := true
 		for i, col := range cols {

--- a/datalog/executor/indexed_memory_matcher.go
+++ b/datalog/executor/indexed_memory_matcher.go
@@ -34,7 +34,7 @@ type IndexedMemoryMatcher struct {
 type boundDatomIterator struct {
 	matcher       *IndexedMemoryMatcher
 	pattern       *query.DataPattern
-	columns       []query.Symbol
+	symbols       []query.Symbol
 	constraints   []StorageConstraint
 	boundTuples   []Tuple
 	bindingRel    Relation
@@ -50,7 +50,7 @@ func (it *boundDatomIterator) Next() bool {
 		for it.datomIdx < len(it.currentDatoms) {
 			datom := it.currentDatoms[it.datomIdx]
 			it.datomIdx++
-			if tuple := query.DatomToTuple(datom, it.pattern, it.columns); tuple != nil {
+			if tuple := query.DatomToTuple(datom, it.pattern, it.symbols); tuple != nil {
 				it.current = tuple
 				return true
 			}
@@ -163,7 +163,7 @@ func (m *IndexedMemoryMatcher) MatchWithConstraints(
 	// Build indices on first use (lazy initialization)
 	m.buildIndices()
 
-	columns := pattern.ExtractColumns()
+	symbols := pattern.ExtractColumns()
 
 	// Extract options: prefer bindings, fall back to matcher's options
 	m.optionsMutex.RLock()
@@ -176,7 +176,7 @@ func (m *IndexedMemoryMatcher) MatchWithConstraints(
 	if bindings == nil || len(bindings) == 0 {
 		// No bindings - use index to match pattern
 		datoms := m.matchWithIndex(pattern, constraints)
-		return datomsToRelationWithOptions(datoms, pattern, columns, opts), nil
+		return datomsToRelationWithOptions(datoms, pattern, symbols, opts), nil
 	}
 
 	// Find best binding relation
@@ -184,7 +184,7 @@ func (m *IndexedMemoryMatcher) MatchWithConstraints(
 	if bindingRel == nil || bindingRel.Size() == 0 {
 		// No relevant bindings - use index
 		datoms := m.matchWithIndex(pattern, constraints)
-		return datomsToRelationWithOptions(datoms, pattern, columns, opts), nil
+		return datomsToRelationWithOptions(datoms, pattern, symbols, opts), nil
 	}
 
 	// Match with bindings - use streaming iterator for lazy evaluation
@@ -197,7 +197,7 @@ func (m *IndexedMemoryMatcher) MatchWithConstraints(
 	iterator := &boundDatomIterator{
 		matcher:     m,
 		pattern:     pattern,
-		columns:     columns,
+		symbols:     symbols,
 		constraints: constraints,
 		boundTuples: bindingRel.Sorted(),
 		bindingRel:  bindingRel,
@@ -205,7 +205,7 @@ func (m *IndexedMemoryMatcher) MatchWithConstraints(
 		datomIdx:    0,
 	}
 
-	return NewStreamingRelationWithOptions(columns, iterator, relOpts), nil
+	return NewStreamingRelationWithOptions(symbols, iterator, relOpts), nil
 }
 
 // matchWithIndex performs indexed pattern matching

--- a/datalog/executor/iterator_composition.go
+++ b/datalog/executor/iterator_composition.go
@@ -10,7 +10,7 @@ import (
 // SimpleFilter is a simple filter function that implements the Filter interface
 type SimpleFilter struct {
 	filterFunc func(Tuple) bool
-	columns    []query.Symbol
+	symbols    []query.Symbol
 }
 
 // NewSimpleFilter creates a filter from a function
@@ -24,7 +24,7 @@ func (f *SimpleFilter) RequiredSymbols() []query.Symbol {
 }
 
 // Evaluate applies the filter function
-func (f *SimpleFilter) Evaluate(tuple Tuple, columns []query.Symbol) bool {
+func (f *SimpleFilter) Evaluate(tuple Tuple, symbols []query.Symbol) bool {
 	return f.filterFunc(tuple)
 }
 
@@ -38,15 +38,15 @@ type FilterIterator struct {
 	source  Iterator
 	filter  Filter
 	current Tuple
-	columns []query.Symbol
+	symbols []query.Symbol
 }
 
 // NewFilterIterator creates a new filtering iterator
-func NewFilterIterator(source Iterator, columns []query.Symbol, filter Filter) *FilterIterator {
+func NewFilterIterator(source Iterator, symbols []query.Symbol, filter Filter) *FilterIterator {
 	return &FilterIterator{
 		source:  source,
 		filter:  filter,
-		columns: columns,
+		symbols: symbols,
 	}
 }
 
@@ -54,7 +54,7 @@ func NewFilterIterator(source Iterator, columns []query.Symbol, filter Filter) *
 func (it *FilterIterator) Next() bool {
 	for it.source.Next() {
 		it.current = it.source.Tuple()
-		if it.filter.Evaluate(it.current, it.columns) {
+		if it.filter.Evaluate(it.current, it.symbols) {
 			return true
 		}
 	}
@@ -71,22 +71,22 @@ func (it *FilterIterator) Close() error {
 	return it.source.Close()
 }
 
-// ProjectIterator projects specific columns from the source relation
+// ProjectIterator projects specific symbols from the source relation
 type ProjectIterator struct {
 	relation   Relation // Source relation (may be cached/materialized)
 	source     Iterator // Lazily obtained from relation.Iterator()
-	indices    []int    // Indices of columns to keep from source
+	indices    []int    // Indices of symbols to keep from source
 	current    Tuple
-	newColumns []query.Symbol
+	newSymbols []query.Symbol
 }
 
 // NewProjectIterator creates a new projection iterator
-func NewProjectIterator(relation Relation, sourceColumns []query.Symbol, targetColumns []query.Symbol) *ProjectIterator {
+func NewProjectIterator(relation Relation, sourceSymbols []query.Symbol, targetSymbols []query.Symbol) *ProjectIterator {
 	// Compute indices for projection
-	indices := make([]int, len(targetColumns))
-	for i, targetCol := range targetColumns {
-		for j, sourceCol := range sourceColumns {
-			if sourceCol == targetCol {
+	indices := make([]int, len(targetSymbols))
+	for i, targetSym := range targetSymbols {
+		for j, sourceSym := range sourceSymbols {
+			if sourceSym == targetSym {
 				indices[i] = j
 				break
 			}
@@ -96,7 +96,7 @@ func NewProjectIterator(relation Relation, sourceColumns []query.Symbol, targetC
 	return &ProjectIterator{
 		relation:   relation,
 		indices:    indices,
-		newColumns: targetColumns,
+		newSymbols: targetSymbols,
 	}
 }
 
@@ -219,16 +219,16 @@ func (it *ConcatIterator) Close() error {
 type PredicateFilterIterator struct {
 	source    Iterator
 	predicate query.Predicate
-	columns   []query.Symbol
+	symbols   []query.Symbol
 	current   Tuple
 }
 
 // NewPredicateFilterIterator creates a new predicate-based filtering iterator
-func NewPredicateFilterIterator(source Iterator, columns []query.Symbol, predicate query.Predicate) *PredicateFilterIterator {
+func NewPredicateFilterIterator(source Iterator, symbols []query.Symbol, predicate query.Predicate) *PredicateFilterIterator {
 	return &PredicateFilterIterator{
 		source:    source,
 		predicate: predicate,
-		columns:   columns,
+		symbols:   symbols,
 	}
 }
 
@@ -239,9 +239,9 @@ func (it *PredicateFilterIterator) Next() bool {
 
 		// Create bindings for predicate evaluation
 		bindings := make(map[query.Symbol]interface{})
-		for i, col := range it.columns {
+		for i, sym := range it.symbols {
 			if i < len(it.current) {
-				bindings[col] = it.current[i]
+				bindings[sym] = it.current[i]
 			}
 		}
 
@@ -264,25 +264,25 @@ func (it *PredicateFilterIterator) Close() error {
 	return it.source.Close()
 }
 
-// FunctionEvaluatorIterator adds a new column by evaluating a function
+// FunctionEvaluatorIterator adds a new symbol by evaluating a function
 type FunctionEvaluatorIterator struct {
 	source       Iterator
 	function     query.Function
 	outputColumn query.Symbol
-	columns      []query.Symbol // Original columns
-	newColumns   []query.Symbol // Columns after adding function output
+	symbols      []query.Symbol // Original symbols
+	newSymbols   []query.Symbol // Symbols after adding function output
 	current      Tuple
 }
 
-// NewFunctionEvaluatorIterator creates an iterator that adds a column via function evaluation
-func NewFunctionEvaluatorIterator(source Iterator, columns []query.Symbol, function query.Function, outputColumn query.Symbol) *FunctionEvaluatorIterator {
-	newColumns := append(columns, outputColumn)
+// NewFunctionEvaluatorIterator creates an iterator that adds a symbol via function evaluation
+func NewFunctionEvaluatorIterator(source Iterator, symbols []query.Symbol, function query.Function, outputColumn query.Symbol) *FunctionEvaluatorIterator {
+	newSymbols := append(symbols, outputColumn)
 	return &FunctionEvaluatorIterator{
 		source:       source,
 		function:     function,
 		outputColumn: outputColumn,
-		columns:      columns,
-		newColumns:   newColumns,
+		symbols:      symbols,
+		newSymbols:   newSymbols,
 	}
 }
 
@@ -296,9 +296,9 @@ func (it *FunctionEvaluatorIterator) Next() bool {
 
 	// Create bindings for function evaluation
 	bindings := make(map[query.Symbol]interface{})
-	for i, col := range it.columns {
+	for i, sym := range it.symbols {
 		if i < len(sourceTuple) {
-			bindings[col] = sourceTuple[i]
+			bindings[sym] = sourceTuple[i]
 		}
 	}
 

--- a/datalog/executor/iterator_composition_test.go
+++ b/datalog/executor/iterator_composition_test.go
@@ -47,14 +47,14 @@ func TestFilterIterator(t *testing.T) {
 		{4, "diana", 35},
 		{5, "eve", 30},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age")}
+	symbols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age")}
 
 	// Test filtering by age
 	source := newMockIterator(tuples)
 	filter := NewSimpleFilter(func(t Tuple) bool {
 		return t[2].(int) == 30 // Age == 30
 	})
-	filterIter := NewFilterIterator(source, columns, filter)
+	filterIter := NewFilterIterator(source, symbols, filter)
 
 	// Collect filtered results
 	var results []Tuple
@@ -99,7 +99,7 @@ func TestProjectIterator(t *testing.T) {
 
 	// Verify results
 	assert.Len(t, results, 3)
-	assert.Len(t, results[0], 2) // Only 2 columns
+	assert.Len(t, results[0], 2) // Only 2 symbols
 	assert.Equal(t, "alice", results[0][0])
 	assert.Equal(t, "NYC", results[0][1])
 	assert.Equal(t, "bob", results[1][0])
@@ -209,14 +209,14 @@ func TestComposedIterators(t *testing.T) {
 		{3, "charlie", 25, 1200},
 		{4, "diana", 35, 2000},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?salary")}
+	symbols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?salary")}
 
 	// Step 1: Filter by age >= 30
 	source := newMockIterator(tuples)
 	filter := NewSimpleFilter(func(t Tuple) bool {
 		return t[2].(int) >= 30
 	})
-	filterIter := NewFilterIterator(source, columns, filter)
+	filterIter := NewFilterIterator(source, symbols, filter)
 
 	// Step 2: Project name and salary only
 	projectedColumns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?salary")}
@@ -224,7 +224,7 @@ func TestComposedIterators(t *testing.T) {
 	projIter := &ProjectIterator{
 		source:     filterIter,
 		indices:    projIndices,
-		newColumns: projectedColumns,
+		newSymbols: projectedColumns,
 	}
 
 	// Step 3: Transform to add bonus (10% of salary)
@@ -268,11 +268,11 @@ func TestStreamingRelationWithComposition(t *testing.T) {
 		{3, "charlie", 25},
 		{4, "diana", 35},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age")}
+	symbols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?age")}
 
 	// Create a StreamingRelation
 	source := newMockIterator(tuples)
-	rel := NewStreamingRelationWithOptions(columns, source, opts)
+	rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 	// Test that Size() doesn't materialize when TrueStreaming is enabled
 	size := rel.Size()
@@ -287,7 +287,7 @@ func TestStreamingRelationWithComposition(t *testing.T) {
 	// Verify it's still streaming (not materialized)
 	assert.IsType(t, &StreamingRelation{}, filtered)
 
-	// Project columns
+	// Project symbols
 	projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age")})
 	assert.NoError(t, err)
 	assert.IsType(t, &StreamingRelation{}, projected)
@@ -319,7 +319,7 @@ func TestPredicateFilterIterator(t *testing.T) {
 		{3, 30},
 		{4, 40},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 	// Create a comparison predicate (y > 20)
 	pred := &query.Comparison{
@@ -329,7 +329,7 @@ func TestPredicateFilterIterator(t *testing.T) {
 	}
 
 	source := newMockIterator(tuples)
-	predIter := NewPredicateFilterIterator(source, columns, pred)
+	predIter := NewPredicateFilterIterator(source, symbols, pred)
 
 	// Collect filtered results
 	var results []Tuple
@@ -348,13 +348,13 @@ func TestPredicateFilterIterator(t *testing.T) {
 }
 
 func TestFunctionEvaluatorIterator(t *testing.T) {
-	// Test function evaluation that adds a new column
+	// Test function evaluation that adds a new symbol
 	tuples := []Tuple{
 		{10, 20},
 		{30, 40},
 		{50, 60},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 	// Create an addition function (x + y)
 	fn := query.ArithmeticFunction{
@@ -364,9 +364,9 @@ func TestFunctionEvaluatorIterator(t *testing.T) {
 	}
 
 	source := newMockIterator(tuples)
-	evalIter := NewFunctionEvaluatorIterator(source, columns, fn, datalog.NewSymbol("?sum"))
+	evalIter := NewFunctionEvaluatorIterator(source, symbols, fn, datalog.NewSymbol("?sum"))
 
-	// Collect results with new column
+	// Collect results with new symbol
 	var results []Tuple
 	for evalIter.Next() {
 		tuple := evalIter.Tuple()
@@ -378,7 +378,7 @@ func TestFunctionEvaluatorIterator(t *testing.T) {
 
 	// Verify results
 	assert.Len(t, results, 3)
-	assert.Len(t, results[0], 3)               // Original 2 columns + 1 new
+	assert.Len(t, results[0], 3)               // Original 2 symbols + 1 new
 	assert.Equal(t, int64(30), results[0][2])  // 10 + 20 (ArithmeticFunction returns int64)
 	assert.Equal(t, int64(70), results[1][2])  // 30 + 40
 	assert.Equal(t, int64(110), results[2][2]) // 50 + 60
@@ -391,7 +391,7 @@ func BenchmarkIteratorComposition(b *testing.B) {
 	for i := 0; i < 10000; i++ {
 		tuples = append(tuples, Tuple{i, i * 2, i * 3})
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 	b.Run("Composed", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -401,11 +401,11 @@ func BenchmarkIteratorComposition(b *testing.B) {
 			filter := NewSimpleFilter(func(t Tuple) bool {
 				return t[0].(int)%2 == 0 // Even numbers
 			})
-			filterIter := NewFilterIterator(source, columns, filter)
+			filterIter := NewFilterIterator(source, symbols, filter)
 
 			// Wrap in a relation for projection
-			filteredRel := NewStreamingRelation(columns, filterIter)
-			projIter := NewProjectIterator(filteredRel, columns, []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")})
+			filteredRel := NewStreamingRelation(symbols, filterIter)
+			projIter := NewProjectIterator(filteredRel, symbols, []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?z")})
 
 			transform := func(t Tuple) Tuple {
 				return Tuple{t[0], t[1].(int) * 10}
@@ -424,7 +424,7 @@ func BenchmarkIteratorComposition(b *testing.B) {
 	b.Run("Materialized", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			// Simulate materialized approach
-			rel := NewMaterializedRelation(columns, tuples)
+			rel := NewMaterializedRelation(symbols, tuples)
 
 			// Filter
 			var filtered []Tuple

--- a/datalog/executor/join.go
+++ b/datalog/executor/join.go
@@ -124,7 +124,7 @@ func (it *hashJoinIterator) Close() error {
 	return nil
 }
 
-// HashJoin performs a hash join on specified columns
+// HashJoin performs a hash join on specified symbols
 // It attempts to get options from the input relations
 func HashJoin(left, right Relation, joinCols []query.Symbol) Relation {
 	// Try to get options from either relation
@@ -164,8 +164,8 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 		if opts.EnableDebugLogging {
 			fmt.Printf("[HashJoin] Called with left (type=%T, size=%d), right (type=%T, size=%d), joinCols=%v, EnableStreamingJoins=%v\n",
 				left, leftSize, right, rightSize, joinCols, opts.EnableStreamingJoins)
-			fmt.Printf("[HashJoin] Left columns: %v\n", left.Columns())
-			fmt.Printf("[HashJoin] Right columns: %v\n", right.Columns())
+			fmt.Printf("[HashJoin] Left symbols: %v\n", left.Symbols())
+			fmt.Printf("[HashJoin] Right symbols: %v\n", right.Symbols())
 
 			// Debug: check left relation's shouldCache flag if it's a StreamingRelation
 			if sr, ok := left.(*StreamingRelation); ok {
@@ -175,14 +175,14 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 		}
 	}
 
-	// Build column mappings
+	// Build symbol mappings
 	leftIndices := make([]int, len(joinCols))
 	rightIndices := make([]int, len(joinCols))
 	for i, col := range joinCols {
-		leftIndices[i] = ColumnIndex(left, col)
-		rightIndices[i] = ColumnIndex(right, col)
+		leftIndices[i] = SymbolIndex(left, col)
+		rightIndices[i] = SymbolIndex(right, col)
 		if leftIndices[i] < 0 || rightIndices[i] < 0 {
-			// Join column not found - return empty relation with options
+			// Join symbol not found - return empty relation with options
 			opts := left.Options()
 			if opts == (ExecutorOptions{}) {
 				opts = right.Options()
@@ -191,15 +191,15 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 		}
 	}
 
-	// Determine output columns (union without duplicates)
-	outputCols := append([]query.Symbol{}, left.Columns()...)
+	// Determine output symbols (union without duplicates)
+	outputCols := append([]query.Symbol{}, left.Symbols()...)
 	rightColSet := make(map[query.Symbol]bool)
 	for _, col := range joinCols {
 		rightColSet[col] = true
 	}
 
-	// Add right columns that aren't in join columns
-	for _, col := range right.Columns() {
+	// Add right symbols that aren't in join symbols
+	for _, col := range right.Symbols() {
 		if !rightColSet[col] {
 			outputCols = append(outputCols, col)
 		}
@@ -279,15 +279,15 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 		fmt.Printf("[HashJoin] Building hash table from relation with Size()=%d\n", buildRel.Size())
 	}
 
-	// Check if any column name matches transaction ID patterns
+	// Check if any symbol name matches transaction ID patterns
 	// We'll verify the actual type on the first tuple during iteration
 	txIndex := -1
-	for i, col := range buildRel.Columns() {
+	for i, col := range buildRel.Symbols() {
 		if col == datalog.NewSymbol("?tx") || col == datalog.NewSymbol("?t") ||
 			col == datalog.NewSymbol("?txid") || col == datalog.NewSymbol("?transaction") {
 			txIndex = i
 			if opts.EnableDebugLogging {
-				fmt.Printf("[HashJoin] Found potential tx column %s at index %d\n", col, i)
+				fmt.Printf("[HashJoin] Found potential tx symbol %s at index %d\n", col, i)
 			}
 			break
 		}
@@ -324,9 +324,9 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 		return t
 	}
 
-	// Check first tuple to determine if we have a valid tx column
+	// Check first tuple to determine if we have a valid tx symbol
 	if txIndex >= 0 {
-		// Potential tx column found - check first tuple's type
+		// Potential tx symbol found - check first tuple's type
 		if !buildIt.Next() {
 			// Empty relation - hash table stays empty
 			if opts.EnableDebugLogging {
@@ -340,11 +340,11 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 				case uint64, int64, int, datalog.ElementID, *datalog.ElementID:
 					hasTxColumn = true
 					if opts.EnableDebugLogging {
-						fmt.Printf("[HashJoin] Confirmed tx column at index %d with type %T\n", txIndex, firstTuple[txIndex])
+						fmt.Printf("[HashJoin] Confirmed tx symbol at index %d with type %T\n", txIndex, firstTuple[txIndex])
 					}
 				default:
 					if opts.EnableDebugLogging {
-						fmt.Printf("[HashJoin] Column at index %d is not a tx ID (type %T), using normal path\n", txIndex, firstTuple[txIndex])
+						fmt.Printf("[HashJoin] Symbol at index %d is not a tx ID (type %T), using normal path\n", txIndex, firstTuple[txIndex])
 					}
 				}
 			}
@@ -425,7 +425,7 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 				for _, entries := range latestTuples.m {
 					for _, entry := range entries {
 						// BUG FIX: Use the join key, not full tuple key!
-						// We need to hash by buildIndices, not all columns
+						// We need to hash by buildIndices, not all symbols
 						tuple := entry.value.(Tuple)
 						key := NewTupleKey(tuple, buildIndices)
 						hashTable.Put(key, []Tuple{tuple})
@@ -436,7 +436,7 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 					fmt.Printf("[HashJoin] Built hash table with %d tuples after tx deduplication\n", txDedupCount)
 				}
 			} else {
-				// No transaction column or not a valid tx type, use normal path
+				// No transaction symbol or not a valid tx type, use normal path
 				// Process first tuple
 				tuple := firstTuple
 				key := NewTupleKey(tuple, buildIndices)
@@ -476,7 +476,7 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 			}
 		}
 	} else {
-		// No potential tx column - use normal path for all tuples
+		// No potential tx symbol - use normal path for all tuples
 		buildCount := 0
 		var firstBuildKey *TupleKey
 		var firstBuildTuple Tuple
@@ -551,8 +551,8 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 			seen:         NewTupleKeyMapWithCapacity(expectedResults),
 			buildIsLeft:  buildIsLeft,
 			joinCols:     joinCols,
-			leftCols:     left.Columns(),
-			rightCols:    right.Columns(),
+			leftCols:     left.Symbols(),
+			rightCols:    right.Symbols(),
 			probeIndices: probeIndices,
 			options:      opts,
 			matchIdx:     0,
@@ -562,7 +562,7 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 		// StreamingRelation enforces single-use semantics via panic if Iterator() called twice
 		// Caller can explicitly call Materialize() if multiple iterations needed
 		return &StreamingRelation{
-			columns:  outputCols,
+			symbols:  outputCols,
 			iterator: iter,
 			size:     -1, // unknown size until consumed
 			options:  opts,
@@ -623,9 +623,9 @@ func HashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts Exe
 				// Combine tuples
 				var joined Tuple
 				if buildIsLeft {
-					joined = combineTuples(buildTuple, probeTuple, joinCols, left.Columns(), right.Columns())
+					joined = combineTuples(buildTuple, probeTuple, joinCols, left.Symbols(), right.Symbols())
 				} else {
-					joined = combineTuples(probeTuple, buildTuple, joinCols, left.Columns(), right.Columns())
+					joined = combineTuples(probeTuple, buildTuple, joinCols, left.Symbols(), right.Symbols())
 				}
 
 				// Create a key for deduplication based on all tuple values
@@ -653,8 +653,8 @@ func SemiJoin(left, right Relation, joinCols []query.Symbol) Relation {
 	leftIndices := make([]int, len(joinCols))
 	rightIndices := make([]int, len(joinCols))
 	for i, col := range joinCols {
-		leftIndices[i] = ColumnIndex(left, col)
-		rightIndices[i] = ColumnIndex(right, col)
+		leftIndices[i] = SymbolIndex(left, col)
+		rightIndices[i] = SymbolIndex(right, col)
 	}
 
 	// Extract options from left relation
@@ -688,7 +688,7 @@ func SemiJoin(left, right Relation, joinCols []query.Symbol) Relation {
 		}
 	}
 
-	return NewMaterializedRelationWithOptions(left.Columns(), results, opts)
+	return NewMaterializedRelationWithOptions(left.Symbols(), results, opts)
 }
 
 // AntiJoin returns tuples from left that have no matches in right
@@ -697,8 +697,8 @@ func AntiJoin(left, right Relation, joinCols []query.Symbol) Relation {
 	leftIndices := make([]int, len(joinCols))
 	rightIndices := make([]int, len(joinCols))
 	for i, col := range joinCols {
-		leftIndices[i] = ColumnIndex(left, col)
-		rightIndices[i] = ColumnIndex(right, col)
+		leftIndices[i] = SymbolIndex(left, col)
+		rightIndices[i] = SymbolIndex(right, col)
 	}
 
 	// Extract options from left relation
@@ -732,7 +732,7 @@ func AntiJoin(left, right Relation, joinCols []query.Symbol) Relation {
 		}
 	}
 
-	return NewMaterializedRelationWithOptions(left.Columns(), results, opts)
+	return NewMaterializedRelationWithOptions(left.Symbols(), results, opts)
 }
 
 // Helper functions
@@ -743,7 +743,7 @@ func isStreaming(rel Relation) bool {
 }
 
 func combineTuples(left, right Tuple, joinCols []query.Symbol, leftCols, rightCols []query.Symbol) Tuple {
-	// Create set of join columns for quick lookup
+	// Create set of join symbols for quick lookup
 	joinSet := make(map[query.Symbol]bool, len(joinCols))
 	for _, col := range joinCols {
 		joinSet[col] = true
@@ -763,7 +763,7 @@ func combineTuples(left, right Tuple, joinCols []query.Symbol, leftCols, rightCo
 	// Copy left tuple
 	copy(result, left)
 
-	// Add values from right that aren't join columns
+	// Add values from right that aren't join symbols
 	offset := len(left)
 	for i, col := range rightCols {
 		if !joinSet[col] {
@@ -783,7 +783,7 @@ func crossProduct(left, right Relation) Relation {
 		opts = right.Options()
 	}
 
-	outputCols := append(left.Columns(), right.Columns()...)
+	outputCols := append(left.Symbols(), right.Symbols()...)
 	var results []Tuple
 
 	leftIt := left.Iterator()

--- a/datalog/executor/join_correctness_test.go
+++ b/datalog/executor/join_correctness_test.go
@@ -140,7 +140,7 @@ func TestJoinCorrectnessEarlyTermination(t *testing.T) {
 // Helper: Get all join results
 func getJoinResults(t *testing.T, leftTuples, rightTuples []Tuple, leftCols, rightCols []query.Symbol, symmetric bool) []Tuple {
 	left := &StreamingRelation{
-		columns:  leftCols,
+		symbols:  leftCols,
 		iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 		size:     -1,
 		options: ExecutorOptions{
@@ -150,7 +150,7 @@ func getJoinResults(t *testing.T, leftTuples, rightTuples []Tuple, leftCols, rig
 		},
 	}
 	right := &StreamingRelation{
-		columns:  rightCols,
+		symbols:  rightCols,
 		iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 		size:     -1,
 		options: ExecutorOptions{
@@ -179,7 +179,7 @@ func getJoinResults(t *testing.T, leftTuples, rightTuples []Tuple, leftCols, rig
 // Helper: Get limited join results
 func getJoinResultsWithLimit(t *testing.T, leftTuples, rightTuples []Tuple, leftCols, rightCols []query.Symbol, symmetric bool, limit int) []Tuple {
 	left := &StreamingRelation{
-		columns:  leftCols,
+		symbols:  leftCols,
 		iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 		size:     -1,
 		options: ExecutorOptions{
@@ -189,7 +189,7 @@ func getJoinResultsWithLimit(t *testing.T, leftTuples, rightTuples []Tuple, left
 		},
 	}
 	right := &StreamingRelation{
-		columns:  rightCols,
+		symbols:  rightCols,
 		iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 		size:     -1,
 		options: ExecutorOptions{

--- a/datalog/executor/join_test.go
+++ b/datalog/executor/join_test.go
@@ -36,10 +36,10 @@ func TestHashJoin(t *testing.T) {
 		t.Errorf("expected 3 joined tuples, got %d", joined.Size())
 	}
 
-	// Check columns
+	// Check symbols
 	expectedCols := []query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?dept"), datalog.NewSymbol("?location")}
-	if !reflect.DeepEqual(joined.Columns(), expectedCols) {
-		t.Errorf("expected columns %v, got %v", expectedCols, joined.Columns())
+	if !reflect.DeepEqual(joined.Symbols(), expectedCols) {
+		t.Errorf("expected symbols %v, got %v", expectedCols, joined.Symbols())
 	}
 
 	// Collect results
@@ -58,7 +58,7 @@ func TestHashJoin(t *testing.T) {
 }
 
 func TestJoinMultipleColumns(t *testing.T) {
-	// Test joining on multiple columns
+	// Test joining on multiple symbols
 	leftCols := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
 	leftTuples := []Tuple{
 		{1, 2, "x"},
@@ -112,7 +112,7 @@ func TestEmptyJoin(t *testing.T) {
 }
 
 func TestCrossProduct(t *testing.T) {
-	// Test cross product (no common columns)
+	// Test cross product (no common symbols)
 	leftCols := []query.Symbol{datalog.NewSymbol("?a")}
 	leftTuples := []Tuple{{"x"}, {"y"}}
 	left := NewMaterializedRelation(leftCols, leftTuples)

--- a/datalog/executor/multi_match_optimization_test.go
+++ b/datalog/executor/multi_match_optimization_test.go
@@ -85,7 +85,7 @@ func (m *MockPatternMatcherWithStats) matchWithoutBindings(pattern *query.DataPa
 }
 
 func (m *MockPatternMatcherWithStats) matchesWithTuple(d datalog.Datom, pattern *query.DataPattern, tuple Tuple, rel Relation) bool {
-	cols := rel.Columns()
+	cols := rel.Symbols()
 
 	// Check each pattern element
 	elements := []struct {
@@ -103,7 +103,7 @@ func (m *MockPatternMatcherWithStats) matchesWithTuple(d datalog.Datom, pattern 
 		}
 
 		if v, ok := elem.patternElem.(query.Variable); ok {
-			// Find this variable in the relation columns
+			// Find this variable in the relation symbols
 			for i, col := range cols {
 				if col == v.Name && i < len(tuple) {
 					// Check if the binding matches
@@ -170,7 +170,7 @@ func TestMultiMatchOptimization(t *testing.T) {
 		seen := make(map[string]bool)
 
 		for _, entity := range entities {
-			// Create single-row relation
+			// Create single-tuple relation
 			singleRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, []Tuple{{entity}})
 
 			results, err := matcher.MatchWithRelation(pattern, singleRel)
@@ -205,7 +205,7 @@ func TestMultiMatchOptimization(t *testing.T) {
 			tuples = append(tuples, Tuple{entity})
 		}
 
-		// Create multi-row relation with all entities
+		// Create multi-tuple relation with all entities
 		multiRel := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, tuples)
 
 		// Pattern: [?e :entity/value ?v]
@@ -217,7 +217,7 @@ func TestMultiMatchOptimization(t *testing.T) {
 			},
 		}
 
-		// New approach: ONE call with multi-row relation
+		// New approach: ONE call with multi-tuple relation
 		start := time.Now()
 		results, err := matcher.MatchWithRelation(pattern, multiRel)
 		if err != nil {
@@ -236,7 +236,7 @@ func TestMultiMatchOptimization(t *testing.T) {
 	})
 
 	t.Run("ProofOfCorrectness", func(t *testing.T) {
-		// Verify that multi-row relations produce the same results as individual calls
+		// Verify that multi-tuple relations produce the same results as individual calls
 		matcher := &MockPatternMatcherWithStats{datoms: datoms}
 
 		// Test entities
@@ -265,7 +265,7 @@ func TestMultiMatchOptimization(t *testing.T) {
 		// Reset matcher
 		matcher.matchCalls = 0
 
-		// Method 2: Multi-row relation
+		// Method 2: Multi-tuple relation
 		var tuples []Tuple
 		for _, e := range entities {
 			tuples = append(tuples, Tuple{e})
@@ -295,6 +295,6 @@ func TestMultiMatchOptimization(t *testing.T) {
 
 		t.Logf("✅ Correctness verified: both methods produce identical results")
 		t.Logf("   Individual calls: %d results", len(individualResults))
-		t.Logf("   Multi-row call: %d results", len(multiResults))
+		t.Logf("   Multi-tuple call: %d results", len(multiResults))
 	})
 }

--- a/datalog/executor/multi_tuple_binding_test.go
+++ b/datalog/executor/multi_tuple_binding_test.go
@@ -27,7 +27,7 @@ func TestMultiRowRelationBinding(t *testing.T) {
 
 	matcher := NewMemoryPatternMatcher(datoms)
 
-	// Test 1: Use a multi-row relation to bind multiple entities at once
+	// Test 1: Use a multi-tuple relation to bind multiple entities at once
 	t.Run("MultipleEntityBinding", func(t *testing.T) {
 		// Create a relation with multiple entities
 		bindingRel := NewMaterializedRelation(
@@ -48,12 +48,12 @@ func TestMultiRowRelationBinding(t *testing.T) {
 			},
 		}
 
-		// Match with the multi-row binding relation
+		// Match with the multi-tuple binding relation
 		results, err := matcher.Match(pattern, Relations{bindingRel})
 		assert.NoError(t, err)
 
-		// Check columns
-		cols := results.Columns()
+		// Check symbols
+		cols := results.Symbols()
 		assert.Equal(t, []query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?age")}, cols)
 
 		// Check we got the right data
@@ -131,7 +131,7 @@ func TestMultiRowRelationBinding(t *testing.T) {
 		assert.Equal(t, "Charlie", foundUsers[int64(35)])
 	})
 
-	// Test 3: Complex multi-column binding
+	// Test 3: Complex multi-symbol binding
 	t.Run("MultiColumnBinding", func(t *testing.T) {
 		// Create a more complex pattern with price data
 		priceAttr := datalog.NewKeyword(":product/price")

--- a/datalog/executor/not_or_test.go
+++ b/datalog/executor/not_or_test.go
@@ -479,7 +479,7 @@ func TestOrFallbackWithGroundExpressionDirectQueryExecutor(t *testing.T) {
 		t.Fatalf("query executor failed: %v", err)
 	}
 
-	t.Logf("Final: columns=%v, size=%d", result.Columns(), result.Size())
+	t.Logf("Final: symbols=%v, size=%d", result.Symbols(), result.Size())
 
 	if result.Size() != 1 {
 		t.Errorf("Expected 1 result, got %d", result.Size())
@@ -903,7 +903,7 @@ func TestOrFallbackWithSubqueryPattern(t *testing.T) {
 		t.Fatalf("query executor failed: %v", err)
 	}
 
-	t.Logf("Final: columns=%v, size=%d", result.Columns(), result.Size())
+	t.Logf("Final: symbols=%v, size=%d", result.Symbols(), result.Size())
 
 	// Should have 1 result with count=1 (one completed task)
 	if result.Size() != 1 {
@@ -1035,7 +1035,7 @@ func TestOrFallbackWithSubqueryPatternAndVariableInput(t *testing.T) {
 		t.Fatalf("query executor failed: %v", err)
 	}
 
-	t.Logf("Final: columns=%v, size=%d", result.Columns(), result.Size())
+	t.Logf("Final: symbols=%v, size=%d", result.Symbols(), result.Size())
 
 	// Should have 2 results: scenario1 with count=2, scenario2 with count=0
 	if result.Size() != 2 {
@@ -1055,8 +1055,8 @@ func TestOrFallbackWithSubqueryPatternAndVariableInput(t *testing.T) {
 }
 
 // TestOrFallbackWithPatternAndTupleGround tests the critical case where:
-// - Outer relation has multiple rows
-// - First OR branch is pattern-only (matches some rows, not others)
+// - Outer relation has multiple tuples
+// - First OR branch is pattern-only (matches some tuples, not others)
 // - Second OR branch is tuple ground fallback
 // This is the exact scenario from TestTupleGroundQBInOr
 func TestOrFallbackWithPatternAndTupleGround(t *testing.T) {
@@ -1145,10 +1145,10 @@ func TestOrFallbackWithPatternAndTupleGround(t *testing.T) {
 		t.Fatalf("execution failed: %v", err)
 	}
 
-	t.Logf("Result columns: %v", result.Columns())
+	t.Logf("Result symbols: %v", result.Symbols())
 	t.Logf("Result size: %d", result.Size())
 	for i := 0; i < result.Size(); i++ {
-		t.Logf("Row %d: %v", i, result.Get(i))
+		t.Logf("Tuple %d: %v", i, result.Get(i))
 	}
 
 	// Log relevant annotations
@@ -1260,10 +1260,10 @@ func TestOrFallbackWithPatternAndScalarGround(t *testing.T) {
 		t.Fatalf("execution failed: %v", err)
 	}
 
-	t.Logf("Result columns: %v", result.Columns())
+	t.Logf("Result symbols: %v", result.Symbols())
 	t.Logf("Result size: %d", result.Size())
 	for i := 0; i < result.Size(); i++ {
-		t.Logf("Row %d: %v", i, result.Get(i))
+		t.Logf("Tuple %d: %v", i, result.Get(i))
 	}
 
 	// Should have 2 results
@@ -1345,7 +1345,7 @@ func TestOrFallbackWithSubqueryPatternEmpty(t *testing.T) {
 		t.Fatalf("query executor failed: %v", err)
 	}
 
-	t.Logf("Final: columns=%v, size=%d", result.Columns(), result.Size())
+	t.Logf("Final: symbols=%v, size=%d", result.Symbols(), result.Size())
 
 	// Should have 1 result with count=0 (fallback)
 	if result.Size() != 1 {

--- a/datalog/executor/ohlc_subquery_performance_test.go
+++ b/datalog/executor/ohlc_subquery_performance_test.go
@@ -120,7 +120,7 @@ func TestOHLCSubqueryPerformance(t *testing.T) {
 		}
 		duration := time.Since(start)
 
-		t.Logf("Single subquery returned %d rows in %v", result.Size(), duration)
+		t.Logf("Single subquery returned %d tuples in %v", result.Size(), duration)
 	})
 
 	// Test 2: Multiple subqueries (open, high, low for each day)
@@ -176,7 +176,7 @@ func TestOHLCSubqueryPerformance(t *testing.T) {
 		}
 		duration := time.Since(start)
 
-		t.Logf("Multiple subqueries returned %d rows in %v", result.Size(), duration)
+		t.Logf("Multiple subqueries returned %d tuples in %v", result.Size(), duration)
 		t.Logf("This demonstrates the O(n×m) pattern: %d days × 3 aggregations", result.Size())
 	})
 }

--- a/datalog/executor/or_fallback_relation.go
+++ b/datalog/executor/or_fallback_relation.go
@@ -19,13 +19,13 @@ type OrFallbackRelation struct {
 	ctx           Context
 	clause        *query.OrClause
 	outerRel      Relation
-	columns       []query.Symbol // Determined lazily from first result
+	symbols       []query.Symbol // Determined lazily from first result
 	options       ExecutorOptions
 	iteratorCount int // Track how many iterators have been created (for debugging)
 }
 
 // NewOrFallbackRelation creates a streaming OR fallback relation.
-// The columns are computed upfront from the outer relation and OR clause
+// The symbols are computed upfront from the outer relation and OR clause
 // to avoid needing to peek at results.
 func NewOrFallbackRelation(
 	executor *DefaultQueryExecutor,
@@ -34,23 +34,23 @@ func NewOrFallbackRelation(
 	outerRel Relation,
 	options ExecutorOptions,
 ) *OrFallbackRelation {
-	// Compute output columns statically:
-	// Output = outer columns + symbols produced by branches (that aren't in outer)
-	outerCols := outerRel.Columns()
-	outerColSet := make(map[query.Symbol]bool)
-	for _, col := range outerCols {
-		outerColSet[col] = true
+	// Compute output symbols statically:
+	// Output = outer symbols + symbols produced by branches (that aren't in outer)
+	outerSyms := outerRel.Symbols()
+	outerSymSet := make(map[query.Symbol]bool)
+	for _, sym := range outerSyms {
+		outerSymSet[sym] = true
 	}
 
 	// Collect symbols that branches produce (common across all branches)
 	branchOutputs := computeOrBranchOutputSymbols(clause)
 
-	// Build output columns: outer columns first, then new symbols from branches
-	columns := make([]query.Symbol, len(outerCols))
-	copy(columns, outerCols)
+	// Build output symbols: outer symbols first, then new symbols from branches
+	symbols := make([]query.Symbol, len(outerSyms))
+	copy(symbols, outerSyms)
 	for _, sym := range branchOutputs {
-		if !outerColSet[sym] {
-			columns = append(columns, sym)
+		if !outerSymSet[sym] {
+			symbols = append(symbols, sym)
 		}
 	}
 
@@ -59,7 +59,7 @@ func NewOrFallbackRelation(
 		ctx:      ctx,
 		clause:   clause,
 		outerRel: outerRel,
-		columns:  columns,
+		symbols:  symbols,
 		options:  options,
 	}
 }
@@ -182,7 +182,7 @@ func (r *OrFallbackRelation) Iterator() Iterator {
 			Start: time.Now(),
 			Data: map[string]interface{}{
 				"iterator_count": r.iteratorCount,
-				"outer_columns":  fmt.Sprintf("%v", r.outerRel.Columns()),
+				"outer_symbols":  fmt.Sprintf("%v", r.outerRel.Symbols()),
 				"outer_type":     fmt.Sprintf("%T", r.outerRel),
 			},
 		})
@@ -193,19 +193,15 @@ func (r *OrFallbackRelation) Iterator() Iterator {
 		ctx:        r.ctx,
 		clause:     r.clause,
 		outerIter:  outerIter,
-		outerCols:  r.outerRel.Columns(),
-		outputCols: r.columns, // Use pre-computed columns
+		outerSyms:  r.outerRel.Symbols(),
+		outputSyms: r.symbols, // Use pre-computed symbols
 		options:    r.options,
 	}
 }
 
-func (r *OrFallbackRelation) Columns() []query.Symbol {
-	// Columns are computed at construction time - no peeking needed
-	return r.columns
-}
-
 func (r *OrFallbackRelation) Symbols() []query.Symbol {
-	return r.Columns()
+	// Symbols are computed at construction time - no peeking needed
+	return r.symbols
 }
 
 func (r *OrFallbackRelation) Size() int {
@@ -223,11 +219,11 @@ func (r *OrFallbackRelation) Get(i int) Tuple {
 }
 
 func (r *OrFallbackRelation) String() string {
-	var symbols []string
-	for _, col := range r.Columns() {
-		symbols = append(symbols, col.String())
+	var symStrs []string
+	for _, sym := range r.Symbols() {
+		symStrs = append(symStrs, sym.String())
 	}
-	return fmt.Sprintf("OrFallbackRelation([%s], streaming)", strings.Join(symbols, " "))
+	return fmt.Sprintf("OrFallbackRelation([%s], streaming)", strings.Join(symStrs, " "))
 }
 
 func (r *OrFallbackRelation) Table() string {
@@ -242,19 +238,19 @@ func (r *OrFallbackRelation) Sorted() []Tuple {
 	return r.Materialize().Sorted()
 }
 
-func (r *OrFallbackRelation) Project(columns []query.Symbol) (Relation, error) {
-	return r.Materialize().Project(columns)
+func (r *OrFallbackRelation) Project(symbols []query.Symbol) (Relation, error) {
+	return r.Materialize().Project(symbols)
 }
 
 func (r *OrFallbackRelation) Materialize() Relation {
 	var tuples []Tuple
 	collectTuplesInto(&tuples, r)
 
-	cols := r.columns
-	if cols == nil {
-		cols = r.Columns()
+	syms := r.symbols
+	if syms == nil {
+		syms = r.Symbols()
 	}
-	return NewMaterializedRelationWithOptions(cols, tuples, r.options)
+	return NewMaterializedRelationWithOptions(syms, tuples, r.options)
 }
 
 func (r *OrFallbackRelation) Sort(orderBy []query.OrderByClause) Relation {
@@ -278,7 +274,7 @@ func (r *OrFallbackRelation) Select(pred func(Tuple) bool) Relation {
 }
 
 func (r *OrFallbackRelation) Join(other Relation) Relation {
-	common := CommonColumns(r, other)
+	common := CommonSymbols(r, other)
 	if len(common) == 0 {
 		return crossProduct(r, other)
 	}
@@ -317,14 +313,14 @@ type OrFallbackIterator struct {
 	ctx       Context
 	clause    *query.OrClause
 	outerIter Iterator
-	outerCols []query.Symbol
+	outerSyms []query.Symbol
 	options   ExecutorOptions
 
 	// Current state
 	currentBranchIter     Iterator
 	currentBranchRelation Relation // Track relation for RequiresCopy check
 	currentTuple          Tuple
-	outputCols            []query.Symbol
+	outputSyms            []query.Symbol
 	done                  bool
 	err                   error
 }
@@ -376,12 +372,12 @@ func (it *OrFallbackIterator) Next() bool {
 		}
 
 		// Build single-tuple relation for this input.
-		// Special case: if outer has no columns (unit relation), pass nil to avoid
+		// Special case: if outer has no symbols (unit relation), pass nil to avoid
 		// creating a ProductRelation that would try to re-iterate streaming results.
 		var inputRel Relation
-		if len(it.outerCols) > 0 {
+		if len(it.outerSyms) > 0 {
 			inputRel = NewMaterializedRelationWithOptions(
-				it.outerCols,
+				it.outerSyms,
 				[]Tuple{outerTuple},
 				it.options,
 			)
@@ -401,7 +397,7 @@ func (it *OrFallbackIterator) Next() bool {
 				branchIter := branchResult.Iterator()
 				if branchIter.Next() {
 					// This branch has results - use it
-					// (outputCols is pre-computed at iterator construction)
+					// (outputSyms is pre-computed at iterator construction)
 
 					// Emit annotation for branch success
 					if collector := it.ctx.Collector(); collector != nil {
@@ -410,20 +406,20 @@ func (it *OrFallbackIterator) Next() bool {
 							Start: time.Now(),
 							Data: map[string]interface{}{
 								"branch_index": branchIdx,
-								"branch_cols":  fmt.Sprintf("%v", branchResult.Columns()),
+								"branch_syms":  fmt.Sprintf("%v", branchResult.Symbols()),
 								"first_tuple":  fmt.Sprintf("%v", branchIter.Tuple()),
 							},
 						})
 					}
 
-					// Project tuple to match output columns if needed
+					// Project tuple to match output symbols if needed
 					// Different branches may produce different schemas (e.g., subquery vs ground)
-					branchCols := branchResult.Columns()
+					branchSyms := branchResult.Symbols()
 					firstTuple := branchIter.Tuple()
 
-					if len(branchCols) != len(it.outputCols) || !columnsMatch(branchCols, it.outputCols) {
+					if len(branchSyms) != len(it.outputSyms) || !symbolsMatch(branchSyms, it.outputSyms) {
 						// Projection allocates new slice - no additional copy needed
-						it.currentTuple = projectTupleToColumns(firstTuple, branchCols, it.outputCols)
+						it.currentTuple = projectTupleToSymbols(firstTuple, branchSyms, it.outputSyms)
 					} else if branchResult.RequiresCopy() {
 						// No projection but unsafe source - copy once
 						it.currentTuple = copyTuple(firstTuple)
@@ -434,8 +430,8 @@ func (it *OrFallbackIterator) Next() bool {
 					it.currentBranchIter = &projectedIterator{
 						inner:          branchIter,
 						branchRelation: branchResult,
-						branchCols:     branchCols,
-						outputCols:     it.outputCols,
+						branchSyms:     branchSyms,
+						outputSyms:     it.outputSyms,
 					}
 					return true
 				}
@@ -467,8 +463,8 @@ func (it *OrFallbackIterator) Error() error {
 	return it.err
 }
 
-// columnsMatch checks if two column slices have the same columns in the same order
-func columnsMatch(a, b []query.Symbol) bool {
+// symbolsMatch checks if two symbol slices have the same symbols in the same order
+func symbolsMatch(a, b []query.Symbol) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -480,21 +476,21 @@ func columnsMatch(a, b []query.Symbol) bool {
 	return true
 }
 
-// projectTupleToColumns projects a tuple from source columns to target columns
-func projectTupleToColumns(tuple Tuple, srcCols, dstCols []query.Symbol) Tuple {
-	// Build index for source columns
+// projectTupleToSymbols projects a tuple from source symbols to target symbols
+func projectTupleToSymbols(tuple Tuple, srcSyms, dstSyms []query.Symbol) Tuple {
+	// Build index for source symbols
 	srcIdx := make(map[query.Symbol]int)
-	for i, col := range srcCols {
-		srcIdx[col] = i
+	for i, sym := range srcSyms {
+		srcIdx[sym] = i
 	}
 
 	// Create projected tuple
-	result := make(Tuple, len(dstCols))
-	for i, col := range dstCols {
-		if idx, ok := srcIdx[col]; ok {
+	result := make(Tuple, len(dstSyms))
+	for i, sym := range dstSyms {
+		if idx, ok := srcIdx[sym]; ok {
 			result[i] = tuple[idx]
 		}
-		// If column not found, leave as nil (shouldn't happen with proper schema)
+		// If symbol not found, leave as nil (shouldn't happen with proper schema)
 	}
 	return result
 }
@@ -503,8 +499,8 @@ func projectTupleToColumns(tuple Tuple, srcCols, dstCols []query.Symbol) Tuple {
 type projectedIterator struct {
 	inner          Iterator
 	branchRelation Relation // For RequiresCopy check
-	branchCols     []query.Symbol
-	outputCols     []query.Symbol
+	branchSyms     []query.Symbol
+	outputSyms     []query.Symbol
 }
 
 func (it *projectedIterator) Next() bool {
@@ -514,9 +510,9 @@ func (it *projectedIterator) Next() bool {
 func (it *projectedIterator) Tuple() Tuple {
 	tuple := it.inner.Tuple()
 
-	if len(it.branchCols) != len(it.outputCols) || !columnsMatch(it.branchCols, it.outputCols) {
+	if len(it.branchSyms) != len(it.outputSyms) || !symbolsMatch(it.branchSyms, it.outputSyms) {
 		// Projection allocates new slice - no additional copy needed
-		return projectTupleToColumns(tuple, it.branchCols, it.outputCols)
+		return projectTupleToSymbols(tuple, it.branchSyms, it.outputSyms)
 	}
 
 	// No projection - copy if source is unsafe

--- a/datalog/executor/parallel_vs_sequential_test.go
+++ b/datalog/executor/parallel_vs_sequential_test.go
@@ -229,20 +229,20 @@ func TestParallelVsSequentialDecorrelation(t *testing.T) {
 			t.Errorf("Size mismatch: sequential=%d, parallel=%d", resultSeq.Size(), resultPar.Size())
 		}
 
-		// Compare each row
+		// Compare each tuple
 		for i := 0; i < resultSeq.Size(); i++ {
 			rowSeq := resultSeq.Get(i)
 			rowPar := resultPar.Get(i)
 
 			if len(rowSeq) != len(rowPar) {
-				t.Errorf("Row %d length mismatch: sequential=%d, parallel=%d",
+				t.Errorf("Tuple %d length mismatch: sequential=%d, parallel=%d",
 					i, len(rowSeq), len(rowPar))
 				continue
 			}
 
 			for j := range rowSeq {
 				if rowSeq[j] != rowPar[j] {
-					t.Errorf("Row %d, col %d mismatch: sequential=%v, parallel=%v",
+					t.Errorf("Tuple %d, col %d mismatch: sequential=%v, parallel=%v",
 						i, j, rowSeq[j], rowPar[j])
 				}
 			}

--- a/datalog/executor/pattern_match.go
+++ b/datalog/executor/pattern_match.go
@@ -50,7 +50,7 @@ func (m *MemoryPatternMatcher) MatchWithConstraints(
 	bindings Relations,
 	constraints []StorageConstraint,
 ) (Relation, error) {
-	columns := pattern.ExtractColumns()
+	symbols := pattern.ExtractColumns()
 
 	// Extract options from bindings if available
 	var opts ExecutorOptions
@@ -64,7 +64,7 @@ func (m *MemoryPatternMatcher) MatchWithConstraints(
 		if err != nil {
 			return nil, err
 		}
-		return datomsToRelationWithOptions(datoms, pattern, columns, opts), nil
+		return datomsToRelationWithOptions(datoms, pattern, symbols, opts), nil
 	}
 
 	// Find best binding relation
@@ -75,7 +75,7 @@ func (m *MemoryPatternMatcher) MatchWithConstraints(
 		if err != nil {
 			return nil, err
 		}
-		return datomsToRelationWithOptions(datoms, pattern, columns, opts), nil
+		return datomsToRelationWithOptions(datoms, pattern, symbols, opts), nil
 	}
 
 	// Match with bindings
@@ -91,13 +91,13 @@ func (m *MemoryPatternMatcher) MatchWithConstraints(
 
 		// Convert datoms to tuples
 		for _, datom := range datoms {
-			if tuple := query.DatomToTuple(datom, pattern, columns); tuple != nil {
+			if tuple := query.DatomToTuple(datom, pattern, symbols); tuple != nil {
 				allTuples = append(allTuples, tuple)
 			}
 		}
 	}
 
-	return NewMaterializedRelationWithOptions(columns, allTuples, bindingRel.Options()), nil
+	return NewMaterializedRelationWithOptions(symbols, allTuples, bindingRel.Options()), nil
 }
 
 // matchWithoutBindings returns datoms matching the pattern without bindings
@@ -149,7 +149,7 @@ func evaluateConstraints(datom *datalog.Datom, constraints []StorageConstraint) 
 // bindPatternFromTuple creates a new pattern with variables replaced by tuple values
 func bindPatternFromTuple(pattern *query.DataPattern, tuple Tuple, rel Relation) *query.DataPattern {
 	// Get symbol positions in the relation
-	symbols := rel.Columns()
+	symbols := rel.Symbols()
 	symbolIndex := make(map[query.Symbol]int)
 	for i, sym := range symbols {
 		symbolIndex[sym] = i
@@ -286,7 +286,7 @@ func matchesConstant(value, constant interface{}) bool {
 type datomIterator struct {
 	datoms  []datalog.Datom
 	pattern *query.DataPattern
-	columns []query.Symbol
+	symbols []query.Symbol
 	pos     int
 	current Tuple
 }
@@ -294,7 +294,7 @@ type datomIterator struct {
 func (it *datomIterator) Next() bool {
 	for it.pos+1 < len(it.datoms) {
 		it.pos++
-		if tuple := query.DatomToTuple(it.datoms[it.pos], it.pattern, it.columns); tuple != nil {
+		if tuple := query.DatomToTuple(it.datoms[it.pos], it.pattern, it.symbols); tuple != nil {
 			it.current = tuple
 			return true
 		}
@@ -311,28 +311,28 @@ func (it *datomIterator) Close() error {
 }
 
 // datomsToRelation converts datoms to a streaming relation (zero-copy lazy evaluation)
-func datomsToRelation(datoms []datalog.Datom, pattern *query.DataPattern, columns []query.Symbol) Relation {
-	return datomsToRelationWithOptions(datoms, pattern, columns, ExecutorOptions{})
+func datomsToRelation(datoms []datalog.Datom, pattern *query.DataPattern, symbols []query.Symbol) Relation {
+	return datomsToRelationWithOptions(datoms, pattern, symbols, ExecutorOptions{})
 }
 
 // datomsToRelationWithOptions converts datoms to a streaming relation with options
-func datomsToRelationWithOptions(datoms []datalog.Datom, pattern *query.DataPattern, columns []query.Symbol, opts ExecutorOptions) Relation {
-	if len(columns) == 0 || len(datoms) == 0 {
-		return NewMaterializedRelationWithOptions(columns, nil, opts)
+func datomsToRelationWithOptions(datoms []datalog.Datom, pattern *query.DataPattern, symbols []query.Symbol, opts ExecutorOptions) Relation {
+	if len(symbols) == 0 || len(datoms) == 0 {
+		return NewMaterializedRelationWithOptions(symbols, nil, opts)
 	}
 
 	iterator := &datomIterator{
 		datoms:  datoms,
 		pattern: pattern,
-		columns: columns,
+		symbols: symbols,
 		pos:     -1,
 	}
 
-	return NewStreamingRelationWithOptions(columns, iterator, opts)
+	return NewStreamingRelationWithOptions(symbols, iterator, opts)
 }
 
 // PatternToRelation converts pattern match results to a relation
 func PatternToRelation(datoms []datalog.Datom, pattern *query.DataPattern) Relation {
-	columns := pattern.ExtractColumns()
-	return datomsToRelation(datoms, pattern, columns)
+	symbols := pattern.ExtractColumns()
+	return datomsToRelation(datoms, pattern, symbols)
 }

--- a/datalog/executor/pattern_match_test.go
+++ b/datalog/executor/pattern_match_test.go
@@ -170,17 +170,17 @@ func TestDatomToRelationExtraction(t *testing.T) {
 	// Convert datom to relation using the pattern
 	rel := PatternToRelation([]datalog.Datom{datom}, pattern)
 
-	// Check relation has correct columns
-	columns := rel.Columns()
-	if len(columns) != 3 {
-		t.Errorf("expected 3 columns, got %d", len(columns))
+	// Check relation has correct symbols
+	symbols := rel.Symbols()
+	if len(symbols) != 3 {
+		t.Errorf("expected 3 symbols, got %d", len(symbols))
 	}
 
-	// Check column names
+	// Check symbol names
 	expectedCols := []query.Symbol{datalog.NewSymbol("?user"), datalog.NewSymbol("?name"), datalog.NewSymbol("?tx")}
-	for i, col := range columns {
+	for i, col := range symbols {
 		if col != expectedCols[i] {
-			t.Errorf("expected column %d to be %s, got %s", i, expectedCols[i], col)
+			t.Errorf("expected symbol %d to be %s, got %s", i, expectedCols[i], col)
 		}
 	}
 
@@ -228,13 +228,13 @@ func TestPatternToRelation(t *testing.T) {
 
 	rel := PatternToRelation(datoms, pattern)
 
-	// Check columns
-	cols := rel.Columns()
+	// Check symbols
+	cols := rel.Symbols()
 	if len(cols) != 2 {
-		t.Errorf("expected 2 columns, got %d", len(cols))
+		t.Errorf("expected 2 symbols, got %d", len(cols))
 	}
 	if cols[0] != datalog.NewSymbol("?user") || cols[1] != datalog.NewSymbol("?name") {
-		t.Errorf("unexpected columns: %v", cols)
+		t.Errorf("unexpected symbols: %v", cols)
 	}
 
 	// Verify tuples contain correct data

--- a/datalog/executor/peak_memory_test.go
+++ b/datalog/executor/peak_memory_test.go
@@ -36,7 +36,7 @@ func TestPeakMemoryFullConsumption(t *testing.T) {
 				runtime.ReadMemStats(&memBefore)
 
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -46,7 +46,7 @@ func TestPeakMemoryFullConsumption(t *testing.T) {
 					},
 				}
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -97,7 +97,7 @@ func TestPeakMemoryFullConsumption(t *testing.T) {
 				runtime.ReadMemStats(&memBefore)
 
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -107,7 +107,7 @@ func TestPeakMemoryFullConsumption(t *testing.T) {
 					},
 				}
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{

--- a/datalog/executor/prepended_relation.go
+++ b/datalog/executor/prepended_relation.go
@@ -10,7 +10,7 @@ import (
 // PrependedRelation wraps a relation with a pre-peeked first tuple.
 // This allows checking if a relation has results without losing the first tuple.
 type PrependedRelation struct {
-	columns      []query.Symbol
+	symbols      []query.Symbol
 	firstTuple   Tuple
 	restRelation Relation
 	options      ExecutorOptions
@@ -19,9 +19,9 @@ type PrependedRelation struct {
 
 // NewPrependedRelation creates a streaming relation that yields firstTuple first,
 // then continues with the rest of the relation.
-func NewPrependedRelation(columns []query.Symbol, firstTuple Tuple, restRelation Relation, options ExecutorOptions) *PrependedRelation {
+func NewPrependedRelation(symbols []query.Symbol, firstTuple Tuple, restRelation Relation, options ExecutorOptions) *PrependedRelation {
 	return &PrependedRelation{
-		columns:      columns,
+		symbols:      symbols,
 		firstTuple:   firstTuple,
 		restRelation: restRelation,
 		options:      options,
@@ -42,12 +42,8 @@ func (r *PrependedRelation) Iterator() Iterator {
 	}
 }
 
-func (r *PrependedRelation) Columns() []query.Symbol {
-	return r.columns
-}
-
 func (r *PrependedRelation) Symbols() []query.Symbol {
-	return r.columns
+	return r.symbols
 }
 
 func (r *PrependedRelation) Size() int {
@@ -63,11 +59,11 @@ func (r *PrependedRelation) Get(i int) Tuple {
 }
 
 func (r *PrependedRelation) String() string {
-	var symbols []string
-	for _, col := range r.columns {
-		symbols = append(symbols, col.String())
+	var symStrs []string
+	for _, sym := range r.symbols {
+		symStrs = append(symStrs, sym.String())
 	}
-	return fmt.Sprintf("PrependedRelation([%s], streaming)", strings.Join(symbols, " "))
+	return fmt.Sprintf("PrependedRelation([%s], streaming)", strings.Join(symStrs, " "))
 }
 
 func (r *PrependedRelation) Table() string {
@@ -82,8 +78,8 @@ func (r *PrependedRelation) Sorted() []Tuple {
 	return r.Materialize().Sorted()
 }
 
-func (r *PrependedRelation) Project(columns []query.Symbol) (Relation, error) {
-	return r.Materialize().Project(columns)
+func (r *PrependedRelation) Project(symbols []query.Symbol) (Relation, error) {
+	return r.Materialize().Project(symbols)
 }
 
 func (r *PrependedRelation) Materialize() Relation {
@@ -100,7 +96,7 @@ func (r *PrependedRelation) Materialize() Relation {
 	}
 	it.Close()
 
-	return NewMaterializedRelationWithOptions(r.columns, tuples, r.options)
+	return NewMaterializedRelationWithOptions(r.symbols, tuples, r.options)
 }
 
 func (r *PrependedRelation) Sort(orderBy []query.OrderByClause) Relation {
@@ -124,7 +120,7 @@ func (r *PrependedRelation) Select(pred func(Tuple) bool) Relation {
 }
 
 func (r *PrependedRelation) Join(other Relation) Relation {
-	common := CommonColumns(r, other)
+	common := CommonSymbols(r, other)
 	if len(common) == 0 {
 		return crossProduct(r, other)
 	}

--- a/datalog/executor/pull.go
+++ b/datalog/executor/pull.go
@@ -222,7 +222,7 @@ func (pe *PullExecutor) lookupAttributeViaPattern(entity datalog.Identity, attr 
 
 	if it.Next() {
 		tuple := it.Tuple()
-		cols := rel.Columns()
+		cols := rel.Symbols()
 		symV := datalog.NewSymbol("?v")
 		for i, col := range cols {
 			if col == symV && i < len(tuple) {
@@ -266,8 +266,8 @@ func (pe *PullExecutor) getAllAttributesInternal(entity datalog.Identity) ([]dat
 		return nil, nil
 	}
 
-	// Find column indices
-	cols := rel.Columns()
+	// Find symbol indices
+	cols := rel.Symbols()
 	symA := datalog.NewSymbol("?a")
 	symV := datalog.NewSymbol("?v")
 	aIdx := -1
@@ -281,7 +281,7 @@ func (pe *PullExecutor) getAllAttributesInternal(entity datalog.Identity) ([]dat
 	}
 
 	if aIdx < 0 || vIdx < 0 {
-		return nil, fmt.Errorf("missing expected columns in result")
+		return nil, fmt.Errorf("missing expected symbols in result")
 	}
 
 	// Collect datoms
@@ -534,8 +534,8 @@ func (pe *PullExecutor) lookupAllValuesInternal(entity datalog.Identity, attr da
 		return nil
 	}
 
-	// Find value column index
-	cols := rel.Columns()
+	// Find value symbol index
+	cols := rel.Symbols()
 	symV := datalog.NewSymbol("?v")
 	vIdx := -1
 	for i, col := range cols {

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -31,7 +31,7 @@ type DefaultQueryExecutor struct {
 	matcher          PatternMatcher
 	entityResolver   EntityResolver
 	options          ExecutorOptions
-	constantBindings map[query.Symbol]interface{} // Scalar inputs resolved as constants (not relation columns)
+	constantBindings map[query.Symbol]interface{} // Scalar inputs resolved as constants (not relation symbols)
 }
 
 // newQueryExecutor creates a new DefaultQueryExecutor.
@@ -208,7 +208,7 @@ func (e *DefaultQueryExecutor) Execute(ctx Context, q *query.Query, inputs []Rel
 			groupsHaveSymbols := make([][]bool, len(groups))
 			for i, group := range groups {
 				groupsHaveSymbols[i] = make([]bool, len(findSymbols))
-				cols := group.Columns()
+				cols := group.Symbols()
 				for j, sym := range findSymbols {
 					for _, col := range cols {
 						if col == sym {
@@ -374,18 +374,18 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 				return nil, fmt.Errorf("tuple mismatch: %d values, %d variables",
 					len(values), len(binding.Variables))
 			}
-			columns := binding.Variables
+			symbols := binding.Variables
 			tuple := make(Tuple, len(values))
 			copy(tuple, values)
-			return []Relation{NewMaterializedRelationWithOptions(columns, []Tuple{tuple}, e.options)}, nil
+			return []Relation{NewMaterializedRelationWithOptions(symbols, []Tuple{tuple}, e.options)}, nil
 
 		case query.Symbol:
 			if binding == nil {
 				return groups, nil
 			}
-			columns := []query.Symbol{binding}
+			symbols := []query.Symbol{binding}
 			tuples := []Tuple{{result}}
-			return []Relation{NewMaterializedRelationWithOptions(columns, tuples, e.options)}, nil
+			return []Relation{NewMaterializedRelationWithOptions(symbols, tuples, e.options)}, nil
 
 		default:
 			return nil, fmt.Errorf("unsupported binding type: %T", expr.Binding)
@@ -402,7 +402,7 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 
 	for _, rel := range groups {
 		hasAny := false
-		relCols := rel.Columns()
+		relCols := rel.Symbols()
 		for _, sym := range unresolvedExprSyms {
 			for _, col := range relCols {
 				if col == sym {
@@ -424,7 +424,7 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 	if len(relevantRels) == 0 {
 		// No relation has required symbols
 		if len(unresolvedExprSyms) == 0 && len(groups) > 0 {
-			// Ground expression (or all-constants) with existing groups - evaluate once and add column(s)
+			// Ground expression (or all-constants) with existing groups - evaluate once and add symbol(s)
 			// This handles OR fallback: (or [subquery] [(ground 0) ?count])
 			// and constant-bindable scalar expressions: [(+ ?age ?bonus) ?adjusted] where ?bonus is constant
 			evalBindings := make(map[query.Symbol]interface{})
@@ -447,7 +447,7 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 				return nil, err
 			}
 
-			// Determine binding columns and values
+			// Determine binding symbols and values
 			var bindingCols []query.Symbol
 			var bindingValues []interface{}
 			switch binding := expr.Binding.(type) {
@@ -469,10 +469,10 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 				}
 			}
 
-			// Add the new columns to each relation in groups
+			// Add the new symbols to each relation in groups
 			var resultRels []Relation
 			for _, rel := range groups {
-				newCols := append(rel.Columns(), bindingCols...)
+				newCols := append(rel.Symbols(), bindingCols...)
 				var newTuples []Tuple
 				iter := rel.Iterator()
 				for iter.Next() {
@@ -594,7 +594,7 @@ func (e *DefaultQueryExecutor) executePredicate(ctx Context, pred query.Predicat
 
 	for _, rel := range groups {
 		hasAny := false
-		relCols := rel.Columns()
+		relCols := rel.Symbols()
 		for _, sym := range unresolvedSyms {
 			for _, col := range relCols {
 				if col == sym {
@@ -703,7 +703,7 @@ func (e *DefaultQueryExecutor) executeSubquery(ctx Context, subq *query.Subquery
 			return nil, fmt.Errorf("nested query execution failed: %w", err)
 		}
 		if len(nestedGroups) == 0 {
-			// Empty result - return empty relation with binding columns
+			// Empty result - return empty relation with binding symbols
 			return NewMaterializedRelationWithOptions(extractBindingSymbols(subq.Binding), nil, e.options), nil
 		}
 		if len(nestedGroups) > 1 {
@@ -742,7 +742,7 @@ func (e *DefaultQueryExecutor) executeSubquery(ctx Context, subq *query.Subquery
 					Name: "subquery/input-relation",
 					Data: map[string]interface{}{
 						"index":   i,
-						"columns": rel.Columns(),
+						"symbols": rel.Symbols(),
 						"size":    rel.Size(),
 					},
 				})
@@ -777,7 +777,7 @@ func (e *DefaultQueryExecutor) executeSubquery(ctx Context, subq *query.Subquery
 
 	// Combine all results
 	if len(allResults) == 0 {
-		// No results - return empty relation with appropriate columns
+		// No results - return empty relation with appropriate symbols
 		return NewMaterializedRelation(extractBindingSymbols(subq.Binding), []Tuple{}), nil
 	}
 
@@ -804,14 +804,14 @@ func combineSubqueryResultsSimple(results []Relation) Relation {
 	}
 
 	// Collect all tuples
-	columns := results[0].Columns()
+	symbols := results[0].Symbols()
 	var allTuples []Tuple
 
 	for _, result := range results {
 		collectTuplesInto(&allTuples, result)
 	}
 
-	return NewMaterializedRelation(columns, allTuples)
+	return NewMaterializedRelation(symbols, allTuples)
 }
 
 // extractBindingSymbols extracts symbols from a binding form
@@ -1026,24 +1026,6 @@ func (e *DefaultQueryExecutor) executeSubquerySequential(
 	return unionBuilder.Union(allResults), nil
 }
 
-// extractFindSymbols extracts symbols from FindElements for projection
-func extractFindSymbols(find []query.FindElement) []query.Symbol {
-	var symbols []query.Symbol
-	for _, elem := range find {
-		switch e := elem.(type) {
-		case query.FindVariable:
-			symbols = append(symbols, e.Symbol)
-		case query.FindAggregate:
-			// For aggregates, include the argument variable
-			symbols = append(symbols, e.Arg)
-		case query.FindPull:
-			// For pulls, include the pulled variable
-			symbols = append(symbols, e.Variable)
-		}
-	}
-	return symbols
-}
-
 // hasPulls checks if any find element is a pull expression
 func hasPulls(find []query.FindElement) bool {
 	for _, elem := range find {
@@ -1058,14 +1040,14 @@ func hasPulls(find []query.FindElement) bool {
 // For each tuple in the relation, it replaces entity values with pulled maps
 // based on the FindPull patterns in the find clause.
 func (e *DefaultQueryExecutor) executePulls(rel Relation, find []query.FindElement) (Relation, error) {
-	// Build mapping: column index -> pull pattern
-	columns := rel.Columns()
+	// Build mapping: symbol index -> pull pattern
+	symbols := rel.Symbols()
 	pullSpecs := make(map[int]query.FindPull)
 
 	for _, elem := range find {
 		if pull, ok := elem.(query.FindPull); ok {
-			// Find the column index for this pull variable
-			for i, col := range columns {
+			// Find the symbol index for this pull variable
+			for i, col := range symbols {
 				if col == pull.Variable {
 					pullSpecs[i] = pull
 					break
@@ -1092,7 +1074,7 @@ func (e *DefaultQueryExecutor) executePulls(rel Relation, find []query.FindEleme
 		newTuple := make(Tuple, len(tuple))
 		copy(newTuple, tuple)
 
-		// Execute pulls for each pull column
+		// Execute pulls for each pull symbol
 		for colIdx, pull := range pullSpecs {
 			if colIdx >= len(tuple) {
 				continue
@@ -1127,7 +1109,7 @@ func (e *DefaultQueryExecutor) executePulls(rel Relation, find []query.FindEleme
 	// Return relation without deduplication - pulled maps (map[string]interface{})
 	// are not comparable and would panic during deduplication
 	return &MaterializedRelation{
-		columns: columns,
+		symbols: symbols,
 		tuples:  resultTuples,
 		options: rel.Options(),
 	}, nil
@@ -1215,7 +1197,7 @@ func (e *DefaultQueryExecutor) executeOrClauseFallback(ctx Context, clause *quer
 
 	// Always have an outer context - use unit relation if none available.
 	// This eliminates the "global fallback" path and unifies execution:
-	// per-row fallback on unit relation (one empty tuple) = try branches until one works.
+	// per-tuple fallback on unit relation (one empty tuple) = try branches until one works.
 	var outerRel Relation
 	if len(groups) == 0 {
 		// No input groups - use unit relation as base case
@@ -1230,7 +1212,7 @@ func (e *DefaultQueryExecutor) executeOrClauseFallback(ctx Context, clause *quer
 		// symbols ARE available from outer context.
 		var outerBindingIdx int = -1
 		for i, rel := range groups {
-			if containsAny(rel.Columns(), neededSymbols) {
+			if containsAny(rel.Symbols(), neededSymbols) {
 				outerBindingIdx = i
 				break
 			}
@@ -1247,29 +1229,29 @@ func (e *DefaultQueryExecutor) executeOrClauseFallback(ctx Context, clause *quer
 		}
 	}
 
-	// Always use OrFallbackRelation for per-row evaluation
+	// Always use OrFallbackRelation for per-tuple evaluation
 	return NewOrFallbackRelation(e, ctx, clause, outerRel, e.options), nil
 }
 
-// findCommonColumns returns columns that exist in all relations
-func findCommonColumns(relations []Relation) []query.Symbol {
+// findCommonColumns returns symbols that exist in all relations
+func findCommonSymbols(relations []Relation) []query.Symbol {
 	if len(relations) == 0 {
 		return nil
 	}
 
-	// Start with first relation's columns
+	// Start with first relation's symbols
 	colSet := make(map[query.Symbol]bool)
-	for _, col := range relations[0].Columns() {
+	for _, col := range relations[0].Symbols() {
 		colSet[col] = true
 	}
 
 	// Intersect with each subsequent relation
 	for i := 1; i < len(relations); i++ {
 		relCols := make(map[query.Symbol]bool)
-		for _, col := range relations[i].Columns() {
+		for _, col := range relations[i].Symbols() {
 			relCols[col] = true
 		}
-		// Keep only columns that exist in both
+		// Keep only symbols that exist in both
 		for col := range colSet {
 			if !relCols[col] {
 				delete(colSet, col)
@@ -1279,7 +1261,7 @@ func findCommonColumns(relations []Relation) []query.Symbol {
 
 	// Preserve order from first relation
 	var result []query.Symbol
-	for _, col := range relations[0].Columns() {
+	for _, col := range relations[0].Symbols() {
 		if colSet[col] {
 			result = append(result, col)
 		}
@@ -1296,7 +1278,7 @@ func antiJoinOnSymbols(left, right Relation, symbols []query.Symbol) Relation {
 	// Build set of key values from right
 	rightKeys := make(map[string]bool)
 	rightIter := right.Iterator()
-	rightCols := right.Columns()
+	rightCols := right.Symbols()
 	for rightIter.Next() {
 		tuple := rightIter.Tuple()
 		key := extractKeyFromTuple(tuple, rightCols, symbols)
@@ -1307,7 +1289,7 @@ func antiJoinOnSymbols(left, right Relation, symbols []query.Symbol) Relation {
 	// Filter left to only tuples not in right
 	var remaining []Tuple
 	leftIter := left.Iterator()
-	leftCols := left.Columns()
+	leftCols := left.Symbols()
 	for leftIter.Next() {
 		tuple := leftIter.Tuple()
 		key := extractKeyFromTuple(tuple, leftCols, symbols)
@@ -1343,10 +1325,10 @@ func crossJoinWithOuter(outer, branch Relation, opts ExecutorOptions) Relation {
 		return branch
 	}
 
-	outerCols := outer.Columns()
-	branchCols := branch.Columns()
+	outerCols := outer.Symbols()
+	branchCols := branch.Symbols()
 
-	// Combined columns: outer columns + branch columns
+	// Combined symbols: outer symbols + branch symbols
 	combinedCols := make([]query.Symbol, 0, len(outerCols)+len(branchCols))
 	combinedCols = append(combinedCols, outerCols...)
 	combinedCols = append(combinedCols, branchCols...)
@@ -1423,13 +1405,13 @@ func (e *DefaultQueryExecutor) executeOrClauseUnion(ctx Context, clause *query.O
 			continue
 		}
 
-		// Track columns for intersection
+		// Track symbols for intersection
 		if len(branchResults) == 0 {
-			commonCols = branchResult.Columns()
+			commonCols = branchResult.Symbols()
 		} else {
-			// Intersect columns
+			// Intersect symbols
 			branchColSet := make(map[query.Symbol]bool)
-			for _, col := range branchResult.Columns() {
+			for _, col := range branchResult.Symbols() {
 				branchColSet[col] = true
 			}
 			var newCommon []query.Symbol
@@ -1448,7 +1430,7 @@ func (e *DefaultQueryExecutor) executeOrClauseUnion(ctx Context, clause *query.O
 		return NewMaterializedRelationWithOptions(nil, nil, e.options), nil
 	}
 
-	// Union all branch results, projecting to common columns
+	// Union all branch results, projecting to common symbols
 	return unionRelations(branchResults, commonCols, e.options), nil
 }
 
@@ -1661,7 +1643,7 @@ func (e *DefaultQueryExecutor) filterWithNotClause(ctx Context, clause *query.No
 	input = input.Materialize()
 
 	// Filter to only variables present in input relation
-	inputCols := input.Columns()
+	inputCols := input.Symbols()
 	inputColSet := make(map[query.Symbol]bool)
 	for _, col := range inputCols {
 		inputColSet[col] = true
@@ -1702,7 +1684,7 @@ func (e *DefaultQueryExecutor) filterWithNotClause(ctx Context, clause *query.No
 		}
 	}
 
-	// Build join key column indices for input
+	// Build join key symbol indices for input
 	keyIndices := make([]int, len(actualJoinVars))
 	for i, v := range actualJoinVars {
 		for j, col := range inputCols {
@@ -1742,7 +1724,7 @@ func (e *DefaultQueryExecutor) filterWithNotJoinClause(ctx Context, clause *quer
 
 	// Materialize input
 	input = input.Materialize()
-	inputCols := input.Columns()
+	inputCols := input.Symbols()
 
 	// Verify join vars exist in input
 	inputColSet := make(map[query.Symbol]bool)

--- a/datalog/executor/query_executor_test.go
+++ b/datalog/executor/query_executor_test.go
@@ -70,13 +70,13 @@ func TestProductRelation(t *testing.T) {
 			t.Errorf("Expected 6 tuples, got %d", product.Size())
 		}
 
-		// Check columns
-		cols := product.Columns()
+		// Check symbols
+		cols := product.Symbols()
 		if len(cols) != 2 {
-			t.Errorf("Expected 2 columns, got %d", len(cols))
+			t.Errorf("Expected 2 symbols, got %d", len(cols))
 		}
 		if cols[0] != datalog.NewSymbol("?x") || cols[1] != datalog.NewSymbol("?y") {
-			t.Errorf("Expected columns [?x ?y], got %v", cols)
+			t.Errorf("Expected symbols [?x ?y], got %v", cols)
 		}
 
 		// Verify all combinations exist
@@ -115,10 +115,10 @@ func TestProductRelation(t *testing.T) {
 			t.Errorf("Expected 4 tuples, got %d", product.Size())
 		}
 
-		// Check columns
-		cols := product.Columns()
+		// Check symbols
+		cols := product.Symbols()
 		if len(cols) != 3 {
-			t.Errorf("Expected 3 columns, got %d", len(cols))
+			t.Errorf("Expected 3 symbols, got %d", len(cols))
 		}
 	})
 }
@@ -196,10 +196,10 @@ func TestExecuteExpression(t *testing.T) {
 			t.Errorf("Expected 2 tuples, got %d", result.Size())
 		}
 
-		// Check columns
-		cols := result.Columns()
+		// Check symbols
+		cols := result.Symbols()
 		if len(cols) != 2 {
-			t.Errorf("Expected 2 columns, got %d", len(cols))
+			t.Errorf("Expected 2 symbols, got %d", len(cols))
 		}
 	})
 
@@ -236,10 +236,10 @@ func TestExecuteExpression(t *testing.T) {
 			t.Errorf("Expected 4 tuples from Cartesian product, got %d", result.Size())
 		}
 
-		// Check columns: should have ?x, ?y, ?z
-		cols := result.Columns()
+		// Check symbols: should have ?x, ?y, ?z
+		cols := result.Symbols()
 		if len(cols) != 3 {
-			t.Errorf("Expected 3 columns (?x, ?y, ?z), got %d: %v", len(cols), cols)
+			t.Errorf("Expected 3 symbols (?x, ?y, ?z), got %d: %v", len(cols), cols)
 		}
 	})
 }
@@ -458,15 +458,15 @@ func TestExecuteTupleGround(t *testing.T) {
 			t.Errorf("Expected 1 tuple, got %d", result.Size())
 		}
 
-		// Check columns
-		cols := result.Columns()
+		// Check symbols
+		cols := result.Symbols()
 		if len(cols) != 3 {
-			t.Errorf("Expected 3 columns, got %d", len(cols))
+			t.Errorf("Expected 3 symbols, got %d", len(cols))
 		}
 		expected := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
 		for i, exp := range expected {
 			if cols[i] != exp {
-				t.Errorf("Column %d = %v, want %v", i, cols[i], exp)
+				t.Errorf("Symbol %d = %v, want %v", i, cols[i], exp)
 			}
 		}
 
@@ -513,15 +513,15 @@ func TestExecuteTupleGround(t *testing.T) {
 		}
 
 		result := groups[0]
-		// Should have 2 rows (one for each ?x value) with ?a, ?b added
+		// Should have 2 tuples (one for each ?x value) with ?a, ?b added
 		if result.Size() != 2 {
 			t.Errorf("Expected 2 tuples, got %d", result.Size())
 		}
 
-		// Check columns: should have ?x, ?a, ?b
-		cols := result.Columns()
+		// Check symbols: should have ?x, ?a, ?b
+		cols := result.Symbols()
 		if len(cols) != 3 {
-			t.Errorf("Expected 3 columns, got %d", len(cols))
+			t.Errorf("Expected 3 symbols, got %d", len(cols))
 		}
 	})
 

--- a/datalog/executor/queryexecutor_correlated_subquery_test.go
+++ b/datalog/executor/queryexecutor_correlated_subquery_test.go
@@ -52,7 +52,7 @@ func TestQueryExecutorCorrelatedSubquery(t *testing.T) {
 
 	if err != nil {
 		t.Logf("Error: %v", err)
-		t.Logf("Result columns (if any): %v", result.Columns())
+		t.Logf("Result symbols (if any): %v", result.Symbols())
 	}
 
 	assert.NoError(t, err, "QueryExecutor should handle correlated subqueries")

--- a/datalog/executor/queryexecutor_multiple_correlated_subqueries_test.go
+++ b/datalog/executor/queryexecutor_multiple_correlated_subqueries_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestQueryExecutorMultipleCorrelatedSubqueries tests the pattern from gopher-street
-// where multiple correlated subqueries are used in sequence to build up result columns
+// where multiple correlated subqueries are used in sequence to build up result symbols
 func TestQueryExecutorMultipleCorrelatedSubqueries(t *testing.T) {
 	// Create test data similar to gopher-street OHLC pattern
 	day1 := datalog.NewIdentity("day1")
@@ -143,7 +143,7 @@ func TestQueryExecutorMultipleCorrelatedSubqueries(t *testing.T) {
 
 		if err != nil {
 			t.Logf("Error: %v", err)
-			t.Logf("Result columns (if any): %v", result.Columns())
+			t.Logf("Result symbols (if any): %v", result.Symbols())
 		}
 
 		assert.NoError(t, err, "QueryExecutor should handle multiple correlated subqueries")

--- a/datalog/executor/queryexecutor_subquery_projection_test.go
+++ b/datalog/executor/queryexecutor_subquery_projection_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 // TestQueryExecutorSubqueryProjection tests that QueryExecutor properly handles
-// subquery result columns for projection in the :find clause.
+// subquery result symbols for projection in the :find clause.
 //
-// Bug: QueryExecutor fails to preserve subquery result column names, causing
-// projection to fail with "cannot project: column ?xxx not found in relation"
+// Bug: QueryExecutor fails to preserve subquery result symbol names, causing
+// projection to fail with "cannot project: symbol ?xxx not found in relation"
 //
 // This reproduces the gopher-street bug:
-// "cannot project: column ?open-price not found in relation"
+// "cannot project: symbol ?open-price not found in relation"
 func TestQueryExecutorSubqueryProjection(t *testing.T) {
 	// Create test data
 	alice := datalog.NewIdentity("alice")
@@ -36,7 +36,7 @@ func TestQueryExecutorSubqueryProjection(t *testing.T) {
 		{E: charlie, A: ageKw, V: int64(35), Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
 	}
 
-	// Query with subquery that projects a result column
+	// Query with subquery that projects a result symbol
 	// The outer query should be able to find ?max-age in its :find clause
 	queryStr := `[:find ?name ?max-age
 	              :where [?e :person/name ?name]
@@ -51,7 +51,7 @@ func TestQueryExecutorSubqueryProjection(t *testing.T) {
 	opts := planner.PlannerOptions{}
 	exec := NewExecutorWithOptions(matcher, nil, opts)
 	result, err := exec.Execute(q)
-	assert.NoError(t, err, "QueryExecutor should preserve subquery result column names")
+	assert.NoError(t, err, "QueryExecutor should preserve subquery result symbol names")
 
 	// Collect results (don't check Size() or IsEmpty() - may be streaming and would consume first tuple)
 	it := result.Iterator()
@@ -70,7 +70,7 @@ func TestQueryExecutorSubqueryProjection(t *testing.T) {
 }
 
 // TestQueryExecutorMultipleSubqueryProjections tests multiple subqueries
-// each contributing columns to the final projection
+// each contributing symbols to the final projection
 func TestQueryExecutorMultipleSubqueryProjections(t *testing.T) {
 	// Create test data - price bars for multiple symbols
 	aapl := datalog.NewIdentity("AAPL")
@@ -158,8 +158,8 @@ func TestQueryExecutorMultipleSubqueryProjections(t *testing.T) {
 		result, err := exec.Execute(q)
 
 		// BUG: This should succeed but fails with:
-		// "cannot project: column ?first-open (or other subquery columns) not found in relation"
-		assert.NoError(t, err, "QueryExecutor should preserve all subquery result column names")
+		// "cannot project: symbol ?first-open (or other subquery symbols) not found in relation"
+		assert.NoError(t, err, "QueryExecutor should preserve all subquery result symbol names")
 
 		// Collect results (don't check Size() - may be streaming)
 		it := result.Iterator()

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -38,6 +38,32 @@ func collectTuplesInto(dest *[]Tuple, rel Relation) {
 	it.Close()
 }
 
+// CollectTuples materializes a Relation into [][]interface{}.
+// Accepts the (Relation, error) pair returned by Query() directly:
+//
+//	results, err := executor.CollectTuples(db.Query(...))
+func CollectTuples(rel Relation, err error) ([][]interface{}, error) {
+	if err != nil {
+		return nil, err
+	}
+	if rel == nil {
+		return [][]interface{}{}, nil
+	}
+	var tuples [][]interface{}
+	it := rel.Iterator()
+	defer it.Close()
+	for it.Next() {
+		src := it.Tuple()
+		t := make([]interface{}, len(src))
+		copy(t, src)
+		tuples = append(tuples, t)
+	}
+	if tuples == nil {
+		tuples = [][]interface{}{}
+	}
+	return tuples, nil
+}
+
 // Relation represents a set of tuples with named symbols
 type Relation interface {
 	// Symbols returns the symbols (attribute names) of this relation

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -38,12 +38,8 @@ func collectTuplesInto(dest *[]Tuple, rel Relation) {
 	it.Close()
 }
 
-// Relation represents a set of tuples with named columns
+// Relation represents a set of tuples with named symbols
 type Relation interface {
-	// Columns returns the column names (symbols) in order
-	// Deprecated: Use Symbols() instead for consistency with relational theory
-	Columns() []query.Symbol
-
 	// Symbols returns the symbols (attribute names) of this relation
 	// In relational theory, a tuple is a map from symbols to values
 	Symbols() []query.Symbol
@@ -74,9 +70,9 @@ type Relation interface {
 	// First symbol is primary sort key, second is secondary, etc.
 	Sorted() []Tuple
 
-	// Project returns a new relation with only the specified columns
-	// Returns an error if any requested column doesn't exist
-	Project(columns []query.Symbol) (Relation, error)
+	// Project returns a new relation with only the specified symbols
+	// Returns an error if any requested symbol doesn't exist
+	Project(symbols []query.Symbol) (Relation, error)
 
 	// Materialize converts a streaming relation to a materialized one
 	// For already-materialized relations, returns self
@@ -91,8 +87,8 @@ type Relation interface {
 	// FilterWithPredicate returns a new relation filtered by a query.Predicate
 	FilterWithPredicate(pred query.Predicate) Relation
 
-	// EvaluateFunction evaluates a function and adds its result as a new column
-	EvaluateFunction(fn query.Function, outputColumn query.Symbol) Relation
+	// EvaluateFunction evaluates a function and adds its result as a new symbol
+	EvaluateFunction(fn query.Function, outputSymbol query.Symbol) Relation
 
 	// Select returns a new relation with only tuples that satisfy the predicate
 	Select(pred func(Tuple) bool) Relation
@@ -100,14 +96,14 @@ type Relation interface {
 	// Join performs a natural join with another relation
 	Join(other Relation) Relation
 
-	// HashJoin performs an equi-join on specified columns
-	HashJoin(other Relation, joinCols []query.Symbol) Relation
+	// HashJoin performs an equi-join on specified symbols
+	HashJoin(other Relation, joinSyms []query.Symbol) Relation
 
 	// SemiJoin returns tuples from this relation that have matches in the other
-	SemiJoin(other Relation, joinCols []query.Symbol) Relation
+	SemiJoin(other Relation, joinSyms []query.Symbol) Relation
 
 	// AntiJoin returns tuples from this relation that have no matches in the other
-	AntiJoin(other Relation, joinCols []query.Symbol) Relation
+	AntiJoin(other Relation, joinSyms []query.Symbol) Relation
 
 	// Aggregate performs aggregation operations
 	Aggregate(findElements []query.FindElement) Relation
@@ -278,29 +274,29 @@ func (ci *CachingIterator) signalComplete() {
 
 // MaterializedRelation holds all tuples in memory
 type MaterializedRelation struct {
-	columns []query.Symbol
+	symbols []query.Symbol
 	tuples  []Tuple
 	options ExecutorOptions
 }
 
-func NewMaterializedRelation(columns []query.Symbol, tuples []Tuple) *MaterializedRelation {
+func NewMaterializedRelation(symbols []query.Symbol, tuples []Tuple) *MaterializedRelation {
 	// Deduplicate tuples at creation
 	dedupedTuples := deduplicateTuples(tuples)
 
 	return &MaterializedRelation{
-		columns: columns,
+		symbols: symbols,
 		tuples:  dedupedTuples,
 		options: ExecutorOptions{}, // Default options
 	}
 }
 
 // NewMaterializedRelationWithOptions creates a materialized relation with specific options
-func NewMaterializedRelationWithOptions(columns []query.Symbol, tuples []Tuple, opts ExecutorOptions) *MaterializedRelation {
+func NewMaterializedRelationWithOptions(symbols []query.Symbol, tuples []Tuple, opts ExecutorOptions) *MaterializedRelation {
 	// Deduplicate tuples at creation
 	dedupedTuples := deduplicateTuples(tuples)
 
 	return &MaterializedRelation{
-		columns: columns,
+		symbols: symbols,
 		tuples:  dedupedTuples,
 		options: opts,
 	}
@@ -308,18 +304,18 @@ func NewMaterializedRelationWithOptions(columns []query.Symbol, tuples []Tuple, 
 
 // NewMaterializedRelationNoDedupe creates a materialized relation without deduplication
 // Use this when you know the tuples are already unique (e.g., from storage scans)
-func NewMaterializedRelationNoDedupe(columns []query.Symbol, tuples []Tuple) *MaterializedRelation {
+func NewMaterializedRelationNoDedupe(symbols []query.Symbol, tuples []Tuple) *MaterializedRelation {
 	return &MaterializedRelation{
-		columns: columns,
+		symbols: symbols,
 		tuples:  tuples,
 		options: ExecutorOptions{}, // Default options
 	}
 }
 
 // NewMaterializedRelationNoDedupeWithOptions creates a new relation without deduplication, with options
-func NewMaterializedRelationNoDedupeWithOptions(columns []query.Symbol, tuples []Tuple, opts ExecutorOptions) *MaterializedRelation {
+func NewMaterializedRelationNoDedupeWithOptions(symbols []query.Symbol, tuples []Tuple, opts ExecutorOptions) *MaterializedRelation {
 	return &MaterializedRelation{
-		columns: columns,
+		symbols: symbols,
 		tuples:  tuples,
 		options: opts,
 	}
@@ -327,10 +323,10 @@ func NewMaterializedRelationNoDedupeWithOptions(columns []query.Symbol, tuples [
 
 // NewUnitRelation returns a relation with one empty tuple (identity for joins).
 // Used when OR fallback needs a base case with no outer context.
-// The unit relation has no columns and one tuple with no values.
+// The unit relation has no symbols and one tuple with no values.
 func NewUnitRelation(opts ExecutorOptions) *MaterializedRelation {
 	return &MaterializedRelation{
-		columns: []query.Symbol{},
+		symbols: []query.Symbol{},
 		tuples:  []Tuple{{}}, // One empty tuple
 		options: opts,
 	}
@@ -357,12 +353,8 @@ func deduplicateTuples(tuples []Tuple) []Tuple {
 	return result
 }
 
-func (r *MaterializedRelation) Columns() []query.Symbol {
-	return r.columns
-}
-
 func (r *MaterializedRelation) Symbols() []query.Symbol {
-	return r.columns
+	return r.symbols
 }
 
 func (r *MaterializedRelation) Iterator() Iterator {
@@ -399,29 +391,29 @@ func (r *MaterializedRelation) Get(i int) Tuple {
 	return r.tuples[i]
 }
 
-// ColumnIndex returns the index of a column by symbol
-func (r *MaterializedRelation) ColumnIndex(sym query.Symbol) int {
-	for i, col := range r.columns {
-		if col == sym {
+// SymbolIndex returns the index of a symbol in this relation
+func (r *MaterializedRelation) SymbolIndex(sym query.Symbol) int {
+	for i, s := range r.symbols {
+		if s == sym {
 			return i
 		}
 	}
 	return -1
 }
 
-// GetValue returns a specific value by row and column symbol
-func (r *MaterializedRelation) GetValue(row int, sym query.Symbol) (interface{}, bool) {
-	tuple := r.Get(row)
+// GetValue returns a specific value by tuple index and symbol
+func (r *MaterializedRelation) GetValue(tupleIdx int, sym query.Symbol) (interface{}, bool) {
+	tuple := r.Get(tupleIdx)
 	if tuple == nil {
 		return nil, false
 	}
 
-	col := r.ColumnIndex(sym)
-	if col < 0 {
+	idx := r.SymbolIndex(sym)
+	if idx < 0 {
 		return nil, false
 	}
 
-	return tuple[col], true
+	return tuple[idx], true
 }
 
 // Tuples returns all tuples (for backward compatibility)
@@ -432,9 +424,9 @@ func (r *MaterializedRelation) Tuples() []Tuple {
 // String returns a compact string representation for annotations
 func (r *MaterializedRelation) String() string {
 	// Format as: Relation([?x ?y], N Tuples) with colors
-	var symbols []string
-	for _, col := range r.columns {
-		symbols = append(symbols, col.String())
+	var symStrs []string
+	for _, sym := range r.symbols {
+		symStrs = append(symStrs, sym.String())
 	}
 
 	// Color the tuple count based on size
@@ -453,7 +445,7 @@ func (r *MaterializedRelation) String() string {
 
 	return fmt.Sprintf("%s%s%s%s%s %s%s",
 		color.BlueString("Relation(["),
-		color.CyanString(strings.Join(symbols, " ")),
+		color.CyanString(strings.Join(symStrs, " ")),
 		color.BlueString("]"),
 		color.BlueString(", "),
 		countStr,
@@ -474,9 +466,9 @@ func (r *MaterializedRelation) ProjectFromPattern(pattern *query.DataPattern) Re
 	neededSymbols := []query.Symbol{}
 	symbolIndices := make(map[query.Symbol]int)
 
-	// Build index of our columns
-	for i, col := range r.columns {
-		symbolIndices[col] = i
+	// Build index of our symbols
+	for i, sym := range r.symbols {
+		symbolIndices[sym] = i
 	}
 
 	// Check each position in the pattern (E, A, V, T)
@@ -522,9 +514,9 @@ func (r *MaterializedRelation) Sorted() []Tuple {
 	sorted := make([]Tuple, len(r.tuples))
 	copy(sorted, r.tuples)
 
-	// Sort tuples lexicographically by columns
+	// Sort tuples lexicographically by symbols
 	sort.Slice(sorted, func(i, j int) bool {
-		for k := 0; k < len(r.columns) && k < len(sorted[i]) && k < len(sorted[j]); k++ {
+		for k := 0; k < len(r.symbols) && k < len(sorted[i]) && k < len(sorted[j]); k++ {
 			cmp := datalog.CompareValues(sorted[i][k], sorted[j][k])
 			if cmp < 0 {
 				return true
@@ -538,26 +530,26 @@ func (r *MaterializedRelation) Sorted() []Tuple {
 	return sorted
 }
 
-// Project returns a new relation with only the specified columns
-func (r *MaterializedRelation) Project(columns []query.Symbol) (Relation, error) {
+// Project returns a new relation with only the specified symbols
+func (r *MaterializedRelation) Project(symbols []query.Symbol) (Relation, error) {
 	// Empty projection is invalid in Datalog - must have at least one find element
-	if len(columns) == 0 {
-		return nil, fmt.Errorf("cannot project empty column list - invalid query")
+	if len(symbols) == 0 {
+		return nil, fmt.Errorf("cannot project empty symbol list - invalid query")
 	}
 
-	// Find column indices
-	indices := make([]int, len(columns))
-	for i, col := range columns {
+	// Find symbol indices
+	indices := make([]int, len(symbols))
+	for i, sym := range symbols {
 		idx := -1
-		for j, existing := range r.columns {
-			if existing == col {
+		for j, existing := range r.symbols {
+			if existing == sym {
 				idx = j
 				break
 			}
 		}
 		if idx < 0 {
-			// Column not found - this is a query error in Datalog
-			return nil, fmt.Errorf("cannot project: column %s not found in relation (has columns: %v)", col, r.columns)
+			// Symbol not found - this is a query error in Datalog
+			return nil, fmt.Errorf("cannot project: symbol %s not found in relation (has symbols: %v)", sym, r.symbols)
 		}
 		indices[i] = idx
 	}
@@ -572,7 +564,7 @@ func (r *MaterializedRelation) Project(columns []query.Symbol) (Relation, error)
 		projected[i] = projTuple
 	}
 
-	return NewMaterializedRelationWithOptions(columns, projected, r.options), nil
+	return NewMaterializedRelationWithOptions(symbols, projected, r.options), nil
 }
 
 // Materialize returns self since MaterializedRelation is already materialized
@@ -591,27 +583,27 @@ func (r *MaterializedRelation) Filter(filter Filter) Relation {
 	// Check if all required symbols are present
 	for _, sym := range filter.RequiredSymbols() {
 		found := false
-		for _, col := range r.columns {
-			if col == sym {
+		for _, s := range r.symbols {
+			if s == sym {
 				found = true
 				break
 			}
 		}
 		if !found {
 			// Missing required symbol - return empty relation
-			return NewMaterializedRelationWithOptions(r.columns, nil, r.options)
+			return NewMaterializedRelationWithOptions(r.symbols, nil, r.options)
 		}
 	}
 
 	// Apply filter directly to our tuples
 	var filtered []Tuple
 	for _, tuple := range r.tuples {
-		if filter.Evaluate(tuple, r.columns) {
+		if filter.Evaluate(tuple, r.symbols) {
 			filtered = append(filtered, tuple)
 		}
 	}
 
-	return NewMaterializedRelationWithOptions(r.columns, filtered, r.options)
+	return NewMaterializedRelationWithOptions(r.symbols, filtered, r.options)
 }
 
 // FilterWithPredicate filters the relation using a query.Predicate
@@ -620,8 +612,8 @@ func (r *MaterializedRelation) FilterWithPredicate(pred query.Predicate) Relatio
 	var filtered []Tuple
 	for _, tuple := range r.tuples {
 		bindings := make(map[query.Symbol]interface{})
-		for i, col := range r.columns {
-			bindings[col] = tuple[i]
+		for i, sym := range r.symbols {
+			bindings[sym] = tuple[i]
 		}
 
 		// Apply the predicate
@@ -630,7 +622,7 @@ func (r *MaterializedRelation) FilterWithPredicate(pred query.Predicate) Relatio
 		}
 	}
 
-	return NewMaterializedRelationWithOptions(r.columns, filtered, r.options)
+	return NewMaterializedRelationWithOptions(r.symbols, filtered, r.options)
 }
 
 // Select returns a new relation with only tuples that satisfy the predicate
@@ -640,28 +632,28 @@ func (r *MaterializedRelation) Select(pred func(Tuple) bool) Relation {
 
 // Join performs a natural join with another relation
 func (r *MaterializedRelation) Join(other Relation) Relation {
-	common := CommonColumns(r, other)
+	common := CommonSymbols(r, other)
 	if len(common) == 0 {
-		// No common columns - cross product (expensive!)
+		// No common symbols - cross product (expensive!)
 		return crossProduct(r, other)
 	}
 	// Use hash join for efficiency
 	return r.HashJoin(other, common)
 }
 
-// HashJoin performs an equi-join on specified columns
-func (r *MaterializedRelation) HashJoin(other Relation, joinCols []query.Symbol) Relation {
-	return HashJoin(r, other, joinCols)
+// HashJoin performs an equi-join on specified symbols
+func (r *MaterializedRelation) HashJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return HashJoin(r, other, joinSyms)
 }
 
 // SemiJoin returns tuples from this relation that have matches in the other
-func (r *MaterializedRelation) SemiJoin(other Relation, joinCols []query.Symbol) Relation {
-	return SemiJoin(r, other, joinCols)
+func (r *MaterializedRelation) SemiJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return SemiJoin(r, other, joinSyms)
 }
 
 // AntiJoin returns tuples from this relation that have no matches in the other
-func (r *MaterializedRelation) AntiJoin(other Relation, joinCols []query.Symbol) Relation {
-	return AntiJoin(r, other, joinCols)
+func (r *MaterializedRelation) AntiJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return AntiJoin(r, other, joinSyms)
 }
 
 // Aggregate performs aggregation operations
@@ -669,18 +661,18 @@ func (r *MaterializedRelation) Aggregate(findElements []query.FindElement) Relat
 	return ExecuteAggregations(r, findElements)
 }
 
-// EvaluateFunction evaluates a function and adds its result as a new column
-func (r *MaterializedRelation) EvaluateFunction(fn query.Function, outputColumn query.Symbol) Relation {
-	// Add the output column
-	newColumns := append(r.columns, outputColumn)
+// EvaluateFunction evaluates a function and adds its result as a new symbol
+func (r *MaterializedRelation) EvaluateFunction(fn query.Function, outputSymbol query.Symbol) Relation {
+	// Add the output symbol
+	newSymbols := append(r.symbols, outputSymbol)
 
 	// Process each tuple
 	var newTuples []Tuple
 	for _, tuple := range r.tuples {
 		// Create bindings from tuple
 		bindings := make(map[query.Symbol]interface{})
-		for i, col := range r.columns {
-			bindings[col] = tuple[i]
+		for i, sym := range r.symbols {
+			bindings[sym] = tuple[i]
 		}
 
 		// Evaluate the function
@@ -695,7 +687,7 @@ func (r *MaterializedRelation) EvaluateFunction(fn query.Function, outputColumn 
 		newTuples = append(newTuples, newTuple)
 	}
 
-	return NewMaterializedRelation(newColumns, newTuples)
+	return NewMaterializedRelation(newSymbols, newTuples)
 }
 
 // contains checks if a symbol is in a slice
@@ -732,7 +724,7 @@ func (it *sliceIterator) Close() error {
 
 // StreamingRelation wraps an iterator as a relation
 type StreamingRelation struct {
-	columns  []query.Symbol
+	symbols  []query.Symbol
 	iterator Iterator
 	size     int             // -1 if unknown
 	options  ExecutorOptions // Options from the factory that created this relation
@@ -758,9 +750,9 @@ type StreamingRelation struct {
 	iteratorCalled bool              // Track if Iterator() was already called (for single-use enforcement)
 }
 
-func NewStreamingRelation(columns []query.Symbol, iterator Iterator) *StreamingRelation {
+func NewStreamingRelation(symbols []query.Symbol, iterator Iterator) *StreamingRelation {
 	return &StreamingRelation{
-		columns:  columns,
+		symbols:  symbols,
 		iterator: iterator,
 		size:     -1,
 		options:  ExecutorOptions{}, // Default options - for backward compatibility
@@ -768,21 +760,17 @@ func NewStreamingRelation(columns []query.Symbol, iterator Iterator) *StreamingR
 }
 
 // NewStreamingRelationWithOptions creates a streaming relation with specific options
-func NewStreamingRelationWithOptions(columns []query.Symbol, iterator Iterator, opts ExecutorOptions) *StreamingRelation {
+func NewStreamingRelationWithOptions(symbols []query.Symbol, iterator Iterator, opts ExecutorOptions) *StreamingRelation {
 	return &StreamingRelation{
-		columns:  columns,
+		symbols:  symbols,
 		iterator: iterator,
 		size:     -1,
 		options:  opts,
 	}
 }
 
-func (r *StreamingRelation) Columns() []query.Symbol {
-	return r.columns
-}
-
 func (r *StreamingRelation) Symbols() []query.Symbol {
-	return r.columns
+	return r.symbols
 }
 
 func (r *StreamingRelation) Iterator() Iterator {
@@ -957,9 +945,9 @@ func (r *StreamingRelation) Get(i int) Tuple {
 // String returns a compact string representation for annotations
 func (r *StreamingRelation) String() string {
 	// Format as: Relation([?x ?y], N Tuples) with colors
-	var symbols []string
-	for _, col := range r.columns {
-		symbols = append(symbols, col.String())
+	var symStrs []string
+	for _, sym := range r.symbols {
+		symStrs = append(symStrs, sym.String())
 	}
 
 	// For streaming relations, we might not know the size
@@ -979,7 +967,7 @@ func (r *StreamingRelation) String() string {
 
 		return fmt.Sprintf("%s%s%s%s%s %s%s",
 			color.BlueString("Relation(["),
-			color.CyanString(strings.Join(symbols, " ")),
+			color.CyanString(strings.Join(symStrs, " ")),
 			color.BlueString("]"),
 			color.BlueString(", "),
 			countStr,
@@ -990,7 +978,7 @@ func (r *StreamingRelation) String() string {
 	// Size unknown
 	return fmt.Sprintf("%s%s%s%s",
 		color.BlueString("Relation(["),
-		color.CyanString(strings.Join(symbols, " ")),
+		color.CyanString(strings.Join(symStrs, " ")),
 		color.BlueString("]"),
 		color.BlueString(", streaming)"))
 }
@@ -1008,9 +996,9 @@ func (r *StreamingRelation) ProjectFromPattern(pattern *query.DataPattern) Relat
 	neededSymbols := []query.Symbol{}
 	symbolIndices := make(map[query.Symbol]int)
 
-	// Build index of our columns
-	for i, col := range r.columns {
-		symbolIndices[col] = i
+	// Build index of our symbols
+	for i, sym := range r.symbols {
+		symbolIndices[sym] = i
 	}
 
 	// Check each position in the pattern (E, A, V, T)
@@ -1060,9 +1048,9 @@ func (r *StreamingRelation) Sorted() []Tuple {
 	var tuples []Tuple
 	collectTuplesInto(&tuples, r)
 
-	// Sort tuples lexicographically by columns
+	// Sort tuples lexicographically by symbols
 	sort.Slice(tuples, func(i, j int) bool {
-		for k := 0; k < len(r.columns) && k < len(tuples[i]) && k < len(tuples[j]); k++ {
+		for k := 0; k < len(r.symbols) && k < len(tuples[i]) && k < len(tuples[j]); k++ {
 			cmp := datalog.CompareValues(tuples[i][k], tuples[j][k])
 			if cmp < 0 {
 				return true
@@ -1076,38 +1064,38 @@ func (r *StreamingRelation) Sorted() []Tuple {
 	return tuples
 }
 
-// Project returns a new relation with only the specified columns
-func (r *StreamingRelation) Project(columns []query.Symbol) (Relation, error) {
+// Project returns a new relation with only the specified symbols
+func (r *StreamingRelation) Project(symbols []query.Symbol) (Relation, error) {
 	// Empty projection is invalid in Datalog - must have at least one find element
-	if len(columns) == 0 {
-		return nil, fmt.Errorf("cannot project empty column list - invalid query")
+	if len(symbols) == 0 {
+		return nil, fmt.Errorf("cannot project empty symbol list - invalid query")
 	}
 
 	// Streaming is now the default behavior
-	// Validate columns exist
-	for _, col := range columns {
+	// Validate symbols exist
+	for _, sym := range symbols {
 		found := false
-		for _, existing := range r.columns {
-			if existing == col {
+		for _, existing := range r.symbols {
+			if existing == sym {
 				found = true
 				break
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("cannot project: column %s not found in relation", col)
+			return nil, fmt.Errorf("cannot project: symbol %s not found in relation", sym)
 		}
 	}
 	// CRITICAL FIX: Pass the relation itself to ProjectIterator, not the raw iterator
 	// This allows ProjectIterator to call r.Iterator(), which respects caching/materialization
 	// When r.shouldCache=true, the first Iterator() call builds the cache, and both the
 	// original relation and the projection can iterate from cached data
-	projIter := NewProjectIterator(r, r.columns, columns)
+	projIter := NewProjectIterator(r, r.symbols, symbols)
 	// SET SEMANTICS: Wrap with DedupIterator to ensure projection maintains set semantics.
 	// Projection can produce duplicates when multiple distinct input tuples map to the same
-	// projected tuple (e.g., [(1,a), (2,a)] projected to column 2 yields [a, a]).
+	// projected tuple (e.g., [(1,a), (2,a)] projected to symbol 2 yields [a, a]).
 	dedupIter := NewDedupIterator(projIter, 0)
 	// BUGFIX: Preserve options (especially EnableTrueStreaming) to prevent re-scanning
-	return NewStreamingRelationWithOptions(columns, dedupIter, r.options), nil
+	return NewStreamingRelationWithOptions(symbols, dedupIter, r.options), nil
 }
 
 // Materialize converts this streaming relation to a materialized one
@@ -1145,7 +1133,7 @@ func (r *StreamingRelation) Sort(orderBy []query.OrderByClause) Relation {
 	collectTuplesInto(&tuples, r)
 
 	// Create MaterializedRelation and delegate to its Sort
-	mat := NewMaterializedRelationWithOptions(r.columns, tuples, r.options)
+	mat := NewMaterializedRelationWithOptions(r.symbols, tuples, r.options)
 	return mat.Sort(orderBy)
 }
 
@@ -1153,8 +1141,8 @@ func (r *StreamingRelation) Sort(orderBy []query.OrderByClause) Relation {
 func (r *StreamingRelation) Filter(filter Filter) Relation {
 	if r.options.EnableIteratorComposition {
 		// Use iterator composition for true streaming
-		filterIter := NewFilterIterator(r.iterator, r.columns, filter)
-		return NewStreamingRelationWithOptions(r.columns, filterIter, r.options)
+		filterIter := NewFilterIterator(r.iterator, r.symbols, filter)
+		return NewStreamingRelationWithOptions(r.symbols, filterIter, r.options)
 	}
 	// Fall back to current behavior
 	return FilterRelation(r, filter)
@@ -1164,25 +1152,25 @@ func (r *StreamingRelation) Filter(filter Filter) Relation {
 func (r *StreamingRelation) FilterWithPredicate(pred query.Predicate) Relation {
 	if r.options.EnableIteratorComposition {
 		// Use iterator composition for true streaming
-		predIter := NewPredicateFilterIterator(r.iterator, r.columns, pred)
-		return NewStreamingRelationWithOptions(r.columns, predIter, r.options)
+		predIter := NewPredicateFilterIterator(r.iterator, r.symbols, pred)
+		return NewStreamingRelationWithOptions(r.symbols, predIter, r.options)
 	}
 	// Fall back to current behavior - materialize then filter
 	materialized := r.Materialize()
 	return materialized.FilterWithPredicate(pred)
 }
 
-// EvaluateFunction evaluates a function and adds its result as a new column
-func (r *StreamingRelation) EvaluateFunction(fn query.Function, outputColumn query.Symbol) Relation {
+// EvaluateFunction evaluates a function and adds its result as a new symbol
+func (r *StreamingRelation) EvaluateFunction(fn query.Function, outputSymbol query.Symbol) Relation {
 	if r.options.EnableIteratorComposition {
 		// Use iterator composition for true streaming
-		evalIter := NewFunctionEvaluatorIterator(r.iterator, r.columns, fn, outputColumn)
-		newColumns := append(r.columns, outputColumn)
-		return NewStreamingRelationWithOptions(newColumns, evalIter, r.options)
+		evalIter := NewFunctionEvaluatorIterator(r.iterator, r.symbols, fn, outputSymbol)
+		newSymbols := append(r.symbols, outputSymbol)
+		return NewStreamingRelationWithOptions(newSymbols, evalIter, r.options)
 	}
 	// Fall back to current behavior - materialize then evaluate
 	materialized := r.Materialize()
-	return materialized.EvaluateFunction(fn, outputColumn)
+	return materialized.EvaluateFunction(fn, outputSymbol)
 }
 
 // Select returns a new relation with only tuples that satisfy the predicate
@@ -1192,28 +1180,28 @@ func (r *StreamingRelation) Select(pred func(Tuple) bool) Relation {
 
 // Join performs a natural join with another relation
 func (r *StreamingRelation) Join(other Relation) Relation {
-	common := CommonColumns(r, other)
+	common := CommonSymbols(r, other)
 	if len(common) == 0 {
-		// No common columns - cross product (expensive!)
+		// No common symbols - cross product (expensive!)
 		return crossProduct(r, other)
 	}
 	// Use hash join for efficiency
 	return r.HashJoin(other, common)
 }
 
-// HashJoin performs an equi-join on specified columns
-func (r *StreamingRelation) HashJoin(other Relation, joinCols []query.Symbol) Relation {
-	return HashJoin(r, other, joinCols)
+// HashJoin performs an equi-join on specified symbols
+func (r *StreamingRelation) HashJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return HashJoin(r, other, joinSyms)
 }
 
 // SemiJoin returns tuples from this relation that have matches in the other
-func (r *StreamingRelation) SemiJoin(other Relation, joinCols []query.Symbol) Relation {
-	return SemiJoin(r, other, joinCols)
+func (r *StreamingRelation) SemiJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return SemiJoin(r, other, joinSyms)
 }
 
 // AntiJoin returns tuples from this relation that have no matches in the other
-func (r *StreamingRelation) AntiJoin(other Relation, joinCols []query.Symbol) Relation {
-	return AntiJoin(r, other, joinCols)
+func (r *StreamingRelation) AntiJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return AntiJoin(r, other, joinSyms)
 }
 
 // Aggregate performs aggregation operations
@@ -1232,29 +1220,29 @@ type PatternBinding struct {
 
 // Utility functions for working with relations
 
-// ColumnIndex returns the index of a column, or -1 if not found
-func ColumnIndex(rel Relation, sym query.Symbol) int {
-	cols := rel.Columns()
-	for i, col := range cols {
-		if col == sym {
+// SymbolIndex returns the index of a symbol in a relation, or -1 if not found
+func SymbolIndex(rel Relation, sym query.Symbol) int {
+	syms := rel.Symbols()
+	for i, s := range syms {
+		if s == sym {
 			return i
 		}
 	}
 	return -1
 }
 
-// CommonColumns returns columns that appear in both relations
-func CommonColumns(r1, r2 Relation) []query.Symbol {
-	cols1 := r1.Columns()
-	cols2Set := make(map[query.Symbol]bool)
-	for _, col := range r2.Columns() {
-		cols2Set[col] = true
+// CommonSymbols returns symbols that appear in both relations
+func CommonSymbols(r1, r2 Relation) []query.Symbol {
+	syms1 := r1.Symbols()
+	syms2Set := make(map[query.Symbol]bool)
+	for _, sym := range r2.Symbols() {
+		syms2Set[sym] = true
 	}
 
 	var common []query.Symbol
-	for _, col := range cols1 {
-		if cols2Set[col] {
-			common = append(common, col)
+	for _, sym := range syms1 {
+		if syms2Set[sym] {
+			common = append(common, sym)
 		}
 	}
 	return common
@@ -1277,14 +1265,14 @@ func Select(rel Relation, pred func(Tuple) bool) Relation {
 		}
 	}
 
-	return NewMaterializedRelation(rel.Columns(), selected)
+	return NewMaterializedRelation(rel.Symbols(), selected)
 }
 
 // ProductRelation represents a streaming Cartesian product of multiple relations
 // Used for expressions/predicates that reference symbols from disjoint relations
 type ProductRelation struct {
 	relations []Relation
-	columns   []query.Symbol
+	symbols   []query.Symbol
 	options   ExecutorOptions
 }
 
@@ -1293,15 +1281,15 @@ func NewProductRelation(relations []Relation) *ProductRelation {
 	if len(relations) == 0 {
 		return &ProductRelation{
 			relations: relations,
-			columns:   nil,
+			symbols:   nil,
 			options:   ExecutorOptions{},
 		}
 	}
 
-	// Combine columns from all relations
-	var allColumns []query.Symbol
+	// Combine symbols from all relations
+	var allSymbols []query.Symbol
 	for _, rel := range relations {
-		allColumns = append(allColumns, rel.Columns()...)
+		allSymbols = append(allSymbols, rel.Symbols()...)
 	}
 
 	// Extract options from first relation
@@ -1309,17 +1297,13 @@ func NewProductRelation(relations []Relation) *ProductRelation {
 
 	return &ProductRelation{
 		relations: relations,
-		columns:   allColumns,
+		symbols:   allSymbols,
 		options:   opts,
 	}
 }
 
-func (p *ProductRelation) Columns() []query.Symbol {
-	return p.columns
-}
-
 func (p *ProductRelation) Symbols() []query.Symbol {
-	return p.columns
+	return p.symbols
 }
 
 func (p *ProductRelation) Iterator() Iterator {
@@ -1365,7 +1349,7 @@ func (p *ProductRelation) Get(i int) Tuple {
 }
 
 func (p *ProductRelation) String() string {
-	return fmt.Sprintf("Product(%d relations, %d columns)", len(p.relations), len(p.columns))
+	return fmt.Sprintf("Product(%d relations, %d symbols)", len(p.relations), len(p.symbols))
 }
 
 func (p *ProductRelation) Table() string {
@@ -1381,36 +1365,36 @@ func (p *ProductRelation) Sorted() []Tuple {
 	return p.Materialize().Sorted()
 }
 
-func (p *ProductRelation) Project(columns []query.Symbol) (Relation, error) {
+func (p *ProductRelation) Project(symbols []query.Symbol) (Relation, error) {
 	// Empty projection is invalid in Datalog - must have at least one find element
-	if len(columns) == 0 {
-		return nil, fmt.Errorf("cannot project empty column list - invalid query")
+	if len(symbols) == 0 {
+		return nil, fmt.Errorf("cannot project empty symbol list - invalid query")
 	}
 
-	// Validate columns exist
-	for _, col := range columns {
+	// Validate symbols exist
+	for _, sym := range symbols {
 		found := false
-		for _, existing := range p.Columns() {
-			if existing == col {
+		for _, existing := range p.Symbols() {
+			if existing == sym {
 				found = true
 				break
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("cannot project: column %s not found in relation", col)
+			return nil, fmt.Errorf("cannot project: symbol %s not found in relation", sym)
 		}
 	}
 	// Product relations are streaming - use iterator composition
 	// Pass the relation itself so ProjectIterator can call Iterator() when needed
-	projIter := NewProjectIterator(p, p.Columns(), columns)
+	projIter := NewProjectIterator(p, p.Symbols(), symbols)
 	// Use default options since ProductRelation is a wrapper
-	return NewStreamingRelation(columns, projIter), nil
+	return NewStreamingRelation(symbols, projIter), nil
 }
 
 func (p *ProductRelation) Materialize() Relation {
 	var tuples []Tuple
 	collectTuplesInto(&tuples, p)
-	return NewMaterializedRelationWithOptions(p.columns, tuples, p.options)
+	return NewMaterializedRelationWithOptions(p.symbols, tuples, p.options)
 }
 
 func (p *ProductRelation) Sort(orderBy []query.OrderByClause) Relation {
@@ -1427,9 +1411,9 @@ func (p *ProductRelation) FilterWithPredicate(pred query.Predicate) Relation {
 	return p.Materialize().FilterWithPredicate(pred)
 }
 
-func (p *ProductRelation) EvaluateFunction(fn query.Function, outputColumn query.Symbol) Relation {
+func (p *ProductRelation) EvaluateFunction(fn query.Function, outputSymbol query.Symbol) Relation {
 	// Materialize then evaluate
-	return p.Materialize().EvaluateFunction(fn, outputColumn)
+	return p.Materialize().EvaluateFunction(fn, outputSymbol)
 }
 
 func (p *ProductRelation) Select(pred func(Tuple) bool) Relation {
@@ -1441,18 +1425,18 @@ func (p *ProductRelation) Join(other Relation) Relation {
 	return p.Materialize().Join(other)
 }
 
-func (p *ProductRelation) HashJoin(other Relation, joinCols []query.Symbol) Relation {
-	return HashJoinWithOptions(p, other, joinCols, p.options)
+func (p *ProductRelation) HashJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return HashJoinWithOptions(p, other, joinSyms, p.options)
 }
 
-func (p *ProductRelation) SemiJoin(other Relation, joinCols []query.Symbol) Relation {
+func (p *ProductRelation) SemiJoin(other Relation, joinSyms []query.Symbol) Relation {
 	// Materialize then semi-join
-	return p.Materialize().SemiJoin(other, joinCols)
+	return p.Materialize().SemiJoin(other, joinSyms)
 }
 
-func (p *ProductRelation) AntiJoin(other Relation, joinCols []query.Symbol) Relation {
+func (p *ProductRelation) AntiJoin(other Relation, joinSyms []query.Symbol) Relation {
 	// Materialize then anti-join
-	return p.Materialize().AntiJoin(other, joinCols)
+	return p.Materialize().AntiJoin(other, joinSyms)
 }
 
 func (p *ProductRelation) Aggregate(findElements []query.FindElement) Relation {

--- a/datalog/executor/relation_concurrent_test.go
+++ b/datalog/executor/relation_concurrent_test.go
@@ -13,7 +13,7 @@ import (
 // TestConcurrentIteratorAccess verifies that multiple goroutines can safely
 // call Iterator() on the same Relation and iterate independently
 func TestConcurrentIteratorAccess(t *testing.T) {
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{1, "a"},
 		{2, "b"},
@@ -28,11 +28,11 @@ func TestConcurrentIteratorAccess(t *testing.T) {
 	}{
 		{
 			name:     "MaterializedRelation",
-			relation: NewMaterializedRelation(columns, tuples),
+			relation: NewMaterializedRelation(symbols, tuples),
 		},
 		{
 			name: "StreamingRelation (materialized)",
-			relation: NewStreamingRelation(columns, &sliceIterator{
+			relation: NewStreamingRelation(symbols, &sliceIterator{
 				tuples: append([]Tuple{}, tuples...), // Copy to avoid sharing
 				pos:    -1,
 			}).Materialize(), // CRITICAL: Must materialize before concurrent access
@@ -113,11 +113,11 @@ func TestConcurrentIteratorAccess(t *testing.T) {
 // TestConcurrentStreamingMaterialization verifies that concurrent calls to
 // Iterator() on a StreamingRelation all see the same materialized data
 func TestConcurrentStreamingMaterialization(t *testing.T) {
-	columns := []query.Symbol{datalog.NewSymbol("?n")}
+	symbols := []query.Symbol{datalog.NewSymbol("?n")}
 	tuples := []Tuple{{1}, {2}, {3}, {4}, {5}}
 
 	// Create streaming relation and materialize it for concurrent access
-	sr := NewStreamingRelation(columns, &sliceIterator{
+	sr := NewStreamingRelation(symbols, &sliceIterator{
 		tuples: append([]Tuple{}, tuples...),
 		pos:    -1,
 	}).Materialize() // CRITICAL: Must materialize before concurrent Iterator() calls

--- a/datalog/executor/relation_input_test.go
+++ b/datalog/executor/relation_input_test.go
@@ -86,7 +86,7 @@ func TestRelationInputIteration(t *testing.T) {
 		for it.Next() {
 			tuple := it.Tuple()
 			if len(tuple) != 3 {
-				t.Errorf("Expected 3 columns, got %d", len(tuple))
+				t.Errorf("Expected 3 symbols, got %d", len(tuple))
 				continue
 			}
 			name := tuple[0].(string)
@@ -210,7 +210,7 @@ func TestRelationInputIterationParallel(t *testing.T) {
 		for it.Next() {
 			tuple := it.Tuple()
 			if len(tuple) != 3 {
-				t.Errorf("Expected 3 columns, got %d", len(tuple))
+				t.Errorf("Expected 3 symbols, got %d", len(tuple))
 				continue
 			}
 			name := tuple[0].(string)

--- a/datalog/executor/relation_materialize_test.go
+++ b/datalog/executor/relation_materialize_test.go
@@ -14,7 +14,7 @@ import (
 // TestLazyMaterializationBasic tests basic lazy materialization behavior
 func TestLazyMaterializationBasic(t *testing.T) {
 	// Create a streaming relation with 10 tuples
-	columns := []query.Symbol{datalog.NewSymbol("?x")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := make([]Tuple, 10)
 	for i := 0; i < 10; i++ {
 		tuples[i] = Tuple{int64(i)}
@@ -23,7 +23,7 @@ func TestLazyMaterializationBasic(t *testing.T) {
 	iter := &sliceIterator{tuples: tuples, pos: -1}
 
 	opts := ExecutorOptions{EnableTrueStreaming: true}
-	rel := NewStreamingRelationWithOptions(columns, iter, opts)
+	rel := NewStreamingRelationWithOptions(symbols, iter, opts)
 
 	// Test 1: Size() before materialization returns -1
 	if size := rel.Size(); size != -1 {
@@ -83,7 +83,7 @@ func TestLazyMaterializationBasic(t *testing.T) {
 // TestConcurrentAccess tests that multiple goroutines can safely access a materialized relation
 func TestConcurrentAccess(t *testing.T) {
 	// Create a streaming relation with 1000 tuples
-	columns := []query.Symbol{datalog.NewSymbol("?x")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := make([]Tuple, 1000)
 	for i := 0; i < 1000; i++ {
 		tuples[i] = Tuple{int64(i)}
@@ -98,7 +98,7 @@ func TestConcurrentAccess(t *testing.T) {
 
 	opts := ExecutorOptions{EnableTrueStreaming: true}
 	rel := &StreamingRelation{
-		columns:  columns,
+		symbols:  symbols,
 		iterator: source(),
 		size:     -1,
 		options:  opts,
@@ -166,12 +166,12 @@ func TestMaterializeAfterIterationPanics(t *testing.T) {
 	}()
 
 	// Create a streaming relation
-	columns := []query.Symbol{datalog.NewSymbol("?x")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := []Tuple{{int64(1)}, {int64(2)}}
 	iter := &sliceIterator{tuples: tuples, pos: -1}
 
 	opts := ExecutorOptions{EnableTrueStreaming: true}
-	rel := NewStreamingRelationWithOptions(columns, iter, opts)
+	rel := NewStreamingRelationWithOptions(symbols, iter, opts)
 
 	// Iterate FIRST
 	it := rel.Iterator()
@@ -191,12 +191,12 @@ func TestDoubleIterationWithoutMaterializePanics(t *testing.T) {
 	}()
 
 	// Create a streaming relation
-	columns := []query.Symbol{datalog.NewSymbol("?x")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := []Tuple{{int64(1)}, {int64(2)}}
 	iter := &sliceIterator{tuples: tuples, pos: -1}
 
 	opts := ExecutorOptions{EnableTrueStreaming: true}
-	rel := NewStreamingRelationWithOptions(columns, iter, opts)
+	rel := NewStreamingRelationWithOptions(symbols, iter, opts)
 
 	// First Iterator() - OK
 	it1 := rel.Iterator()
@@ -210,7 +210,7 @@ func TestDoubleIterationWithoutMaterializePanics(t *testing.T) {
 // TestSizeBlocksWhileCaching tests that Size() blocks while caching is in progress
 func TestSizeBlocksWhileCaching(t *testing.T) {
 	// Create a streaming relation with 100 tuples
-	columns := []query.Symbol{datalog.NewSymbol("?x")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := make([]Tuple, 100)
 	for i := 0; i < 100; i++ {
 		tuples[i] = Tuple{int64(i)}
@@ -219,7 +219,7 @@ func TestSizeBlocksWhileCaching(t *testing.T) {
 	iter := &sliceIterator{tuples: tuples, pos: -1}
 
 	opts := ExecutorOptions{EnableTrueStreaming: true}
-	rel := NewStreamingRelationWithOptions(columns, iter, opts)
+	rel := NewStreamingRelationWithOptions(symbols, iter, opts)
 
 	// Call Materialize() to enable caching
 	rel = rel.Materialize().(*StreamingRelation)

--- a/datalog/executor/relation_predicate_test.go
+++ b/datalog/executor/relation_predicate_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestFilterWithPredicate(t *testing.T) {
 	// Create a test relation
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 	tuples := []Tuple{
 		{1, 2, 3},
 		{4, 5, 6},
 		{7, 8, 9},
 		{10, 11, 12},
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// Test with a comparison predicate
 	pred := &query.Comparison{
@@ -46,13 +46,13 @@ func TestFilterWithPredicate(t *testing.T) {
 
 func TestEvaluateFunction(t *testing.T) {
 	// Create a test relation
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{int64(10), int64(20)},
 		{int64(5), int64(15)},
 		{int64(3), int64(7)},
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// Test with an arithmetic function
 	fn := &query.ArithmeticFunction{
@@ -63,9 +63,9 @@ func TestEvaluateFunction(t *testing.T) {
 
 	result := rel.EvaluateFunction(fn, datalog.NewSymbol("?sum"))
 
-	// Should have 3 columns now
-	if len(result.Columns()) != 3 {
-		t.Errorf("Expected 3 columns after evaluation, got %d", len(result.Columns()))
+	// Should have 3 symbols now
+	if len(result.Symbols()) != 3 {
+		t.Errorf("Expected 3 symbols after evaluation, got %d", len(result.Symbols()))
 	}
 
 	// Check the computed values
@@ -87,14 +87,14 @@ func TestEvaluateFunction(t *testing.T) {
 
 func TestChainedComparison(t *testing.T) {
 	// Test the variadic comparison with FilterWithPredicate
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 	tuples := []Tuple{
 		{1, 5, 10},
 		{2, 3, 4}, // This one satisfies 2 < 3 < 4 < 5
 		{6, 7, 8},
 		{3, 4, 2}, // Not in order
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// Test: [(< ?x ?y ?z 5)]
 	pred := &query.ChainedComparison{

--- a/datalog/executor/relation_test.go
+++ b/datalog/executor/relation_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestMaterializedRelation(t *testing.T) {
-	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
+	symbols := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
 	tuples := []Tuple{
 		{"Alice", 30, "NYC"},
 		{"Bob", 25, "LA"},
 		{"Charlie", 35, "NYC"},
 	}
 
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// Test basic properties
 	if rel.Size() != 3 {
@@ -27,10 +27,10 @@ func TestMaterializedRelation(t *testing.T) {
 		t.Error("expected non-empty relation")
 	}
 
-	// Test columns
-	cols := rel.Columns()
+	// Test symbols
+	cols := rel.Symbols()
 	if len(cols) != 3 || cols[0] != datalog.NewSymbol("?name") || cols[1] != datalog.NewSymbol("?age") || cols[2] != datalog.NewSymbol("?city") {
-		t.Errorf("unexpected columns: %v", cols)
+		t.Errorf("unexpected symbols: %v", cols)
 	}
 
 	// Test iteration
@@ -52,8 +52,8 @@ func TestMaterializedRelation(t *testing.T) {
 }
 
 func TestEmptyRelation(t *testing.T) {
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
-	rel := NewMaterializedRelation(columns, nil)
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+	rel := NewMaterializedRelation(symbols, nil)
 
 	if !rel.IsEmpty() {
 		t.Error("expected empty relation")
@@ -69,9 +69,9 @@ func TestEmptyRelation(t *testing.T) {
 	}
 }
 
-func TestColumnIndex(t *testing.T) {
-	columns := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
-	rel := NewMaterializedRelation(columns, nil)
+func TestSymbolIndex(t *testing.T) {
+	symbols := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
+	rel := NewMaterializedRelation(symbols, nil)
 
 	tests := []struct {
 		symbol   query.Symbol
@@ -84,21 +84,21 @@ func TestColumnIndex(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		idx := ColumnIndex(rel, tt.symbol)
+		idx := SymbolIndex(rel, tt.symbol)
 		if idx != tt.expected {
-			t.Errorf("ColumnIndex(%s) = %d, want %d", tt.symbol, idx, tt.expected)
+			t.Errorf("SymbolIndex(%s) = %d, want %d", tt.symbol, idx, tt.expected)
 		}
 	}
 }
 
-func TestCommonColumns(t *testing.T) {
+func TestCommonSymbols(t *testing.T) {
 	rel1 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}, nil)
 	rel2 := NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?b"), datalog.NewSymbol("?c"), datalog.NewSymbol("?d")}, nil)
 
-	common := CommonColumns(rel1, rel2)
+	common := CommonSymbols(rel1, rel2)
 
 	if len(common) != 2 {
-		t.Errorf("expected 2 common columns, got %d", len(common))
+		t.Errorf("expected 2 common symbols, got %d", len(common))
 	}
 
 	// Check that ?b and ?c are in common
@@ -108,29 +108,29 @@ func TestCommonColumns(t *testing.T) {
 	}
 
 	if !commonSet[datalog.NewSymbol("?b")] || !commonSet[datalog.NewSymbol("?c")] {
-		t.Errorf("expected ?b and ?c in common columns, got %v", common)
+		t.Errorf("expected ?b and ?c in common symbols, got %v", common)
 	}
 }
 
 func TestProject(t *testing.T) {
-	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
+	symbols := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
 	tuples := []Tuple{
 		{"Alice", 30, "NYC"},
 		{"Bob", 25, "LA"},
 	}
 
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
-	// Project to subset of columns using method
+	// Project to subset of symbols using method
 	projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?city")})
 	if err != nil {
 		t.Fatalf("Project failed: %v", err)
 	}
 
-	// Check columns
-	projCols := projected.Columns()
+	// Check symbols
+	projCols := projected.Symbols()
 	if len(projCols) != 2 || projCols[0] != datalog.NewSymbol("?name") || projCols[1] != datalog.NewSymbol("?city") {
-		t.Errorf("unexpected projected columns: %v", projCols)
+		t.Errorf("unexpected projected symbols: %v", projCols)
 	}
 
 	// Check tuples
@@ -154,15 +154,15 @@ func TestProject(t *testing.T) {
 		i++
 	}
 
-	// Test projecting non-existent column using method
+	// Test projecting non-existent symbol using method
 	_, err = rel.Project([]query.Symbol{datalog.NewSymbol("?nonexistent")})
 	if err == nil {
-		t.Fatal("Expected error when projecting non-existent column")
+		t.Fatal("Expected error when projecting non-existent symbol")
 	}
 }
 
 func TestSelect(t *testing.T) {
-	columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
+	symbols := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?city")}
 	tuples := []Tuple{
 		{"Alice", 30, "NYC"},
 		{"Bob", 25, "LA"},
@@ -170,7 +170,7 @@ func TestSelect(t *testing.T) {
 		{"David", 28, "NYC"},
 	}
 
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// Select people in NYC
 	nycOnly := Select(rel, func(tuple Tuple) bool {
@@ -211,13 +211,13 @@ func TestStreamingRelation(t *testing.T) {
 	}
 
 	it := &sliceIterator{tuples: tuples, pos: -1}
-	columns := []query.Symbol{datalog.NewSymbol("?letter"), datalog.NewSymbol("?number")}
+	symbols := []query.Symbol{datalog.NewSymbol("?letter"), datalog.NewSymbol("?number")}
 
-	rel := NewStreamingRelation(columns, it)
+	rel := NewStreamingRelation(symbols, it)
 
-	// Test columns
-	if len(rel.Columns()) != 2 {
-		t.Errorf("expected 2 columns, got %d", len(rel.Columns()))
+	// Test symbols
+	if len(rel.Symbols()) != 2 {
+		t.Errorf("expected 2 symbols, got %d", len(rel.Symbols()))
 	}
 
 	// Test iteration

--- a/datalog/executor/relations.go
+++ b/datalog/executor/relations.go
@@ -16,13 +16,13 @@ func (rs Relations) Project(symbols ...query.Symbol) Relation {
 	}
 
 	var bestRel Relation
-	minExtraColumns := int(^uint(0) >> 1) // Max int
+	minExtraSymbols := int(^uint(0) >> 1) // Max int
 
 	for _, rel := range rs {
-		if containsAll(rel.Columns(), symbols) {
-			extraColumns := len(rel.Columns()) - len(symbols)
-			if extraColumns < minExtraColumns {
-				minExtraColumns = extraColumns
+		if containsAll(rel.Symbols(), symbols) {
+			extraSymbols := len(rel.Symbols()) - len(symbols)
+			if extraSymbols < minExtraSymbols {
+				minExtraSymbols = extraSymbols
 				bestRel = rel
 			}
 		}
@@ -47,28 +47,28 @@ func (rs Relations) FindBestForPattern(pattern *query.DataPattern) Relation {
 
 	for _, rel := range rs {
 		score := 0
-		cols := rel.Columns()
-		colSet := make(map[query.Symbol]bool)
-		for _, col := range cols {
-			colSet[col] = true
+		syms := rel.Symbols()
+		symSet := make(map[query.Symbol]bool)
+		for _, sym := range syms {
+			symSet[sym] = true
 		}
 
 		// Score based on which positions are bound
 		// E position is most selective (uses EAVT index efficiently)
-		if v, ok := pattern.GetE().(query.Variable); ok && colSet[v.Name] {
+		if v, ok := pattern.GetE().(query.Variable); ok && symSet[v.Name] {
 			score += 1000
 		}
 		// A position is moderately selective (uses AEVT index)
-		if v, ok := pattern.GetA().(query.Variable); ok && colSet[v.Name] {
+		if v, ok := pattern.GetA().(query.Variable); ok && symSet[v.Name] {
 			score += 100
 		}
 		// V position is least selective (uses VAET index)
-		if v, ok := pattern.GetV().(query.Variable); ok && colSet[v.Name] {
+		if v, ok := pattern.GetV().(query.Variable); ok && symSet[v.Name] {
 			score += 10
 		}
 		// T position is rarely used
 		if len(pattern.Elements) > 3 {
-			if v, ok := pattern.GetT().(query.Variable); ok && colSet[v.Name] {
+			if v, ok := pattern.GetT().(query.Variable); ok && symSet[v.Name] {
 				score += 1
 			}
 		}
@@ -104,8 +104,8 @@ func (rs Relations) FindRelationsForSymbols(symbols ...query.Symbol) Relations {
 
 	var result Relations
 	for _, rel := range rs {
-		for _, col := range rel.Columns() {
-			if symbolSet[col] {
+		for _, sym := range rel.Symbols() {
+			if symbolSet[sym] {
 				result = append(result, rel)
 				break
 			}
@@ -129,9 +129,9 @@ func (rs Relations) Product() Relation {
 	return NewProductRelation(rs)
 }
 
-// Collapse joins relations that share columns and returns all relation groups.
+// Collapse joins relations that share symbols and returns all relation groups.
 // Relations that can be joined are combined into single relations.
-// Relations that share no columns remain separate.
+// Relations that share no symbols remain separate.
 func (rs Relations) Collapse(ctx Context) Relations {
 	if len(rs) == 0 {
 		return Relations{}
@@ -160,8 +160,8 @@ func (rs Relations) Collapse(ctx Context) Relations {
 			changed = false
 
 			for i := 0; i < len(remaining); i++ {
-				// Check if this relation shares columns with current group
-				if hasSharedColumns(currentGroup, remaining[i]) {
+				// Check if this relation shares symbols with current group
+				if hasSharedSymbols(currentGroup, remaining[i]) {
 					// Join them
 					currentGroup = ctx.JoinRelations(currentGroup, remaining[i], func() Relation {
 						return currentGroup.Join(remaining[i])
@@ -186,13 +186,13 @@ func (rs Relations) Collapse(ctx Context) Relations {
 	return groups
 }
 
-// hasSharedColumns checks if two relations share any columns
-func hasSharedColumns(r1, r2 Relation) bool {
-	cols1 := r1.Columns()
-	cols2 := r2.Columns()
+// hasSharedSymbols checks if two relations share any symbols
+func hasSharedSymbols(r1, r2 Relation) bool {
+	syms1 := r1.Symbols()
+	syms2 := r2.Symbols()
 
-	for _, c1 := range cols1 {
-		for _, c2 := range cols2 {
+	for _, c1 := range syms1 {
+		for _, c2 := range syms2 {
 			if c1 == c2 {
 				return true
 			}
@@ -202,30 +202,30 @@ func hasSharedColumns(r1, r2 Relation) bool {
 	return false
 }
 
-// containsAll checks if cols contains all symbols
-func containsAll(cols []query.Symbol, symbols []query.Symbol) bool {
-	colSet := make(map[query.Symbol]bool)
-	for _, col := range cols {
-		colSet[col] = true
+// containsAll checks if syms contains all symbols
+func containsAll(syms []query.Symbol, symbols []query.Symbol) bool {
+	symSet := make(map[query.Symbol]bool)
+	for _, sym := range syms {
+		symSet[sym] = true
 	}
 
 	for _, sym := range symbols {
-		if !colSet[sym] {
+		if !symSet[sym] {
 			return false
 		}
 	}
 	return true
 }
 
-// containsAny checks if cols contains any of the symbols
-func containsAny(cols []query.Symbol, symbols []query.Symbol) bool {
-	colSet := make(map[query.Symbol]bool)
-	for _, col := range cols {
-		colSet[col] = true
+// containsAny checks if syms contains any of the symbols
+func containsAny(syms []query.Symbol, symbols []query.Symbol) bool {
+	symSet := make(map[query.Symbol]bool)
+	for _, sym := range syms {
+		symSet[sym] = true
 	}
 
 	for _, sym := range symbols {
-		if colSet[sym] {
+		if symSet[sym] {
 			return true
 		}
 	}

--- a/datalog/executor/relations_test.go
+++ b/datalog/executor/relations_test.go
@@ -32,9 +32,9 @@ func TestRelationsProject(t *testing.T) {
 		expected Relation
 	}{
 		{
-			name:     "exact match prefers fewer columns",
+			name:     "exact match prefers fewer symbols",
 			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
-			expected: r1, // r1 has exactly these columns, r2 has extra
+			expected: r1, // r1 has exactly these symbols, r2 has extra
 		},
 		{
 			name:     "requires all symbols",
@@ -49,7 +49,7 @@ func TestRelationsProject(t *testing.T) {
 		{
 			name:     "single symbol matches smallest relation",
 			symbols:  []query.Symbol{datalog.NewSymbol("?x")},
-			expected: r1, // both r1 and r2 have ?x, but r1 has fewer columns
+			expected: r1, // both r1 and r2 have ?x, but r1 has fewer symbols
 		},
 	}
 
@@ -65,19 +65,19 @@ func TestRelationsFindBestForPattern(t *testing.T) {
 	// Create test relations
 	rEntity := NewMaterializedRelation(
 		[]query.Symbol{datalog.NewSymbol("?e")},
-		[]Tuple{{1}, {2}, {3}}, // 3 rows
+		[]Tuple{{1}, {2}, {3}}, // 3 tuples
 	)
 	rAttribute := NewMaterializedRelation(
 		[]query.Symbol{datalog.NewSymbol("?a")},
-		[]Tuple{{1}, {2}}, // 2 rows
+		[]Tuple{{1}, {2}}, // 2 tuples
 	)
 	rValue := NewMaterializedRelation(
 		[]query.Symbol{datalog.NewSymbol("?v")},
-		[]Tuple{{1}, {2}, {3}, {4}}, // 4 rows
+		[]Tuple{{1}, {2}, {3}, {4}}, // 4 tuples
 	)
 	rEntityValue := NewMaterializedRelation(
 		[]query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")},
-		[]Tuple{{1, 10}, {2, 20}}, // 2 rows
+		[]Tuple{{1, 10}, {2, 20}}, // 2 tuples
 	)
 
 	tests := []struct {
@@ -182,7 +182,7 @@ func TestRelationsFindRelationsForSymbols(t *testing.T) {
 }
 
 func TestRelationsCollapse(t *testing.T) {
-	t.Run("joins relations with shared columns", func(t *testing.T) {
+	t.Run("joins relations with shared symbols", func(t *testing.T) {
 		// R1: ?person -> ?dept
 		r1 := NewMaterializedRelation(
 			[]query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?dept")},
@@ -215,15 +215,15 @@ func TestRelationsCollapse(t *testing.T) {
 		relations := Relations{r1, r2, r3}
 		groups := relations.Collapse(NewContext(nil))
 
-		// Should have exactly one group since all relations share columns
+		// Should have exactly one group since all relations share symbols
 		assert.Equal(t, 1, len(groups))
 
 		result := groups[0]
 		assert.False(t, result.IsEmpty())
 		assert.Equal(t, 2, result.Size()) // Alice and Bob's full paths
 
-		// Check columns
-		cols := result.Columns()
+		// Check symbols
+		cols := result.Symbols()
 		assert.Equal(t, 4, len(cols)) // ?person, ?dept, ?building, ?floor
 	})
 
@@ -253,7 +253,7 @@ func TestRelationsCollapse(t *testing.T) {
 		// Check the groups
 		var joinedGroup, disjointGroup Relation
 		for _, g := range groups {
-			cols := g.Columns()
+			cols := g.Symbols()
 			if len(cols) == 3 { // ?x, ?y, ?z
 				joinedGroup = g
 			} else if len(cols) == 2 { // ?a, ?b
@@ -268,7 +268,7 @@ func TestRelationsCollapse(t *testing.T) {
 	})
 
 	t.Run("returns empty for non-matching join", func(t *testing.T) {
-		// Relations share columns but values don't match
+		// Relations share symbols but values don't match
 		r1 := NewMaterializedRelation(
 			[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			[]Tuple{{1, 2}},

--- a/datalog/executor/semantic_rewriting_test.go
+++ b/datalog/executor/semantic_rewriting_test.go
@@ -96,10 +96,10 @@ func TestSemanticRewritingTimePredicates(t *testing.T) {
 
 	// Verify all results are from 2024
 	for i := 0; i < resultWith.Size(); i++ {
-		row := resultWith.Get(i)
-		timeVal := row[0].(time.Time)
+		tuple := resultWith.Get(i)
+		timeVal := tuple[0].(time.Time)
 		if timeVal.Year() != 2024 {
-			t.Errorf("Row %d: expected year 2024, got %d", i, timeVal.Year())
+			t.Errorf("Tuple %d: expected year 2024, got %d", i, timeVal.Year())
 		}
 	}
 
@@ -183,20 +183,20 @@ func TestSemanticRewritingMultipleTimeComponents(t *testing.T) {
 
 	// Verify all results match the constraints
 	for i := 0; i < result.Size(); i++ {
-		row := result.Get(i)
-		timeVal := row[0].(time.Time)
+		tuple := result.Get(i)
+		timeVal := tuple[0].(time.Time)
 
 		if timeVal.Year() != 2025 {
-			t.Errorf("Row %d: expected year 2025, got %d", i, timeVal.Year())
+			t.Errorf("Tuple %d: expected year 2025, got %d", i, timeVal.Year())
 		}
 		if timeVal.Month() != 6 {
-			t.Errorf("Row %d: expected month 6, got %d", i, int(timeVal.Month()))
+			t.Errorf("Tuple %d: expected month 6, got %d", i, int(timeVal.Month()))
 		}
 		if timeVal.Day() != 20 {
-			t.Errorf("Row %d: expected day 20, got %d", i, timeVal.Day())
+			t.Errorf("Tuple %d: expected day 20, got %d", i, timeVal.Day())
 		}
 		if timeVal.Hour() != 10 {
-			t.Errorf("Row %d: expected hour 10, got %d", i, timeVal.Hour())
+			t.Errorf("Tuple %d: expected hour 10, got %d", i, timeVal.Hour())
 		}
 	}
 

--- a/datalog/executor/set_semantics_test.go
+++ b/datalog/executor/set_semantics_test.go
@@ -12,7 +12,7 @@ import (
 //
 // Relations in Datalog are SETS, not BAGS. This means:
 // - No duplicate tuples should ever appear in a relation
-// - Projection must deduplicate (projecting away columns can create duplicates)
+// - Projection must deduplicate (projecting away symbols can create duplicates)
 // - All relation operations must maintain set semantics
 //
 // These tests verify set semantics are maintained throughout the pipeline.
@@ -78,7 +78,7 @@ func setTestCollectTuples(rel Relation) []Tuple {
 
 func TestSetSemantics_MaterializedRelation(t *testing.T) {
 	t.Run("NewMaterializedRelation deduplicates", func(t *testing.T) {
-		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+		symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 		tuples := []Tuple{
 			{1, "a"},
 			{2, "b"},
@@ -87,7 +87,7 @@ func TestSetSemantics_MaterializedRelation(t *testing.T) {
 			{2, "b"}, // duplicate
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 
 		if rel.Size() != 3 {
 			t.Errorf("expected 3 unique tuples, got %d", rel.Size())
@@ -96,7 +96,7 @@ func TestSetSemantics_MaterializedRelation(t *testing.T) {
 	})
 
 	t.Run("NewMaterializedRelationWithOptions deduplicates", func(t *testing.T) {
-		columns := []query.Symbol{datalog.NewSymbol("?x")}
+		symbols := []query.Symbol{datalog.NewSymbol("?x")}
 		tuples := []Tuple{
 			{"foo"},
 			{"bar"},
@@ -104,7 +104,7 @@ func TestSetSemantics_MaterializedRelation(t *testing.T) {
 			{"foo"}, // duplicate
 		}
 
-		rel := NewMaterializedRelationWithOptions(columns, tuples, ExecutorOptions{})
+		rel := NewMaterializedRelationWithOptions(symbols, tuples, ExecutorOptions{})
 
 		if rel.Size() != 2 {
 			t.Errorf("expected 2 unique tuples, got %d", rel.Size())
@@ -120,7 +120,7 @@ func TestSetSemantics_MaterializedRelation(t *testing.T) {
 func TestSetSemantics_Projection(t *testing.T) {
 	t.Run("MaterializedRelation.Project deduplicates", func(t *testing.T) {
 		// Create relation with distinct full tuples that become duplicates after projection
-		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+		symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"entity1", "same_value"},
 			{"entity2", "same_value"}, // Different entity, same value
@@ -128,7 +128,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 			{"entity4", "same_value"}, // Another with same value
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 
 		// Project to just ?v - should deduplicate
 		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})
@@ -145,7 +145,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 
 	t.Run("StreamingRelation.Project deduplicates", func(t *testing.T) {
 		// Create streaming relation with tuples that become duplicates after projection
-		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+		symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"entity1", "value_a"},
 			{"entity2", "value_a"}, // Same value, different entity
@@ -156,7 +156,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 
 		// Create a streaming relation
 		iter := &sliceIterator{tuples: tuples, pos: -1}
-		rel := NewStreamingRelation(columns, iter)
+		rel := NewStreamingRelation(symbols, iter)
 
 		// Project to just ?v - should deduplicate
 		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})
@@ -175,9 +175,9 @@ func TestSetSemantics_Projection(t *testing.T) {
 		assertNoDuplicates(t, "StreamingRelation.Project", materialized)
 	})
 
-	t.Run("Multiple column projection deduplicates", func(t *testing.T) {
-		// Project from 3 columns to 2 columns
-		columns := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
+	t.Run("Multiple symbol projection deduplicates", func(t *testing.T) {
+		// Project from 3 symbols to 2 symbols
+		symbols := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
 		tuples := []Tuple{
 			{1, "x", 100},
 			{1, "x", 200}, // Same ?a, ?b - different ?c
@@ -185,7 +185,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 			{1, "x", 300}, // Same ?a, ?b again
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
@@ -195,7 +195,7 @@ func TestSetSemantics_Projection(t *testing.T) {
 		if projected.Size() != 2 {
 			t.Errorf("expected 2 unique tuples after projection, got %d", projected.Size())
 		}
-		assertNoDuplicates(t, "Multi-column projection", projected)
+		assertNoDuplicates(t, "Multi-symbol projection", projected)
 	})
 }
 
@@ -332,14 +332,14 @@ func TestSetSemantics_Union(t *testing.T) {
 
 func TestSetSemantics_Filter(t *testing.T) {
 	t.Run("Filter preserves set semantics", func(t *testing.T) {
-		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+		symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 		tuples := []Tuple{
 			{1, "a"},
 			{2, "b"},
 			{3, "c"},
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 		filtered := rel.Select(func(t Tuple) bool {
 			return t[0].(int) > 1
 		})
@@ -385,7 +385,7 @@ func TestSetSemantics_Iterators(t *testing.T) {
 
 	t.Run("ProjectIterator should work with DedupIterator", func(t *testing.T) {
 		// This tests the fix: ProjectIterator output wrapped with DedupIterator
-		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+		symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"e1", "same"},
 			{"e2", "same"},
@@ -393,10 +393,10 @@ func TestSetSemantics_Iterators(t *testing.T) {
 		}
 
 		source := &sliceIterator{tuples: tuples, pos: -1}
-		rel := NewStreamingRelation(columns, source)
+		rel := NewStreamingRelation(symbols, source)
 
 		// Create project iterator
-		projIter := NewProjectIterator(rel, columns, []query.Symbol{datalog.NewSymbol("?v")})
+		projIter := NewProjectIterator(rel, symbols, []query.Symbol{datalog.NewSymbol("?v")})
 
 		// Wrap with dedup (this is what the fix should do)
 		dedupIter := NewDedupIterator(projIter, 10)
@@ -423,7 +423,7 @@ func TestSetSemantics_EndToEnd(t *testing.T) {
 		// Multiple entities with the same attribute value should produce one result
 
 		// This is what comes from storage: multiple datoms with same value
-		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
+		symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"entity1", ":attr", "shared_value"},
 			{"entity2", ":attr", "shared_value"},
@@ -431,7 +431,7 @@ func TestSetSemantics_EndToEnd(t *testing.T) {
 			{"entity4", ":attr", "shared_value"},
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 
 		// Project to just ?v (like :find ?v)
 		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})
@@ -450,7 +450,7 @@ func TestSetSemantics_EndToEnd(t *testing.T) {
 
 	t.Run("Streaming query projection deduplicates", func(t *testing.T) {
 		// Same test but with streaming relation
-		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+		symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := []Tuple{
 			{"e1", "val1"},
 			{"e2", "val1"}, // duplicate value
@@ -460,7 +460,7 @@ func TestSetSemantics_EndToEnd(t *testing.T) {
 		}
 
 		iter := &sliceIterator{tuples: tuples, pos: -1}
-		rel := NewStreamingRelation(columns, iter)
+		rel := NewStreamingRelation(symbols, iter)
 
 		// Project and materialize
 		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})
@@ -487,7 +487,7 @@ func TestSetSemantics_Aggregation(t *testing.T) {
 	t.Run("Aggregation receives deduplicated input", func(t *testing.T) {
 		// When aggregating, the input should be deduplicated
 		// This matters for COUNT - counting duplicates would be wrong
-		columns := []query.Symbol{datalog.NewSymbol("?group"), datalog.NewSymbol("?value")}
+		symbols := []query.Symbol{datalog.NewSymbol("?group"), datalog.NewSymbol("?value")}
 		tuples := []Tuple{
 			{"A", int64(10)},
 			{"A", int64(20)},
@@ -495,7 +495,7 @@ func TestSetSemantics_Aggregation(t *testing.T) {
 			{"B", int64(30)},
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 
 		// The relation should already be deduplicated
 		if rel.Size() != 3 {
@@ -511,7 +511,7 @@ func TestSetSemantics_Aggregation(t *testing.T) {
 
 func TestSetSemantics_OperationChain(t *testing.T) {
 	t.Run("Filter then Project maintains set semantics", func(t *testing.T) {
-		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
+		symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 		tuples := []Tuple{
 			{1, "a", 100},
 			{2, "a", 200}, // Same ?y as above
@@ -519,7 +519,7 @@ func TestSetSemantics_OperationChain(t *testing.T) {
 			{4, "a", 400}, // Same ?y as first two
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 
 		// Filter to x > 1
 		filtered := rel.Select(func(t Tuple) bool {
@@ -638,14 +638,14 @@ func TestSetSemantics_Contract_ProjectionAlwaysDeduplicates(t *testing.T) {
 	// SEMANTIC CONTRACT: Projection MUST deduplicate, regardless of input relation type.
 	// This is not an implementation detail - it's fundamental to relational algebra.
 
-	columns := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
+	symbols := []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")}
 	// Create tuples that are unique in full form but duplicate after projection
 	inputTuples := []Tuple{
 		{1, "x", 100},
 		{2, "x", 200}, // Same ?b
 		{3, "y", 300},
 		{4, "x", 400}, // Same ?b again
-		{5, "y", 500}, // Same ?b as row 3
+		{5, "y", 500}, // Same ?b as tuple 3
 	}
 
 	testCases := []struct {
@@ -655,35 +655,35 @@ func TestSetSemantics_Contract_ProjectionAlwaysDeduplicates(t *testing.T) {
 		expectSize int
 	}{
 		{
-			name: "MaterializedRelation project to single column",
+			name: "MaterializedRelation project to single symbol",
 			createRel: func() Relation {
-				return NewMaterializedRelation(columns, inputTuples)
+				return NewMaterializedRelation(symbols, inputTuples)
 			},
 			projectTo:  []query.Symbol{datalog.NewSymbol("?b")},
 			expectSize: 2, // "x" and "y"
 		},
 		{
-			name: "StreamingRelation project to single column",
+			name: "StreamingRelation project to single symbol",
 			createRel: func() Relation {
 				iter := &sliceIterator{tuples: inputTuples, pos: -1}
-				return NewStreamingRelation(columns, iter)
+				return NewStreamingRelation(symbols, iter)
 			},
 			projectTo:  []query.Symbol{datalog.NewSymbol("?b")},
 			expectSize: 2, // "x" and "y"
 		},
 		{
-			name: "MaterializedRelation project to two columns",
+			name: "MaterializedRelation project to two symbols",
 			createRel: func() Relation {
-				return NewMaterializedRelation(columns, inputTuples)
+				return NewMaterializedRelation(symbols, inputTuples)
 			},
 			projectTo:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			expectSize: 5, // All unique (a,b) pairs
 		},
 		{
-			name: "StreamingRelation project to two columns",
+			name: "StreamingRelation project to two symbols",
 			createRel: func() Relation {
 				iter := &sliceIterator{tuples: inputTuples, pos: -1}
-				return NewStreamingRelation(columns, iter)
+				return NewStreamingRelation(symbols, iter)
 			},
 			projectTo:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
 			expectSize: 5, // All unique (a,b) pairs
@@ -786,7 +786,7 @@ func TestSetSemantics_Contract_FilterPreservesSetSemantics(t *testing.T) {
 	// SEMANTIC CONTRACT: Filter cannot introduce duplicates.
 	// Input is a set, output must be a set.
 
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{1, "a"},
 		{2, "b"},
@@ -795,21 +795,21 @@ func TestSetSemantics_Contract_FilterPreservesSetSemantics(t *testing.T) {
 	}
 
 	t.Run("Filter then project must deduplicate", func(t *testing.T) {
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 
 		// Filter to x > 1
 		filtered := rel.Select(func(t Tuple) bool {
 			return t[0].(int) > 1
 		})
 
-		// Project to ?y - should dedupe "a" (from row 3) and "b", "c"
+		// Project to ?y - should dedupe "a" (from tuple 3) and "b", "c"
 		projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?y")})
 		if err != nil {
 			t.Fatalf("projection failed: %v", err)
 		}
 
 		collected := setTestCollectTuples(projected.Materialize())
-		// Rows 2,3,4 pass filter -> ?y values are "b", "a", "c" -> 3 unique
+		// Tuples 2,3,4 pass filter -> ?y values are "b", "a", "c" -> 3 unique
 		if len(collected) != 3 {
 			t.Errorf("expected 3 unique values, got %d: %v", len(collected), collected)
 		}
@@ -818,7 +818,7 @@ func TestSetSemantics_Contract_FilterPreservesSetSemantics(t *testing.T) {
 
 	t.Run("Streaming filter then project must deduplicate", func(t *testing.T) {
 		iter := &sliceIterator{tuples: tuples, pos: -1}
-		rel := NewStreamingRelation(columns, iter)
+		rel := NewStreamingRelation(symbols, iter)
 
 		filtered := rel.Select(func(t Tuple) bool {
 			return t[0].(int) > 1
@@ -875,7 +875,7 @@ func TestSetSemantics_Contract_ChainedOperationsPreserveSetSemantics(t *testing.
 		}
 
 		collected := setTestCollectTuples(projected.Materialize())
-		// After filter: rows with a=2,3,4 -> b values "x", "y", "x"
+		// After filter: tuples with a=2,3,4 -> b values "x", "y", "x"
 		// After project to ?b: should be 2 unique ("x", "y")
 		if len(collected) != 2 {
 			t.Errorf("expected 2 unique values, got %d: %v", len(collected), collected)
@@ -888,11 +888,11 @@ func TestSetSemantics_Contract_IteratorMultiplePassesSameResults(t *testing.T) {
 	// SEMANTIC CONTRACT: Multiple iterations over a relation must produce identical results.
 	// This ensures the relation behaves as a stable set, not a stream that changes.
 
-	columns := []query.Symbol{datalog.NewSymbol("?x")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x")}
 	tuples := []Tuple{{1}, {2}, {3}, {2}, {1}} // With duplicates
 
 	t.Run("MaterializedRelation multiple iterations", func(t *testing.T) {
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 
 		// First iteration
 		var first []Tuple
@@ -943,13 +943,13 @@ func TestSetSemantics_StoragePattern(t *testing.T) {
 		}
 
 		// Convert to tuples as pattern matcher would
-		columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+		symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 		tuples := make([]Tuple, len(datoms))
 		for i, d := range datoms {
 			tuples[i] = Tuple{d.E, d.V}
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 
 		// Project to just ?v (the find clause)
 		projected, err := rel.Project([]query.Symbol{datalog.NewSymbol("?v")})

--- a/datalog/executor/streaming_aggregation_test.go
+++ b/datalog/executor/streaming_aggregation_test.go
@@ -13,7 +13,7 @@ import (
 func TestStreamingAggregation(t *testing.T) {
 	// Create a large relation to aggregate
 	// Include an ID to make each tuple unique (avoid deduplication)
-	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?category"), datalog.NewSymbol("?price")}
+	symbols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?category"), datalog.NewSymbol("?price")}
 	tuples := make([]Tuple, 0, 10000)
 
 	// Generate 10,000 tuples across 10 categories
@@ -23,12 +23,12 @@ func TestStreamingAggregation(t *testing.T) {
 		tuples = append(tuples, Tuple{i, category, price})
 	}
 
-	baseRel := NewMaterializedRelation(columns, tuples)
+	baseRel := NewMaterializedRelation(symbols, tuples)
 
 	t.Run("grouped aggregation with streaming", func(t *testing.T) {
 		// Create a StreamingRelation with streaming aggregation enabled
 		opts := ExecutorOptions{EnableStreamingAggregation: true}
-		rel := NewStreamingRelationWithOptions(columns, baseRel.Iterator(), opts)
+		rel := NewStreamingRelationWithOptions(symbols, baseRel.Iterator(), opts)
 
 		findElements := []query.FindElement{
 			query.FindVariable{Symbol: datalog.NewSymbol("?category")},
@@ -78,7 +78,7 @@ func TestStreamingAggregation(t *testing.T) {
 	t.Run("single aggregation with streaming", func(t *testing.T) {
 		// Create a StreamingRelation with streaming aggregation enabled
 		opts := ExecutorOptions{EnableStreamingAggregation: true}
-		rel := NewStreamingRelationWithOptions(columns, baseRel.Iterator(), opts)
+		rel := NewStreamingRelationWithOptions(symbols, baseRel.Iterator(), opts)
 
 		findElements := []query.FindElement{
 			query.FindAggregate{Function: "count", Arg: datalog.NewSymbol("?price")},
@@ -107,7 +107,7 @@ func TestStreamingAggregation(t *testing.T) {
 // produces identical results to batch aggregation
 func TestStreamingAggregationCorrectness(t *testing.T) {
 	// Create test data
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{"A", 10.0},
 		{"A", 20.0},
@@ -116,7 +116,7 @@ func TestStreamingAggregationCorrectness(t *testing.T) {
 		{"B", 25.0},
 		{"C", 5.0},
 	}
-	baseRel := NewMaterializedRelation(columns, tuples)
+	baseRel := NewMaterializedRelation(symbols, tuples)
 
 	findElements := []query.FindElement{
 		query.FindVariable{Symbol: datalog.NewSymbol("?x")},
@@ -129,12 +129,12 @@ func TestStreamingAggregationCorrectness(t *testing.T) {
 
 	// Run with streaming
 	streamingOpts := ExecutorOptions{EnableStreamingAggregation: true}
-	streamingRel := NewStreamingRelationWithOptions(columns, baseRel.Iterator(), streamingOpts)
+	streamingRel := NewStreamingRelationWithOptions(symbols, baseRel.Iterator(), streamingOpts)
 	streamingResult := ExecuteAggregations(streamingRel, findElements)
 
 	// Run with batch (old implementation)
 	batchOpts := ExecutorOptions{EnableStreamingAggregation: false}
-	batchRel := NewStreamingRelationWithOptions(columns, baseRel.Iterator(), batchOpts)
+	batchRel := NewStreamingRelationWithOptions(symbols, baseRel.Iterator(), batchOpts)
 	batchResult := ExecuteAggregations(batchRel, findElements)
 
 	// Compare results
@@ -188,7 +188,7 @@ func TestStreamingAggregationCorrectness(t *testing.T) {
 
 // TestStreamingAggregationThreshold verifies that small relations use batch aggregation
 func TestStreamingAggregationThreshold(t *testing.T) {
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 	// Small relation (below threshold)
 	smallTuples := []Tuple{
@@ -203,7 +203,7 @@ func TestStreamingAggregationThreshold(t *testing.T) {
 	}
 
 	opts := ExecutorOptions{EnableStreamingAggregation: true}
-	smallRel := NewMaterializedRelationWithOptions(columns, smallTuples, opts)
+	smallRel := NewMaterializedRelationWithOptions(symbols, smallTuples, opts)
 	result := ExecuteAggregations(smallRel, findElements)
 
 	// Should use batch aggregation (below threshold)
@@ -216,7 +216,7 @@ func TestStreamingAggregationThreshold(t *testing.T) {
 	for i := 0; i < len(largeTuples); i++ {
 		largeTuples[i] = Tuple{"A", float64(i)}
 	}
-	largeRel := NewMaterializedRelationWithOptions(columns, largeTuples, opts)
+	largeRel := NewMaterializedRelationWithOptions(symbols, largeTuples, opts)
 
 	result = ExecuteAggregations(largeRel, findElements)
 

--- a/datalog/executor/streaming_correctness_test.go
+++ b/datalog/executor/streaming_correctness_test.go
@@ -19,7 +19,7 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 		for i := 0; i < size; i++ {
 			tuples = append(tuples, Tuple{i, i * 2, i * 3})
 		}
-		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
+		symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 		// Test with materialized (EnableTrueStreaming=false)
 		matOpts := ExecutorOptions{
@@ -28,7 +28,7 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 		}
 
 		matSource := newMockIterator(tuples)
-		matRel := NewStreamingRelationWithOptions(columns, matSource, matOpts)
+		matRel := NewStreamingRelationWithOptions(symbols, matSource, matOpts)
 
 		// Filter to 1%
 		matFiltered := matRel.Filter(NewSimpleFilter(func(t Tuple) bool {
@@ -57,7 +57,7 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 		}
 
 		streamSource := newMockIterator(tuples)
-		streamRel := NewStreamingRelationWithOptions(columns, streamSource, streamOpts)
+		streamRel := NewStreamingRelationWithOptions(symbols, streamSource, streamOpts)
 
 		// Filter to 1%
 		streamFiltered := streamRel.Filter(NewSimpleFilter(func(t Tuple) bool {
@@ -156,7 +156,7 @@ func TestStreamingVsMaterializedCorrectness(t *testing.T) {
 
 		// Sort both for comparison (join order may vary)
 		sortTuples := func(tuples []Tuple) {
-			// Simple sort by first column (name)
+			// Simple sort by first symbol (name)
 			for i := 0; i < len(tuples); i++ {
 				for j := i + 1; j < len(tuples); j++ {
 					if tuples[i][0].(string) > tuples[j][0].(string) {

--- a/datalog/executor/streaming_integration_test.go
+++ b/datalog/executor/streaming_integration_test.go
@@ -76,7 +76,7 @@ func TestStreamingIntegration(t *testing.T) {
 		_, isStreaming = joined.(*StreamingRelation)
 		assert.True(t, isStreaming, "Join should return StreamingRelation")
 
-		// Project to keep only certain columns
+		// Project to keep only certain symbols
 		projected, err := joined.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?score"), datalog.NewSymbol("?city")})
 		assert.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestStreamingIntegration(t *testing.T) {
 
 		// Verify we can iterate the collected results
 		// Create a materialized relation from the results we already collected
-		materialized := NewMaterializedRelation(projected.Columns(), results)
+		materialized := NewMaterializedRelation(projected.Symbols(), results)
 		it2 := materialized.Iterator()
 		count := 0
 		for it2.Next() {
@@ -170,10 +170,10 @@ func TestStreamingIntegration(t *testing.T) {
 			{50, 60},
 			{70, 80},
 		}
-		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+		symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 		source := newMockIterator(tuples)
-		rel := NewStreamingRelationWithOptions(columns, source, opts)
+		rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 		// Apply predicate filter (x > 30)
 		pred := &query.Comparison{
@@ -215,10 +215,10 @@ func TestStreamingIntegration(t *testing.T) {
 			{10, 20},
 			{30, 40},
 		}
-		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+		symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 
 		source := newMockIterator(tuples)
-		rel := NewStreamingRelationWithOptions(columns, source, opts)
+		rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 		// Apply function evaluation (x + y)
 		fn := query.ArithmeticFunction{
@@ -233,8 +233,8 @@ func TestStreamingIntegration(t *testing.T) {
 		_, isStreaming := withFunction.(*StreamingRelation)
 		assert.True(t, isStreaming)
 
-		// Check columns
-		assert.Equal(t, []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?sum")}, withFunction.Columns())
+		// Check symbols
+		assert.Equal(t, []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?sum")}, withFunction.Symbols())
 
 		// Iterate results
 		it := withFunction.Iterator()
@@ -264,10 +264,10 @@ func TestStreamingIntegration(t *testing.T) {
 		for i := 0; i < 1000; i++ {
 			largeTuples = append(largeTuples, Tuple{i, i * 2, i * 3})
 		}
-		columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
+		symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 		source := newMockIterator(largeTuples)
-		rel := NewStreamingRelationWithOptions(columns, source, opts)
+		rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 		// Apply aggressive filter (only 1% pass)
 		filter := NewSimpleFilter(func(t Tuple) bool {
@@ -275,7 +275,7 @@ func TestStreamingIntegration(t *testing.T) {
 		})
 		filtered := rel.Filter(filter)
 
-		// Project to single column
+		// Project to single symbol
 		projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?x")})
 		assert.NoError(t, err)
 
@@ -305,7 +305,7 @@ func BenchmarkStreamingVsMaterialized(b *testing.B) {
 	for i := 0; i < size; i++ {
 		tuples = append(tuples, Tuple{i, i * 2, i * 3})
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 	b.Run("Materialized", func(b *testing.B) {
 		opts := ExecutorOptions{
@@ -316,7 +316,7 @@ func BenchmarkStreamingVsMaterialized(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			source := newMockIterator(tuples)
-			rel := NewStreamingRelationWithOptions(columns, source, opts)
+			rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 			// Filter to 1%
 			filtered := rel.Filter(NewSimpleFilter(func(t Tuple) bool {
@@ -344,7 +344,7 @@ func BenchmarkStreamingVsMaterialized(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			source := newMockIterator(tuples)
-			rel := NewStreamingRelationWithOptions(columns, source, opts)
+			rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 			// Filter to 1%
 			filtered := rel.Filter(NewSimpleFilter(func(t Tuple) bool {
@@ -375,7 +375,7 @@ func BenchmarkStreamingVsMaterialized(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			source := newMockIterator(tuples)
-			rel := NewStreamingRelationWithOptions(columns, source, opts)
+			rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 			// Filter to 1%
 			filtered := rel.Filter(NewSimpleFilter(func(t Tuple) bool {

--- a/datalog/executor/streaming_performance_demo_test.go
+++ b/datalog/executor/streaming_performance_demo_test.go
@@ -98,11 +98,11 @@ func runPipeline(t *testing.T, size int, filterRatio float64, ops []string, opts
 	for i := 0; i < size; i++ {
 		tuples = append(tuples, Tuple{i, fmt.Sprintf("name%d", i), i * 10, i * 100})
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score"), datalog.NewSymbol("?value")}
+	symbols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score"), datalog.NewSymbol("?value")}
 
 	// Create initial relation with options
 	source := newMockIterator(tuples)
-	rel := NewStreamingRelationWithOptions(columns, source, opts)
+	rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 	// Apply operations
 	var current Relation = rel
@@ -124,7 +124,7 @@ func runPipeline(t *testing.T, size int, filterRatio float64, ops []string, opts
 			current = current.Filter(filter)
 
 		case "project":
-			// Project to subset of columns
+			// Project to subset of symbols
 			projected, err := current.Project([]query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?score")})
 			assert.NoError(t, err)
 			current = projected
@@ -204,10 +204,10 @@ func benchmarkScenarioWithOpts(b *testing.B, size int, filterRatio float64, opts
 	for i := 0; i < size; i++ {
 		tuples = append(tuples, Tuple{i, i * 10, i * 100})
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")}
 
 	source := newMockIterator(tuples)
-	rel := NewStreamingRelationWithOptions(columns, source, opts)
+	rel := NewStreamingRelationWithOptions(symbols, source, opts)
 
 	// Apply aggressive filter
 	threshold := int(float64(size) * filterRatio)

--- a/datalog/executor/streaming_pipeline_bench_test.go
+++ b/datalog/executor/streaming_pipeline_bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkTimeToFirstResult(b *testing.B) {
 			var totalTime time.Duration
 			for i := 0; i < b.N; i++ {
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -45,7 +45,7 @@ func BenchmarkTimeToFirstResult(b *testing.B) {
 					},
 				}
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -72,7 +72,7 @@ func BenchmarkTimeToFirstResult(b *testing.B) {
 			var totalTime time.Duration
 			for i := 0; i < b.N; i++ {
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -82,7 +82,7 @@ func BenchmarkTimeToFirstResult(b *testing.B) {
 					},
 				}
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -128,7 +128,7 @@ func BenchmarkLimitQueries(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -138,7 +138,7 @@ func BenchmarkLimitQueries(b *testing.B) {
 					},
 				}
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -165,7 +165,7 @@ func BenchmarkLimitQueries(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -175,7 +175,7 @@ func BenchmarkLimitQueries(b *testing.B) {
 					},
 				}
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -223,7 +223,7 @@ func BenchmarkPeakMemory(b *testing.B) {
 			runtime.ReadMemStats(&memBefore)
 
 			left := &StreamingRelation{
-				columns:  leftCols,
+				symbols:  leftCols,
 				iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 				size:     -1,
 				options: ExecutorOptions{
@@ -233,7 +233,7 @@ func BenchmarkPeakMemory(b *testing.B) {
 				},
 			}
 			right := &StreamingRelation{
-				columns:  rightCols,
+				symbols:  rightCols,
 				iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 				size:     -1,
 				options: ExecutorOptions{
@@ -279,7 +279,7 @@ func BenchmarkPeakMemory(b *testing.B) {
 			runtime.ReadMemStats(&memBefore)
 
 			left := &StreamingRelation{
-				columns:  leftCols,
+				symbols:  leftCols,
 				iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 				size:     -1,
 				options: ExecutorOptions{
@@ -289,7 +289,7 @@ func BenchmarkPeakMemory(b *testing.B) {
 				},
 			}
 			right := &StreamingRelation{
-				columns:  rightCols,
+				symbols:  rightCols,
 				iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 				size:     -1,
 				options: ExecutorOptions{
@@ -349,7 +349,7 @@ func BenchmarkMultiStagePipeline(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			left := &StreamingRelation{
-				columns:  leftCols,
+				symbols:  leftCols,
 				iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 				size:     -1,
 				options: ExecutorOptions{
@@ -359,7 +359,7 @@ func BenchmarkMultiStagePipeline(b *testing.B) {
 				},
 			}
 			right := &StreamingRelation{
-				columns:  rightCols,
+				symbols:  rightCols,
 				iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 				size:     -1,
 				options: ExecutorOptions{
@@ -380,7 +380,7 @@ func BenchmarkMultiStagePipeline(b *testing.B) {
 				return false
 			})
 
-			// Project: drop the ID column
+			// Project: drop the ID symbol
 			projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?value")})
 			if err != nil {
 				b.Fatal(err)
@@ -401,7 +401,7 @@ func BenchmarkMultiStagePipeline(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			left := &StreamingRelation{
-				columns:  leftCols,
+				symbols:  leftCols,
 				iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 				size:     -1,
 				options: ExecutorOptions{
@@ -411,7 +411,7 @@ func BenchmarkMultiStagePipeline(b *testing.B) {
 				},
 			}
 			right := &StreamingRelation{
-				columns:  rightCols,
+				symbols:  rightCols,
 				iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 				size:     -1,
 				options: ExecutorOptions{
@@ -432,7 +432,7 @@ func BenchmarkMultiStagePipeline(b *testing.B) {
 				return false
 			})
 
-			// Project: drop the ID column
+			// Project: drop the ID symbol
 			projected, err := filtered.Project([]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?value")})
 			if err != nil {
 				b.Fatal(err)

--- a/datalog/executor/streaming_union.go
+++ b/datalog/executor/streaming_union.go
@@ -38,7 +38,7 @@ func (s *StreamingUnionBuilder) Union(relations []Relation) Relation {
 // unionStreaming creates a streaming union via channel
 // Results are consumed lazily as they're iterated
 func (s *StreamingUnionBuilder) unionStreaming(relations []Relation) Relation {
-	columns := relations[0].Columns()
+	symbols := relations[0].Symbols()
 
 	// Create channel for streaming
 	unionChan := make(chan relationItem, 1)
@@ -50,39 +50,39 @@ func (s *StreamingUnionBuilder) unionStreaming(relations []Relation) Relation {
 		}
 	}()
 
-	return NewUnionRelation(unionChan, columns, s.opts)
+	return NewUnionRelation(unionChan, symbols, s.opts)
 }
 
 // unionMaterialized combines all relations by materializing
 // All results are collected before returning
 func (s *StreamingUnionBuilder) unionMaterialized(relations []Relation) Relation {
-	columns := relations[0].Columns()
+	symbols := relations[0].Symbols()
 	var allTuples []Tuple
 
 	for _, rel := range relations {
 		collectTuplesInto(&allTuples, rel)
 	}
 
-	return NewMaterializedRelation(columns, allTuples)
+	return NewMaterializedRelation(symbols, allTuples)
 }
 
-// UnionWithColumns combines relations and ensures specific column schema
-// Useful when relations might have different column orders
+// UnionWithColumns combines relations and ensures specific symbol schema
+// Useful when relations might have different symbol orders
 //
 // Parameters:
 // - relations: Relations to combine
-// - columns: Desired column schema for result
+// - symbols: Desired symbol schema for result
 //
-// Returns: Combined relation with specified column schema
-func (s *StreamingUnionBuilder) UnionWithColumns(relations []Relation, columns []query.Symbol) (Relation, error) {
+// Returns: Combined relation with specified symbol schema
+func (s *StreamingUnionBuilder) UnionWithColumns(relations []Relation, symbols []query.Symbol) (Relation, error) {
 	if len(relations) == 0 {
-		return NewMaterializedRelation(columns, []Tuple{}), nil
+		return NewMaterializedRelation(symbols, []Tuple{}), nil
 	}
 	if len(relations) == 1 {
-		// Project to ensure correct column order
+		// Project to ensure correct symbol order
 		rel := relations[0]
-		if !symbolsEqual(rel.Columns(), columns) {
-			projected, err := rel.Project(columns)
+		if !symbolsEqual(rel.Symbols(), symbols) {
+			projected, err := rel.Project(symbols)
 			if err != nil {
 				return nil, err
 			}
@@ -91,10 +91,10 @@ func (s *StreamingUnionBuilder) UnionWithColumns(relations []Relation, columns [
 		return rel, nil
 	}
 
-	// Check if all relations have same column schema
+	// Check if all relations have same symbol schema
 	allMatch := true
 	for _, rel := range relations {
-		if !symbolsEqual(rel.Columns(), columns) {
+		if !symbolsEqual(rel.Symbols(), symbols) {
 			allMatch = false
 			break
 		}
@@ -108,7 +108,7 @@ func (s *StreamingUnionBuilder) UnionWithColumns(relations []Relation, columns [
 	// Slow path: need to project each relation first
 	projectedRelations := make([]Relation, len(relations))
 	for i, rel := range relations {
-		projected, err := rel.Project(columns)
+		projected, err := rel.Project(symbols)
 		if err != nil {
 			return nil, err
 		}

--- a/datalog/executor/streaming_union_test.go
+++ b/datalog/executor/streaming_union_test.go
@@ -46,10 +46,10 @@ func TestUnionBuilder_Streaming(t *testing.T) {
 		t.Errorf("Expected UnionRelation (streaming), got %T", result)
 	}
 
-	// Verify columns
+	// Verify symbols
 	expectedColumns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
-	if !symbolsEqual(result.Columns(), expectedColumns) {
-		t.Errorf("Expected columns %v, got %v", expectedColumns, result.Columns())
+	if !symbolsEqual(result.Symbols(), expectedColumns) {
+		t.Errorf("Expected symbols %v, got %v", expectedColumns, result.Symbols())
 	}
 
 	// Collect all tuples
@@ -74,7 +74,7 @@ func TestUnionBuilder_Streaming(t *testing.T) {
 
 	for _, expected := range expectedValues {
 		if !foundValues[expected] {
-			t.Errorf("Missing value %d in first column", expected)
+			t.Errorf("Missing value %d in first symbol", expected)
 		}
 	}
 }
@@ -158,7 +158,7 @@ func TestUnionBuilder_WithColumns_Matching(t *testing.T) {
 	}
 	builder := NewStreamingUnionBuilder(opts)
 
-	// Relations with matching columns
+	// Relations with matching symbols
 	rel1 := NewMaterializedRelation(
 		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		[]Tuple{{1, 2}},
@@ -169,7 +169,7 @@ func TestUnionBuilder_WithColumns_Matching(t *testing.T) {
 		[]Tuple{{3, 4}},
 	)
 
-	// Union with matching columns
+	// Union with matching symbols
 	result, err := builder.UnionWithColumns(
 		[]Relation{rel1, rel2},
 		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
@@ -182,9 +182,9 @@ func TestUnionBuilder_WithColumns_Matching(t *testing.T) {
 		t.Errorf("Expected 2 tuples, got %d", result.Size())
 	}
 
-	// Verify columns
-	if !symbolsEqual(result.Columns(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
-		t.Errorf("Columns mismatch: %v", result.Columns())
+	// Verify symbols
+	if !symbolsEqual(result.Symbols(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
+		t.Errorf("Symbols mismatch: %v", result.Symbols())
 	}
 }
 
@@ -194,7 +194,7 @@ func TestUnionBuilder_WithColumns_NeedProjection(t *testing.T) {
 	}
 	builder := NewStreamingUnionBuilder(opts)
 
-	// Relations with different column order
+	// Relations with different symbol order
 	rel1 := NewMaterializedRelation(
 		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 		[]Tuple{{1, 2}},
@@ -205,7 +205,7 @@ func TestUnionBuilder_WithColumns_NeedProjection(t *testing.T) {
 		[]Tuple{{4, 3}},
 	)
 
-	// Union with specific column order
+	// Union with specific symbol order
 	result, err := builder.UnionWithColumns(
 		[]Relation{rel1, rel2},
 		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
@@ -218,9 +218,9 @@ func TestUnionBuilder_WithColumns_NeedProjection(t *testing.T) {
 		t.Errorf("Expected 2 tuples, got %d", result.Size())
 	}
 
-	// Verify columns are in requested order
-	if !symbolsEqual(result.Columns(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
-		t.Errorf("Columns mismatch: %v", result.Columns())
+	// Verify symbols are in requested order
+	if !symbolsEqual(result.Symbols(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
+		t.Errorf("Symbols mismatch: %v", result.Symbols())
 	}
 
 	// Verify values are correctly ordered
@@ -241,7 +241,7 @@ func TestUnionBuilder_WithColumns_Empty(t *testing.T) {
 	}
 	builder := NewStreamingUnionBuilder(opts)
 
-	// Empty relations with column spec
+	// Empty relations with symbol spec
 	result, err := builder.UnionWithColumns(
 		[]Relation{},
 		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
@@ -254,9 +254,9 @@ func TestUnionBuilder_WithColumns_Empty(t *testing.T) {
 		t.Errorf("Expected 0 tuples, got %d", result.Size())
 	}
 
-	// Should have correct columns
-	if !symbolsEqual(result.Columns(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
-		t.Errorf("Columns mismatch: %v", result.Columns())
+	// Should have correct symbols
+	if !symbolsEqual(result.Symbols(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
+		t.Errorf("Symbols mismatch: %v", result.Symbols())
 	}
 }
 
@@ -271,7 +271,7 @@ func TestUnionBuilder_WithColumns_SingleRelation(t *testing.T) {
 		[]Tuple{{2, 1}},
 	)
 
-	// Should project single relation to match columns
+	// Should project single relation to match symbols
 	result, err := builder.UnionWithColumns(
 		[]Relation{rel},
 		[]query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
@@ -280,8 +280,8 @@ func TestUnionBuilder_WithColumns_SingleRelation(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if !symbolsEqual(result.Columns(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
-		t.Errorf("Columns mismatch: %v", result.Columns())
+	if !symbolsEqual(result.Symbols(), []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}) {
+		t.Errorf("Symbols mismatch: %v", result.Symbols())
 	}
 
 	tuple := result.Get(0)

--- a/datalog/executor/subquery.go
+++ b/datalog/executor/subquery.go
@@ -104,8 +104,8 @@ func executeSubquerySequentialStreaming(ctx Context, parentExec *Executor, subqP
 	firstItem, ok := <-unionChan
 	if !ok {
 		// No results at all - empty
-		columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
-		return NewMaterializedRelation(columns, []Tuple{}), nil
+		symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+		return NewMaterializedRelation(symbols, []Tuple{}), nil
 	}
 	if firstItem.err != nil {
 		// First result is an error - return it immediately
@@ -124,8 +124,8 @@ func executeSubquerySequentialStreaming(ctx Context, parentExec *Executor, subqP
 	}()
 
 	// Return UnionRelation that will consume from channel
-	columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
-	return NewUnionRelation(newChan, columns, parentExec.options), nil
+	symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+	return NewUnionRelation(newChan, symbols, parentExec.options), nil
 }
 
 // executeSubquerySequentialMaterialized executes subqueries sequentially and materializes all results
@@ -247,8 +247,8 @@ func executeSubqueryParallelStreaming(ctx Context, parentExec *Executor, subqPla
 	firstItem, ok := <-unionChan
 	if !ok {
 		// No results at all - empty
-		columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
-		return NewMaterializedRelation(columns, []Tuple{}), nil
+		symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+		return NewMaterializedRelation(symbols, []Tuple{}), nil
 	}
 	if firstItem.err != nil {
 		// First result is an error - return it immediately
@@ -267,8 +267,8 @@ func executeSubqueryParallelStreaming(ctx Context, parentExec *Executor, subqPla
 	}()
 
 	// Return UnionRelation that will consume from channel
-	columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
-	return NewUnionRelation(newChan, columns, parentExec.options), nil
+	symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+	return NewUnionRelation(newChan, symbols, parentExec.options), nil
 }
 
 // executeSubqueryParallelMaterialized executes subqueries in parallel and materializes all results
@@ -386,21 +386,21 @@ func combineSubqueryResults(allResults []Relation, subqPlan planner.SubqueryPlan
 		}
 	}
 
-	// If no results - return empty relation with expected columns
+	// If no results - return empty relation with expected symbols
 	if len(validResults) == 0 {
-		columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
-		return NewMaterializedRelation(columns, []Tuple{}), nil
+		symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+		return NewMaterializedRelation(symbols, []Tuple{}), nil
 	}
 
 	// Union all results by collecting all tuples
 	var allTuples []Tuple
-	columns := validResults[0].Columns()
+	symbols := validResults[0].Symbols()
 
 	for _, rel := range validResults {
 		collectTuplesInto(&allTuples, rel)
 	}
 
-	result := NewMaterializedRelation(columns, allTuples)
+	result := NewMaterializedRelation(symbols, allTuples)
 
 	return result, nil
 }
@@ -418,14 +418,14 @@ func executePhasesWithInputs(ctx Context, parentExec *Executor, plan *planner.Qu
 // getUniqueInputCombinations extracts unique combinations of input values.
 // This is a pure function that performs data transformation.
 func getUniqueInputCombinations(rel Relation, inputSymbols []query.Symbol) []map[query.Symbol]interface{} {
-	// Find column indices for input symbols
+	// Find symbol indices for input symbols
 	indices := make([]int, len(inputSymbols))
 	for i, sym := range inputSymbols {
 		if sym.IsSource() {
-			// Source marker - not a column, use special index
+			// Source marker - not a symbol, use special index
 			indices[i] = -1
 		} else {
-			indices[i] = ColumnIndex(rel, sym)
+			indices[i] = SymbolIndex(rel, sym)
 			if indices[i] < 0 {
 				// Symbol not found - should not happen if planner is correct
 				return nil
@@ -596,7 +596,7 @@ func createInputRelationsFromValuesWithOptions(q *query.Query, orderedValues []i
 			}
 
 		case query.CollectionInput:
-			// Create a single-column relation with one tuple per collection element
+			// Create a single-symbol relation with one tuple per collection element
 			if valueIndex < len(orderedValues) {
 				var tuples []Tuple
 
@@ -665,11 +665,11 @@ func createSubqueryContext(parentCtx Context, inputs []query.InputSpec, inputVal
 	}
 }
 
-// augmentWithInputValues adds input values as constant columns to a relation.
+// augmentWithInputValues adds input values as constant symbols to a relation.
 // This is a pure function that performs relation transformation.
 func augmentWithInputValues(rel Relation, inputSymbols []query.Symbol, inputValues []interface{}) Relation {
-	// Create new columns list
-	newColumns := append(rel.Columns(), inputSymbols...)
+	// Create new symbols list
+	newColumns := append(rel.Symbols(), inputSymbols...)
 
 	// Create augmented tuples
 	var augmentedTuples []Tuple
@@ -690,7 +690,7 @@ func augmentWithInputValues(rel Relation, inputSymbols []query.Symbol, inputValu
 // This is a pure function that handles different binding forms (TupleBinding, RelationBinding).
 func applyBindingForm(result Relation, binding query.BindingForm, inputValues map[query.Symbol]interface{}, inputSymbols []query.Symbol) (Relation, error) {
 	// fmt.Printf("DEBUG: applyBindingForm - binding type: %T, binding: %v\n", binding, binding)
-	// fmt.Printf("DEBUG: Result columns: %v\n", result.Columns)
+	// fmt.Printf("DEBUG: Result symbols: %v\n", result.Symbols)
 
 	switch b := binding.(type) {
 	case query.TupleBinding:
@@ -707,10 +707,10 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 		// EMPTY RESULT = PATTERN FAILS TO MATCH
 		// Return empty relation instead of error (datalog semantics)
 		if result.Size() == 0 {
-			columns := make([]query.Symbol, len(realInputSymbols)+len(b.Variables))
-			copy(columns, realInputSymbols)
-			copy(columns[len(realInputSymbols):], b.Variables)
-			return NewMaterializedRelation(columns, []Tuple{}), nil
+			symbols := make([]query.Symbol, len(realInputSymbols)+len(b.Variables))
+			copy(symbols, realInputSymbols)
+			copy(symbols[len(realInputSymbols):], b.Variables)
+			return NewMaterializedRelation(symbols, []Tuple{}), nil
 		}
 
 		if result.Size() != 1 {
@@ -719,13 +719,13 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 
 		// fmt.Printf("DEBUG: TupleBinding variables: %v\n", b.Variables)
 
-		// Create relation with input columns + binding columns (excluding $)
-		columns := make([]query.Symbol, len(realInputSymbols)+len(b.Variables))
-		copy(columns, realInputSymbols)
-		copy(columns[len(realInputSymbols):], b.Variables)
+		// Create relation with input symbols + binding symbols (excluding $)
+		symbols := make([]query.Symbol, len(realInputSymbols)+len(b.Variables))
+		copy(symbols, realInputSymbols)
+		copy(symbols[len(realInputSymbols):], b.Variables)
 
 		// Create tuple with input values + result values (excluding $)
-		tuple := make(Tuple, len(columns))
+		tuple := make(Tuple, len(symbols))
 		for i, sym := range realInputSymbols {
 			tuple[i] = inputValues[sym]
 		}
@@ -742,7 +742,7 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 		}
 
 		for i := range b.Variables {
-			// For aggregates, the result column is the aggregate expression (e.g., "(max ?price)")
+			// For aggregates, the result symbol is the aggregate expression (e.g., "(max ?price)")
 			// We need to match this with the binding variable
 			if i < len(resultTuple) {
 				tuple[len(realInputSymbols)+i] = resultTuple[i]
@@ -753,10 +753,10 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 		}
 
 		// fmt.Printf("DEBUG: Final tuple: %v\n", tuple)
-		return NewMaterializedRelation(columns, []Tuple{tuple}), nil
+		return NewMaterializedRelation(symbols, []Tuple{tuple}), nil
 
 	case query.ScalarBinding:
-		// ?var - expect single result with single column, bind to variable
+		// ?var - expect single result with single symbol, bind to variable
 		// This is the Datomic scalar binding pattern used with scalar find spec
 
 		// Filter out source markers from input symbols
@@ -769,42 +769,42 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 
 		// EMPTY RESULT = PATTERN FAILS TO MATCH
 		if result.Size() == 0 {
-			columns := append(realInputSymbols, b.Variable)
-			return NewMaterializedRelation(columns, []Tuple{}), nil
+			symbols := append(realInputSymbols, b.Variable)
+			return NewMaterializedRelation(symbols, []Tuple{}), nil
 		}
 
-		// Scalar binding expects exactly 1 row
+		// Scalar binding expects exactly 1 tuple
 		if result.Size() != 1 {
 			return nil, fmt.Errorf("scalar binding expects 1 result, got %d", result.Size())
 		}
 
 		resultTuple := result.Get(0)
 
-		// Scalar binding expects exactly 1 column
+		// Scalar binding expects exactly 1 symbol
 		if len(resultTuple) != 1 {
-			return nil, fmt.Errorf("scalar binding expects 1 column, got %d", len(resultTuple))
+			return nil, fmt.Errorf("scalar binding expects 1 symbol, got %d", len(resultTuple))
 		}
 
-		// Create relation with input columns + binding variable
-		columns := append(realInputSymbols, b.Variable)
-		tuple := make(Tuple, len(columns))
+		// Create relation with input symbols + binding variable
+		symbols := append(realInputSymbols, b.Variable)
+		tuple := make(Tuple, len(symbols))
 		for i, sym := range realInputSymbols {
 			tuple[i] = inputValues[sym]
 		}
 		tuple[len(realInputSymbols)] = resultTuple[0]
 
-		return NewMaterializedRelation(columns, []Tuple{tuple}), nil
+		return NewMaterializedRelation(symbols, []Tuple{tuple}), nil
 
 	case query.CollectionBinding:
-		// [?coll ...] - collect all values from a single column into a collection
+		// [?coll ...] - collect all values from a single symbol into a collection
 		// For now, implement as a simple relation
 		return nil, fmt.Errorf("collection binding not yet implemented")
 
 	case query.RelationBinding:
-		// [[?a ?b] ...] - bind as relation with multiple columns
-		resultCols := result.Columns()
+		// [[?a ?b] ...] - bind as relation with multiple symbols
+		resultCols := result.Symbols()
 		if len(b.Variables) != len(resultCols) {
-			return nil, fmt.Errorf("relation binding expects %d columns, got %d", len(b.Variables), len(resultCols))
+			return nil, fmt.Errorf("relation binding expects %d symbols, got %d", len(b.Variables), len(resultCols))
 		}
 
 		// Filter out source markers from input symbols - they're not real variables
@@ -815,15 +815,15 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 			}
 		}
 
-		// Create relation with input columns + binding columns (excluding source markers)
-		columns := make([]query.Symbol, len(realInputSymbols)+len(b.Variables))
-		copy(columns, realInputSymbols)
-		copy(columns[len(realInputSymbols):], b.Variables)
+		// Create relation with input symbols + binding symbols (excluding source markers)
+		symbols := make([]query.Symbol, len(realInputSymbols)+len(b.Variables))
+		copy(symbols, realInputSymbols)
+		copy(symbols[len(realInputSymbols):], b.Variables)
 
-		// Create tuples with input values + each result row (excluding $)
+		// Create tuples with input values + each result tuple (excluding $)
 		var tuples []Tuple
 		for i := 0; i < result.Size(); i++ {
-			tuple := make(Tuple, len(columns))
+			tuple := make(Tuple, len(symbols))
 
 			// Add input values (excluding $)
 			for j, sym := range realInputSymbols {
@@ -839,31 +839,31 @@ func applyBindingForm(result Relation, binding query.BindingForm, inputValues ma
 			tuples = append(tuples, tuple)
 		}
 
-		return NewMaterializedRelation(columns, tuples), nil
+		return NewMaterializedRelation(symbols, tuples), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported binding form: %T", binding)
 	}
 }
 
-// getBindingColumns returns the expected columns for a binding form.
+// getBindingColumns returns the expected symbols for a binding form.
 // This is a pure function that computes output schema.
 func getBindingColumns(binding query.BindingForm, inputSymbols []query.Symbol) []query.Symbol {
-	columns := make([]query.Symbol, len(inputSymbols))
-	copy(columns, inputSymbols)
+	symbols := make([]query.Symbol, len(inputSymbols))
+	copy(symbols, inputSymbols)
 
 	switch b := binding.(type) {
 	case query.TupleBinding:
-		columns = append(columns, b.Variables...)
+		symbols = append(symbols, b.Variables...)
 	case query.ScalarBinding:
-		columns = append(columns, b.Variable)
+		symbols = append(symbols, b.Variable)
 	case query.CollectionBinding:
-		columns = append(columns, b.Variable)
+		symbols = append(symbols, b.Variable)
 	case query.RelationBinding:
-		columns = append(columns, b.Variables...)
+		symbols = append(symbols, b.Variables...)
 	}
 
-	return columns
+	return symbols
 }
 
 // subqueryContext wraps a parent context and provides input bindings
@@ -900,12 +900,12 @@ func (sc *subqueryContext) MatchPattern(pattern query.Pattern, fn func() ([]data
 
 // matchesWithRelation checks if a datom matches pattern with given relation
 func (sc *subqueryContext) matchesWithRelation(datom datalog.Datom, pattern *query.DataPattern, rel Relation) bool {
-	// Get columns and build a map of values from the first tuple
+	// Get symbols and build a map of values from the first tuple
 	if rel == nil || rel.IsEmpty() {
 		return true // No constraints
 	}
 
-	cols := rel.Columns()
+	cols := rel.Symbols()
 	it := rel.Iterator()
 	if !it.Next() {
 		it.Close()
@@ -1022,20 +1022,20 @@ func canBatchSubquery(q *query.Query) bool {
 // the aggregation will compute over the entire dataset instead of per input tuple.
 func executeBatchedSubqueryWithCombinations(ctx Context, parentExec *Executor, subqPlan planner.SubqueryPlan, inputCombinations []map[query.Symbol]interface{}) (Relation, error) {
 	if len(inputCombinations) == 0 {
-		columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
-		return NewMaterializedRelation(columns, []Tuple{}), nil
+		symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+		return NewMaterializedRelation(symbols, []Tuple{}), nil
 	}
 
 	// Build a relation with all input combinations
-	// The columns should match the input symbols from the subquery
-	var columns []query.Symbol
+	// The symbols should match the input symbols from the subquery
+	var symbols []query.Symbol
 	var allTuples []Tuple
 
 	// Extract the symbols we're passing (excluding $)
 	for _, input := range subqPlan.Subquery.Inputs {
 		switch inp := input.(type) {
 		case query.Variable:
-			columns = append(columns, inp.Name)
+			symbols = append(symbols, inp.Name)
 		case query.Constant:
 			// Skip source markers like $, $users, etc.
 			if sym, ok := inp.Value.(query.Symbol); ok && sym.IsSource() {
@@ -1047,18 +1047,18 @@ func executeBatchedSubqueryWithCombinations(ctx Context, parentExec *Executor, s
 	// Build tuples from all combinations
 	for _, values := range inputCombinations {
 		var tuple Tuple
-		for _, col := range columns {
+		for _, col := range symbols {
 			if val, ok := values[col]; ok {
 				tuple = append(tuple, val)
 			}
 		}
-		if len(tuple) == len(columns) {
+		if len(tuple) == len(symbols) {
 			allTuples = append(allTuples, tuple)
 		}
 	}
 
 	// Create the batched input relation
-	batchedInputRel := NewMaterializedRelation(columns, allTuples)
+	batchedInputRel := NewMaterializedRelation(symbols, allTuples)
 
 	// Create input relations for the subquery
 	// We need to pass $ and the batched relation
@@ -1084,7 +1084,7 @@ func executeBatchedSubqueryWithCombinations(ctx Context, parentExec *Executor, s
 	}
 
 	// For batched execution, we can't apply the binding form per-input
-	// The result should already have all rows
+	// The result should already have all tuples
 	// Just apply the binding with empty input values (no scalar substitution needed)
 	boundResult, err := applyBindingForm(result, subqPlan.Subquery.Binding, nil, subqPlan.Inputs)
 	if err != nil {

--- a/datalog/executor/subquery_batcher.go
+++ b/datalog/executor/subquery_batcher.go
@@ -20,35 +20,35 @@ func NewSubqueryBatcher() *SubqueryBatcher {
 // - combinations: Map of symbol -> value for each input combination
 // - inputSymbols: List of symbols to extract (may include "$")
 //
-// Returns: Relation with columns matching inputSymbols (excluding "$")
+// Returns: Relation with symbols matching inputSymbols (excluding "$")
 func (b *SubqueryBatcher) BuildBatchedInput(
 	combinations []map[query.Symbol]interface{},
 	inputSymbols []query.Symbol,
 ) Relation {
 	if len(combinations) == 0 {
-		// Filter source markers from columns
-		var columns []query.Symbol
+		// Filter source markers from symbols
+		var symbols []query.Symbol
 		for _, sym := range inputSymbols {
 			if !sym.IsSource() {
-				columns = append(columns, sym)
+				symbols = append(symbols, sym)
 			}
 		}
-		return NewMaterializedRelation(columns, []Tuple{})
+		return NewMaterializedRelation(symbols, []Tuple{})
 	}
 
 	// Filter to only the symbols we're passing (exclude source markers)
-	var columns []query.Symbol
+	var symbols []query.Symbol
 	for _, sym := range inputSymbols {
 		if !sym.IsSource() {
-			columns = append(columns, sym)
+			symbols = append(symbols, sym)
 		}
 	}
 
 	// Build tuples from all combinations
 	var tuples []Tuple
 	for _, values := range combinations {
-		tuple := make(Tuple, len(columns))
-		for i, col := range columns {
+		tuple := make(Tuple, len(symbols))
+		for i, col := range symbols {
 			if val, ok := values[col]; ok {
 				tuple[i] = val
 			}
@@ -58,7 +58,7 @@ func (b *SubqueryBatcher) BuildBatchedInput(
 		tuples = append(tuples, tuple)
 	}
 
-	return NewMaterializedRelation(columns, tuples)
+	return NewMaterializedRelation(symbols, tuples)
 }
 
 // ExtractInputSymbols extracts variable symbols from subquery inputs
@@ -93,7 +93,7 @@ func (b *SubqueryBatcher) ExtractInputSymbols(inputs []query.InputSpec) []query.
 }
 
 // ExtractRelationSymbols extracts symbols from RelationInput only
-// This is useful when you need to know what columns the batched relation will have.
+// This is useful when you need to know what symbols the batched relation will have.
 //
 // Parameters:
 // - inputs: Subquery input specifications from :in clause

--- a/datalog/executor/subquery_batcher_test.go
+++ b/datalog/executor/subquery_batcher_test.go
@@ -32,15 +32,15 @@ func TestBatcher_BuildBatchedInput(t *testing.T) {
 	// Build batched input
 	rel := batcher.BuildBatchedInput(combinations, inputSymbols)
 
-	// Verify columns (should exclude $)
+	// Verify symbols (should exclude $)
 	expectedColumns := []query.Symbol{datalog.NewSymbol("?sym"), datalog.NewSymbol("?hour")}
-	columns := rel.Columns()
-	if len(columns) != len(expectedColumns) {
-		t.Fatalf("Expected %d columns, got %d", len(expectedColumns), len(columns))
+	symbols := rel.Symbols()
+	if len(symbols) != len(expectedColumns) {
+		t.Fatalf("Expected %d symbols, got %d", len(expectedColumns), len(symbols))
 	}
-	for i, col := range columns {
+	for i, col := range symbols {
 		if col != expectedColumns[i] {
-			t.Errorf("Column %d: expected %v, got %v", i, expectedColumns[i], col)
+			t.Errorf("Symbol %d: expected %v, got %v", i, expectedColumns[i], col)
 		}
 	}
 
@@ -80,12 +80,12 @@ func TestBatcher_BuildBatchedInput_SingleColumn(t *testing.T) {
 
 	rel := batcher.BuildBatchedInput(combinations, inputSymbols)
 
-	// Verify single column (excluding $)
-	if len(rel.Columns()) != 1 {
-		t.Fatalf("Expected 1 column, got %d", len(rel.Columns()))
+	// Verify single symbol (excluding $)
+	if len(rel.Symbols()) != 1 {
+		t.Fatalf("Expected 1 symbol, got %d", len(rel.Symbols()))
 	}
-	if rel.Columns()[0] != datalog.NewSymbol("?sym") {
-		t.Errorf("Expected column ?sym, got %v", rel.Columns()[0])
+	if rel.Symbols()[0] != datalog.NewSymbol("?sym") {
+		t.Errorf("Expected symbol ?sym, got %v", rel.Symbols()[0])
 	}
 
 	// Verify tuples
@@ -103,9 +103,9 @@ func TestBatcher_BuildBatchedInput_Empty(t *testing.T) {
 
 	rel := batcher.BuildBatchedInput(combinations, inputSymbols)
 
-	// Should return empty relation with correct columns
-	if len(rel.Columns()) != 1 {
-		t.Errorf("Expected 1 column, got %d", len(rel.Columns()))
+	// Should return empty relation with correct symbols
+	if len(rel.Symbols()) != 1 {
+		t.Errorf("Expected 1 symbol, got %d", len(rel.Symbols()))
 	}
 	if rel.Size() != 0 {
 		t.Errorf("Expected 0 tuples, got %d", rel.Size())

--- a/datalog/executor/subquery_decorrelation.go
+++ b/datalog/executor/subquery_decorrelation.go
@@ -128,7 +128,7 @@ func executeDecorrelatedSubqueries(ctx Context,
 				if collector != nil {
 					collector.AddTiming(fmt.Sprintf("decorrelated_subqueries/merged_query_%d", idx), timings[idx], map[string]interface{}{
 						"result_size":    result.Size(),
-						"result_columns": result.Columns(),
+						"result_symbols": result.Symbols(),
 					})
 				}
 			}(i, mergedPlan)
@@ -155,7 +155,7 @@ func executeDecorrelatedSubqueries(ctx Context,
 			if collector != nil {
 				collector.AddTiming(fmt.Sprintf("decorrelated_subqueries/merged_query_%d", i), mergedStart, map[string]interface{}{
 					"result_size":    result.Size(),
-					"result_columns": result.Columns(),
+					"result_symbols": result.Symbols(),
 				})
 			}
 		}
@@ -180,7 +180,7 @@ func executeDecorrelatedSubqueries(ctx Context,
 			Start: start,
 			Data: map[string]interface{}{
 				"combined_size":    combinedResult.Size(),
-				"combined_columns": combinedResult.Columns(),
+				"combined_symbols": combinedResult.Symbols(),
 			},
 		})
 	}
@@ -198,14 +198,14 @@ func executeDecorrelatedSubqueries(ctx Context,
 			Start: start,
 			Data: map[string]interface{}{
 				"joined_size":    joined.Size(),
-				"joined_columns": joined.Columns(),
+				"joined_symbols": joined.Symbols(),
 			},
 		})
 	}
 
-	// Rename and reorder columns in one step to match original subquery order
-	// This fixes the parallel decorrelation column ordering bug
-	finalResult := applyBindingRenamesAndReorder(joined, groupResults, decorPlan, inputRelation.Columns())
+	// Rename and reorder symbols in one step to match original subquery order
+	// This fixes the parallel decorrelation symbol ordering bug
+	finalResult := applyBindingRenamesAndReorder(joined, groupResults, decorPlan, inputRelation.Symbols())
 
 	// Add completion event
 	if collector != nil {
@@ -218,54 +218,54 @@ func executeDecorrelatedSubqueries(ctx Context,
 	return finalResult, nil
 }
 
-// applyBindingRenamesAndReorder renames and reorders columns in one operation.
+// applyBindingRenamesAndReorder renames and reorders symbols in one operation.
 //
-// This function fixes the parallel decorrelation column ordering bug by:
-// 1. Building the final column list in original subquery order (from :where clause)
+// This function fixes the parallel decorrelation symbol ordering bug by:
+// 1. Building the final symbol list in original subquery order (from :where clause)
 // 2. Creating tuples with values in that order
 //
-// The joined result has: [input columns] + [aggregate columns in join order]
-// We transform to: [input columns] + [aggregate columns in original subquery order]
+// The joined result has: [input symbols] + [aggregate symbols in join order]
+// We transform to: [input symbols] + [aggregate symbols in original subquery order]
 func applyBindingRenamesAndReorder(joined Relation, groupResults []Relation, decorPlan *planner.DecorrelatedSubqueryPlan,
 	inputColumns []query.Symbol) Relation {
 
 	// Find the maximum original subquery index to determine how many subqueries there were
 	maxSubqIdx := -1
-	for subqIdx := range decorPlan.ColumnMapping {
+	for subqIdx := range decorPlan.SymbolMapping {
 		if subqIdx > maxSubqIdx {
 			maxSubqIdx = subqIdx
 		}
 	}
 
-	// Build final columns in correct order: [input columns] + [binding vars in original subquery order]
+	// Build final symbols in correct order: [input symbols] + [binding vars in original subquery order]
 	finalColumns := make([]query.Symbol, len(inputColumns))
 	copy(finalColumns, inputColumns)
 
 	// Collect binding variables in original subquery order
 	var orderedBindingVars []query.Symbol
 	for subqIdx := 0; subqIdx <= maxSubqIdx; subqIdx++ {
-		if resultMap, exists := decorPlan.ColumnMapping[subqIdx]; exists {
+		if resultMap, exists := decorPlan.SymbolMapping[subqIdx]; exists {
 			orderedBindingVars = append(orderedBindingVars, resultMap.BindingVars...)
 		}
 	}
 	finalColumns = append(finalColumns, orderedBindingVars...)
 
-	// Build mapping from binding variables to aggregate column symbols
+	// Build mapping from binding variables to aggregate symbol symbols
 	// We need to look at each filter group's output to know which aggregate corresponds to which binding var
 	bindingToSymbol := make(map[query.Symbol]query.Symbol)
 
 	for subqIdx := 0; subqIdx <= maxSubqIdx; subqIdx++ {
-		if resultMap, exists := decorPlan.ColumnMapping[subqIdx]; exists {
-			// Get this filter group's result columns
+		if resultMap, exists := decorPlan.SymbolMapping[subqIdx]; exists {
+			// Get this filter group's result symbols
 			filterGroupResult := groupResults[resultMap.FilterGroupIdx]
-			filterGroupCols := filterGroupResult.Columns()
+			filterGroupCols := filterGroupResult.Symbols()
 
-			// Map each binding variable to its actual column symbol in the filter group
+			// Map each binding variable to its actual symbol symbol in the filter group
 			for i, bindingVar := range resultMap.BindingVars {
-				if i < len(resultMap.ColumnIndices) {
-					colIdx := resultMap.ColumnIndices[i]
+				if i < len(resultMap.SymbolIndices) {
+					colIdx := resultMap.SymbolIndices[i]
 					if colIdx < len(filterGroupCols) {
-						// The actual column symbol (like "(max ?h)") in the filter group
+						// The actual symbol symbol (like "(max ?h)") in the filter group
 						bindingToSymbol[bindingVar] = filterGroupCols[colIdx]
 					}
 				}
@@ -273,14 +273,14 @@ func applyBindingRenamesAndReorder(joined Relation, groupResults []Relation, dec
 		}
 	}
 
-	// Build index mapping: for each final column position, where to find it in joined relation
-	oldColumns := joined.Columns()
+	// Build index mapping: for each final symbol position, where to find it in joined relation
+	oldColumns := joined.Symbols()
 	indexMapping := make([]int, len(finalColumns))
 
 	for finalIdx, col := range finalColumns {
 		// Check if this is a binding variable that maps to an aggregate
 		if aggSymbol, isBound := bindingToSymbol[col]; isBound {
-			// Find the aggregate column in the joined result
+			// Find the aggregate symbol in the joined result
 			for joinedIdx, joinedCol := range oldColumns {
 				if aggSymbol == joinedCol {
 					indexMapping[finalIdx] = joinedIdx
@@ -288,7 +288,7 @@ func applyBindingRenamesAndReorder(joined Relation, groupResults []Relation, dec
 				}
 			}
 		} else {
-			// This is an input column - find by name directly
+			// This is an input symbol - find by name directly
 			for joinedIdx, joinedCol := range oldColumns {
 				if col == joinedCol {
 					indexMapping[finalIdx] = joinedIdx
@@ -341,8 +341,8 @@ func joinDecorrelatedResults(results []Relation, keys []query.Symbol) (Relation,
 
 // hashJoinWithMapping performs hash join with different key names on each side
 //
-// leftKeys: key column names in left relation
-// rightKeys: key column names in right relation (must correspond positionally to leftKeys)
+// leftKeys: key symbol names in left relation
+// rightKeys: key symbol names in right relation (must correspond positionally to leftKeys)
 func hashJoinWithMapping(left, right Relation, leftKeys, rightKeys []query.Symbol) Relation {
 	// Filter out source markers from keys
 	var filteredLeftKeys, filteredRightKeys []query.Symbol
@@ -358,17 +358,17 @@ func hashJoinWithMapping(left, right Relation, leftKeys, rightKeys []query.Symbo
 		}
 	}
 
-	// Find key column indices in both relations
+	// Find key symbol indices in both relations
 	leftIndices := make([]int, len(filteredLeftKeys))
 	rightIndices := make([]int, len(filteredRightKeys))
 
 	for i := range filteredLeftKeys {
-		leftIndices[i] = ColumnIndex(left, filteredLeftKeys[i])
-		rightIndices[i] = ColumnIndex(right, filteredRightKeys[i])
+		leftIndices[i] = SymbolIndex(left, filteredLeftKeys[i])
+		rightIndices[i] = SymbolIndex(right, filteredRightKeys[i])
 
 		// If key not found in either relation, return empty
 		if leftIndices[i] < 0 || rightIndices[i] < 0 {
-			resultColumns := append(left.Columns(), filterColumns(right.Columns(), filteredRightKeys)...)
+			resultColumns := append(left.Symbols(), filterColumns(right.Symbols(), filteredRightKeys)...)
 			return NewMaterializedRelation(resultColumns, []Tuple{})
 		}
 	}
@@ -405,7 +405,7 @@ func hashJoinWithMapping(left, right Relation, leftKeys, rightKeys []query.Symbo
 
 	// Probe and build result
 	var resultTuples []Tuple
-	resultColumns := append(left.Columns(), filterColumns(right.Columns(), filteredRightKeys)...)
+	resultColumns := append(left.Symbols(), filterColumns(right.Symbols(), filteredRightKeys)...)
 
 	it = probeRel.Iterator()
 	for it.Next() {
@@ -414,7 +414,7 @@ func hashJoinWithMapping(left, right Relation, leftKeys, rightKeys []query.Symbo
 
 		if buildTuples, found := hashTable[key]; found {
 			for _, buildTuple := range buildTuples {
-				// Combine tuples, filtering out duplicate key columns from right side
+				// Combine tuples, filtering out duplicate key symbols from right side
 				var combined Tuple
 				if buildIsLeft {
 					// left is build, right is probe
@@ -434,26 +434,26 @@ func hashJoinWithMapping(left, right Relation, leftKeys, rightKeys []query.Symbo
 	return NewMaterializedRelation(resultColumns, resultTuples)
 }
 
-// hashJoinOnKeys performs hash join on specified key columns
+// hashJoinOnKeys performs hash join on specified key symbols
 //
 // This is a standard hash join implementation:
 // 1. Build hash table from smaller relation
 // 2. Probe with larger relation
-// 3. Filter out duplicate key columns from result
+// 3. Filter out duplicate key symbols from result
 func hashJoinOnKeys(left, right Relation, keys []query.Symbol) Relation {
-	// Find key column indices in both relations
+	// Find key symbol indices in both relations
 	leftIndices := make([]int, len(keys))
 	rightIndices := make([]int, len(keys))
 
 	for i, key := range keys {
-		leftIndices[i] = ColumnIndex(left, key)
-		rightIndices[i] = ColumnIndex(right, key)
+		leftIndices[i] = SymbolIndex(left, key)
+		rightIndices[i] = SymbolIndex(right, key)
 
 		// If key not found in either relation, this is an error
 		// But we'll handle it gracefully by treating it as no match
 		if leftIndices[i] < 0 || rightIndices[i] < 0 {
 			// Return empty relation
-			resultColumns := append(left.Columns(), filterColumns(right.Columns(), keys)...)
+			resultColumns := append(left.Symbols(), filterColumns(right.Symbols(), keys)...)
 			return NewMaterializedRelation(resultColumns, []Tuple{})
 		}
 	}
@@ -490,7 +490,7 @@ func hashJoinOnKeys(left, right Relation, keys []query.Symbol) Relation {
 
 	// Probe and build result
 	var resultTuples []Tuple
-	resultColumns := append(left.Columns(), filterColumns(right.Columns(), keys)...)
+	resultColumns := append(left.Symbols(), filterColumns(right.Symbols(), keys)...)
 
 	it = probeRel.Iterator()
 	for it.Next() {
@@ -499,7 +499,7 @@ func hashJoinOnKeys(left, right Relation, keys []query.Symbol) Relation {
 
 		if buildTuples, found := hashTable[key]; found {
 			for _, buildTuple := range buildTuples {
-				// Combine tuples, filtering out duplicate key columns
+				// Combine tuples, filtering out duplicate key symbols
 				var combined Tuple
 				if buildIsLeft {
 					// left is build, right is probe
@@ -532,15 +532,15 @@ func makeJoinKey(tuple Tuple, indices []int) string {
 	return strings.Join(parts, "|")
 }
 
-// filterColumns removes key columns from column list (to avoid duplicates in join result)
-func filterColumns(columns []query.Symbol, keys []query.Symbol) []query.Symbol {
+// filterColumns removes key symbols from symbol list (to avoid duplicates in join result)
+func filterColumns(symbols []query.Symbol, keys []query.Symbol) []query.Symbol {
 	keySet := make(map[query.Symbol]bool)
 	for _, key := range keys {
 		keySet[key] = true
 	}
 
 	var result []query.Symbol
-	for _, col := range columns {
+	for _, col := range symbols {
 		if !keySet[col] {
 			result = append(result, col)
 		}
@@ -578,13 +578,13 @@ type timeKey struct {
 // extractTimeRanges converts correlation key tuples into time ranges
 // This enables semi-join pushdown by constraining merged queries to scan only relevant time periods
 func extractTimeRanges(inputRelation Relation, correlationKeys []query.Symbol) ([]TimeRange, error) {
-	// Get columns from input relation
-	cols := inputRelation.Columns()
+	// Get symbols from input relation
+	cols := inputRelation.Symbols()
 	if len(cols) == 0 {
 		return nil, nil
 	}
 
-	// Find column indices for time components
+	// Find symbol indices for time components
 	symYear := datalog.NewSymbol("?year")
 	symY := datalog.NewSymbol("?y")
 	symMonth := datalog.NewSymbol("?month")

--- a/datalog/executor/subquery_find_clause_bug_test.go
+++ b/datalog/executor/subquery_find_clause_bug_test.go
@@ -64,7 +64,7 @@ func TestSubqueryFindClauseBug(t *testing.T) {
 	}
 
 	// Debug: print result structure
-	t.Logf("Result columns: %v", result.Columns())
+	t.Logf("Result symbols: %v", result.Symbols())
 	t.Logf("Result size: %d", result.Size())
 	if result.Size() > 0 {
 		t.Logf("First tuple: %v", result.Get(0))

--- a/datalog/executor/symmetric_hash_join.go
+++ b/datalog/executor/symmetric_hash_join.go
@@ -36,27 +36,27 @@ func SymmetricHashJoin(left, right Relation, joinCols []query.Symbol) Relation {
 
 // SymmetricHashJoinWithOptions performs a streaming symmetric hash join with explicit options
 func SymmetricHashJoinWithOptions(left, right Relation, joinCols []query.Symbol, opts ExecutorOptions) Relation {
-	// Build column mappings
+	// Build symbol mappings
 	leftIndices := make([]int, len(joinCols))
 	rightIndices := make([]int, len(joinCols))
 	for i, col := range joinCols {
-		leftIndices[i] = ColumnIndex(left, col)
-		rightIndices[i] = ColumnIndex(right, col)
+		leftIndices[i] = SymbolIndex(left, col)
+		rightIndices[i] = SymbolIndex(right, col)
 		if leftIndices[i] < 0 || rightIndices[i] < 0 {
-			// Join column not found
+			// Join symbol not found
 			return NewMaterializedRelation(nil, nil)
 		}
 	}
 
-	// Determine output columns (union without duplicates)
-	outputCols := append([]query.Symbol{}, left.Columns()...)
+	// Determine output symbols (union without duplicates)
+	outputCols := append([]query.Symbol{}, left.Symbols()...)
 	rightColSet := make(map[query.Symbol]bool)
 	for _, col := range joinCols {
 		rightColSet[col] = true
 	}
 
-	// Add right columns that aren't in join columns
-	for _, col := range right.Columns() {
+	// Add right symbols that aren't in join symbols
+	for _, col := range right.Symbols() {
 		if !rightColSet[col] {
 			outputCols = append(outputCols, col)
 		}
@@ -80,8 +80,8 @@ func SymmetricHashJoinWithOptions(left, right Relation, joinCols []query.Symbol,
 		leftIndices:  leftIndices,
 		rightIndices: rightIndices,
 		joinCols:     joinCols,
-		leftCols:     left.Columns(),
-		rightCols:    right.Columns(),
+		leftCols:     left.Symbols(),
+		rightCols:    right.Symbols(),
 		outputCols:   outputCols,
 		resultQueue:  make([]Tuple, 0),
 		seen:         NewTupleKeyMapWithCapacity(tableSize),
@@ -230,17 +230,17 @@ func (it *symmetricHashJoinIterator) processRightBatch() {
 	}
 }
 
-// combineTuples combines left and right tuples, avoiding duplication of join columns
+// combineTuples combines left and right tuples, avoiding duplication of join symbols
 func (it *symmetricHashJoinIterator) combineTuples(leftTuple, rightTuple Tuple, leftFirst bool) Tuple {
-	// Start with all columns from left
+	// Start with all symbols from left
 	result := make(Tuple, len(it.outputCols))
 	copy(result, leftTuple)
 
-	// Add non-join columns from right
+	// Add non-join symbols from right
 	rightOffset := len(leftTuple)
 	rightColIndex := 0
 	for i, col := range it.rightCols {
-		// Skip join columns
+		// Skip join symbols
 		isJoinCol := false
 		for _, joinCol := range it.joinCols {
 			if col == joinCol {

--- a/datalog/executor/symmetric_hash_join_bench_test.go
+++ b/datalog/executor/symmetric_hash_join_bench_test.go
@@ -33,7 +33,7 @@ func BenchmarkSymmetricVsAsymmetricHashJoin(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -43,7 +43,7 @@ func BenchmarkSymmetricVsAsymmetricHashJoin(b *testing.B) {
 					},
 				}
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -69,7 +69,7 @@ func BenchmarkSymmetricVsAsymmetricHashJoin(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				left := &StreamingRelation{
-					columns:  leftCols,
+					symbols:  leftCols,
 					iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -79,7 +79,7 @@ func BenchmarkSymmetricVsAsymmetricHashJoin(b *testing.B) {
 					},
 				}
 				right := &StreamingRelation{
-					columns:  rightCols,
+					symbols:  rightCols,
 					iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 					size:     -1,
 					options: ExecutorOptions{
@@ -125,7 +125,7 @@ func BenchmarkSymmetricHashJoinTableSize(b *testing.B) {
 
 				for i := 0; i < b.N; i++ {
 					left := &StreamingRelation{
-						columns:  leftCols,
+						symbols:  leftCols,
 						iterator: &sliceIterator{tuples: leftTuples, pos: -1},
 						size:     -1,
 						options: ExecutorOptions{
@@ -135,7 +135,7 @@ func BenchmarkSymmetricHashJoinTableSize(b *testing.B) {
 						},
 					}
 					right := &StreamingRelation{
-						columns:  rightCols,
+						symbols:  rightCols,
 						iterator: &sliceIterator{tuples: rightTuples, pos: -1},
 						size:     -1,
 						options: ExecutorOptions{

--- a/datalog/executor/symmetric_hash_join_test.go
+++ b/datalog/executor/symmetric_hash_join_test.go
@@ -55,9 +55,9 @@ func TestSymmetricHashJoin(t *testing.T) {
 		// Verify results
 		assert.Len(t, results, 3) // alice, bob, charlie match
 
-		// Check output columns
+		// Check output symbols
 		expectedCols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?name"), datalog.NewSymbol("?score"), datalog.NewSymbol("?city"), datalog.NewSymbol("?age")}
-		assert.Equal(t, expectedCols, result.Columns())
+		assert.Equal(t, expectedCols, result.Symbols())
 
 		// Verify specific results (order may vary due to hash tables)
 		foundAlice, foundBob, foundCharlie := false, false, false
@@ -90,7 +90,7 @@ func TestSymmetricHashJoin(t *testing.T) {
 	})
 
 	t.Run("MultiColumnJoin", func(t *testing.T) {
-		// Test data with multiple join columns
+		// Test data with multiple join symbols
 		leftTuples := []Tuple{
 			{1, "alice", 100},
 			{2, "bob", 200},
@@ -276,13 +276,13 @@ func TestSymmetricHashJoin(t *testing.T) {
 		rightIter := newMockIterator(rightTuples)
 		rightRel := NewStreamingRelation(rightColumns, rightIter)
 
-		// Try to join on non-existent column
+		// Try to join on non-existent symbol
 		joinCols := []query.Symbol{datalog.NewSymbol("?nonexistent")}
 		result := SymmetricHashJoin(leftRel, rightRel, joinCols)
 
 		// Should return empty relation
 		it := result.Iterator()
-		assert.False(t, it.Next(), "Should have no results with invalid join column")
+		assert.False(t, it.Next(), "Should have no results with invalid join symbol")
 		it.Close()
 	})
 }

--- a/datalog/executor/table_formatter.go
+++ b/datalog/executor/table_formatter.go
@@ -15,7 +15,7 @@ import (
 
 // TableFormatter provides utilities for formatting Relations as tables
 type TableFormatter struct {
-	// MaxWidth is the maximum width for a column
+	// MaxWidth is the maximum width for a symbol
 	MaxWidth int
 	// TruncateString is the string to append when truncating
 	TruncateString string
@@ -39,20 +39,20 @@ func (tf *TableFormatter) FormatRelation(rel Relation) string {
 	var tuples []Tuple
 	collectTuplesInto(&tuples, rel)
 
-	columns := rel.Columns()
-	return tf.formatTable(columns, tuples)
+	symbols := rel.Symbols()
+	return tf.formatTable(symbols, tuples)
 }
 
-// formatTable formats columns and tuples as a markdown table
-func (tf *TableFormatter) formatTable(columns []query.Symbol, tuples []Tuple) string {
+// formatTable formats symbols and tuples as a markdown table
+func (tf *TableFormatter) formatTable(symbols []query.Symbol, tuples []Tuple) string {
 	if len(tuples) == 0 {
-		return fmt.Sprintf("_Columns: %v_\n\n_No rows_", columns)
+		return fmt.Sprintf("_Symbols: %v_\n\n_No tuples_", symbols)
 	}
 
 	tableString := &strings.Builder{}
 
-	// Create alignment array with all columns using AlignNone for simple separators
-	alignment := make([]tw.Align, len(columns))
+	// Create alignment array with all symbols using AlignNone for simple separators
+	alignment := make([]tw.Align, len(symbols))
 	for i := range alignment {
 		alignment[i] = tw.AlignNone
 	}
@@ -64,26 +64,26 @@ func (tf *TableFormatter) formatTable(columns []query.Symbol, tuples []Tuple) st
 	)
 
 	// Set headers
-	headers := make([]string, len(columns))
-	for i, col := range columns {
+	headers := make([]string, len(symbols))
+	for i, col := range symbols {
 		headers[i] = col.String()
 	}
 	table.Header(headers)
 
-	// Append rows
+	// Append tuples
 	for _, tuple := range tuples {
-		row := make([]string, len(tuple))
+		cells := make([]string, len(tuple))
 		for j, val := range tuple {
-			row[j] = tf.formatValue(val)
+			cells[j] = tf.formatValue(val)
 		}
-		table.Append(row)
+		table.Append(cells)
 	}
 
 	// Render the table
 	table.Render()
 
-	// Add row count
-	tableString.WriteString(fmt.Sprintf("\n_%d rows_\n", len(tuples)))
+	// Add tuple count
+	tableString.WriteString(fmt.Sprintf("\n_%d tuples_\n", len(tuples)))
 
 	return tableString.String()
 }
@@ -124,7 +124,7 @@ func (tf *TableFormatter) formatValue(val interface{}) string {
 	return tf.truncate(s)
 }
 
-// truncate shortens a string to MaxWidth display columns, appending TruncateString if truncated
+// truncate shortens a string to MaxWidth display symbols, appending TruncateString if truncated
 func (tf *TableFormatter) truncate(s string) string {
 	if tf.MaxWidth <= 0 || runewidth.StringWidth(s) <= tf.MaxWidth {
 		return s

--- a/datalog/executor/table_formatter_test.go
+++ b/datalog/executor/table_formatter_test.go
@@ -21,30 +21,30 @@ func TestTableFormatter(t *testing.T) {
 	})
 
 	t.Run("FormatSimpleRelation", func(t *testing.T) {
-		columns := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?active")}
+		symbols := []query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?age"), datalog.NewSymbol("?active")}
 		tuples := []Tuple{
 			{"Alice", int64(30), true},
 			{"Bob", int64(25), false},
 			{"Charlie", int64(35), true},
 		}
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 
 		result := formatter.FormatRelation(rel)
 
 		// Check that it contains expected elements
 		if !strings.Contains(result, "?name") {
-			t.Error("Missing column ?name")
+			t.Error("Missing symbol ?name")
 		}
 		if !strings.Contains(result, "Alice") {
 			t.Error("Missing value Alice")
 		}
-		if !strings.Contains(result, "3 rows") {
-			t.Error("Missing row count")
+		if !strings.Contains(result, "3 tuples") {
+			t.Error("Missing tuple count")
 		}
 	})
 
 	t.Run("FormatWithDifferentTypes", func(t *testing.T) {
-		columns := []query.Symbol{datalog.NewSymbol("?entity"), datalog.NewSymbol("?keyword"), datalog.NewSymbol("?value"), datalog.NewSymbol("?time")}
+		symbols := []query.Symbol{datalog.NewSymbol("?entity"), datalog.NewSymbol("?keyword"), datalog.NewSymbol("?value"), datalog.NewSymbol("?time")}
 		testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
 		tuples := []Tuple{
@@ -68,7 +68,7 @@ func TestTableFormatter(t *testing.T) {
 			},
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 		result := formatter.FormatRelation(rel)
 
 		// Check formatting
@@ -89,7 +89,7 @@ func TestTableFormatter(t *testing.T) {
 	t.Run("FormatWithLongStrings", func(t *testing.T) {
 		formatter.MaxWidth = 20
 
-		columns := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?description")}
+		symbols := []query.Symbol{datalog.NewSymbol("?id"), datalog.NewSymbol("?description")}
 		longString := "This is a very long string that should be truncated because it exceeds the maximum width"
 
 		tuples := []Tuple{
@@ -97,24 +97,24 @@ func TestTableFormatter(t *testing.T) {
 			{int64(2), "Short"},
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 		result := formatter.FormatRelation(rel)
 
 		// Tablewriter handles truncation differently - it wraps or shows full text
 		// Just check that the table is formatted
 		if !strings.Contains(result, "?id") {
-			t.Error("Missing column header")
+			t.Error("Missing symbol header")
 		}
 	})
 
 	t.Run("FormatMarkdownTable", func(t *testing.T) {
-		columns := []query.Symbol{datalog.NewSymbol("?symbol"), datalog.NewSymbol("?price"), datalog.NewSymbol("?volume")}
+		symbols := []query.Symbol{datalog.NewSymbol("?symbol"), datalog.NewSymbol("?price"), datalog.NewSymbol("?volume")}
 		tuples := []Tuple{
 			{"AAPL", 150.25, int64(1000000)},
 			{"GOOG", 2800.50, int64(500000)},
 		}
 
-		rel := NewMaterializedRelation(columns, tuples)
+		rel := NewMaterializedRelation(symbols, tuples)
 		result := formatter.FormatRelation(rel)
 
 		// Check markdown format - tablewriter uses different separator style
@@ -125,7 +125,7 @@ func TestTableFormatter(t *testing.T) {
 			t.Error("Missing markdown separator")
 		}
 		if !strings.Contains(result, "| AAPL") && !strings.Contains(result, "150.25") {
-			t.Error("Missing markdown row data")
+			t.Error("Missing markdown tuple data")
 		}
 	})
 
@@ -141,27 +141,27 @@ func TestTableFormatter(t *testing.T) {
 		formatted := formatter.FormatRelation(result)
 
 		if !strings.Contains(formatted, "?name") {
-			t.Error("Missing column in result format")
+			t.Error("Missing symbol in result format")
 		}
-		if !strings.Contains(formatted, "_2 rows_") {
-			t.Error("Missing row count in result format")
+		if !strings.Contains(formatted, "_2 tuples_") {
+			t.Error("Missing tuple count in result format")
 		}
 	})
 }
 
 func TestPrintHelpers(t *testing.T) {
 	// Just test that these don't panic
-	columns := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+	symbols := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
 	tuples := []Tuple{
 		{int64(1), "a"},
 		{int64(2), "b"},
 	}
-	rel := NewMaterializedRelation(columns, tuples)
+	rel := NewMaterializedRelation(symbols, tuples)
 
 	// These print to stdout, so we just ensure they don't panic
 	PrintRelation(rel)
 
-	result := NewMaterializedRelation(columns, tuples)
+	result := NewMaterializedRelation(symbols, tuples)
 	PrintResult(result)
 
 	// Test string helpers
@@ -177,14 +177,14 @@ func TestPrintHelpers(t *testing.T) {
 // This is a regression test for the CLI empty results bug.
 func TestTableFormatterTupleCopying(t *testing.T) {
 	// Create a relation with streaming behavior enabled
-	columns := []query.Symbol{datalog.NewSymbol("x"), datalog.NewSymbol("y"), datalog.NewSymbol("z")}
+	symbols := []query.Symbol{datalog.NewSymbol("x"), datalog.NewSymbol("y"), datalog.NewSymbol("z")}
 	tuples := []Tuple{
 		{int64(1), int64(10), int64(100)},
 		{int64(2), int64(20), int64(200)},
 		{int64(3), int64(30), int64(300)},
 	}
 
-	rel := NewMaterializedRelationWithOptions(columns, tuples, ExecutorOptions{
+	rel := NewMaterializedRelationWithOptions(symbols, tuples, ExecutorOptions{
 		EnableTrueStreaming: true, // Enable streaming mode
 	})
 
@@ -192,7 +192,7 @@ func TestTableFormatterTupleCopying(t *testing.T) {
 	formatter := NewTableFormatter()
 	table := formatter.FormatRelation(rel)
 
-	// Verify all three rows appear in the output (not just the last one)
+	// Verify all three tuples appear in the output (not just the last one)
 	if !strings.Contains(table, "1") {
 		t.Errorf("Expected to find value 1 in table output:\n%s", table)
 	}
@@ -203,21 +203,21 @@ func TestTableFormatterTupleCopying(t *testing.T) {
 		t.Errorf("Expected to find value 3 in table output:\n%s", table)
 	}
 
-	// Verify row count
-	if !strings.Contains(table, "3 rows") {
-		t.Errorf("Expected '3 rows' in output, got:\n%s", table)
+	// Verify tuple count
+	if !strings.Contains(table, "3 tuples") {
+		t.Errorf("Expected '3 tuples' in output, got:\n%s", table)
 	}
 
-	// Verify column headers
+	// Verify symbol headers
 	if !strings.Contains(table, "x") || !strings.Contains(table, "y") || !strings.Contains(table, "z") {
-		t.Errorf("Expected column headers x, y, z in output, got:\n%s", table)
+		t.Errorf("Expected symbol headers x, y, z in output, got:\n%s", table)
 	}
 
-	// Verify all values from different rows are present
+	// Verify all values from different tuples are present
 	if !strings.Contains(table, "10") || !strings.Contains(table, "20") || !strings.Contains(table, "30") {
-		t.Errorf("Expected y-column values (10, 20, 30) in output, got:\n%s", table)
+		t.Errorf("Expected y-symbol values (10, 20, 30) in output, got:\n%s", table)
 	}
 	if !strings.Contains(table, "100") || !strings.Contains(table, "200") || !strings.Contains(table, "300") {
-		t.Errorf("Expected z-column values (100, 200, 300) in output, got:\n%s", table)
+		t.Errorf("Expected z-symbol values (100, 200, 300) in output, got:\n%s", table)
 	}
 }

--- a/datalog/executor/test_fixtures.go
+++ b/datalog/executor/test_fixtures.go
@@ -45,7 +45,7 @@ func (m *MockPatternMatcher) Match(pattern *query.DataPattern, bindings Relation
 
 		// Create a map of bound values
 		boundValues := make(map[query.Symbol]interface{})
-		cols := bindingRel.Columns()
+		cols := bindingRel.Symbols()
 		for i, col := range cols {
 			if i < len(tuple) {
 				boundValues[col] = tuple[i]

--- a/datalog/executor/testing.go
+++ b/datalog/executor/testing.go
@@ -37,11 +37,11 @@ func DualTestExecutorVariantsWithBase(base planner.PlannerOptions) []TestExecuto
 	}
 }
 
-// CompareRelations compares two relations for equality (column names and sorted tuples).
+// CompareRelations compares two relations for equality (symbol names and sorted tuples).
 // Returns true if they are equal.
 func CompareRelations(a, b Relation) bool {
-	// Compare columns
-	if !compareColumns(a.Columns(), b.Columns()) {
+	// Compare symbols
+	if !compareSymbols(a.Symbols(), b.Symbols()) {
 		return false
 	}
 
@@ -62,22 +62,22 @@ func CompareRelations(a, b Relation) bool {
 	return true
 }
 
-// CompareRelationsIgnoreColumnOrder compares relations allowing different column orders.
+// CompareRelationsIgnoreColumnOrder compares relations allowing different symbol orders.
 func CompareRelationsIgnoreColumnOrder(a, b Relation) bool {
-	aCols := a.Columns()
-	bCols := b.Columns()
+	aSyms := a.Symbols()
+	bSyms := b.Symbols()
 
-	if len(aCols) != len(bCols) {
+	if len(aSyms) != len(bSyms) {
 		return false
 	}
 
-	// Build column index mapping from b to a's order
-	colMap := make(map[int]int) // b index -> a index
-	for i, aCol := range aCols {
+	// Build symbol index mapping from b to a's order
+	symMap := make(map[int]int) // b index -> a index
+	for i, aSym := range aSyms {
 		found := false
-		for j, bCol := range bCols {
-			if aCol == bCol {
-				colMap[j] = i
+		for j, bSym := range bSyms {
+			if aSym == bSym {
+				symMap[j] = i
 				found = true
 				break
 			}
@@ -89,7 +89,7 @@ func CompareRelationsIgnoreColumnOrder(a, b Relation) bool {
 
 	// Collect tuples
 	aTuples := collectSortedTuples(a)
-	bTuples := collectSortedTuplesReordered(b, colMap)
+	bTuples := collectSortedTuplesReordered(b, symMap)
 
 	if len(aTuples) != len(bTuples) {
 		return false
@@ -108,9 +108,9 @@ func CompareRelationsIgnoreColumnOrder(a, b Relation) bool {
 func RelationDiff(a, b Relation) string {
 	result := ""
 
-	// Compare columns
-	if !compareColumns(a.Columns(), b.Columns()) {
-		result += fmt.Sprintf("Column mismatch:\n  a: %v\n  b: %v\n", a.Columns(), b.Columns())
+	// Compare symbols
+	if !compareSymbols(a.Symbols(), b.Symbols()) {
+		result += fmt.Sprintf("Symbol mismatch:\n  a: %v\n  b: %v\n", a.Symbols(), b.Symbols())
 	}
 
 	// Compare sizes
@@ -139,7 +139,7 @@ func RelationDiff(a, b Relation) string {
 		}
 
 		if !compareTuplesEqual(aTuple, bTuple) {
-			result += fmt.Sprintf("Row %d differs:\n  a: %v\n  b: %v\n", i, aTuple, bTuple)
+			result += fmt.Sprintf("Tuple %d differs:\n  a: %v\n  b: %v\n", i, aTuple, bTuple)
 			diffCount++
 		}
 	}
@@ -155,7 +155,7 @@ func RelationDiff(a, b Relation) string {
 	return result
 }
 
-// FormatRelationSummary formats a relation for display (first 20 rows).
+// FormatRelationSummary formats a relation for display (first 20 tuples).
 func FormatRelationSummary(rel Relation) string {
 	var tuples []string
 	it := rel.Iterator()
@@ -167,12 +167,12 @@ func FormatRelationSummary(rel Relation) string {
 	if rel.Size() > 20 {
 		tuples = append(tuples, fmt.Sprintf("... and %d more", rel.Size()-20))
 	}
-	return fmt.Sprintf("columns=%v, tuples=%v", rel.Columns(), tuples)
+	return fmt.Sprintf("symbols=%v, tuples=%v", rel.Symbols(), tuples)
 }
 
 // Helper functions (unexported)
 
-func compareColumns(a, b []query.Symbol) bool {
+func compareSymbols(a, b []query.Symbol) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -198,13 +198,13 @@ func collectSortedTuples(rel Relation) []Tuple {
 	return tuples
 }
 
-func collectSortedTuplesReordered(rel Relation, colMap map[int]int) []Tuple {
+func collectSortedTuplesReordered(rel Relation, symMap map[int]int) []Tuple {
 	var tuples []Tuple
 	it := rel.Iterator()
 	for it.Next() {
 		origTuple := it.Tuple()
 		newTuple := make(Tuple, len(origTuple))
-		for origIdx, newIdx := range colMap {
+		for origIdx, newIdx := range symMap {
 			newTuple[newIdx] = origTuple[origIdx]
 		}
 		tuples = append(tuples, newTuple)

--- a/datalog/executor/theta_join.go
+++ b/datalog/executor/theta_join.go
@@ -33,8 +33,8 @@ func thetaJoinWithPredicate(relevantRels []Relation, pred query.Predicate, looku
 // thetaJoinPair performs a nested-loop join between two relations with optional predicate.
 // The outer relation streams; the inner is buffered for re-iteration via BufferedIterator.
 func thetaJoinPair(outer, inner Relation, pred query.Predicate, lookup query.EntityLookup, constants map[query.Symbol]interface{}, opts ExecutorOptions) Relation {
-	outerCols := outer.Columns()
-	innerCols := inner.Columns()
+	outerCols := outer.Symbols()
+	innerCols := inner.Symbols()
 	combinedCols := make([]query.Symbol, 0, len(outerCols)+len(innerCols))
 	combinedCols = append(combinedCols, outerCols...)
 	combinedCols = append(combinedCols, innerCols...)

--- a/datalog/executor/time_range_bench_test.go
+++ b/datalog/executor/time_range_bench_test.go
@@ -51,17 +51,17 @@ func BenchmarkExtractTimeRanges(b *testing.B) {
 				}
 			}
 
-			var columns []query.Symbol
+			var symbols []query.Symbol
 			var correlationKeys []query.Symbol
 			if bm.daily {
-				columns = []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day")}
+				symbols = []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day")}
 				correlationKeys = []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day")}
 			} else {
-				columns = []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")}
+				symbols = []query.Symbol{datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")}
 				correlationKeys = []query.Symbol{datalog.NewSymbol("$"), datalog.NewSymbol("?s"), datalog.NewSymbol("?year"), datalog.NewSymbol("?month"), datalog.NewSymbol("?day"), datalog.NewSymbol("?hour")}
 			}
 
-			inputRel := NewMaterializedRelation(columns, inputTuples)
+			inputRel := NewMaterializedRelation(symbols, inputTuples)
 
 			// Reset timer before actual benchmark
 			b.ResetTimer()

--- a/datalog/executor/time_range_integration_test.go
+++ b/datalog/executor/time_range_integration_test.go
@@ -111,7 +111,7 @@ func TestTimeRangeMetadataFlow(t *testing.T) {
 		t.Errorf("Expected 2 hours (9, 10), got %d", baselineResult.Size())
 	}
 
-	// Sort both results by first column (hour) for deterministic comparison
+	// Sort both results by first symbol (hour) for deterministic comparison
 	baselineSorted := baselineResult.Sorted()
 	optimizedSorted := optimizedResult.Sorted()
 
@@ -128,7 +128,7 @@ func TestTimeRangeMetadataFlow(t *testing.T) {
 
 		for j := 0; j < len(baselineTuple); j++ {
 			if baselineTuple[j] != optimizedTuple[j] {
-				t.Errorf("Tuple %d column %d mismatch: baseline=%v, optimized=%v",
+				t.Errorf("Tuple %d symbol %d mismatch: baseline=%v, optimized=%v",
 					i, j, baselineTuple[j], optimizedTuple[j])
 			}
 		}

--- a/datalog/executor/tuple_key.go
+++ b/datalog/executor/tuple_key.go
@@ -17,7 +17,7 @@ type TupleKey struct {
 
 // NewTupleKey creates a key from specific tuple positions
 func NewTupleKey(tuple Tuple, indices []int) TupleKey {
-	// Special case for single column - avoid allocation
+	// Special case for single symbol - avoid allocation
 	if len(indices) == 1 {
 		val := tuple[indices[0]]
 		return TupleKey{

--- a/datalog/executor/two_collections_debug_test.go
+++ b/datalog/executor/two_collections_debug_test.go
@@ -68,13 +68,13 @@ func TestTwoCollections_PlanAndBind(t *testing.T) {
 
 	// Test BindQueryInputs
 	bound := BindQueryInputs(q, inputRelations)
-	t.Logf("Bound relation - columns: %v, size: %d", bound.Columns(), bound.Size())
+	t.Logf("Bound relation - symbols: %v, size: %d", bound.Symbols(), bound.Size())
 	it := bound.Iterator()
 	for it.Next() {
 		t.Logf("  Bound tuple: %v", it.Tuple())
 	}
 	it.Close()
 
-	// The bound relation should have 4 tuples with [?e, ?a] columns
+	// The bound relation should have 4 tuples with [?e, ?a] symbols
 	require.Equal(t, 4, bound.Size(), "should have 4 tuples from cross-product")
 }

--- a/datalog/executor/union_relation.go
+++ b/datalog/executor/union_relation.go
@@ -17,7 +17,7 @@ import (
 // Solution: First Iterator() call consumes channel and caches results, subsequent calls replay from cache.
 type UnionRelation struct {
 	source     <-chan relationItem
-	columns    []query.Symbol
+	symbols    []query.Symbol
 	opts       ExecutorOptions
 	cached     []Tuple    // Cache for reuse after first iteration
 	cacheBuilt bool       // Has cache been built?
@@ -31,22 +31,17 @@ type relationItem struct {
 }
 
 // NewUnionRelation creates a union relation that consumes from a channel
-func NewUnionRelation(source <-chan relationItem, columns []query.Symbol, opts ExecutorOptions) *UnionRelation {
+func NewUnionRelation(source <-chan relationItem, symbols []query.Symbol, opts ExecutorOptions) *UnionRelation {
 	return &UnionRelation{
 		source:  source,
-		columns: columns,
+		symbols: symbols,
 		opts:    opts,
 	}
 }
 
-// Columns returns the column names
-func (ur *UnionRelation) Columns() []query.Symbol {
-	return ur.columns
-}
-
-// Symbols returns the symbols (same as Columns)
+// Symbols returns the symbol names of this relation
 func (ur *UnionRelation) Symbols() []query.Symbol {
-	return ur.columns
+	return ur.symbols
 }
 
 // Iterator returns an iterator that consumes from the channel (first call) or cache (subsequent calls)
@@ -96,7 +91,7 @@ func (ur *UnionRelation) Table() string {
 	return ur.Materialize().Table()
 }
 
-// ProjectFromPattern projects columns based on pattern
+// ProjectFromPattern projects symbols based on pattern
 func (ur *UnionRelation) ProjectFromPattern(pattern *query.DataPattern) Relation {
 	return ur.Materialize().ProjectFromPattern(pattern)
 }
@@ -107,8 +102,8 @@ func (ur *UnionRelation) Sorted() []Tuple {
 }
 
 // Project returns a projection of this relation
-func (ur *UnionRelation) Project(columns []query.Symbol) (Relation, error) {
-	return ur.Materialize().Project(columns)
+func (ur *UnionRelation) Project(symbols []query.Symbol) (Relation, error) {
+	return ur.Materialize().Project(symbols)
 }
 
 // Materialize forces consumption of all relations and returns a materialized result
@@ -117,7 +112,7 @@ func (ur *UnionRelation) Project(columns []query.Symbol) (Relation, error) {
 func (ur *UnionRelation) Materialize() Relation {
 	var allTuples []Tuple
 	collectTuplesInto(&allTuples, ur)
-	return NewMaterializedRelation(ur.columns, allTuples)
+	return NewMaterializedRelation(ur.symbols, allTuples)
 }
 
 // Sort returns a sorted relation (forces materialization)

--- a/datalog/executor/variadic_test.go
+++ b/datalog/executor/variadic_test.go
@@ -13,7 +13,7 @@ func TestVariadicFilter(t *testing.T) {
 		name     string
 		filter   VariadicFilter
 		tuple    Tuple
-		columns  []query.Symbol
+		symbols  []query.Symbol
 		expected bool
 	}{
 		{
@@ -27,7 +27,7 @@ func TestVariadicFilter(t *testing.T) {
 				},
 			},
 			tuple:    Tuple{1, 5, 10},
-			columns:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
 			expected: true,
 		},
 		{
@@ -41,7 +41,7 @@ func TestVariadicFilter(t *testing.T) {
 				},
 			},
 			tuple:    Tuple{10, 5, 1},
-			columns:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b"), datalog.NewSymbol("?c")},
 			expected: false,
 		},
 		{
@@ -55,7 +55,7 @@ func TestVariadicFilter(t *testing.T) {
 				},
 			},
 			tuple:    Tuple{50},
-			columns:  []query.Symbol{datalog.NewSymbol("?x")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x")},
 			expected: true,
 		},
 		{
@@ -69,7 +69,7 @@ func TestVariadicFilter(t *testing.T) {
 				},
 			},
 			tuple:    Tuple{150},
-			columns:  []query.Symbol{datalog.NewSymbol("?x")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x")},
 			expected: false,
 		},
 		{
@@ -83,7 +83,7 @@ func TestVariadicFilter(t *testing.T) {
 				},
 			},
 			tuple:    Tuple{42, 42, 42},
-			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
 			expected: true,
 		},
 		{
@@ -97,7 +97,7 @@ func TestVariadicFilter(t *testing.T) {
 				},
 			},
 			tuple:    Tuple{42, 42, 43},
-			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y"), datalog.NewSymbol("?z")},
 			expected: false,
 		},
 		{
@@ -112,14 +112,14 @@ func TestVariadicFilter(t *testing.T) {
 				},
 			},
 			tuple:    Tuple{10, 20},
-			columns:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
+			symbols:  []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")},
 			expected: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.filter.Evaluate(tt.tuple, tt.columns)
+			got := tt.filter.Evaluate(tt.tuple, tt.symbols)
 			if got != tt.expected {
 				t.Errorf("Evaluate() = %v, want %v", got, tt.expected)
 			}

--- a/datalog/executor/wrapper_relation_copy_test.go
+++ b/datalog/executor/wrapper_relation_copy_test.go
@@ -16,20 +16,19 @@ import (
 // Its iterator overwrites a shared workspace slice on each Next() call,
 // just like storage iterators do with BuildTupleInternedInto.
 type mockUnsafeRelation struct {
-	columns []query.Symbol
+	symbols []query.Symbol
 	data    [][]interface{} // Source data (will be copied into workspace)
 	options ExecutorOptions
 }
 
-func newMockUnsafeRelation(columns []query.Symbol, data [][]interface{}) *mockUnsafeRelation {
+func newMockUnsafeRelation(symbols []query.Symbol, data [][]interface{}) *mockUnsafeRelation {
 	return &mockUnsafeRelation{
-		columns: columns,
+		symbols: symbols,
 		data:    data,
 	}
 }
 
-func (r *mockUnsafeRelation) Columns() []query.Symbol                                { return r.columns }
-func (r *mockUnsafeRelation) Symbols() []query.Symbol                                { return r.columns }
+func (r *mockUnsafeRelation) Symbols() []query.Symbol                                { return r.symbols }
 func (r *mockUnsafeRelation) Size() int                                              { return len(r.data) }
 func (r *mockUnsafeRelation) IsEmpty() bool                                          { return len(r.data) == 0 }
 func (r *mockUnsafeRelation) Get(i int) Tuple                                        { return nil }
@@ -57,7 +56,7 @@ func (r *mockUnsafeRelation) RequiresCopy() bool { return true }
 func (r *mockUnsafeRelation) Iterator() Iterator {
 	return &mockUnsafeIterator{
 		data:      r.data,
-		workspace: make(Tuple, len(r.columns)), // Shared workspace
+		workspace: make(Tuple, len(r.symbols)), // Shared workspace
 		pos:       -1,
 	}
 }
@@ -74,7 +73,7 @@ func (it *mockUnsafeIterator) Next() bool {
 	if it.pos >= len(it.data) {
 		return false
 	}
-	// Overwrite workspace with current row's data
+	// Overwrite workspace with current tuple's data
 	copy(it.workspace, it.data[it.pos])
 	return true
 }
@@ -538,8 +537,8 @@ func TestOrFallbackIteratorWithUnsafeBranchResult(t *testing.T) {
 	projIt := &projectedIterator{
 		inner:          branchIt,
 		branchRelation: unsafeBranch, // This has RequiresCopy() = true
-		branchCols:     branchCols,
-		outputCols:     branchCols, // Same columns, no projection needed
+		branchSyms:     branchCols,
+		outputSyms:     branchCols, // Same symbols, no projection needed
 	}
 
 	var storedTuples []Tuple

--- a/datalog/parser/parser.go
+++ b/datalog/parser/parser.go
@@ -507,14 +507,14 @@ func parseSubqueryPattern(list *edn.Node, bindingNode *edn.Node) (*query.Subquer
 
 // parseBindingForm parses a binding form for subqueries
 // Datomic binding forms:
-//   - ?var         = Scalar binding (expects single row, single column)
-//   - [?var ...]   = Collection binding (collects all values from single column)
-//   - [[?a ?b]]    = Tuple binding (expects single row, multiple columns)
-//   - [[?a ?b] ...] = Relation binding (multiple rows and columns)
+//   - ?var         = Scalar binding (expects single tuple, single symbol)
+//   - [?var ...]   = Collection binding (collects all values from single symbol)
+//   - [[?a ?b]]    = Tuple binding (expects single tuple, multiple symbols)
+//   - [[?a ?b] ...] = Relation binding (multiple tuples and symbols)
 func parseBindingForm(node *edn.Node) (query.BindingForm, error) {
 	switch node.Type {
 	case edn.NodeSymbol:
-		// Scalar binding: ?var (expects one row, one column)
+		// Scalar binding: ?var (expects one tuple, one symbol)
 		sym := datalog.NewSymbol(node.Value)
 		if !sym.IsVariable() {
 			return nil, fmt.Errorf("scalar binding must be a variable, got %s", sym)

--- a/datalog/planner/clause_utils.go
+++ b/datalog/planner/clause_utils.go
@@ -293,7 +293,7 @@ func extractOrClauseSymbols(o *query.OrClause) ClauseSymbols {
 	// For fallback semantics, require the "correlation" symbol from pattern branches.
 	// This is the entity variable (first element) of the first pattern in each
 	// pattern branch. It represents the connection to outer context that enables
-	// per-row fallback evaluation.
+	// per-tuple fallback evaluation.
 	//
 	// Example: (or [?scenario :task ?t] [(ground 0) ?x])
 	// Here ?scenario is the correlation symbol that should be bound from outside.

--- a/datalog/planner/types.go
+++ b/datalog/planner/types.go
@@ -329,7 +329,7 @@ type DecorrelatedSubqueryPlan struct {
 	MergedPlans        []*QueryPlan      // One plan per filter group
 	CorrelationKeys    []query.Symbol    // Keys to join on from outer query (e.g., ?year, ?month, ?day, ?hour)
 	GroupingVars       [][]query.Symbol  // Actual grouping variables in merged queries (per filter group)
-	ColumnMapping      map[int]ResultMap // Original subquery -> result columns
+	SymbolMapping      map[int]ResultMap // Original subquery -> result symbols
 
 	// Metadata for annotations (captured at plan time, reported at execution time)
 	SignatureHash     string // Hash of the correlation signature
@@ -337,10 +337,10 @@ type DecorrelatedSubqueryPlan struct {
 	DecorrelatedCount int    // How many were actually decorrelated
 }
 
-// ResultMap maps original subquery to columns in merged result
+// ResultMap maps original subquery to symbols in merged result
 type ResultMap struct {
 	FilterGroupIdx int            // Which merged query produced this result
-	ColumnIndices  []int          // Which columns in that result
+	SymbolIndices  []int          // Which symbols in that result
 	BindingVars    []query.Symbol // Variable names from the binding form
 }
 

--- a/datalog/qb/doc.go
+++ b/datalog/qb/doc.go
@@ -29,7 +29,7 @@
 //	    ).
 //	    MustBuild()
 //
-//	results, err := db.ExecuteQuery(q)
+//	results, err := db.Query(q)
 //
 // # Variables
 //

--- a/datalog/qb/input.go
+++ b/datalog/qb/input.go
@@ -48,7 +48,7 @@ type scalarInput struct {
 //	        qb.Gte(age, minAge),
 //	    ).MustBuild()
 //
-//	db.ExecuteQueryWithInputs(q, 21)  // 21 is bound to minAge
+//	db.Query(q, 21)  // 21 is bound to minAge
 func Scalar(v *Var) InputSpec {
 	return scalarInput{v: v}
 }
@@ -75,7 +75,7 @@ type collectionInput struct {
 //	    Where(qb.Pat(e, PersonID, id), qb.Pat(e, PersonName, name)).
 //	    MustBuild()
 //
-//	db.ExecuteQueryWithInputs(q, []string{"id1", "id2", "id3"})
+//	db.Query(q, []string{"id1", "id2", "id3"})
 func Collection(v *Var) InputSpec {
 	return collectionInput{v: v}
 }
@@ -101,7 +101,7 @@ type tupleInput struct {
 //	    Where(...).
 //	    MustBuild()
 //
-//	db.ExecuteQueryWithInputs(q, []interface{}{10, 20})
+//	db.Query(q, []interface{}{10, 20})
 func Tuple(vars ...*Var) InputSpec {
 	return tupleInput{vars: vars}
 }
@@ -131,7 +131,7 @@ type relationInput struct {
 //	    Where(...).
 //	    MustBuild()
 //
-//	db.ExecuteQueryWithInputs(q, [][]interface{}{{1, 2}, {3, 4}})
+//	db.Query(q, [][]interface{}{{1, 2}, {3, 4}})
 func Relation(vars ...*Var) InputSpec {
 	return relationInput{vars: vars}
 }

--- a/datalog/qb/input.go
+++ b/datalog/qb/input.go
@@ -120,7 +120,7 @@ type relationInput struct {
 }
 
 // Relation creates a relation input parameter specification.
-// The corresponding input should be a slice of slices (rows).
+// The corresponding input should be a slice of slices (tuples).
 //
 // Example:
 //

--- a/datalog/qb/integration_test.go
+++ b/datalog/qb/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/qb"
 	"github.com/wbrown/janus-datalog/datalog/storage"
 )
@@ -93,7 +94,7 @@ func TestIntegration_BasicQuery(t *testing.T) {
 		Where(qb.Pat(e, PersonName, name)).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -136,7 +137,7 @@ func TestIntegration_JoinQuery(t *testing.T) {
 		).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -176,7 +177,7 @@ func TestIntegration_PredicateQuery(t *testing.T) {
 		).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -223,7 +224,7 @@ func TestIntegration_MultiplePredicates(t *testing.T) {
 		).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -252,7 +253,7 @@ func TestIntegration_AggregationQuery(t *testing.T) {
 		).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -301,7 +302,7 @@ func TestIntegration_CountAggregation(t *testing.T) {
 		).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -344,7 +345,7 @@ func TestIntegration_InputParameters(t *testing.T) {
 		MustBuild()
 
 	// Find person named "Alice" and return their age
-	results, err := db.ExecuteQueryWithInputs(q, "Alice")
+	results, err := executor.CollectTuples(db.Query(q, "Alice"))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -384,7 +385,7 @@ func TestIntegration_CollectionInput(t *testing.T) {
 		MustBuild()
 
 	// Find people named Alice or Bob and their ages
-	results, err := db.ExecuteQueryWithInputs(q, []string{"Alice", "Bob"})
+	results, err := executor.CollectTuples(db.Query(q, []string{"Alice", "Bob"}))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -423,7 +424,7 @@ func TestIntegration_OrderBy(t *testing.T) {
 		OrderBy(qb.Desc(age)).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -619,12 +620,12 @@ func TestIntegration_CompareWithEDN(t *testing.T) {
 		MustBuild()
 
 	// Execute both
-	ednResults, err := db.ExecuteQuery(ednQuery)
+	ednResults, err := executor.CollectTuples(db.Query(ednQuery))
 	if err != nil {
 		t.Fatalf("EDN query failed: %v", err)
 	}
 
-	builtResults, err := db.ExecuteQuery(builtQuery)
+	builtResults, err := executor.CollectTuples(db.Query(builtQuery))
 	if err != nil {
 		t.Fatalf("Built query failed: %v", err)
 	}
@@ -674,7 +675,7 @@ func TestIntegration_ConstantValue(t *testing.T) {
 		).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -704,7 +705,7 @@ func TestIntegration_BooleanPredicate(t *testing.T) {
 		).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -731,7 +732,7 @@ func TestIntegration_AvgAggregation(t *testing.T) {
 		).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -769,12 +770,12 @@ func TestIntegration_MinMaxAggregation(t *testing.T) {
 		Where(qb.Pat(e, PersonSalary, salary)).
 		MustBuild()
 
-	minResults, err := db.ExecuteQuery(minQ)
+	minResults, err := executor.CollectTuples(db.Query(minQ))
 	if err != nil {
 		t.Fatalf("Min query failed: %v", err)
 	}
 
-	maxResults, err := db.ExecuteQuery(maxQ)
+	maxResults, err := executor.CollectTuples(db.Query(maxQ))
 	if err != nil {
 		t.Fatalf("Max query failed: %v", err)
 	}
@@ -813,7 +814,7 @@ func TestIntegration_ThreeWayJoin(t *testing.T) {
 		).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -905,7 +906,7 @@ func TestIntegration_TupleInput(t *testing.T) {
 		MustBuild()
 
 	// Find person with name "Alice" and age 30
-	results, err := db.ExecuteQueryWithInputs(q, []interface{}{"Alice", int64(30)})
+	results, err := executor.CollectTuples(db.Query(q, []interface{}{"Alice", int64(30)}))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -950,10 +951,10 @@ func TestIntegration_RelationInput(t *testing.T) {
 		MustBuild()
 
 	// Find people matching (name, city) pairs
-	results, err := db.ExecuteQueryWithInputs(q, [][]interface{}{
+	results, err := executor.CollectTuples(db.Query(q, [][]interface{}{
 		{"Alice", "NYC"},
 		{"Eve", "LA"},
-	})
+	}))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -995,10 +996,10 @@ func TestIntegration_RelationInputNoMatch(t *testing.T) {
 		MustBuild()
 
 	// Alice is in NYC, not LA - should not match
-	results, err := db.ExecuteQueryWithInputs(q, [][]interface{}{
+	results, err := executor.CollectTuples(db.Query(q, [][]interface{}{
 		{"Alice", "LA"},
 		{"Bob", "NYC"},
-	})
+	}))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -1031,7 +1032,7 @@ func TestIntegration_MultipleScalarInputs(t *testing.T) {
 		MustBuild()
 
 	// Find Alice in NYC
-	results, err := db.ExecuteQueryWithInputs(q, "Alice", "NYC")
+	results, err := executor.CollectTuples(db.Query(q, "Alice", "NYC"))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -1072,12 +1073,12 @@ func TestIntegration_CompareInputBindingsWithEDN(t *testing.T) {
 			).
 			MustBuild()
 
-		ednResults, err := db.ExecuteQueryWithInputs(ednQuery, "Bob")
+		ednResults, err := executor.CollectTuples(db.Query(ednQuery, "Bob"))
 		if err != nil {
 			t.Fatalf("EDN query failed: %v", err)
 		}
 
-		builtResults, err := db.ExecuteQueryWithInputs(builtQuery, "Bob")
+		builtResults, err := executor.CollectTuples(db.Query(builtQuery, "Bob"))
 		if err != nil {
 			t.Fatalf("Built query failed: %v", err)
 		}
@@ -1113,12 +1114,12 @@ func TestIntegration_CompareInputBindingsWithEDN(t *testing.T) {
 			).
 			MustBuild()
 
-		ednResults, err := db.ExecuteQueryWithInputs(ednQuery, []string{"Alice", "Charlie"})
+		ednResults, err := executor.CollectTuples(db.Query(ednQuery, []string{"Alice", "Charlie"}))
 		if err != nil {
 			t.Fatalf("EDN query failed: %v", err)
 		}
 
-		builtResults, err := db.ExecuteQueryWithInputs(builtQuery, []string{"Alice", "Charlie"})
+		builtResults, err := executor.CollectTuples(db.Query(builtQuery, []string{"Alice", "Charlie"}))
 		if err != nil {
 			t.Fatalf("Built query failed: %v", err)
 		}
@@ -1162,12 +1163,12 @@ func TestIntegration_CompareInputBindingsWithEDN(t *testing.T) {
 			{"Bob", "LA"},
 		}
 
-		ednResults, err := db.ExecuteQueryWithInputs(ednQuery, input)
+		ednResults, err := executor.CollectTuples(db.Query(ednQuery, input))
 		if err != nil {
 			t.Fatalf("EDN query failed: %v", err)
 		}
 
-		builtResults, err := db.ExecuteQueryWithInputs(builtQuery, input)
+		builtResults, err := executor.CollectTuples(db.Query(builtQuery, input))
 		if err != nil {
 			t.Fatalf("Built query failed: %v", err)
 		}
@@ -1207,7 +1208,7 @@ func TestIntegration_ComparisonBinding(t *testing.T) {
 		OrderBy(qb.Asc(name)).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -1270,12 +1271,12 @@ func TestIntegration_ComparisonBindingEDNEquivalence(t *testing.T) {
 		).
 		MustBuild()
 
-	ednResults, err := db.ExecuteQuery(ednQuery)
+	ednResults, err := executor.CollectTuples(db.Query(ednQuery))
 	if err != nil {
 		t.Fatalf("EDN query failed: %v", err)
 	}
 
-	builtResults, err := db.ExecuteQuery(builtQuery)
+	builtResults, err := executor.CollectTuples(db.Query(builtQuery))
 	if err != nil {
 		t.Fatalf("Built query failed: %v", err)
 	}
@@ -1311,7 +1312,7 @@ func TestIntegration_ChainedComparisonBinding(t *testing.T) {
 		OrderBy(qb.Asc(name)).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -1429,7 +1430,7 @@ func TestIntegration_GetElse(t *testing.T) {
 		OrderBy(qb.Asc(name)).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -1488,12 +1489,12 @@ func TestIntegration_GetElseEDNEquivalence(t *testing.T) {
 		).
 		MustBuild()
 
-	ednResults, err := db.ExecuteQuery(ednQuery)
+	ednResults, err := executor.CollectTuples(db.Query(ednQuery))
 	if err != nil {
 		t.Fatalf("EDN query failed: %v", err)
 	}
 
-	builtResults, err := db.ExecuteQuery(builtQuery)
+	builtResults, err := executor.CollectTuples(db.Query(builtQuery))
 	if err != nil {
 		t.Fatalf("Built query failed: %v", err)
 	}
@@ -1526,7 +1527,7 @@ func TestIntegration_MissingPredicate(t *testing.T) {
 		OrderBy(qb.Asc(name)).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -1572,12 +1573,12 @@ func TestIntegration_MissingPredicateEDNEquivalence(t *testing.T) {
 		).
 		MustBuild()
 
-	ednResults, err := db.ExecuteQuery(ednQuery)
+	ednResults, err := executor.CollectTuples(db.Query(ednQuery))
 	if err != nil {
 		t.Fatalf("EDN query failed: %v", err)
 	}
 
-	builtResults, err := db.ExecuteQuery(builtQuery)
+	builtResults, err := executor.CollectTuples(db.Query(builtQuery))
 	if err != nil {
 		t.Fatalf("Built query failed: %v", err)
 	}
@@ -1611,7 +1612,7 @@ func TestIntegration_MissingExpression(t *testing.T) {
 		OrderBy(qb.Asc(name)).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -1665,7 +1666,7 @@ func TestIntegration_GetSome(t *testing.T) {
 		OrderBy(qb.Asc(name)).
 		MustBuild()
 
-	results, err := db.ExecuteQuery(q)
+	results, err := executor.CollectTuples(db.Query(q))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}

--- a/datalog/qb/integration_test.go
+++ b/datalog/qb/integration_test.go
@@ -104,8 +104,8 @@ func TestIntegration_BasicQuery(t *testing.T) {
 
 	// Verify all names are present
 	names := make(map[string]bool)
-	for _, row := range results {
-		if name, ok := row[0].(string); ok {
+	for _, tuple := range results {
+		if name, ok := tuple[0].(string); ok {
 			names[name] = true
 		}
 	}
@@ -146,9 +146,9 @@ func TestIntegration_JoinQuery(t *testing.T) {
 	}
 
 	// Verify Alice is 30
-	for _, row := range results {
-		if row[0] == "Alice" {
-			if age, ok := row[1].(int64); ok {
+	for _, tuple := range results {
+		if tuple[0] == "Alice" {
+			if age, ok := tuple[1].(int64); ok {
 				if age != 30 {
 					t.Errorf("Expected Alice age 30, got %d", age)
 				}
@@ -187,8 +187,8 @@ func TestIntegration_PredicateQuery(t *testing.T) {
 	}
 
 	names := make(map[string]bool)
-	for _, row := range results {
-		if name, ok := row[0].(string); ok {
+	for _, tuple := range results {
+		if name, ok := tuple[0].(string); ok {
 			names[name] = true
 		}
 	}
@@ -264,9 +264,9 @@ func TestIntegration_AggregationQuery(t *testing.T) {
 
 	// Verify totals
 	totals := make(map[string]float64)
-	for _, row := range results {
-		if d, ok := row[0].(string); ok {
-			if s, ok := row[1].(float64); ok {
+	for _, tuple := range results {
+		if d, ok := tuple[0].(string); ok {
+			if s, ok := tuple[1].(float64); ok {
 				totals[d] = s
 			}
 		}
@@ -307,9 +307,9 @@ func TestIntegration_CountAggregation(t *testing.T) {
 	}
 
 	counts := make(map[string]int64)
-	for _, row := range results {
-		if d, ok := row[0].(string); ok {
-			if c, ok := row[1].(int64); ok {
+	for _, tuple := range results {
+		if d, ok := tuple[0].(string); ok {
+			if c, ok := tuple[1].(int64); ok {
 				counts[d] = c
 			}
 		}
@@ -395,8 +395,8 @@ func TestIntegration_CollectionInput(t *testing.T) {
 	}
 
 	names := make(map[string]bool)
-	for _, row := range results {
-		if n, ok := row[0].(string); ok {
+	for _, tuple := range results {
+		if n, ok := tuple[0].(string); ok {
 			names[n] = true
 		}
 	}
@@ -638,13 +638,13 @@ func TestIntegration_CompareWithEDN(t *testing.T) {
 	ednNames := make(map[string]bool)
 	builtNames := make(map[string]bool)
 
-	for _, row := range ednResults {
-		if n, ok := row[0].(string); ok {
+	for _, tuple := range ednResults {
+		if n, ok := tuple[0].(string); ok {
 			ednNames[n] = true
 		}
 	}
-	for _, row := range builtResults {
-		if n, ok := row[0].(string); ok {
+	for _, tuple := range builtResults {
+		if n, ok := tuple[0].(string); ok {
 			builtNames[n] = true
 		}
 	}
@@ -823,13 +823,13 @@ func TestIntegration_ThreeWayJoin(t *testing.T) {
 	}
 
 	// Verify Alice's data
-	for _, row := range results {
-		if row[0] == "Alice" {
-			if row[1] != int64(30) {
-				t.Errorf("Expected Alice age 30, got %v", row[1])
+	for _, tuple := range results {
+		if tuple[0] == "Alice" {
+			if tuple[1] != int64(30) {
+				t.Errorf("Expected Alice age 30, got %v", tuple[1])
 			}
-			if row[2] != "NYC" {
-				t.Errorf("Expected Alice city NYC, got %v", row[2])
+			if tuple[2] != "NYC" {
+				t.Errorf("Expected Alice city NYC, got %v", tuple[2])
 			}
 		}
 	}
@@ -964,8 +964,8 @@ func TestIntegration_RelationInput(t *testing.T) {
 
 	// Verify we got Alice and Eve
 	names := make(map[string]bool)
-	for _, row := range results {
-		if n, ok := row[0].(string); ok {
+	for _, tuple := range results {
+		if n, ok := tuple[0].(string); ok {
 			names[n] = true
 		}
 	}
@@ -1219,9 +1219,9 @@ func TestIntegration_ComparisonBinding(t *testing.T) {
 
 	// Verify specific results
 	resultMap := make(map[string]bool)
-	for _, row := range results {
-		name := row[0].(string)
-		isOver30Val := row[2].(bool)
+	for _, tuple := range results {
+		name := tuple[0].(string)
+		isOver30Val := tuple[2].(bool)
 		resultMap[name] = isOver30Val
 	}
 
@@ -1327,9 +1327,9 @@ func TestIntegration_ChainedComparisonBinding(t *testing.T) {
 	// Diana (28): 26 < 28 < 34 = true
 	// Eve (32): 26 < 32 < 34 = true
 	resultMap := make(map[string]bool)
-	for _, row := range results {
-		name := row[0].(string)
-		inRangeVal := row[2].(bool)
+	for _, tuple := range results {
+		name := tuple[0].(string)
+		inRangeVal := tuple[2].(bool)
 		resultMap[name] = inRangeVal
 	}
 
@@ -1440,9 +1440,9 @@ func TestIntegration_GetElse(t *testing.T) {
 
 	// Verify results
 	resultMap := make(map[string]string)
-	for _, row := range results {
-		name := row[0].(string)
-		nick := row[1].(string)
+	for _, tuple := range results {
+		name := tuple[0].(string)
+		nick := tuple[1].(string)
 		resultMap[name] = nick
 	}
 
@@ -1537,8 +1537,8 @@ func TestIntegration_MissingPredicate(t *testing.T) {
 	}
 
 	names := make(map[string]bool)
-	for _, row := range results {
-		names[row[0].(string)] = true
+	for _, tuple := range results {
+		names[tuple[0].(string)] = true
 	}
 
 	if !names["Charlie"] {
@@ -1622,9 +1622,9 @@ func TestIntegration_MissingExpression(t *testing.T) {
 
 	// Verify results
 	resultMap := make(map[string]bool)
-	for _, row := range results {
-		name := row[0].(string)
-		needsEmailVal := row[1].(bool)
+	for _, tuple := range results {
+		name := tuple[0].(string)
+		needsEmailVal := tuple[1].(bool)
 		resultMap[name] = needsEmailVal
 	}
 

--- a/datalog/qb/subquery.go
+++ b/datalog/qb/subquery.go
@@ -85,21 +85,21 @@ func Subquery(innerQuery *QueryBuilder, inputs ...*Var) *SubqueryBuilder {
 }
 
 // BindTuple binds subquery results as a single tuple [[?a ?b]].
-// Use when the subquery returns exactly one row.
+// Use when the subquery returns exactly one tuple.
 func (s *SubqueryBuilder) BindTuple(vars ...*Var) *SubqueryBuilder {
 	s.binding = tupleBind{vars: vars}
 	return s
 }
 
 // BindRelation binds subquery results as a relation [[?a ?b] ...].
-// Use when the subquery may return multiple rows.
+// Use when the subquery may return multiple tuples.
 func (s *SubqueryBuilder) BindRelation(vars ...*Var) *SubqueryBuilder {
 	s.binding = relationBind{vars: vars}
 	return s
 }
 
 // BindCollection binds subquery results to a collection variable.
-// Use when the subquery returns a single column of values.
+// Use when the subquery returns a single symbol of values.
 func (s *SubqueryBuilder) BindCollection(v *Var) *SubqueryBuilder {
 	s.binding = collectionBind{v: v}
 	return s

--- a/datalog/query/aggregate.go
+++ b/datalog/query/aggregate.go
@@ -43,7 +43,7 @@ func (c CountAggregate) Aggregate(values []interface{}) (interface{}, error) {
 }
 
 func (c CountAggregate) RequiresValues() bool {
-	return false // Count just needs the number of rows
+	return false // Count just needs the number of tuples
 }
 
 func (c CountAggregate) String() string {

--- a/datalog/query/database_function.go
+++ b/datalog/query/database_function.go
@@ -213,7 +213,7 @@ func toIdentity(val interface{}) (datalog.Identity, error) {
 
 // DatabaseFunctionPredicate wraps a DatabaseFunction for use as a filter predicate.
 // This is used when database functions like missing? are used without a binding,
-// e.g., [(missing? $ ?e :attr)] filters to rows where the condition is true.
+// e.g., [(missing? $ ?e :attr)] filters to tuples where the condition is true.
 type DatabaseFunctionPredicate struct {
 	Function DatabaseFunction
 }

--- a/datalog/query/pattern_utils.go
+++ b/datalog/query/pattern_utils.go
@@ -4,21 +4,21 @@ package query
 // This consolidates logic that was previously duplicated across multiple iterators.
 type PatternExtractor struct {
 	pattern *DataPattern
-	columns []Symbol
-	colMap  map[Symbol]int
+	symbols []Symbol
+	symMap  map[Symbol]int
 }
 
-// NewPatternExtractor creates a new pattern extractor for the given pattern and binding columns.
-func NewPatternExtractor(pattern *DataPattern, columns []Symbol) *PatternExtractor {
-	colMap := make(map[Symbol]int, len(columns))
-	for i, col := range columns {
-		colMap[col] = i
+// NewPatternExtractor creates a new pattern extractor for the given pattern and binding symbols.
+func NewPatternExtractor(pattern *DataPattern, symbols []Symbol) *PatternExtractor {
+	symMap := make(map[Symbol]int, len(symbols))
+	for i, sym := range symbols {
+		symMap[sym] = i
 	}
 
 	return &PatternExtractor{
 		pattern: pattern,
-		columns: columns,
-		colMap:  colMap,
+		symbols: symbols,
+		symMap:  symMap,
 	}
 }
 
@@ -54,7 +54,7 @@ func (pe *PatternExtractor) extractElement(elem PatternElement, bindingTuple Tup
 
 	// Variables look up the value in the binding tuple
 	if v, ok := elem.(Variable); ok {
-		if idx, found := pe.colMap[v.Name]; found && idx < len(bindingTuple) {
+		if idx, found := pe.symMap[v.Name]; found && idx < len(bindingTuple) {
 			return bindingTuple[idx]
 		}
 	}
@@ -83,22 +83,22 @@ func (pe *PatternExtractor) ExtractT(bindingTuple Tuple) interface{} {
 	return pe.extractElement(pe.pattern.GetT(), bindingTuple)
 }
 
-// BuildColumnIndexMap creates a map from symbols to their column indices.
-// This is a utility function for code that needs to build column maps independently.
-func BuildColumnIndexMap(columns []Symbol) map[Symbol]int {
-	colMap := make(map[Symbol]int, len(columns))
-	for i, col := range columns {
-		colMap[col] = i
+// BuildSymbolIndexMap creates a map from symbols to their index positions.
+// This is a utility function for code that needs to build symbol maps independently.
+func BuildSymbolIndexMap(symbols []Symbol) map[Symbol]int {
+	symMap := make(map[Symbol]int, len(symbols))
+	for i, sym := range symbols {
+		symMap[sym] = i
 	}
-	return colMap
+	return symMap
 }
 
 // ExtractPatternValues is a convenience function that extracts E, A, V, T values
 // from a pattern without creating a PatternExtractor.
 // Use this for one-off extractions. For repeated extractions on the same pattern,
 // create a PatternExtractor and reuse it.
-func ExtractPatternValues(pattern *DataPattern, columns []Symbol, bindingTuple Tuple) (e, a, v, t interface{}) {
-	extractor := NewPatternExtractor(pattern, columns)
+func ExtractPatternValues(pattern *DataPattern, symbols []Symbol, bindingTuple Tuple) (e, a, v, t interface{}) {
+	extractor := NewPatternExtractor(pattern, symbols)
 	values := extractor.Extract(bindingTuple)
 	return values.E, values.A, values.V, values.T
 }

--- a/datalog/query/pattern_utils_test.go
+++ b/datalog/query/pattern_utils_test.go
@@ -49,10 +49,10 @@ func TestPatternExtractor_Variables(t *testing.T) {
 	alice := datalog.NewIdentity("user:alice")
 	nameAttr := datalog.NewKeyword(":user/name")
 
-	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
+	symbols := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice, nameAttr, "Alice"}
 
-	extractor := NewPatternExtractor(pattern, columns)
+	extractor := NewPatternExtractor(pattern, symbols)
 	values := extractor.Extract(bindingTuple)
 
 	if values.E == nil || !values.E.(datalog.Identity).Equal(alice) {
@@ -82,10 +82,10 @@ func TestPatternExtractor_MixedConstantsAndVariables(t *testing.T) {
 	}
 
 	alice := datalog.NewIdentity("user:alice")
-	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+	symbols := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice, "Alice"}
 
-	extractor := NewPatternExtractor(pattern, columns)
+	extractor := NewPatternExtractor(pattern, symbols)
 	values := extractor.Extract(bindingTuple)
 
 	if values.E == nil || !values.E.(datalog.Identity).Equal(alice) {
@@ -111,10 +111,10 @@ func TestPatternExtractor_Blanks(t *testing.T) {
 		},
 	}
 
-	columns := []Symbol{datalog.NewSymbol("?v")}
+	symbols := []Symbol{datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{"Alice"}
 
-	extractor := NewPatternExtractor(pattern, columns)
+	extractor := NewPatternExtractor(pattern, symbols)
 	values := extractor.Extract(bindingTuple)
 
 	if values.E != nil {
@@ -139,10 +139,10 @@ func TestPatternExtractor_VariableNotInBinding(t *testing.T) {
 	}
 
 	alice := datalog.NewIdentity("user:alice")
-	columns := []Symbol{datalog.NewSymbol("?e")}
+	symbols := []Symbol{datalog.NewSymbol("?e")}
 	bindingTuple := Tuple{alice}
 
-	extractor := NewPatternExtractor(pattern, columns)
+	extractor := NewPatternExtractor(pattern, symbols)
 	values := extractor.Extract(bindingTuple)
 
 	if values.E == nil || !values.E.(datalog.Identity).Equal(alice) {
@@ -170,10 +170,10 @@ func TestPatternExtractor_WithTransaction(t *testing.T) {
 	alice := datalog.NewIdentity("user:alice")
 	nameAttr := datalog.NewKeyword(":user/name")
 
-	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v"), datalog.NewSymbol("?t")}
+	symbols := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v"), datalog.NewSymbol("?t")}
 	bindingTuple := Tuple{alice, nameAttr, "Alice", uint64(123)}
 
-	extractor := NewPatternExtractor(pattern, columns)
+	extractor := NewPatternExtractor(pattern, symbols)
 	values := extractor.Extract(bindingTuple)
 
 	if values.E == nil || !values.E.(datalog.Identity).Equal(alice) {
@@ -203,10 +203,10 @@ func TestPatternExtractor_IndividualExtractors(t *testing.T) {
 		},
 	}
 
-	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+	symbols := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice, "Alice"}
 
-	extractor := NewPatternExtractor(pattern, columns)
+	extractor := NewPatternExtractor(pattern, symbols)
 
 	e := extractor.ExtractE(bindingTuple)
 	if e == nil || !e.(datalog.Identity).Equal(alice) {
@@ -229,9 +229,9 @@ func TestPatternExtractor_IndividualExtractors(t *testing.T) {
 	}
 }
 
-func TestBuildColumnIndexMap(t *testing.T) {
-	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
-	colMap := BuildColumnIndexMap(columns)
+func TestBuildSymbolIndexMap(t *testing.T) {
+	symbols := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
+	colMap := BuildSymbolIndexMap(symbols)
 
 	if colMap[datalog.NewSymbol("?e")] != 0 {
 		t.Errorf("Expected ?e at index 0, got %d", colMap[datalog.NewSymbol("?e")])
@@ -257,10 +257,10 @@ func TestExtractPatternValues_ConvenienceFunction(t *testing.T) {
 		},
 	}
 
-	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+	symbols := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice, "Alice"}
 
-	e, a, v, tx := ExtractPatternValues(pattern, columns, bindingTuple)
+	e, a, v, tx := ExtractPatternValues(pattern, symbols, bindingTuple)
 
 	if e == nil || !e.(datalog.Identity).Equal(alice) {
 		t.Errorf("Expected E=%v, got %v", alice, e)
@@ -277,7 +277,7 @@ func TestExtractPatternValues_ConvenienceFunction(t *testing.T) {
 }
 
 func TestPatternExtractor_OutOfBoundsTuple(t *testing.T) {
-	// Pattern expects more columns than the binding tuple has
+	// Pattern expects more symbols than the binding tuple has
 	pattern := &DataPattern{
 		Elements: []PatternElement{
 			Variable{Name: datalog.NewSymbol("?e")},
@@ -287,10 +287,10 @@ func TestPatternExtractor_OutOfBoundsTuple(t *testing.T) {
 	}
 
 	alice := datalog.NewIdentity("user:alice")
-	columns := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
+	symbols := []Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")}
 	bindingTuple := Tuple{alice} // Only has 1 value instead of 3
 
-	extractor := NewPatternExtractor(pattern, columns)
+	extractor := NewPatternExtractor(pattern, symbols)
 	values := extractor.Extract(bindingTuple)
 
 	if values.E == nil || !values.E.(datalog.Identity).Equal(alice) {
@@ -328,7 +328,7 @@ func TestPatternExtractor_EmptyPattern(t *testing.T) {
 }
 
 func TestPatternExtractor_ColumnsInDifferentOrder(t *testing.T) {
-	// Test that column ordering doesn't matter - it's the symbol name that counts
+	// Test that symbol ordering doesn't matter - it's the symbol name that counts
 	alice := datalog.NewIdentity("user:alice")
 	nameAttr := datalog.NewKeyword(":user/name")
 
@@ -340,11 +340,11 @@ func TestPatternExtractor_ColumnsInDifferentOrder(t *testing.T) {
 		},
 	}
 
-	// Columns in different order: ?v, ?e, ?a
-	columns := []Symbol{datalog.NewSymbol("?v"), datalog.NewSymbol("?e"), datalog.NewSymbol("?a")}
+	// Symbols in different order: ?v, ?e, ?a
+	symbols := []Symbol{datalog.NewSymbol("?v"), datalog.NewSymbol("?e"), datalog.NewSymbol("?a")}
 	bindingTuple := Tuple{"Alice", alice, nameAttr}
 
-	extractor := NewPatternExtractor(pattern, columns)
+	extractor := NewPatternExtractor(pattern, symbols)
 	values := extractor.Extract(bindingTuple)
 
 	if values.E == nil || !values.E.(datalog.Identity).Equal(alice) {

--- a/datalog/query/tuple_builder.go
+++ b/datalog/query/tuple_builder.go
@@ -11,7 +11,7 @@ import (
 // TupleBuilder is an optimized builder for converting datoms to tuples
 // It pre-computes the mapping from pattern variables to tuple positions
 type TupleBuilder struct {
-	columns []Symbol
+	symbols []Symbol
 
 	// Pre-computed indexes for each position (-1 means not captured)
 	eIndex int
@@ -26,13 +26,13 @@ type TupleBuilder struct {
 	tIsVar bool
 }
 
-// NewTupleBuilder creates an optimized tuple builder for a pattern and columns
-func NewTupleBuilder(pattern *DataPattern, columns []Symbol) *TupleBuilder {
+// NewTupleBuilder creates an optimized tuple builder for a pattern and symbols
+func NewTupleBuilder(pattern *DataPattern, symbols []Symbol) *TupleBuilder {
 	// Use shared indexer to compute indices
-	indexer := NewTupleIndexer(pattern, columns)
+	indexer := NewTupleIndexer(pattern, symbols)
 
 	return &TupleBuilder{
-		columns: columns,
+		symbols: symbols,
 		eIndex:  indexer.EIndex,
 		aIndex:  indexer.AIndex,
 		vIndex:  indexer.VIndex,
@@ -47,7 +47,7 @@ func NewTupleBuilder(pattern *DataPattern, columns []Symbol) *TupleBuilder {
 // BuildTuple efficiently converts a datom to a tuple using pre-computed indexes
 func (tb *TupleBuilder) BuildTuple(datom *datalog.Datom) Tuple {
 	// Allocate tuple once
-	tuple := make(Tuple, len(tb.columns))
+	tuple := make(Tuple, len(tb.symbols))
 
 	// Direct assignment using pre-computed indexes
 	if tb.eIndex >= 0 {
@@ -68,19 +68,19 @@ func (tb *TupleBuilder) BuildTuple(datom *datalog.Datom) Tuple {
 
 // DatomToTupleOptimized is a drop-in replacement for DatomToTuple
 // For one-off conversions where creating a TupleBuilder isn't worth it
-func DatomToTupleOptimized(datom datalog.Datom, pattern *DataPattern, columns []Symbol) Tuple {
-	if len(columns) == 0 {
+func DatomToTupleOptimized(datom datalog.Datom, pattern *DataPattern, symbols []Symbol) Tuple {
+	if len(symbols) == 0 {
 		return nil
 	}
 
-	// For small column counts, use direct approach
-	if len(columns) <= 4 {
-		tuple := make(Tuple, len(columns))
+	// For small symbol counts, use direct approach
+	if len(symbols) <= 4 {
+		tuple := make(Tuple, len(symbols))
 
-		// Check each pattern element and find its column index
+		// Check each pattern element and find its symbol index
 		if v, ok := pattern.GetE().(Variable); ok {
-			for i, col := range columns {
-				if col == v.Name {
+			for i, sym := range symbols {
+				if sym == v.Name {
 					tuple[i] = datom.E
 					break
 				}
@@ -88,8 +88,8 @@ func DatomToTupleOptimized(datom datalog.Datom, pattern *DataPattern, columns []
 		}
 
 		if v, ok := pattern.GetA().(Variable); ok {
-			for i, col := range columns {
-				if col == v.Name {
+			for i, sym := range symbols {
+				if sym == v.Name {
 					tuple[i] = datom.A
 					break
 				}
@@ -97,8 +97,8 @@ func DatomToTupleOptimized(datom datalog.Datom, pattern *DataPattern, columns []
 		}
 
 		if v, ok := pattern.GetV().(Variable); ok {
-			for i, col := range columns {
-				if col == v.Name {
+			for i, sym := range symbols {
+				if sym == v.Name {
 					tuple[i] = datom.V
 					break
 				}
@@ -107,8 +107,8 @@ func DatomToTupleOptimized(datom datalog.Datom, pattern *DataPattern, columns []
 
 		if len(pattern.Elements) > 3 {
 			if v, ok := pattern.GetT().(Variable); ok {
-				for i, col := range columns {
-					if col == v.Name {
+				for i, sym := range symbols {
+					if sym == v.Name {
 						tuple[i] = datom.Tx
 						break
 					}
@@ -119,7 +119,7 @@ func DatomToTupleOptimized(datom datalog.Datom, pattern *DataPattern, columns []
 		return tuple
 	}
 
-	// For larger column counts, fall back to map approach
+	// For larger symbol counts, fall back to map approach
 	// (though this shouldn't happen in practice with EAVT patterns)
 	values := make(map[Symbol]interface{}, 4)
 
@@ -138,9 +138,9 @@ func DatomToTupleOptimized(datom datalog.Datom, pattern *DataPattern, columns []
 		}
 	}
 
-	tuple := make(Tuple, len(columns))
-	for i, col := range columns {
-		if val, found := values[col]; found {
+	tuple := make(Tuple, len(symbols))
+	for i, sym := range symbols {
+		if val, found := values[sym]; found {
 			tuple[i] = val
 		}
 	}

--- a/datalog/query/tuple_builder_interned.go
+++ b/datalog/query/tuple_builder_interned.go
@@ -8,7 +8,7 @@ import (
 
 // InternedTupleBuilder uses interning to minimize allocations
 type InternedTupleBuilder struct {
-	columns []Symbol
+	symbols []Symbol
 
 	// Pre-computed indexes for each position (-1 means not captured)
 	eIndex int
@@ -28,18 +28,18 @@ type InternedTupleBuilder struct {
 }
 
 // NewInternedTupleBuilder creates a tuple builder that uses interning
-func NewInternedTupleBuilder(pattern *DataPattern, columns []Symbol) *InternedTupleBuilder {
+func NewInternedTupleBuilder(pattern *DataPattern, symbols []Symbol) *InternedTupleBuilder {
 	// Use shared indexer to compute indices
-	indexer := NewTupleIndexer(pattern, columns)
+	indexer := NewTupleIndexer(pattern, symbols)
 
 	return &InternedTupleBuilder{
-		columns:   columns,
+		symbols:   symbols,
 		eIndex:    indexer.EIndex,
 		aIndex:    indexer.AIndex,
 		vIndex:    indexer.VIndex,
 		tIndex:    indexer.TIndex,
 		numVars:   indexer.NumVars,
-		workspace: make(Tuple, len(columns)),
+		workspace: make(Tuple, len(symbols)),
 		txCache:   make(map[datalog.ElementID]*datalog.ElementID),
 	}
 }
@@ -61,7 +61,7 @@ func (tb *InternedTupleBuilder) getTxPtr(tx datalog.ElementID) *datalog.ElementI
 
 // BuildTupleInterned builds a tuple using interned values to minimize allocations
 func (tb *InternedTupleBuilder) BuildTupleInterned(datom *datalog.Datom) Tuple {
-	result := make(Tuple, len(tb.columns))
+	result := make(Tuple, len(tb.symbols))
 
 	// Use interned values where possible - store pointers to avoid interface boxing
 	if tb.eIndex >= 0 {

--- a/datalog/query/tuple_builder_optimized.go
+++ b/datalog/query/tuple_builder_optimized.go
@@ -38,7 +38,7 @@ func PutTuple(t Tuple) {
 
 // OptimizedTupleBuilder is a highly optimized tuple builder
 type OptimizedTupleBuilder struct {
-	columns []Symbol
+	symbols []Symbol
 
 	// Pre-computed indexes for each position (-1 means not captured)
 	eIndex int
@@ -54,18 +54,18 @@ type OptimizedTupleBuilder struct {
 }
 
 // NewOptimizedTupleBuilder creates an optimized tuple builder
-func NewOptimizedTupleBuilder(pattern *DataPattern, columns []Symbol) *OptimizedTupleBuilder {
+func NewOptimizedTupleBuilder(pattern *DataPattern, symbols []Symbol) *OptimizedTupleBuilder {
 	// Use shared indexer to compute indices
-	indexer := NewTupleIndexer(pattern, columns)
+	indexer := NewTupleIndexer(pattern, symbols)
 
 	return &OptimizedTupleBuilder{
-		columns:   columns,
+		symbols:   symbols,
 		eIndex:    indexer.EIndex,
 		aIndex:    indexer.AIndex,
 		vIndex:    indexer.VIndex,
 		tIndex:    indexer.TIndex,
 		numVars:   indexer.NumVars,
-		workspace: make(Tuple, len(columns)), // Pre-allocate workspace
+		workspace: make(Tuple, len(symbols)), // Pre-allocate workspace
 	}
 }
 
@@ -89,7 +89,7 @@ func (tb *OptimizedTupleBuilder) BuildTupleInto(datom *datalog.Datom, tuple Tupl
 
 // BuildTuplePooled builds a tuple using the pool to avoid allocation
 func (tb *OptimizedTupleBuilder) BuildTuplePooled(datom *datalog.Datom) Tuple {
-	tuple := GetTuple(len(tb.columns))
+	tuple := GetTuple(len(tb.symbols))
 	tb.BuildTupleInto(datom, tuple)
 	return tuple
 }
@@ -101,7 +101,7 @@ func (tb *OptimizedTupleBuilder) BuildTupleCopy(datom *datalog.Datom) Tuple {
 	tb.BuildTupleInto(datom, tb.workspace)
 
 	// Make a copy for storage
-	result := make(Tuple, len(tb.columns))
+	result := make(Tuple, len(tb.symbols))
 	copy(result, tb.workspace)
 	return result
 }

--- a/datalog/query/tuple_indexer.go
+++ b/datalog/query/tuple_indexer.go
@@ -12,30 +12,30 @@ type TupleIndexer struct {
 	// Number of variables actually captured
 	NumVars int
 
-	// Column index map for quick lookups
-	ColIndex map[Symbol]int
+	// Symbol index map for quick lookups
+	SymIndex map[Symbol]int
 }
 
-// NewTupleIndexer computes the index mapping for a pattern and columns.
+// NewTupleIndexer computes the index mapping for a pattern and symbols.
 // This consolidates the constructor logic that was duplicated ~240 lines across three builders.
-func NewTupleIndexer(pattern *DataPattern, columns []Symbol) *TupleIndexer {
+func NewTupleIndexer(pattern *DataPattern, symbols []Symbol) *TupleIndexer {
 	indexer := &TupleIndexer{
 		EIndex:   -1,
 		AIndex:   -1,
 		VIndex:   -1,
 		TIndex:   -1,
 		NumVars:  0,
-		ColIndex: make(map[Symbol]int, len(columns)),
+		SymIndex: make(map[Symbol]int, len(symbols)),
 	}
 
-	// Build column index map for quick lookups
-	for i, col := range columns {
-		indexer.ColIndex[col] = i
+	// Build symbol index map for quick lookups
+	for i, sym := range symbols {
+		indexer.SymIndex[sym] = i
 	}
 
 	// Check E position
 	if v, ok := pattern.GetE().(Variable); ok {
-		if idx, found := indexer.ColIndex[v.Name]; found {
+		if idx, found := indexer.SymIndex[v.Name]; found {
 			indexer.EIndex = idx
 			indexer.NumVars++
 		}
@@ -43,7 +43,7 @@ func NewTupleIndexer(pattern *DataPattern, columns []Symbol) *TupleIndexer {
 
 	// Check A position
 	if v, ok := pattern.GetA().(Variable); ok {
-		if idx, found := indexer.ColIndex[v.Name]; found {
+		if idx, found := indexer.SymIndex[v.Name]; found {
 			indexer.AIndex = idx
 			indexer.NumVars++
 		}
@@ -51,7 +51,7 @@ func NewTupleIndexer(pattern *DataPattern, columns []Symbol) *TupleIndexer {
 
 	// Check V position
 	if v, ok := pattern.GetV().(Variable); ok {
-		if idx, found := indexer.ColIndex[v.Name]; found {
+		if idx, found := indexer.SymIndex[v.Name]; found {
 			indexer.VIndex = idx
 			indexer.NumVars++
 		}
@@ -60,7 +60,7 @@ func NewTupleIndexer(pattern *DataPattern, columns []Symbol) *TupleIndexer {
 	// Check T position
 	if len(pattern.Elements) > 3 {
 		if v, ok := pattern.GetT().(Variable); ok {
-			if idx, found := indexer.ColIndex[v.Name]; found {
+			if idx, found := indexer.SymIndex[v.Name]; found {
 				indexer.TIndex = idx
 				indexer.NumVars++
 			}

--- a/datalog/query/types.go
+++ b/datalog/query/types.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wbrown/janus-datalog/datalog"
 )
 
-// Tuple represents a row of values in a relation
+// Tuple represents a tuple of values in a relation
 // It's used throughout the executor and storage layers for query results
 type Tuple []interface{}
 
@@ -96,7 +96,7 @@ type BindingForm interface {
 	String() string
 }
 
-// TupleBinding binds a single row: [[?a ?b]]
+// TupleBinding binds a single tuple: [[?a ?b]]
 type TupleBinding struct {
 	Variables []Symbol
 }
@@ -114,8 +114,8 @@ func (t TupleBinding) String() string {
 	return result
 }
 
-// CollectionBinding binds a single column from all rows: [?coll ...]
-// This collects all values from a single-column result into a collection.
+// CollectionBinding binds a single symbol from all tuples: [?coll ...]
+// This collects all values from a single-symbol result into a collection.
 type CollectionBinding struct {
 	Variable Symbol
 }
@@ -126,7 +126,7 @@ func (c CollectionBinding) String() string {
 }
 
 // ScalarBinding binds a single value to a single variable: ?var
-// Expects exactly one row with one column. Used with scalar find spec (.:find ... .)
+// Expects exactly one tuple with one symbol. Used with scalar find spec (.:find ... .)
 type ScalarBinding struct {
 	Variable Symbol
 }
@@ -476,19 +476,19 @@ type Result []interface{}
 
 // ResultSet represents a set of query results
 type ResultSet struct {
-	Columns []Symbol // Column names (from Find clause)
-	Rows    []Result // Result tuples
+	Symbols []Symbol // Symbol names (from Find clause)
+	Tuples  []Result // Result tuples
 }
 
-// ToMap converts a result row to a map using column names
-func (rs ResultSet) ToMap(row int) map[Symbol]interface{} {
-	if row < 0 || row >= len(rs.Rows) {
+// ToMap converts a result tuple to a map using symbol names
+func (rs ResultSet) ToMap(tupleIdx int) map[Symbol]interface{} {
+	if tupleIdx < 0 || tupleIdx >= len(rs.Tuples) {
 		return nil
 	}
 	result := make(map[Symbol]interface{})
-	for i, col := range rs.Columns {
-		if i < len(rs.Rows[row]) {
-			result[col] = rs.Rows[row][i]
+	for i, sym := range rs.Symbols {
+		if i < len(rs.Tuples[tupleIdx]) {
+			result[sym] = rs.Tuples[tupleIdx][i]
 		}
 	}
 	return result
@@ -496,7 +496,7 @@ func (rs ResultSet) ToMap(row int) map[Symbol]interface{} {
 
 // Relation represents an intermediate relation during query execution
 type Relation struct {
-	Columns []Symbol
+	Symbols []Symbol
 	Tuples  [][]interface{}
 }
 
@@ -510,22 +510,22 @@ func (r Relation) Size() int {
 	return len(r.Tuples)
 }
 
-// ColumnIndex returns the index of a column, or -1 if not found
-func (r Relation) ColumnIndex(col Symbol) int {
-	for i, c := range r.Columns {
-		if c == col {
+// SymbolIndex returns the index of a symbol, or -1 if not found
+func (r Relation) SymbolIndex(sym Symbol) int {
+	for i, s := range r.Symbols {
+		if s == sym {
 			return i
 		}
 	}
 	return -1
 }
 
-// CommonColumns returns the columns that appear in both relations
-func (r Relation) CommonColumns(other Relation) []Symbol {
+// CommonSymbols returns the symbols that appear in both relations
+func (r Relation) CommonSymbols(other Relation) []Symbol {
 	common := []Symbol{}
-	for _, col := range r.Columns {
-		if other.ColumnIndex(col) >= 0 {
-			common = append(common, col)
+	for _, sym := range r.Symbols {
+		if other.SymbolIndex(sym) >= 0 {
+			common = append(common, sym)
 		}
 	}
 	return common
@@ -565,15 +565,15 @@ func (o OrderByClause) String() string {
 	return fmt.Sprintf("[%s :%s]", o.Variable, o.Direction)
 }
 
-// DatomToTuple converts a datom to a tuple based on the pattern and requested columns.
+// DatomToTuple converts a datom to a tuple based on the pattern and requested symbols.
 // This is used by both executor and storage packages to extract values from datoms
-// in the order specified by the columns.
-func DatomToTuple(datom datalog.Datom, pattern *DataPattern, columns []Symbol) Tuple {
-	if len(columns) == 0 {
+// in the order specified by the symbols.
+func DatomToTuple(datom datalog.Datom, pattern *DataPattern, symbols []Symbol) Tuple {
+	if len(symbols) == 0 {
 		return nil
 	}
 
-	// Build column to value mapping
+	// Build symbol to value mapping
 	values := make(map[Symbol]interface{})
 
 	// Map E position
@@ -598,10 +598,10 @@ func DatomToTuple(datom datalog.Datom, pattern *DataPattern, columns []Symbol) T
 		}
 	}
 
-	// Build tuple in column order
-	tuple := make(Tuple, len(columns))
-	for i, col := range columns {
-		if val, found := values[col]; found {
+	// Build tuple in symbol order
+	tuple := make(Tuple, len(symbols))
+	for i, sym := range symbols {
+		if val, found := values[sym]; found {
 			tuple[i] = val
 		}
 	}

--- a/datalog/reflect/integration_test.go
+++ b/datalog/reflect/integration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 	"github.com/wbrown/janus-datalog/datalog/storage"
@@ -434,10 +435,10 @@ func TestSaveStructCardinalityOne(t *testing.T) {
 
 	// Verify there's only ONE age value (not both 30 and 31)
 	// Query for all age values of this entity
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?age :in $ ?e :where [?e :person/age ?age]]`,
 		id,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -478,10 +479,10 @@ func TestSaveStructCardinalityMany(t *testing.T) {
 	}
 
 	// Verify initial tags
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?tag :in $ ?e :where [?e :person-with-tags/tags ?tag]]`,
 		id,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -501,10 +502,10 @@ func TestSaveStructCardinalityMany(t *testing.T) {
 	}
 
 	// Verify only new tags exist
-	results, err = db.ExecuteQueryWithInputs(
+	results, err = executor.CollectTuples(db.Query(
 		`[:find ?tag :in $ ?e :where [?e :person-with-tags/tags ?tag]]`,
 		id,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -569,10 +570,10 @@ func TestNilVsEmptySliceSemantics(t *testing.T) {
 	}
 
 	// Verify tags unchanged
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?tag :in $ ?e :where [?e :person-with-tags/tags ?tag]]`,
 		id,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -592,10 +593,10 @@ func TestNilVsEmptySliceSemantics(t *testing.T) {
 	}
 
 	// Verify tags cleared
-	results, err = db.ExecuteQueryWithInputs(
+	results, err = executor.CollectTuples(db.Query(
 		`[:find ?tag :in $ ?e :where [?e :person-with-tags/tags ?tag]]`,
 		id,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -668,10 +669,10 @@ func TestSaveStructUpsertSemantics(t *testing.T) {
 	}
 
 	// Verify only one value for each attribute (no duplicates)
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?age :in $ ?e :where [?e :person/age ?age]]`,
 		id,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -741,10 +742,10 @@ func TestPullInto_CardinalityManyRefs(t *testing.T) {
 	t.Logf("Created Alice with ID: %s", aliceID.L85()[:20])
 
 	// Verify all 5 friends are stored via direct query
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?f :in $ ?alice :where [?alice :person-with-friend-refs/friends ?f]]`,
 		aliceID,
-	)
+	))
 	if err != nil {
 		t.Fatalf("direct query failed: %v", err)
 	}
@@ -832,10 +833,10 @@ func TestPullInto_CardinalityManyRefs_ManualSchema(t *testing.T) {
 	t.Logf("Created Alice with ID: %s", aliceID.L85()[:20])
 
 	// Verify all 5 friends are stored via direct query
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?f :in $ ?alice :where [?alice :person-with-friend-refs/friends ?f]]`,
 		aliceID,
-	)
+	))
 	if err != nil {
 		t.Fatalf("direct query failed: %v", err)
 	}
@@ -921,10 +922,10 @@ func TestLookupAttributeWithStructAPI(t *testing.T) {
 	}
 
 	// Verify query also works (sanity check)
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name ?age :in $ ?e :where [?e :person/name ?name] [?e :person/age ?age]]`,
 		id,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -1272,10 +1273,10 @@ func TestSaveStructAndPullInto_WorldEntity(t *testing.T) {
 	// This mimics store_world.go findWorldEntity() + GetWorldTags()
 	t.Run("QueryThenPullInto", func(t *testing.T) {
 		// First, let's see what's actually stored for this entity
-		debugTuples, err := db.ExecuteQueryWithInputs(
+		debugTuples, err := executor.CollectTuples(db.Query(
 			`[:find ?a ?v :in $ ?e :where [?e ?a ?v]]`,
 			worldID,
-		)
+		))
 		if err != nil {
 			t.Fatalf("debug query failed: %v", err)
 		}
@@ -1286,10 +1287,10 @@ func TestSaveStructAndPullInto_WorldEntity(t *testing.T) {
 
 		// Check if the type attribute is stored correctly
 		// Note: struct tag "entity/type" contains "/" so it's a full path :entity/type
-		typeTuples, err := db.ExecuteQueryWithInputs(
+		typeTuples, err := executor.CollectTuples(db.Query(
 			`[:find ?type :in $ ?e :where [?e :entity/type ?type]]`,
 			worldID,
-		)
+		))
 		if err != nil {
 			t.Fatalf("type query failed: %v", err)
 		}
@@ -1300,12 +1301,12 @@ func TestSaveStructAndPullInto_WorldEntity(t *testing.T) {
 
 		// Query to find the world entity by type and map (like findWorldEntity)
 		// Note: struct tags with "/" are treated as full paths, not prefixed with struct name
-		tuples, err := db.ExecuteQueryWithInputs(
+		tuples, err := executor.CollectTuples(db.Query(
 			`[:find ?e :in $ ?map :where
 			  [?e :entity/type :entity.type/world]
 			  [?e :entity/map ?map]]`,
 			mapID,
-		)
+		))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -1464,10 +1465,10 @@ func TestPullInto_CardinalityManyStrings_MultipleValues(t *testing.T) {
 	t.Logf("Created dungeon with ID: %s", dungeonID.L85())
 
 	// Query raw datoms to verify all hooks are stored
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e :where [?e :dungeon/hooks ?v]]`,
 		dungeonID,
-	)
+	))
 	if err != nil {
 		t.Fatalf("direct query failed: %v", err)
 	}

--- a/datalog/reflect/ordered_set_test.go
+++ b/datalog/reflect/ordered_set_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 	"github.com/wbrown/janus-datalog/datalog/storage"
@@ -299,10 +300,10 @@ func TestSaveStruct_OrderedSet_SchemaVerify(t *testing.T) {
 	// Query to verify values stored
 	// Note: Vectors return the entire ordered list as a single value (array)
 	// This is different from sets where each element is a separate tuple
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e :where [?e :character-with-preferences/prefs ?v]]`,
 		entityID,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -372,10 +373,10 @@ func TestSaveStruct_OrderedSet(t *testing.T) {
 
 	// Query to verify values are stored
 	// Note: Vectors return entire ordered list as single array value
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e :where [?e :character-with-preferences/prefs ?v]]`,
 		charID,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -445,10 +446,10 @@ func TestSaveStruct_OrderedSetDuplicates(t *testing.T) {
 	}
 
 	// Query to verify - vectors return as single array value
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e :where [?e :character-with-preferences/prefs ?v]]`,
 		charID,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -769,10 +770,10 @@ func TestSaveStruct_OrderedSetRefs(t *testing.T) {
 
 	// Query to verify refs are stored
 	// Note: Vectors return entire ordered list as single array value
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?f :in $ ?e :where [?e :entity-with-ordered-refs/follows ?f]]`,
 		entityID,
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}

--- a/datalog/reflect/query_reader.go
+++ b/datalog/reflect/query_reader.go
@@ -23,37 +23,37 @@ var (
 	ErrSymbolNotFound     = errors.New("tagged symbol not found in query results")
 )
 
-// QueryFieldMapping maps a struct field to a query result column
+// QueryFieldMapping maps a struct field to a query result symbol
 type QueryFieldMapping struct {
 	FieldIndex int          // Index in struct
 	FieldName  string       // Go field name
 	FieldType  reflect.Type // Go type
 	Tag        string       // The datalog tag value (e.g., "?name" or "(sum ?x)")
-	ColIndex   int          // Column index in result tuple (-1 if unmapped)
+	TupleIndex int          // Index in result tuple (-1 if unmapped)
 }
 
 // QueryResultMapper handles query result -> struct conversion
 type QueryResultMapper struct {
 	elemType      reflect.Type
-	mappings      []QueryFieldMapping // Query variable mappings (with ColIndex set)
+	mappings      []QueryFieldMapping // Query variable mappings (with TupleIndex set)
 	pullMappings  []QueryFieldMapping // Attribute tag mappings (for pull result maps)
 	isPullMapping bool                // true if struct uses ONLY attribute-style tags
 }
 
-// NewQueryResultMapper creates a mapper from struct type and :find column names.
+// NewQueryResultMapper creates a mapper from struct type and :find symbol names.
 // The findColumns should be the string representations of FindElements
 // (e.g., "?name", "(sum ?salary)").
 //
 // The mapper supports three modes:
-// 1. Query-style tags only (`datalog:"?name"`) - maps query result columns to struct fields
+// 1. Query-style tags only (`datalog:"?name"`) - maps query result symbols to struct fields
 // 2. Attribute-style tags only (`datalog:"person/name"`) - maps pull result maps to struct fields
 // 3. Mixed mode - both query-style AND attribute-style tags in the same struct
 //
-// For pure attribute-style structs, the query should return a pull expression column
+// For pure attribute-style structs, the query should return a pull expression symbol
 // like `[:find (pull ?e [*]) :where ...]`.
 //
 // For mixed mode, use queries like `[:find ?name (pull ?e [:person/age]) :where ...]`
-// where query variables map to their columns and attribute tags map from the pull result.
+// where query variables map to their symbols and attribute tags map from the pull result.
 func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryResultMapper, error) {
 	// Handle pointer to struct
 	if elemType.Kind() == reflect.Ptr {
@@ -64,7 +64,7 @@ func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryRe
 		return nil, fmt.Errorf("expected struct type, got %s", elemType.Kind())
 	}
 
-	// Build column index map
+	// Build symbol index map
 	colIndex := make(map[string]int)
 	for i, col := range findColumns {
 		colIndex[col] = i
@@ -94,20 +94,20 @@ func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryRe
 			FieldIndex: i,
 			FieldName:  field.Name,
 			FieldType:  field.Type,
-			ColIndex:   -1,
+			TupleIndex: -1,
 		}
 
 		// Check if this is a query symbol tag (starts with ? or ()
 		if isQueryTag(tag) {
 			mapping.Tag = tag
 
-			// Look up column index
+			// Look up symbol index
 			idx, found := colIndex[tag]
 			if !found {
 				return nil, fmt.Errorf("%w: field %s tagged with %q not found in query results %v",
 					ErrSymbolNotFound, field.Name, tag, findColumns)
 			}
-			mapping.ColIndex = idx
+			mapping.TupleIndex = idx
 			queryMappings = append(queryMappings, mapping)
 		} else if tag == "" {
 			// No tag - will use positional mapping
@@ -147,7 +147,7 @@ func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryRe
 	}
 
 	// Mixed mode: query tags AND attribute tags
-	// Query variables map from tuple columns, attribute tags map from pull result in tuple
+	// Query variables map from tuple positions, attribute tags map from pull result in tuple
 	if hasQueryTags && hasAttributeTags {
 		return &QueryResultMapper{
 			elemType:      elemType,
@@ -171,7 +171,7 @@ func NewQueryResultMapper(elemType reflect.Type, findColumns []string) (*QueryRe
 	if hasUntagged {
 		for i := range untaggedMappings {
 			if i < len(findColumns) {
-				untaggedMappings[i].ColIndex = i
+				untaggedMappings[i].TupleIndex = i
 				untaggedMappings[i].Tag = findColumns[i] // For error messages
 			}
 		}
@@ -225,7 +225,7 @@ func (m *QueryResultMapper) MapTuple(tuple []interface{}, dest reflect.Value) er
 	// Pure pull mapping mode: expect a map value in the tuple
 	if m.isPullMapping {
 		if len(tuple) == 0 {
-			return fmt.Errorf("pull mapping expects at least one column, got empty tuple")
+			return fmt.Errorf("pull mapping expects at least one symbol, got empty tuple")
 		}
 		pullMap := m.findPullMap(tuple)
 		if pullMap == nil {
@@ -234,13 +234,13 @@ func (m *QueryResultMapper) MapTuple(tuple []interface{}, dest reflect.Value) er
 		return m.mapPullResult(pullMap, dest)
 	}
 
-	// Map query variable fields from tuple columns
+	// Map query variable fields from tuple positions
 	for _, mapping := range m.mappings {
-		if mapping.ColIndex < 0 || mapping.ColIndex >= len(tuple) {
-			continue // Skip unmapped or out-of-range columns
+		if mapping.TupleIndex < 0 || mapping.TupleIndex >= len(tuple) {
+			continue // Skip unmapped or out-of-range positions
 		}
 
-		value := tuple[mapping.ColIndex]
+		value := tuple[mapping.TupleIndex]
 		fieldVal := dest.Field(mapping.FieldIndex)
 
 		if err := setQueryValue(fieldVal, mapping.FieldType, value); err != nil {
@@ -310,7 +310,7 @@ func (m *QueryResultMapper) MapAll(tuples [][]interface{}, destSlice reflect.Val
 	for i, tuple := range tuples {
 		elem := reflect.New(m.elemType).Elem()
 		if err := m.MapTuple(tuple, elem); err != nil {
-			return fmt.Errorf("row %d: %w", i, err)
+			return fmt.Errorf("tuple %d: %w", i, err)
 		}
 		newSlice = reflect.Append(newSlice, elem)
 	}

--- a/datalog/reflect/query_reader_test.go
+++ b/datalog/reflect/query_reader_test.go
@@ -84,12 +84,12 @@ func TestNewQueryResultMapper_TaggedFields(t *testing.T) {
 	}
 
 	// Verify name mapping
-	if mapper.mappings[0].Tag != "?name" || mapper.mappings[0].ColIndex != 0 {
+	if mapper.mappings[0].Tag != "?name" || mapper.mappings[0].TupleIndex != 0 {
 		t.Errorf("name mapping incorrect: %+v", mapper.mappings[0])
 	}
 
 	// Verify age mapping
-	if mapper.mappings[1].Tag != "?age" || mapper.mappings[1].ColIndex != 1 {
+	if mapper.mappings[1].Tag != "?age" || mapper.mappings[1].TupleIndex != 1 {
 		t.Errorf("age mapping incorrect: %+v", mapper.mappings[1])
 	}
 }
@@ -105,12 +105,12 @@ func TestNewQueryResultMapper_PositionalMapping(t *testing.T) {
 		t.Errorf("expected 2 mappings, got %d", len(mapper.mappings))
 	}
 
-	// Positional: first field -> column 0, second field -> column 1
-	if mapper.mappings[0].ColIndex != 0 {
-		t.Errorf("first field should map to column 0, got %d", mapper.mappings[0].ColIndex)
+	// Positional: first field -> symbol 0, second field -> symbol 1
+	if mapper.mappings[0].TupleIndex != 0 {
+		t.Errorf("first field should map to symbol 0, got %d", mapper.mappings[0].TupleIndex)
 	}
-	if mapper.mappings[1].ColIndex != 1 {
-		t.Errorf("second field should map to column 1, got %d", mapper.mappings[1].ColIndex)
+	if mapper.mappings[1].TupleIndex != 1 {
+		t.Errorf("second field should map to symbol 1, got %d", mapper.mappings[1].TupleIndex)
 	}
 }
 
@@ -129,16 +129,16 @@ func TestNewQueryResultMapper_Aggregates(t *testing.T) {
 	for _, m := range mapper.mappings {
 		switch m.Tag {
 		case "?dept":
-			if m.ColIndex != 0 {
-				t.Errorf("?dept should map to column 0, got %d", m.ColIndex)
+			if m.TupleIndex != 0 {
+				t.Errorf("?dept should map to symbol 0, got %d", m.TupleIndex)
 			}
 		case "(sum ?salary)":
-			if m.ColIndex != 1 {
-				t.Errorf("(sum ?salary) should map to column 1, got %d", m.ColIndex)
+			if m.TupleIndex != 1 {
+				t.Errorf("(sum ?salary) should map to symbol 1, got %d", m.TupleIndex)
 			}
 		case "(count ?emp)":
-			if m.ColIndex != 2 {
-				t.Errorf("(count ?emp) should map to column 2, got %d", m.ColIndex)
+			if m.TupleIndex != 2 {
+				t.Errorf("(count ?emp) should map to symbol 2, got %d", m.TupleIndex)
 			}
 		}
 	}
@@ -867,7 +867,7 @@ func TestMapTuple_PullResult_MissingFields(t *testing.T) {
 
 // MixedModeStruct has both query variable tags and attribute tags
 type MixedModeStruct struct {
-	// Query variable - comes from tuple column
+	// Query variable - comes from tuple symbol
 	Name string `datalog:"?name"`
 	// Attribute tags - come from pull result map in tuple
 	ID  datalog.Identity `datalog:"db/id"`
@@ -951,7 +951,7 @@ func TestMapTuple_MixedMode_NoPullMap(t *testing.T) {
 }
 
 func TestMapTuple_MixedMode_PullMapFirst(t *testing.T) {
-	// Test with pull map as first column: [:find (pull ?e [*]) ?name ...]
+	// Test with pull map as first symbol: [:find (pull ?e [*]) ?name ...]
 	findColumns := []string{"(pull ?e [*])", "?name"}
 	mapper, err := NewQueryResultMapper(reflect.TypeOf(MixedModeStruct{}), findColumns)
 	if err != nil {

--- a/datalog/storage/aetv_index_test.go
+++ b/datalog/storage/aetv_index_test.go
@@ -435,10 +435,10 @@ func TestAETVCRDTResolutionSingleEntity(t *testing.T) {
 	}
 
 	// Query should return only "Charlie" (last write)
-	result, err := db.ExecuteQueryWithInputs(
+	result, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e :where [?e :person/name ?v]]`,
 		entity,
-	)
+	))
 	require.NoError(t, err)
 
 	require.Len(t, result, 1, "CardinalityOne should return single result")
@@ -491,10 +491,10 @@ func TestAETVCRDTResolutionMultipleEntities(t *testing.T) {
 	}
 
 	// Query with all entities as input - should use AETV with CRDT resolution
-	result, err := db.ExecuteQueryWithInputs(
+	result, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`,
 		entities,
-	)
+	))
 	require.NoError(t, err)
 
 	// Should have exactly 3 results (one per entity)
@@ -550,7 +550,7 @@ func TestAETVCRDTResolutionUnboundEntity(t *testing.T) {
 	}
 
 	// Query all statuses (E unbound) - should use AETV
-	result, err := db.ExecuteQuery(`[:find ?e ?v :where [?e :person/status ?v]]`)
+	result, err := executor.CollectTuples(db.Query(`[:find ?e ?v :where [?e :person/status ?v]]`))
 	require.NoError(t, err)
 
 	// Should have 5 results (one per entity, LWW resolved)
@@ -671,9 +671,9 @@ func TestAETVCrossProductInputs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with both E and A from separate collections
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]`,
-		entities, attrs)
+		entities, attrs))
 	require.NoError(t, err)
 
 	// Expected: 4 results (2 entities × 2 attributes)

--- a/datalog/storage/aetv_index_test.go
+++ b/datalog/storage/aetv_index_test.go
@@ -501,9 +501,9 @@ func TestAETVCRDTResolutionMultipleEntities(t *testing.T) {
 	require.Len(t, result, 3, "should return one result per entity")
 
 	// Verify each entity got its LWW winner
-	for _, row := range result {
-		entity := row[0].(datalog.Identity)
-		name := row[1].(string)
+	for _, tuple := range result {
+		entity := tuple[0].(datalog.Identity)
+		name := tuple[1].(string)
 
 		hash := entity.Hash()
 		expected := expectedNames[string(hash[:])]
@@ -557,8 +557,8 @@ func TestAETVCRDTResolutionUnboundEntity(t *testing.T) {
 	require.Len(t, result, 5, "should return one result per entity")
 
 	// All should have "completed" (last write)
-	for _, row := range result {
-		status := row[1].(string)
+	for _, tuple := range result {
+		status := tuple[1].(string)
 		assert.Equal(t, "completed", status, "all entities should have LWW winner")
 	}
 }

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"runtime"
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/wbrown/janus-datalog/datalog"
@@ -152,14 +153,16 @@ func (s *BadgerStore) Scan(index IndexType, start, end []byte) (Iterator, error)
 
 	it := txn.NewIterator(opts)
 
-	return &BadgerIterator{
+	iter := &BadgerIterator{
 		txn:     txn,
 		it:      it,
 		start:   start,
 		end:     end,
 		index:   index,
 		encoder: s.encoder, // For decoding Op from key
-	}, nil
+	}
+	runtime.SetFinalizer(iter, (*BadgerIterator).Close)
+	return iter, nil
 }
 
 // Get retrieves a single datom by key
@@ -467,10 +470,16 @@ func (i *BadgerIterator) Datom() (*datalog.Datom, error) {
 	return &datom, nil
 }
 
-// Close closes the iterator
+// Close closes the iterator and releases the underlying BadgerDB transaction.
+// Safe to call multiple times.
 func (i *BadgerIterator) Close() error {
+	if i.txn == nil {
+		return nil
+	}
+	runtime.SetFinalizer(i, nil)
 	i.it.Close()
 	i.txn.Discard()
+	i.txn = nil
 	return nil
 }
 

--- a/datalog/storage/batch_iterator.go
+++ b/datalog/storage/batch_iterator.go
@@ -16,7 +16,7 @@ type batchScanIterator struct {
 	tuples      []executor.Tuple
 	position    int       // Which position is changing (0=E, 1=A, 2=V)
 	index       IndexType // Which index to use
-	columns     []query.Symbol
+	symbols     []query.Symbol
 	constraints []executor.StorageConstraint
 
 	// Batch state
@@ -56,7 +56,7 @@ func newBatchScanIterator(
 	tuples []executor.Tuple,
 	position int,
 	index IndexType,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	constraints []executor.StorageConstraint,
 ) *batchScanIterator {
 	return &batchScanIterator{
@@ -66,7 +66,7 @@ func newBatchScanIterator(
 		tuples:      tuples,
 		position:    position,
 		index:       index,
-		columns:     columns,
+		symbols:     symbols,
 		constraints: constraints,
 		batchSize:   100, // Default batch size - tune based on performance
 		batchStart:  0,
@@ -326,7 +326,7 @@ func (it *batchScanIterator) scanRange(rg RangeGroup) {
 
 		if satisfiesAll {
 			// Convert to tuple and add to results
-			resultTuple := query.DatomToTuple(*datom, it.pattern, it.columns)
+			resultTuple := query.DatomToTuple(*datom, it.pattern, it.symbols)
 			if resultTuple != nil {
 				it.pendingMatches = append(it.pendingMatches, resultTuple)
 				it.datomsMatched++

--- a/datalog/storage/batch_scan_debug_test.go
+++ b/datalog/storage/batch_scan_debug_test.go
@@ -69,7 +69,7 @@ func TestBatchScanDebug(t *testing.T) {
 		// First get entities (this simulates having bindings)
 		rel1, _ := matcher.Match(pattern, nil)
 
-		// Create binding relation with just the entity column
+		// Create binding relation with just the entity symbol
 		var tuples []executor.Tuple
 		it := rel1.Iterator()
 		for it.Next() {

--- a/datalog/storage/cache_integration_test.go
+++ b/datalog/storage/cache_integration_test.go
@@ -411,8 +411,8 @@ func TestJoinQueryUsesCache(t *testing.T) {
 
 	// Verify results contain expected data
 	names := make(map[string]string)
-	for _, row := range result {
-		names[row[0].(string)] = row[1].(string)
+	for _, tuple := range result {
+		names[tuple[0].(string)] = tuple[1].(string)
 	}
 	assert.Equal(t, "NYC", names["Alice"])
 	assert.Equal(t, "LA", names["Bob"])
@@ -464,8 +464,8 @@ func TestCardinalityManyQueryUsesCache(t *testing.T) {
 
 	// Verify results
 	tags := make(map[interface{}]bool)
-	for _, row := range result {
-		tags[row[0]] = true
+	for _, tuple := range result {
+		tags[tuple[0]] = true
 	}
 	assert.True(t, tags["developer"])
 	assert.True(t, tags["golang"])

--- a/datalog/storage/cache_integration_test.go
+++ b/datalog/storage/cache_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -354,7 +355,7 @@ func TestQueryExecutionUsesCache(t *testing.T) {
 	db.Cache().Clear()
 
 	// Execute a Datalog query - this should use the cache path
-	result, err := db.ExecuteQuery(`[:find ?name :where [?e :person/name ?name]]`)
+	result, err := executor.CollectTuples(db.Query(`[:find ?name :where [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, "Alice", result[0][0])
@@ -405,7 +406,7 @@ func TestJoinQueryUsesCache(t *testing.T) {
 
 	// Execute a join query - the second pattern should use cache after ?e is bound
 	// from the first pattern
-	result, err := db.ExecuteQuery(`[:find ?name ?city :where [?e :person/name ?name] [?e :person/city ?city]]`)
+	result, err := executor.CollectTuples(db.Query(`[:find ?name ?city :where [?e :person/name ?name] [?e :person/city ?city]]`))
 	require.NoError(t, err)
 	require.Len(t, result, 2, "should return 2 person results")
 
@@ -458,7 +459,7 @@ func TestCardinalityManyQueryUsesCache(t *testing.T) {
 	db.Cache().Clear()
 
 	// Execute query for cardinality-many attribute
-	result, err := db.ExecuteQuery(`[:find ?tag :where [?e :person/name "Alice"] [?e :person/tags ?tag]]`)
+	result, err := executor.CollectTuples(db.Query(`[:find ?tag :where [?e :person/name "Alice"] [?e :person/tags ?tag]]`))
 	require.NoError(t, err)
 	require.Len(t, result, 2, "should return 2 tags")
 

--- a/datalog/storage/choose_index_values_test.go
+++ b/datalog/storage/choose_index_values_test.go
@@ -118,7 +118,7 @@ func TestChooseIndexForValuesAVET(t *testing.T) {
 		queryStr := `[:find ?e :in $ ?scenario :where [?e :task/scenario ?scenario]]`
 
 		// Query for scenario1 - should return 10 results
-		result, err := db.ExecuteQueryWithInputs(queryStr, scenario1)
+		result, err := executor.CollectTuples(db.Query(queryStr, scenario1))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}
@@ -127,7 +127,7 @@ func TestChooseIndexForValuesAVET(t *testing.T) {
 		}
 
 		// Query for scenario2 - should return 5 results
-		result, err = db.ExecuteQueryWithInputs(queryStr, scenario2)
+		result, err = executor.CollectTuples(db.Query(queryStr, scenario2))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}
@@ -136,7 +136,7 @@ func TestChooseIndexForValuesAVET(t *testing.T) {
 		}
 
 		// Query for scenario3 - should return 3 results
-		result, err = db.ExecuteQueryWithInputs(queryStr, scenario3)
+		result, err = executor.CollectTuples(db.Query(queryStr, scenario3))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}
@@ -254,7 +254,7 @@ func TestChooseIndexForValuesVAET(t *testing.T) {
 		// Find all entities that reference parent1
 		queryStr := `[:find ?child :in $ ?parent :where [?child :child/parent ?parent]]`
 
-		result, err := db.ExecuteQueryWithInputs(queryStr, parent1)
+		result, err := executor.CollectTuples(db.Query(queryStr, parent1))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}
@@ -262,7 +262,7 @@ func TestChooseIndexForValuesVAET(t *testing.T) {
 			t.Errorf("Expected 8 children for parent1, got %d", len(result))
 		}
 
-		result, err = db.ExecuteQueryWithInputs(queryStr, parent2)
+		result, err = executor.CollectTuples(db.Query(queryStr, parent2))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}

--- a/datalog/storage/collection_input_test.go
+++ b/datalog/storage/collection_input_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -45,9 +46,9 @@ func TestCollectionInput_SingleCollection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with single collection input
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`,
-		entities)
+		entities))
 	require.NoError(t, err)
 
 	t.Logf("Results (%d):", len(results))
@@ -76,9 +77,9 @@ func TestCollectionInput_SingleElement(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with single-element collection
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`,
-		[]datalog.Identity{entity})
+		[]datalog.Identity{entity}))
 	require.NoError(t, err)
 
 	assert.Len(t, results, 1, "should return one result for single-element collection")
@@ -101,9 +102,9 @@ func TestCollectionInput_EmptyCollection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with empty collection
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ [?e ...] :where [?e :person/name ?v]]`,
-		[]datalog.Identity{})
+		[]datalog.Identity{}))
 	require.NoError(t, err)
 
 	assert.Len(t, results, 0, "empty collection should return no results")
@@ -158,9 +159,9 @@ func TestCollectionInput_TwoCollections(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with two collection inputs - should get cross-product
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]`,
-		entities, attrs)
+		entities, attrs))
 	require.NoError(t, err)
 
 	t.Logf("Results (%d):", len(results))
@@ -209,9 +210,9 @@ func TestCollectionInput_ThreeCollections(t *testing.T) {
 
 	// Query: find all (entity, tag) pairs where tag matches input collection
 	// Using entity collection and value collection
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ [?e ...] [?v ...] :where [?e :person/tag ?v]]`,
-		entities, tags)
+		entities, tags))
 	require.NoError(t, err)
 
 	t.Logf("Results (%d):", len(results))
@@ -252,9 +253,9 @@ func TestCollectionInput_ScalarPlusCollection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with scalar attribute and collection of entities
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ ?a [?e ...] :where [?e ?a ?v]]`,
-		attr, entities)
+		attr, entities))
 	require.NoError(t, err)
 
 	t.Logf("Results (%d):", len(results))
@@ -289,9 +290,9 @@ func TestCollectionInput_CollectionPlusScalar(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with collection first, then scalar
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ [?e ...] ?a :where [?e ?a ?v]]`,
-		entities, attr)
+		entities, attr))
 	require.NoError(t, err)
 
 	assert.Len(t, results, 2, "should return one result per entity")
@@ -324,9 +325,9 @@ func TestCollectionInput_KeywordCollection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with collection of keywords (attributes)
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?a ?v :in $ ?e [?a ...] :where [?e ?a ?v]]`,
-		entity, attrs)
+		entity, attrs))
 	require.NoError(t, err)
 
 	t.Logf("Results (%d):", len(results))
@@ -366,9 +367,9 @@ func TestCollectionInput_IntCollection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with collection of integers
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ ?e [?v ...] :where [?e :item/score ?v]]`,
-		entity, scores)
+		entity, scores))
 	require.NoError(t, err)
 
 	assert.Len(t, results, 3, "should return one result per score in collection")
@@ -403,9 +404,9 @@ func TestCollectionInput_StringCollection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query with collection of strings
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ ?e [?v ...] :where [?e :person/tag ?v]]`,
-		entity, tags)
+		entity, tags))
 	require.NoError(t, err)
 
 	assert.Len(t, results, 3, "should return one result per tag in collection")

--- a/datalog/storage/convenience.go
+++ b/datalog/storage/convenience.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/parser"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
@@ -15,10 +16,12 @@ var queryGetAttr = func() *query.Query {
 	return q
 }()
 
-// Query executes a Datalog query string or pre-parsed *query.Query.
-// This is a convenience alias for ExecuteQueryWithInputs.
-func (d *Database) Query(queryInput interface{}, inputs ...interface{}) ([][]interface{}, error) {
-	return d.ExecuteQueryWithInputs(queryInput, inputs...)
+// Query executes a Datalog query and returns a streaming Relation.
+// The caller should iterate via rel.Iterator() and must call iter.Close()
+// when done. For full materialization, call rel.Materialize() or use
+// ExecuteQueryWithInputs() which returns [][]any.
+func (d *Database) Query(queryInput interface{}, inputs ...interface{}) (executor.Relation, error) {
+	return d.ExecuteQueryRelation(queryInput, inputs...)
 }
 
 // Assert adds datoms in a single transaction.

--- a/datalog/storage/convenience.go
+++ b/datalog/storage/convenience.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"fmt"
+
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/parser"
@@ -18,10 +20,42 @@ var queryGetAttr = func() *query.Query {
 
 // Query executes a Datalog query and returns a streaming Relation.
 // The caller should iterate via rel.Iterator() and must call iter.Close()
-// when done. For full materialization, call rel.Materialize() or use
-// ExecuteQueryWithInputs() which returns [][]any.
+// when done.
 func (d *Database) Query(queryInput interface{}, inputs ...interface{}) (executor.Relation, error) {
-	return d.ExecuteQueryRelation(queryInput, inputs...)
+	// Separate QueryOptions from regular inputs
+	opts, regularInputs := extractQueryOptions(inputs)
+
+	q, err := resolveQuery(queryInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve query: %w", err)
+	}
+
+	// Build source map — database is always $
+	sources := buildSourceMap(opts.sources, d.Matcher())
+
+	// Validate declared sources exist
+	if err := validateQuerySources(q, sources); err != nil {
+		return nil, err
+	}
+
+	// Create SourceRouter with full source map
+	router := executor.NewSourceRouter(sources)
+
+	inputRelations, err := d.convertInputsToRelations(q, regularInputs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute with the SourceRouter as the PatternMatcher
+	planOpts := DefaultPlannerOptions()
+	planOpts.Cache = d.planCache
+	exec := executor.NewExecutorWithOptions(router, d, planOpts)
+	result, err := exec.ExecuteWithRelations(executor.NewContext(d.annotationHandler), q, inputRelations)
+	if err != nil {
+		return nil, fmt.Errorf("query execution failed: %w", err)
+	}
+
+	return result, nil
 }
 
 // Assert adds datoms in a single transaction.

--- a/datalog/storage/copy_annotation_test.go
+++ b/datalog/storage/copy_annotation_test.go
@@ -45,7 +45,7 @@ func TestJoinCopyAnnotationE2E(t *testing.T) {
                   :where [?p :person/name ?name]
                          [?p :person/dept ?dept]]`
 
-	results, err := db.ExecuteQuery(queryStr)
+	results, err := executor.CollectTuples(db.Query(queryStr))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}

--- a/datalog/storage/count_repro_test.go
+++ b/datalog/storage/count_repro_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 )
 
 func TestCountRepro_WithVector(t *testing.T) {
@@ -31,12 +32,12 @@ func TestCountRepro_WithVector(t *testing.T) {
 		events = append(events, e)
 	})
 
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
 		[][]any{
 			{person1, nameAttr},
 			{person1, contentAttr},
-		})
+		}))
 	require.NoError(t, err)
 
 	db.SetAnnotationHandler(nil)

--- a/datalog/storage/crdt_benchmark_test.go
+++ b/datalog/storage/crdt_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -368,7 +369,7 @@ func BenchmarkCRDTQuery(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			result, err := db.ExecuteQuery(`[:find ?e ?name :where [?e :person/name ?name]]`)
+			result, err := executor.CollectTuples(db.Query(`[:find ?e ?name :where [?e :person/name ?name]]`))
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -399,7 +400,7 @@ func BenchmarkCRDTQuery(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			result, err := db.ExecuteQuery(`[:find ?e ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
+			result, err := executor.CollectTuples(db.Query(`[:find ?e ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`))
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -431,7 +432,7 @@ func BenchmarkCRDTQuery(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			result, err := db.ExecuteQuery(`[:find ?e :where [?e :person/tags "common"]]`)
+			result, err := executor.CollectTuples(db.Query(`[:find ?e :where [?e :person/tags "common"]]`))
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -464,7 +465,7 @@ func BenchmarkCRDTQuery(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			result, err := db.ExecuteQuery(`[:find ?name ?skills :where [?e :person/name ?name] [?e :person/skills ?skills]]`)
+			result, err := executor.CollectTuples(db.Query(`[:find ?name ?skills :where [?e :person/name ?name] [?e :person/skills ?skills]]`))
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/datalog/storage/crdt_cache_matrix_test.go
+++ b/datalog/storage/crdt_cache_matrix_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -74,9 +75,9 @@ func TestCacheMatrix_AConstant(t *testing.T) {
 			}
 
 			// Pattern: A as constant (baseline - should work)
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e :where [?e :person/name ?v]]`,
-				personID)
+				personID))
 			require.NoError(t, err)
 			assert.Len(t, results, 1, "[%s] A as constant should return 1 result", mode.name)
 			if len(results) == 1 {
@@ -111,9 +112,9 @@ func TestCacheMatrix_AFromScalarInput(t *testing.T) {
 			}
 
 			// Pattern: A from scalar input
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-				personID, nameAttr)
+				personID, nameAttr))
 			require.NoError(t, err)
 			assert.Len(t, results, 1, "[%s] A from scalar input should return 1 result", mode.name)
 			if len(results) == 1 {
@@ -160,9 +161,9 @@ func TestCacheMatrix_AUnbound(t *testing.T) {
 			}
 
 			// Pattern: A completely unbound - should get 2 results (one per attribute)
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?a ?v :in $ ?e :where [?e ?a ?v]]`,
-				personID)
+				personID))
 			require.NoError(t, err)
 
 			// Should return 2 results: one for name (Charlie), one for age (30)
@@ -215,8 +216,8 @@ func TestCacheMatrix_EConstantAUnbound(t *testing.T) {
 			// This goes through matchUnboundAsRelation → chooseIndex with e != nil
 			// The bug was: chooseIndex used EAVT (V-before-Tx) for E-only case
 			// Fixed: now uses EATV (Tx-first) for proper CRDT resolution
-			results, err := db.ExecuteQuery(
-				`[:find ?a ?v :where ["person-1" ?a ?v]]`)
+			results, err := executor.CollectTuples(db.Query(
+				`[:find ?a ?v :where ["person-1" ?a ?v]]`))
 			require.NoError(t, err)
 
 			// Should return 2 results: one for name (Charlie), one for age (30)
@@ -280,9 +281,9 @@ func TestCacheMatrix_VOnlyBound(t *testing.T) {
 
 			// Pattern: ONLY V bound - "what entities/attributes reference leader?"
 			// This uses VAET index with per-datom cardinality resolution
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
-				leader)
+				leader))
 			require.NoError(t, err)
 
 			// Should return 2 results: emp1/:person/manager and proj1/:project/lead
@@ -344,9 +345,9 @@ func TestCacheMatrix_VOnlyBound_Supersede(t *testing.T) {
 			// Query: find all (E, A) where V = leader
 			// CRDT-resolved, emp-1/:person/manager is now "new-leader", NOT "leader"
 			// So only proj-1/:project/lead should be returned
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
-				leader)
+				leader))
 			require.NoError(t, err)
 
 			// Should return 1 result: ONLY proj1/:project/lead
@@ -457,9 +458,9 @@ func TestVOnlyBound_CardinalityMany_Retracted(t *testing.T) {
 
 			// Query: find all (E, A) where V = "go"
 			// Since "go" was retracted, should return nothing
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
-				"go")
+				"go"))
 			require.NoError(t, err)
 
 			// Should return 0 results - "go" was retracted
@@ -515,9 +516,9 @@ func TestVOnlyBound_MixedCardinality(t *testing.T) {
 			tx.Commit()
 
 			// Query: find all (E, A) where V = "Alice"
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
-				"Alice")
+				"Alice"))
 			require.NoError(t, err)
 
 			// Should return 1 result: emp-1/:person/tags
@@ -559,9 +560,9 @@ func TestVOnlyBound_Schemaless(t *testing.T) {
 
 			// Query: find all (E, A) where V = "test"
 			// Schemaless uses add-wins, so retracted value should not appear
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a :in $ ?v :where [?e ?a ?v]]`,
-				"test")
+				"test"))
 			require.NoError(t, err)
 
 			// Should return 0 results - value was retracted
@@ -610,9 +611,9 @@ func TestCacheMatrix_AVBound(t *testing.T) {
 
 			// Pattern: A and V bound - "who has manager-1 as :person/manager?"
 			// This uses AVET index
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e :in $ ?mgr :where [?e :person/manager ?mgr]]`,
-				manager)
+				manager))
 			require.NoError(t, err)
 
 			// Should return 2 results: emp1 and emp2
@@ -656,9 +657,9 @@ func TestCacheMatrix_EFromCollection_AFromScalar(t *testing.T) {
 			}
 
 			// Pattern: E from collection, A from scalar
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?v :in $ [?e ...] ?a :where [?e ?a ?v]]`,
-				entities, nameAttr)
+				entities, nameAttr))
 			require.NoError(t, err)
 
 			// Should return 3 results (one per entity, CRDT resolved)
@@ -707,9 +708,9 @@ func TestCacheMatrix_CardinalityMany(t *testing.T) {
 			expectedCount := 3 // Last set has 3 tags
 
 			// Query with A from scalar input
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-				personID, tagsAttr)
+				personID, tagsAttr))
 			require.NoError(t, err)
 
 			// Should return 3 results (current set members)
@@ -806,9 +807,9 @@ func TestCacheMatrix_AFromCollection(t *testing.T) {
 				datalog.NewKeyword(":person/name"),
 				datalog.NewKeyword(":person/age"),
 			}
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?a ?v :in $ ?e [?a ...] :where [?e ?a ?v]]`,
-				personID, attrs)
+				personID, attrs))
 			require.NoError(t, err)
 
 			// Should return 2 results: one for name (Charlie), one for age (30)
@@ -846,9 +847,9 @@ func TestCacheMatrix_AFromTupleInput(t *testing.T) {
 
 			// Pattern: E and A from tuple input [[?e ?a]]
 			// Tuple input syntax requires double brackets
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ [[?e ?a]] :where [?e ?a ?v]]`,
-				[]any{personID, nameAttr})
+				[]any{personID, nameAttr}))
 			require.NoError(t, err)
 
 			assert.Len(t, results, 1, "[%s] Tuple input should return 1 result", mode.name)
@@ -907,9 +908,9 @@ func TestCacheMatrix_AFromRelationInput(t *testing.T) {
 				{person1, nameAttr},
 				{person2, ageAttr},
 			}
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
-				relationInput)
+				relationInput))
 			require.NoError(t, err)
 
 			// Should return 2 results: person1's name (Charlie), person2's age (30)
@@ -958,11 +959,11 @@ func TestCacheMatrix_ABoundViaJoin(t *testing.T) {
 			tx.Commit()
 
 			// Pattern: A bound via join - get attribute from config, then use it
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?person ?config :where
 				  [?config :config/tracked-attr ?a]
 				  [?person ?a ?v]]`,
-				personID, configID)
+				personID, configID))
 			require.NoError(t, err)
 
 			// Should return 1 result (Charlie) - CRDT resolved
@@ -1020,9 +1021,9 @@ func TestCacheMatrix_EAndABothFromCollections(t *testing.T) {
 			}
 
 			// Pattern: Both E and A from collections
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a ?v :in $ [?e ...] [?a ...] :where [?e ?a ?v]]`,
-				entities, attrs)
+				entities, attrs))
 			require.NoError(t, err)
 
 			// Should return 4 results: 2 entities × 2 attributes
@@ -1080,12 +1081,12 @@ func TestCacheMatrix_WithNotClause(t *testing.T) {
 			tx.Commit()
 
 			// Query: find names of active people (using NOT to exclude inactive)
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?name :where
 				  [?e :person/name ?name]
 				  [?e :person/active true]
 				  (not [?e :person/active false])]`,
-			)
+			))
 			require.NoError(t, err)
 
 			// Should return 1 result (Charlie) - only active person's current name
@@ -1143,12 +1144,12 @@ func TestCacheMatrix_WithOrClause(t *testing.T) {
 			}
 
 			// Query: find names where status is "active" OR "pending"
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?name :where
 				  [?e :person/name ?name]
 				  (or [?e :person/status "active"]
 				      [?e :person/status "pending"])]`,
-			)
+			))
 			require.NoError(t, err)
 
 			// Should return 2 results (Person1-Final, Person2-Final)
@@ -1186,9 +1187,9 @@ func TestCacheMatrix_WithAggregation(t *testing.T) {
 			}
 
 			// Query: sum of all scores
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find (sum ?score) :where [?e :person/score ?score]]`,
-			)
+			))
 			require.NoError(t, err)
 
 			// Should sum only the CURRENT scores: 30 + 60 + 90 = 180
@@ -1244,9 +1245,9 @@ func TestCacheMatrix_CardinalityVector(t *testing.T) {
 			}
 
 			// Query with A from scalar input
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-				docID, contentAttr)
+				docID, contentAttr))
 			require.NoError(t, err)
 
 			// Should return 1 result (the resolved vector as a single value)
@@ -1297,19 +1298,19 @@ func TestCacheMatrix_ABoundViaSubquery(t *testing.T) {
 			tx.Commit()
 
 			// First verify the subquery works alone
-			subResults, err := db.ExecuteQueryWithInputs(
+			subResults, err := executor.CollectTuples(db.Query(
 				`[:find ?a :in $ ?c :where [?c :config/attr ?a]]`,
-				configID)
+				configID))
 			require.NoError(t, err)
 			t.Logf("[%s] Subquery results: %v", mode.name, subResults)
 
 			// Pattern: A bound via subquery using scalar binding
 			// The subquery returns a single attribute value
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?person ?config :where
 				  [(q [:find ?a . :in $ ?c :where [?c :config/attr ?a]] $ ?config) ?a]
 				  [?person ?a ?v]]`,
-				personID, configID)
+				personID, configID))
 			require.NoError(t, err)
 
 			// Should return 1 result (Charlie) - CRDT resolved
@@ -1349,9 +1350,9 @@ func TestCacheMatrix_AsOfQuery(t *testing.T) {
 			}
 
 			// First, query all values with their tx times to find the Lamport values
-			allResults, err := db.ExecuteQueryWithInputs(
+			allResults, err := executor.CollectTuples(db.Query(
 				`[:find ?v ?tx :in $ ?e ?a :where [?e ?a ?v ?tx]]`,
-				personID, nameAttr)
+				personID, nameAttr))
 			require.NoError(t, err)
 			t.Logf("[%s] All values with tx: %v", mode.name, allResults)
 
@@ -1377,9 +1378,9 @@ func TestCacheMatrix_AsOfQuery(t *testing.T) {
 			}
 
 			// Query as-of the first transaction - should return "Alice"
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				fmt.Sprintf(`[:find ?v :in $ ?e :where [?e :person/name ?v ?tx] [(as-of ?tx %d)]]`, aliceLamport),
-				personID)
+				personID))
 			require.NoError(t, err)
 
 			// as-of should return only values at or before that Lamport time
@@ -1435,9 +1436,9 @@ func TestCacheMatrix_SchemaAfterWrite(t *testing.T) {
 			db.SetSchema(s)
 
 			// Pattern: E bound, A unbound - entity browser pattern
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?a ?v :in $ ?e :where [?e ?a ?v]]`,
-				personID)
+				personID))
 			require.NoError(t, err)
 
 			// Should return 2 results: one for name (Charlie), one for age (30)
@@ -1511,7 +1512,7 @@ func TestCacheMatrix_AllUnbound(t *testing.T) {
 
 			// Pattern: All unbound - scans entire database
 			// This goes through matchUnboundAsRelation
-			results, err := db.ExecuteQuery(`[:find ?e ?a ?v :where [?e ?a ?v]]`)
+			results, err := executor.CollectTuples(db.Query(`[:find ?e ?a ?v :where [?e ?a ?v]]`))
 			require.NoError(t, err)
 
 			// Count only person entities (filter out tx:* system entities)

--- a/datalog/storage/crdt_one_remove_cache_test.go
+++ b/datalog/storage/crdt_one_remove_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -313,8 +314,8 @@ func TestCacheRemove_JoinBoundE_RoundTrip(t *testing.T) {
 
 	// Verify both exist via multi-clause query
 	// :person/city binds ?e, then :person/name resolves with bound E → cache path
-	results, err := db.ExecuteQuery(
-		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(
+		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	require.Len(t, results, 1, "precondition: should find 1 result")
 
@@ -325,8 +326,8 @@ func TestCacheRemove_JoinBoundE_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	// Multi-clause query → name clause should fail to match (tombstoned)
-	results, err = db.ExecuteQuery(
-		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`)
+	results, err = executor.CollectTuples(db.Query(
+		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	assert.Len(t, results, 0,
 		"BUG: join-bound query returns stale data after Remove(). "+
@@ -360,8 +361,8 @@ func TestCacheRemove_JoinBoundE_ThenReAdd(t *testing.T) {
 	require.NoError(t, err)
 
 	// Latest Add wins
-	results, err := db.ExecuteQuery(
-		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(
+		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	require.Len(t, results, 1, "should find 1 result after re-Add")
 	assert.Equal(t, "Bob", results[0][0])
@@ -391,8 +392,8 @@ func TestCacheRemove_JoinBoundE_MultipleEntities(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query: entity1 should not appear, entity2 should
-	results, err := db.ExecuteQuery(
-		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(
+		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	assert.Len(t, results, 1, "only entity2 should appear")
 	if len(results) == 1 {
@@ -422,8 +423,8 @@ func TestCacheRemove_JoinBoundE_VIsIrrelevant(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should return 0 results — name is tombstoned regardless of V
-	results, err := db.ExecuteQuery(
-		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(
+		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	assert.Len(t, results, 0,
 		"attribute should not exist — V is irrelevant for CardinalityOne Remove")
@@ -560,8 +561,8 @@ func TestCacheRemove_StaleInvalidation(t *testing.T) {
 			"Cache invalidation or rebuild doesn't handle tombstone.")
 
 	// Also verify via multi-clause join query
-	results, err := db.ExecuteQuery(
-		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(
+		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	assert.Len(t, results, 0,
 		"BUG: Join query returns stale cached data after Remove()")
@@ -629,8 +630,8 @@ func TestCacheRemove_JoinBoundE_SetThenRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	// Join query → absent
-	results, err := db.ExecuteQuery(
-		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(
+		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	assert.Len(t, results, 0,
 		"BUG: Join query returns value after Set() then Remove()")
@@ -700,8 +701,8 @@ func TestCacheRemove_JoinBoundE_AfterOverwrite(t *testing.T) {
 	require.NoError(t, err)
 
 	// Join query → absent
-	results, err := db.ExecuteQuery(
-		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(
+		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	assert.Len(t, results, 0,
 		"attribute should not exist after overwrite then Remove")
@@ -733,8 +734,8 @@ func TestCacheRemove_JoinBoundE_BeforeAnyAdd(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add has higher Tx, wins
-	results, err := db.ExecuteQuery(
-		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(
+		`[:find ?name ?city :where [?e :person/city ?city] [?e :person/name ?name]]`))
 	require.NoError(t, err)
 	require.Len(t, results, 1, "Add should win over earlier Remove")
 	assert.Equal(t, "Alice", results[0][0])

--- a/datalog/storage/crdt_one_remove_test.go
+++ b/datalog/storage/crdt_one_remove_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/query"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
@@ -54,10 +55,10 @@ func createCardinalityOneDB(t *testing.T) (*Database, func()) {
 // helper: run a bound query for a single attribute value
 func queryBoundValue(t *testing.T, db *Database, e datalog.Identity, a datalog.Keyword) [][]interface{} {
 	t.Helper()
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
 		e, a,
-	)
+	))
 	require.NoError(t, err)
 	return results
 }
@@ -65,9 +66,9 @@ func queryBoundValue(t *testing.T, db *Database, e datalog.Identity, a datalog.K
 // helper: run an unbound query and filter for a specific (E, A)
 func queryUnboundForEA(t *testing.T, db *Database, e datalog.Identity, a datalog.Keyword) [][]interface{} {
 	t.Helper()
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?a ?v :where [?e ?a ?v]]`,
-	)
+	))
 	require.NoError(t, err)
 
 	var filtered [][]interface{}
@@ -294,10 +295,10 @@ func TestCardinalityOneRemove_BoundQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Bound query with E and A from :in
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
 		e, a,
-	)
+	))
 	require.NoError(t, err)
 	assert.Len(t, results, 0, "bound query should return empty after Remove")
 }

--- a/datalog/storage/crdt_one_remove_test.go
+++ b/datalog/storage/crdt_one_remove_test.go
@@ -71,12 +71,12 @@ func queryUnboundForEA(t *testing.T, db *Database, e datalog.Identity, a datalog
 	require.NoError(t, err)
 
 	var filtered [][]interface{}
-	for _, row := range results {
-		if len(row) >= 3 {
-			if rowE, ok := row[0].(datalog.Identity); ok {
-				if rowA, ok := row[1].(datalog.Keyword); ok {
+	for _, tuple := range results {
+		if len(tuple) >= 3 {
+			if rowE, ok := tuple[0].(datalog.Identity); ok {
+				if rowA, ok := tuple[1].(datalog.Keyword); ok {
 					if rowE.Hash() == e.Hash() && rowA == a {
-						filtered = append(filtered, row)
+						filtered = append(filtered, tuple)
 					}
 				}
 			}

--- a/datalog/storage/crdt_orderedset_test.go
+++ b/datalog/storage/crdt_orderedset_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -182,10 +183,10 @@ func TestOrderedSet_QueryIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query returns vector as single array value
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?prefs :in $ ?e :where [?e :character/prefs ?prefs]]`,
 		alice,
-	)
+	))
 	require.NoError(t, err)
 
 	t.Logf("Query result: %v", tuples)

--- a/datalog/storage/crdt_query_resolution_test.go
+++ b/datalog/storage/crdt_query_resolution_test.go
@@ -36,7 +36,7 @@ import (
 func TestExecuteQueryWithInputs_CardinalityOne_ReturnsMultipleValues(t *testing.T) {
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dir,
+		Path: dir,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -108,7 +108,7 @@ func TestExecuteQueryWithInputs_CardinalityOne_ReturnsMultipleValues(t *testing.
 func TestExecuteQueryWithInputs_CardinalityMany_ReturnsAllHistoricalValues(t *testing.T) {
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dir,
+		Path: dir,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -187,7 +187,7 @@ func TestExecuteQueryWithInputs_CardinalityMany_ReturnsAllHistoricalValues(t *te
 func TestDirectMatch_VsExecuteQuery_CRDTResolution(t *testing.T) {
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dir,
+		Path: dir,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -277,8 +277,8 @@ func TestSchemaAwareness_InQueryExecution(t *testing.T) {
 
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dir,
-		Schema:    s,
+		Path:   dir,
+		Schema: s,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -308,7 +308,7 @@ func TestSchemaAwareness_InQueryExecution(t *testing.T) {
 func TestAllQueryMethods_CRDTResolution(t *testing.T) {
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dir,
+		Path: dir,
 	})
 	require.NoError(t, err)
 	defer db.Close()

--- a/datalog/storage/crdt_query_resolution_test.go
+++ b/datalog/storage/crdt_query_resolution_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/query"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
@@ -77,9 +78,9 @@ func TestExecuteQueryWithInputs_CardinalityOne_ReturnsMultipleValues(t *testing.
 	assert.Equal(t, expectedName, person.Name, "PullInto should return LWW-resolved value")
 
 	// THE BUG: ExecuteQueryWithInputs returns ALL historical values
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-		personID, nameAttr)
+		personID, nameAttr))
 	require.NoError(t, err)
 
 	t.Logf("ExecuteQueryWithInputs returned %d results: %v", len(results), results)
@@ -158,9 +159,9 @@ func TestExecuteQueryWithInputs_CardinalityMany_ReturnsAllHistoricalValues(t *te
 	t.Logf("PullInto returned tags: %v", person.Tags)
 
 	// THE BUG: ExecuteQueryWithInputs returns ALL ever-added tags
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-		personID, tagsAttr)
+		personID, tagsAttr))
 	require.NoError(t, err)
 
 	t.Logf("ExecuteQueryWithInputs returned %d results", len(results))
@@ -249,9 +250,9 @@ func TestDirectMatch_VsExecuteQuery_CRDTResolution(t *testing.T) {
 	}
 
 	// Also test ExecuteQueryWithInputs for comparison
-	queryResults, err := db.ExecuteQueryWithInputs(
+	queryResults, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-		personID, nameAttr)
+		personID, nameAttr))
 	require.NoError(t, err)
 
 	t.Logf("ExecuteQueryWithInputs returned %d results", len(queryResults))
@@ -427,8 +428,8 @@ func TestAllQueryMethods_CRDTResolution(t *testing.T) {
 	// 4. ExecuteQuery (basic, no inputs)
 	t.Run("ExecuteQuery", func(t *testing.T) {
 		// Use a query that doesn't need inputs by hardcoding the entity lookup
-		queryResults, err := db.ExecuteQuery(
-			`[:find ?v :where [?e :person/name ?v]]`)
+		queryResults, err := executor.CollectTuples(db.Query(
+			`[:find ?v :where [?e :person/name ?v]]`))
 		require.NoError(t, err)
 
 		count := len(queryResults)
@@ -444,9 +445,9 @@ func TestAllQueryMethods_CRDTResolution(t *testing.T) {
 
 	// 5. ExecuteQueryWithInputs (known broken)
 	t.Run("ExecuteQueryWithInputs", func(t *testing.T) {
-		queryResults, err := db.ExecuteQueryWithInputs(
+		queryResults, err := executor.CollectTuples(db.Query(
 			`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-			personID, nameAttr)
+			personID, nameAttr))
 		require.NoError(t, err)
 
 		count := len(queryResults)
@@ -460,9 +461,9 @@ func TestAllQueryMethods_CRDTResolution(t *testing.T) {
 		t.Logf("ExecuteQueryWithInputs: %d results, correct=%v", count, correct)
 	})
 
-	// 6. ExecuteQueryRelation
-	t.Run("ExecuteQueryRelation", func(t *testing.T) {
-		rel, err := db.ExecuteQueryRelation(
+	// 6. Query (streaming Relation)
+	t.Run("Query", func(t *testing.T) {
+		rel, err := db.Query(
 			`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
 			personID, nameAttr)
 		require.NoError(t, err)
@@ -476,8 +477,8 @@ func TestAllQueryMethods_CRDTResolution(t *testing.T) {
 		}
 
 		correct := count == 1
-		results = append(results, methodResult{"ExecuteQueryRelation", count, value, correct})
-		t.Logf("ExecuteQueryRelation: %d results, correct=%v", count, correct)
+		results = append(results, methodResult{"Query", count, value, correct})
+		t.Logf("Query (streaming): %d results, correct=%v", count, correct)
 	})
 
 	// 7. QueryInto

--- a/datalog/storage/crdt_schemaless_attr_test.go
+++ b/datalog/storage/crdt_schemaless_attr_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/query"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
@@ -49,10 +50,10 @@ func TestSchemalessAttrBoundQuery_BugRepro(t *testing.T) {
 			require.NoError(t, err)
 
 			// Bound query — should find the data
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
 				entityID, datalog.NewKeyword(":module/input"),
-			)
+			))
 			require.NoError(t, err)
 
 			assert.Len(t, results, 1,
@@ -90,9 +91,9 @@ func TestSchemalessAttrUnboundQuery_BugRepro(t *testing.T) {
 			require.NoError(t, err)
 
 			// Unbound query — should find the data
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a ?v :where [?e ?a ?v]]`,
-			)
+			))
 			require.NoError(t, err)
 
 			// Should find at least the schemaless attribute
@@ -142,10 +143,10 @@ func TestSchemalessAttrMultipleWrites(t *testing.T) {
 			}
 
 			// Bound query — schemaless = CardinalityOne (LWW), only latest value
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
 				entityID, datalog.NewKeyword(":test/counter"),
-			)
+			))
 			require.NoError(t, err)
 
 			require.Len(t, results, 1,
@@ -154,9 +155,9 @@ func TestSchemalessAttrMultipleWrites(t *testing.T) {
 				"[%s] Latest value should be 2 (third write)", mode.name)
 
 			// Unbound query should also return only latest
-			unboundResults, err := db.ExecuteQueryWithInputs(
+			unboundResults, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a ?v :where [?e ?a ?v]]`,
-			)
+			))
 			require.NoError(t, err)
 
 			var counterValues []any
@@ -210,10 +211,10 @@ func TestSchemalessRemove_RoundTrip(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify exists
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
 				entityID, attr,
-			)
+			))
 			require.NoError(t, err)
 			require.Len(t, results, 1, "[%s] value should exist after Add", mode.name)
 
@@ -224,18 +225,18 @@ func TestSchemalessRemove_RoundTrip(t *testing.T) {
 			require.NoError(t, err)
 
 			// Bound query → attribute doesn't exist
-			results, err = db.ExecuteQueryWithInputs(
+			results, err = executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
 				entityID, attr,
-			)
+			))
 			require.NoError(t, err)
 			assert.Len(t, results, 0,
 				"[%s] bound query: schemaless attribute should not exist after Remove", mode.name)
 
 			// Unbound query → also doesn't exist
-			unboundResults, err := db.ExecuteQueryWithInputs(
+			unboundResults, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a ?v :where [?e ?a ?v]]`,
-			)
+			))
 			require.NoError(t, err)
 			for _, tuple := range unboundResults {
 				if len(tuple) >= 3 {
@@ -279,10 +280,10 @@ func TestSchemalessRemove_ThenReAdd(t *testing.T) {
 			require.NoError(t, err)
 
 			// Latest Add wins
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
 				entityID, attr,
-			)
+			))
 			require.NoError(t, err)
 			require.Len(t, results, 1, "[%s] attribute should exist after re-Add", mode.name)
 			assert.Equal(t, "second", results[0][0],
@@ -327,10 +328,10 @@ func TestSchemalessAttr_UnregisteredDefaultsToCardinalityOne(t *testing.T) {
 			require.NoError(t, err)
 
 			// Only latest value returned (LWW)
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
 				entityID, attr,
-			)
+			))
 			require.NoError(t, err)
 			require.Len(t, results, 1,
 				"[%s] unregistered attr defaults to CardinalityOne: only latest", mode.name)
@@ -343,10 +344,10 @@ func TestSchemalessAttr_UnregisteredDefaultsToCardinalityOne(t *testing.T) {
 			_, err = tx4.Commit()
 			require.NoError(t, err)
 
-			results, err = db.ExecuteQueryWithInputs(
+			results, err = executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`,
 				entityID, attr,
-			)
+			))
 			require.NoError(t, err)
 			assert.Len(t, results, 0,
 				"[%s] unregistered attr Remove should work", mode.name)

--- a/datalog/storage/crdt_schemaless_attr_test.go
+++ b/datalog/storage/crdt_schemaless_attr_test.go
@@ -97,12 +97,12 @@ func TestSchemalessAttrUnboundQuery_BugRepro(t *testing.T) {
 
 			// Should find at least the schemaless attribute
 			found := false
-			for _, row := range results {
-				if len(row) >= 3 {
-					if kw, ok := row[1].(datalog.Keyword); ok {
+			for _, tuple := range results {
+				if len(tuple) >= 3 {
+					if kw, ok := tuple[1].(datalog.Keyword); ok {
 						if kw.String() == ":test/data" {
 							found = true
-							assert.Equal(t, "hello", row[2],
+							assert.Equal(t, "hello", tuple[2],
 								"[%s] Should find correct value for schemaless attr", mode.name)
 						}
 					}
@@ -160,11 +160,11 @@ func TestSchemalessAttrMultipleWrites(t *testing.T) {
 			require.NoError(t, err)
 
 			var counterValues []any
-			for _, row := range unboundResults {
-				if len(row) >= 3 {
-					if kw, ok := row[1].(datalog.Keyword); ok {
+			for _, tuple := range unboundResults {
+				if len(tuple) >= 3 {
+					if kw, ok := tuple[1].(datalog.Keyword); ok {
 						if kw.String() == ":test/counter" {
-							counterValues = append(counterValues, row[2])
+							counterValues = append(counterValues, tuple[2])
 						}
 					}
 				}
@@ -237,9 +237,9 @@ func TestSchemalessRemove_RoundTrip(t *testing.T) {
 				`[:find ?e ?a ?v :where [?e ?a ?v]]`,
 			)
 			require.NoError(t, err)
-			for _, row := range unboundResults {
-				if len(row) >= 3 {
-					if kw, ok := row[1].(datalog.Keyword); ok {
+			for _, tuple := range unboundResults {
+				if len(tuple) >= 3 {
+					if kw, ok := tuple[1].(datalog.Keyword); ok {
 						assert.NotEqual(t, ":test/data", kw.String(),
 							"[%s] unbound query should not find removed schemaless attribute", mode.name)
 					}

--- a/datalog/storage/crdt_vector_test.go
+++ b/datalog/storage/crdt_vector_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -504,7 +505,7 @@ func TestVectorQueryIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query for entities with skills (should return both)
-	results, err := db.ExecuteQuery(`[:find ?name :where [?e :character/name ?name] [?e :character/skills ?skills]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name :where [?e :character/name ?name] [?e :character/skills ?skills]]`))
 	require.NoError(t, err)
 	require.Len(t, results, 2, "should find both characters with skills")
 
@@ -545,7 +546,7 @@ func TestVectorQueryWithBoundEntity(t *testing.T) {
 	require.NoError(t, err)
 
 	// First verify basic query works
-	basicResults, err := db.ExecuteQuery(`[:find ?name :where [?e :character/name ?name]]`)
+	basicResults, err := executor.CollectTuples(db.Query(`[:find ?name :where [?e :character/name ?name]]`))
 	require.NoError(t, err)
 	t.Logf("Basic query results: %d tuples", len(basicResults))
 	for i, tuple := range basicResults {
@@ -560,7 +561,7 @@ func TestVectorQueryWithBoundEntity(t *testing.T) {
 
 	// Query with E bound via join - this binds ?e first, then queries skills
 	// Pattern: [?e :name "Alice"] binds ?e, then [?e :skills ?skills] has E bound
-	results, err := db.ExecuteQuery(`[:find ?skills :where [?e :character/name "Alice"] [?e :character/skills ?skills]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?skills :where [?e :character/name "Alice"] [?e :character/skills ?skills]]`))
 	require.NoError(t, err, "query with bound E should not error")
 
 	t.Logf("Vector query results count: %d", len(results))
@@ -608,7 +609,7 @@ func TestVectorQueryProjectSkills(t *testing.T) {
 
 	// Query that projects the skills variable directly
 	// This tests whether vector values can be returned from queries
-	results, err := db.ExecuteQuery(`[:find ?skills :where [?e :character/skills ?skills]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?skills :where [?e :character/skills ?skills]]`))
 	require.NoError(t, err, "query for vector values should not error")
 
 	// Log what we actually get for debugging
@@ -652,7 +653,7 @@ func TestVectorQueryNameAndSkills(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query that joins name with skills and projects both
-	results, err := db.ExecuteQuery(`[:find ?name ?skills :where [?e :character/name ?name] [?e :character/skills ?skills]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name ?skills :where [?e :character/name ?name] [?e :character/skills ?skills]]`))
 	require.NoError(t, err, "join query should not error")
 
 	t.Logf("Results count: %d", len(results))
@@ -702,7 +703,7 @@ func TestVectorPullIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use Pull API to get skills
-	results, err := db.ExecuteQuery(`[:find (pull ?e [:character/name :character/skills]) :where [?e :character/name "Alice"]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find (pull ?e [:character/name :character/skills]) :where [?e :character/name "Alice"]]`))
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -1284,12 +1285,12 @@ func TestVectorEnumerateQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	// enumerate should expand the vector into 3 tuples, one per element
-	results, err := db.ExecuteQuery(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?idx ?tag
 		  :where
 		  [?e :product/label "Widget"]
 		  [?e :product/tags ?vec]
-		  [(enumerate ?vec) [?idx ?tag]]]`)
+		  [(enumerate ?vec) [?idx ?tag]]]`))
 	require.NoError(t, err)
 	require.Len(t, results, 3, "enumerate should produce one tuple per vector element")
 
@@ -1342,12 +1343,12 @@ func TestVectorEnumerateMultipleEntities(t *testing.T) {
 
 	// Each entity's vector should expand independently:
 	// Widget: 2 tags, Gadget: 1 tag → 3 total tuples
-	results, err := db.ExecuteQuery(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?label ?tag
 		  :where
 		  [?e :product/label ?label]
 		  [?e :product/tags ?vec]
-		  [(enumerate ?vec) [?idx ?tag]]]`)
+		  [(enumerate ?vec) [?idx ?tag]]]`))
 	require.NoError(t, err)
 	require.Len(t, results, 3, "should get Widget's 2 tags + Gadget's 1 tag = 3 tuples")
 
@@ -1423,7 +1424,7 @@ func TestVectorEnumerateRefWithFilter(t *testing.T) {
 
 	// Query: enumerate folder items, filter to red only
 	// Should return only Folder-A's red item, NOT Folder-B
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?folderName ?itemLabel
 		  :in $ ?color
 		  :where
@@ -1432,7 +1433,7 @@ func TestVectorEnumerateRefWithFilter(t *testing.T) {
 		  [(enumerate ?vec) [?idx ?item]]
 		  [?item :item/color ?color]
 		  [?item :item/label ?itemLabel]]`,
-		red)
+		red))
 	require.NoError(t, err)
 	require.Len(t, results, 1, "only Folder-A has a red item")
 	assert.Equal(t, "Folder-A", results[0][0].(string))
@@ -1499,7 +1500,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Step 1: Without instance joins (should work — proven by TestVectorEnumerateRefWithFilter)
-	r1, err := db.ExecuteQueryWithInputs(
+	r1, err := executor.CollectTuples(db.Query(
 		`[:find ?folderName ?itemLabel
 		  :in $ ?color
 		  :where
@@ -1508,13 +1509,13 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [(enumerate ?vec) [?idx ?item]]
 		  [?item :item/color ?color]
 		  [?item :item/label ?itemLabel]]`,
-		red)
+		red))
 	require.NoError(t, err)
 	t.Logf("step1 (no instance joins): %d tuples: %v", len(r1), r1)
 	require.Len(t, r1, 1, "step1: only Folder-A has a red item")
 
 	// Step 2: Add instance→template join but no :in room filter
-	r2, err := db.ExecuteQuery(
+	r2, err := executor.CollectTuples(db.Query(
 		`[:find ?folderName ?itemLabel
 		  :where
 		  [?inst :instance/template ?folder]
@@ -1522,13 +1523,13 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?folder :folder/items ?vec]
 		  [(enumerate ?vec) [?idx ?item]]
 		  [?item :item/color :color/red]
-		  [?item :item/label ?itemLabel]]`)
+		  [?item :item/label ?itemLabel]]`))
 	require.NoError(t, err)
 	t.Logf("step2 (instance join, inline color): %d tuples: %v", len(r2), r2)
 	require.Len(t, r2, 1, "step2: only Folder-A has a red item")
 
 	// Step 2b: Instance join + :in color (no :in room)
-	r2b, err := db.ExecuteQueryWithInputs(
+	r2b, err := executor.CollectTuples(db.Query(
 		`[:find ?folderName ?itemLabel
 		  :in $ ?color
 		  :where
@@ -1538,13 +1539,13 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [(enumerate ?vec) [?idx ?item]]
 		  [?item :item/color ?color]
 		  [?item :item/label ?itemLabel]]`,
-		red)
+		red))
 	require.NoError(t, err)
 	t.Logf("step2b (instance join, :in color): %d tuples: %v", len(r2b), r2b)
 	require.Len(t, r2b, 1, "step2b: only Folder-A has a red item")
 
 	// Step 2c: Instance join + :in room + inline color
-	r2c, err := db.ExecuteQueryWithInputs(
+	r2c, err := executor.CollectTuples(db.Query(
 		`[:find ?folderName ?itemLabel
 		  :in $ ?room
 		  :where
@@ -1555,13 +1556,13 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [(enumerate ?vec) [?idx ?item]]
 		  [?item :item/color :color/red]
 		  [?item :item/label ?itemLabel]]`,
-		room)
+		room))
 	require.NoError(t, err)
 	t.Logf("step2c (instance join, :in room, inline color): %d tuples: %v", len(r2c), r2c)
 	require.Len(t, r2c, 1, "step2c: only Folder-A has a red item")
 
 	// Step 2d: Enumerate only (no color filter) with both :in params
-	r2d, err := db.ExecuteQueryWithInputs(
+	r2d, err := executor.CollectTuples(db.Query(
 		`[:find ?folderName ?itemLabel ?idx
 		  :in $ ?room ?color
 		  :where
@@ -1572,7 +1573,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?folder :folder/items ?vec]
 		  [(enumerate ?vec) [?idx ?item]]
 		  [?item :item/label ?itemLabel]]`,
-		room, red)
+		room, red))
 	require.NoError(t, err)
 	t.Logf("step2d (enumerate only, both :in params, no color filter): %d tuples: %v", len(r2d), r2d)
 
@@ -1586,7 +1587,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 				event.Data["left.size"], event.Data["right.size"], event.Data["result.size"])
 		}
 	})
-	r2e, err := db.ExecuteQueryWithInputs(
+	r2e, err := executor.CollectTuples(db.Query(
 		`[:find ?folderName ?item ?color
 		  :in $ ?room ?color
 		  :where
@@ -1597,7 +1598,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?folder :folder/items ?vec]
 		  [(enumerate ?vec) [?idx ?item]]
 		  [?item :item/color ?color]]`,
-		room, red)
+		room, red))
 	require.NoError(t, err)
 	for i, tuple := range r2e {
 		t.Logf("step2e tuple[%d]: folderName=%v item=%v color=%v", i, tuple[0], tuple[1], tuple[2])
@@ -1606,7 +1607,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 	db.SetAnnotationHandler(nil) // disable after step2e
 
 	// Step 3: Full query with :in room and color
-	r3, err := db.ExecuteQueryWithInputs(
+	r3, err := executor.CollectTuples(db.Query(
 		`[:find ?folderName ?itemLabel
 		  :in $ ?room ?color
 		  :where
@@ -1618,7 +1619,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [(enumerate ?vec) [?idx ?item]]
 		  [?item :item/color ?color]
 		  [?item :item/label ?itemLabel]]`,
-		room, red)
+		room, red))
 	require.NoError(t, err)
 	t.Logf("step3 (full query): %d tuples: %v", len(r3), r3)
 	require.Len(t, r3, 1, "step3: only Folder-A has a red item")
@@ -1732,7 +1733,7 @@ func TestPlannerReordersDataPatternBeforeEnumerate(t *testing.T) {
 	// so it scans ALL items with color=red. The join with the accumulated relation
 	// is on ?color only (not ?item), creating a cross-product: every container gets
 	// ?item=redItem regardless of what's actually in its vector.
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?name ?label
 		  :in $ ?room ?color
 		  :where
@@ -1742,7 +1743,7 @@ func TestPlannerReordersDataPatternBeforeEnumerate(t *testing.T) {
 		  [(enumerate ?vec) [?idx ?item]]
 		  [?item :item/color ?color]
 		  [?item :item/label ?label]]`,
-		room, red)
+		room, red))
 	require.NoError(t, err)
 	t.Logf("tuples: %v", tuples)
 	require.Len(t, tuples, 1, "only container A has a red item; container B has blue")

--- a/datalog/storage/crdt_vector_test.go
+++ b/datalog/storage/crdt_vector_test.go
@@ -510,8 +510,8 @@ func TestVectorQueryIntegration(t *testing.T) {
 
 	// Verify both names are present (order not guaranteed)
 	names := make(map[string]bool)
-	for _, row := range results {
-		names[row[0].(string)] = true
+	for _, tuple := range results {
+		names[tuple[0].(string)] = true
 	}
 	assert.True(t, names["Alice"])
 	assert.True(t, names["Bob"])
@@ -547,9 +547,9 @@ func TestVectorQueryWithBoundEntity(t *testing.T) {
 	// First verify basic query works
 	basicResults, err := db.ExecuteQuery(`[:find ?name :where [?e :character/name ?name]]`)
 	require.NoError(t, err)
-	t.Logf("Basic query results: %d rows", len(basicResults))
-	for i, row := range basicResults {
-		t.Logf("  Basic row %d: %v", i, row)
+	t.Logf("Basic query results: %d tuples", len(basicResults))
+	for i, tuple := range basicResults {
+		t.Logf("  Basic tuple %d: %v", i, tuple)
 	}
 
 	// Check if LookupAttribute still works
@@ -564,12 +564,12 @@ func TestVectorQueryWithBoundEntity(t *testing.T) {
 	require.NoError(t, err, "query with bound E should not error")
 
 	t.Logf("Vector query results count: %d", len(results))
-	for i, row := range results {
-		t.Logf("  Row %d: %v (type: %T)", i, row[0], row[0])
+	for i, tuple := range results {
+		t.Logf("  Tuple %d: %v (type: %T)", i, tuple[0], tuple[0])
 	}
 
-	// With E bound via join, should return 1 row with the vector
-	require.Len(t, results, 1, "should return 1 row with vector")
+	// With E bound via join, should return 1 tuple with the vector
+	require.Len(t, results, 1, "should return 1 tuple with vector")
 
 	// The value should be a slice, not raw bytes
 	vec, ok := results[0][0].([]interface{})
@@ -613,13 +613,13 @@ func TestVectorQueryProjectSkills(t *testing.T) {
 
 	// Log what we actually get for debugging
 	t.Logf("Results count: %d", len(results))
-	for i, row := range results {
-		t.Logf("  Row %d: %v (type: %T)", i, row[0], row[0])
+	for i, tuple := range results {
+		t.Logf("  Tuple %d: %v (type: %T)", i, tuple[0], tuple[0])
 	}
 
 	// The behavior here depends on implementation:
 	// Option A: Returns the whole vector as one result
-	// Option B: Returns each element as separate rows
+	// Option B: Returns each element as separate tuples
 	// Either is valid, but we need to verify SOMETHING works
 	require.NotEmpty(t, results, "should return some results for vector query")
 }
@@ -656,16 +656,16 @@ func TestVectorQueryNameAndSkills(t *testing.T) {
 	require.NoError(t, err, "join query should not error")
 
 	t.Logf("Results count: %d", len(results))
-	for i, row := range results {
-		t.Logf("  Row %d: name=%v, skills=%v (type: %T)", i, row[0], row[1], row[1])
+	for i, tuple := range results {
+		t.Logf("  Tuple %d: name=%v, skills=%v (type: %T)", i, tuple[0], tuple[1], tuple[1])
 	}
 
 	require.NotEmpty(t, results, "should return some results for join query")
 
 	// Verify Alice is in the results
 	foundAlice := false
-	for _, row := range results {
-		if row[0] == "Alice" {
+	for _, tuple := range results {
+		if tuple[0] == "Alice" {
 			foundAlice = true
 		}
 	}
@@ -1257,7 +1257,7 @@ func TestVectorSetFromEmpty(t *testing.T) {
 }
 
 // TestVectorEnumerateQuery verifies that [(enumerate ?vec) [?idx ?val]] expands
-// a vector into multiple result rows in a Datalog query.
+// a vector into multiple result tuples in a Datalog query.
 func TestVectorEnumerateQuery(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "vector-enumerate-query-test")
 	require.NoError(t, err)
@@ -1283,7 +1283,7 @@ func TestVectorEnumerateQuery(t *testing.T) {
 	_, err = tx.Commit()
 	require.NoError(t, err)
 
-	// enumerate should expand the vector into 3 rows, one per element
+	// enumerate should expand the vector into 3 tuples, one per element
 	results, err := db.ExecuteQuery(
 		`[:find ?idx ?tag
 		  :where
@@ -1291,7 +1291,7 @@ func TestVectorEnumerateQuery(t *testing.T) {
 		  [?e :product/tags ?vec]
 		  [(enumerate ?vec) [?idx ?tag]]]`)
 	require.NoError(t, err)
-	require.Len(t, results, 3, "enumerate should produce one row per vector element")
+	require.Len(t, results, 3, "enumerate should produce one tuple per vector element")
 
 	// Verify index-value pairs
 	type pair struct {
@@ -1299,10 +1299,10 @@ func TestVectorEnumerateQuery(t *testing.T) {
 		tag string
 	}
 	var pairs []pair
-	for _, row := range results {
+	for _, tuple := range results {
 		pairs = append(pairs, pair{
-			idx: row[0].(int64),
-			tag: row[1].(string),
+			idx: tuple[0].(int64),
+			tag: tuple[1].(string),
 		})
 	}
 
@@ -1341,7 +1341,7 @@ func TestVectorEnumerateMultipleEntities(t *testing.T) {
 	require.NoError(t, err)
 
 	// Each entity's vector should expand independently:
-	// Widget: 2 tags, Gadget: 1 tag → 3 total rows
+	// Widget: 2 tags, Gadget: 1 tag → 3 total tuples
 	results, err := db.ExecuteQuery(
 		`[:find ?label ?tag
 		  :where
@@ -1349,13 +1349,13 @@ func TestVectorEnumerateMultipleEntities(t *testing.T) {
 		  [?e :product/tags ?vec]
 		  [(enumerate ?vec) [?idx ?tag]]]`)
 	require.NoError(t, err)
-	require.Len(t, results, 3, "should get Widget's 2 tags + Gadget's 1 tag = 3 rows")
+	require.Len(t, results, 3, "should get Widget's 2 tags + Gadget's 1 tag = 3 tuples")
 
 	// Count per product
 	productTags := make(map[string][]string)
-	for _, row := range results {
-		label := row[0].(string)
-		tag := row[1].(string)
+	for _, tuple := range results {
+		label := tuple[0].(string)
+		tag := tuple[1].(string)
 		productTags[label] = append(productTags[label], tag)
 	}
 
@@ -1510,7 +1510,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?item :item/label ?itemLabel]]`,
 		red)
 	require.NoError(t, err)
-	t.Logf("step1 (no instance joins): %d rows: %v", len(r1), r1)
+	t.Logf("step1 (no instance joins): %d tuples: %v", len(r1), r1)
 	require.Len(t, r1, 1, "step1: only Folder-A has a red item")
 
 	// Step 2: Add instance→template join but no :in room filter
@@ -1524,7 +1524,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?item :item/color :color/red]
 		  [?item :item/label ?itemLabel]]`)
 	require.NoError(t, err)
-	t.Logf("step2 (instance join, inline color): %d rows: %v", len(r2), r2)
+	t.Logf("step2 (instance join, inline color): %d tuples: %v", len(r2), r2)
 	require.Len(t, r2, 1, "step2: only Folder-A has a red item")
 
 	// Step 2b: Instance join + :in color (no :in room)
@@ -1540,7 +1540,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?item :item/label ?itemLabel]]`,
 		red)
 	require.NoError(t, err)
-	t.Logf("step2b (instance join, :in color): %d rows: %v", len(r2b), r2b)
+	t.Logf("step2b (instance join, :in color): %d tuples: %v", len(r2b), r2b)
 	require.Len(t, r2b, 1, "step2b: only Folder-A has a red item")
 
 	// Step 2c: Instance join + :in room + inline color
@@ -1557,7 +1557,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?item :item/label ?itemLabel]]`,
 		room)
 	require.NoError(t, err)
-	t.Logf("step2c (instance join, :in room, inline color): %d rows: %v", len(r2c), r2c)
+	t.Logf("step2c (instance join, :in room, inline color): %d tuples: %v", len(r2c), r2c)
 	require.Len(t, r2c, 1, "step2c: only Folder-A has a red item")
 
 	// Step 2d: Enumerate only (no color filter) with both :in params
@@ -1574,7 +1574,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?item :item/label ?itemLabel]]`,
 		room, red)
 	require.NoError(t, err)
-	t.Logf("step2d (enumerate only, both :in params, no color filter): %d rows: %v", len(r2d), r2d)
+	t.Logf("step2d (enumerate only, both :in params, no color filter): %d tuples: %v", len(r2d), r2d)
 
 	// Step 2e: Without label join — just enumerate + color filter, find ?item entity
 	// Enable annotation tracing for this query
@@ -1599,10 +1599,10 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?item :item/color ?color]]`,
 		room, red)
 	require.NoError(t, err)
-	for i, row := range r2e {
-		t.Logf("step2e row[%d]: folderName=%v item=%v color=%v", i, row[0], row[1], row[2])
+	for i, tuple := range r2e {
+		t.Logf("step2e tuple[%d]: folderName=%v item=%v color=%v", i, tuple[0], tuple[1], tuple[2])
 	}
-	t.Logf("step2e (enumerate + color filter, find ?item): %d rows", len(r2e))
+	t.Logf("step2e (enumerate + color filter, find ?item): %d tuples", len(r2e))
 	db.SetAnnotationHandler(nil) // disable after step2e
 
 	// Step 3: Full query with :in room and color
@@ -1620,7 +1620,7 @@ func TestVectorEnumerateRefWithJoinsAndFilter(t *testing.T) {
 		  [?item :item/label ?itemLabel]]`,
 		room, red)
 	require.NoError(t, err)
-	t.Logf("step3 (full query): %d rows: %v", len(r3), r3)
+	t.Logf("step3 (full query): %d tuples: %v", len(r3), r3)
 	require.Len(t, r3, 1, "step3: only Folder-A has a red item")
 	assert.Equal(t, "Folder-A", r3[0][0].(string))
 	assert.Equal(t, "Apple", r3[0][1].(string))
@@ -1732,7 +1732,7 @@ func TestPlannerReordersDataPatternBeforeEnumerate(t *testing.T) {
 	// so it scans ALL items with color=red. The join with the accumulated relation
 	// is on ?color only (not ?item), creating a cross-product: every container gets
 	// ?item=redItem regardless of what's actually in its vector.
-	rows, err := db.ExecuteQueryWithInputs(
+	tuples, err := db.ExecuteQueryWithInputs(
 		`[:find ?name ?label
 		  :in $ ?room ?color
 		  :where
@@ -1744,8 +1744,8 @@ func TestPlannerReordersDataPatternBeforeEnumerate(t *testing.T) {
 		  [?item :item/label ?label]]`,
 		room, red)
 	require.NoError(t, err)
-	t.Logf("rows: %v", rows)
-	require.Len(t, rows, 1, "only container A has a red item; container B has blue")
-	assert.Equal(t, "A", rows[0][0])
-	assert.Equal(t, "Apple", rows[0][1])
+	t.Logf("tuples: %v", tuples)
+	require.Len(t, tuples, 1, "only container A has a red item; container B has blue")
+	assert.Equal(t, "A", tuples[0][0])
+	assert.Equal(t, "Apple", tuples[0][1])
 }

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -313,7 +313,7 @@ func (d *Database) AnnotationHandler() annotations.Handler {
 }
 
 // SetAnnotationHandler sets a handler for query tracing and performance observability.
-// When set, all queries executed via ExecuteQueryWithInputs will emit annotation events.
+// When set, all queries executed via Query will emit annotation events.
 // Pass nil to disable annotations.
 //
 // Example:
@@ -590,129 +590,6 @@ func extractQueryOptions(inputs []interface{}) (queryOptions, []interface{}) {
 	return opts, regularInputs
 }
 
-// ExecuteQuery executes a Datalog query and returns results as a slice of tuples.
-// The query can be either an EDN string or a *query.Query from the query builder.
-//
-// Example with string:
-//
-//	results, err := db.ExecuteQuery(`[:find ?name :where [?e :person/name ?name]]`)
-//
-// Example with query builder:
-//
-//	e, name := qb.NewVar("e"), qb.NewVar("name")
-//	q := qb.Query().Find(name).Where(qb.Pat(e, PersonName, name)).MustBuild()
-//	results, err := db.ExecuteQuery(q)
-func (d *Database) ExecuteQuery(q interface{}) ([][]interface{}, error) {
-	return d.ExecuteQueryWithInputs(q)
-}
-
-// ExecuteQueryWithInputs executes a parameterized Datalog query with input parameters.
-// The query can be either an EDN string or a *query.Query from the query builder.
-// This provides type-safe query execution without string formatting.
-//
-// Input parameters are matched with the :in clause in order (after the $ database parameter):
-//   - Scalar inputs: ?name
-//   - Collection inputs: [?foods ...]
-//   - Tuple inputs: [[?name ?age]]
-//   - Relation inputs: [[?name ?age] ...]
-//
-// Examples:
-//
-//	// Scalar input with string query
-//	results, err := db.ExecuteQueryWithInputs(
-//	    `[:find ?e :in $ ?name :where [?e :person/name ?name]]`,
-//	    "Alice",
-//	)
-//
-//	// Scalar input with query builder
-//	e, name, minAge := qb.NewVar("e"), qb.NewVar("name"), qb.NewVar("minAge")
-//	q := qb.Query().Find(e).In(qb.DB, qb.Scalar(minAge)).Where(...).MustBuild()
-//	results, err := db.ExecuteQueryWithInputs(q, 25)
-//
-//	// Collection input
-//	results, err := db.ExecuteQueryWithInputs(
-//	    `[:find ?e ?food :in $ [?food ...] :where [?e :person/likes ?food]]`,
-//	    []string{"pizza", "pasta"},
-//	)
-func (d *Database) ExecuteQueryWithInputs(queryInput interface{}, inputs ...interface{}) ([][]interface{}, error) {
-	// Separate QueryOptions from regular inputs
-	opts, regularInputs := extractQueryOptions(inputs)
-
-	// Resolve the query (string or *query.Query)
-	q, err := resolveQuery(queryInput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve query: %w", err)
-	}
-
-	// Build source map — database is always $
-	sources := buildSourceMap(opts.sources, d.Matcher())
-
-	// Validate declared sources exist
-	if err := validateQuerySources(q, sources); err != nil {
-		return nil, err
-	}
-
-	// Create SourceRouter with full source map
-	router := executor.NewSourceRouter(sources)
-
-	// Convert inputs to Relations based on :in clause
-	inputRelations, err := d.convertInputsToRelations(q, regularInputs)
-	if err != nil {
-		return nil, err
-	}
-
-	// Execute with the SourceRouter as the PatternMatcher
-	planOpts := DefaultPlannerOptions()
-	planOpts.Cache = d.planCache
-	exec := executor.NewExecutorWithOptions(router, d, planOpts)
-	result, err := exec.ExecuteWithRelations(executor.NewContext(d.annotationHandler), q, inputRelations)
-	if err != nil {
-		return nil, fmt.Errorf("query execution failed: %w", err)
-	}
-
-	// Convert result to [][]interface{}
-	return relationToSlice(result), nil
-}
-
-// ExecuteQueryRelation executes a query and returns the Relation directly.
-// This preserves symbol names (via Symbols()) which are lost in ExecuteQuery.
-func (d *Database) ExecuteQueryRelation(queryInput interface{}, inputs ...interface{}) (executor.Relation, error) {
-	// Separate QueryOptions from regular inputs
-	opts, regularInputs := extractQueryOptions(inputs)
-
-	q, err := resolveQuery(queryInput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve query: %w", err)
-	}
-
-	// Build source map — database is always $
-	sources := buildSourceMap(opts.sources, d.Matcher())
-
-	// Validate declared sources exist
-	if err := validateQuerySources(q, sources); err != nil {
-		return nil, err
-	}
-
-	// Create SourceRouter with full source map
-	router := executor.NewSourceRouter(sources)
-
-	inputRelations, err := d.convertInputsToRelations(q, regularInputs)
-	if err != nil {
-		return nil, err
-	}
-
-	// Execute with the SourceRouter as the PatternMatcher
-	planOpts := DefaultPlannerOptions()
-	planOpts.Cache = d.planCache
-	exec := executor.NewExecutorWithOptions(router, d, planOpts)
-	result, err := exec.ExecuteWithRelations(executor.NewContext(d.annotationHandler), q, inputRelations)
-	if err != nil {
-		return nil, fmt.Errorf("query execution failed: %w", err)
-	}
-
-	return result, nil
-}
-
 // Explain returns the query plan for a query without executing it.
 // The query can be either an EDN string or a *query.Query from the query builder.
 // This is useful for understanding index selection, phase structure, and
@@ -736,7 +613,7 @@ func (d *Database) Explain(queryInput interface{}, inputs ...interface{}) (*plan
 		return nil, fmt.Errorf("failed to resolve query: %w", err)
 	}
 
-	// Validate inputs match :in clause (same validation as ExecuteQueryWithInputs)
+	// Validate inputs match :in clause (same validation as Query)
 	_, err = d.convertInputsToRelations(q, inputs)
 	if err != nil {
 		return nil, err
@@ -957,7 +834,7 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 	}
 
 	// Execute query as streaming relation
-	rel, err := d.ExecuteQueryRelation(q, inputs...)
+	rel, err := d.Query(q, inputs...)
 	if err != nil {
 		return err
 	}
@@ -1054,7 +931,7 @@ func (d *Database) QueryOneInto(dest interface{}, queryInput interface{}, inputs
 	}
 
 	// Execute query as streaming relation
-	rel, err := d.ExecuteQueryRelation(q, inputs...)
+	rel, err := d.Query(q, inputs...)
 	if err != nil {
 		return false, err
 	}
@@ -2309,36 +2186,6 @@ func (d *Database) convertInputsToRelations(q *query.Query, inputs []interface{}
 	}
 
 	return inputRelations, nil
-}
-
-// relationToSlice converts an executor.Relation to [][]interface{}
-func relationToSlice(rel executor.Relation) [][]interface{} {
-	// Handle nil relation (e.g., query returned no results)
-	if rel == nil {
-		return [][]interface{}{}
-	}
-	// Don't preallocate if size is unknown (-1)
-	size := rel.Size()
-	var tuples [][]interface{}
-	if size >= 0 {
-		tuples = make([][]interface{}, 0, size)
-	} else {
-		tuples = make([][]interface{}, 0)
-	}
-
-	it := rel.Iterator()
-	defer it.Close()
-
-	for it.Next() {
-		src := it.Tuple()
-		t := make([]interface{}, len(src))
-		for i, v := range src {
-			t[i] = v
-		}
-		tuples = append(tuples, t)
-	}
-
-	return tuples
 }
 
 // Pull retrieves entity data according to a pull pattern

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -675,7 +675,7 @@ func (d *Database) ExecuteQueryWithInputs(queryInput interface{}, inputs ...inte
 }
 
 // ExecuteQueryRelation executes a query and returns the Relation directly.
-// This preserves column names (via Symbols()) which are lost in ExecuteQuery.
+// This preserves symbol names (via Symbols()) which are lost in ExecuteQuery.
 func (d *Database) ExecuteQueryRelation(queryInput interface{}, inputs ...interface{}) (executor.Relation, error) {
 	// Separate QueryOptions from regular inputs
 	opts, regularInputs := extractQueryOptions(inputs)
@@ -772,9 +772,9 @@ func (ar *AnalyzeResult) String() string {
 	sb.WriteString(fmt.Sprintf("  Total time: %v\n", ar.TotalTime))
 	size := ar.Result.Size()
 	if size >= 0 {
-		sb.WriteString(fmt.Sprintf("  Result rows: %d\n", size))
+		sb.WriteString(fmt.Sprintf("  Result tuples: %d\n", size))
 	} else {
-		sb.WriteString("  Result rows: (streaming - call Result.Size() to materialize)\n")
+		sb.WriteString("  Result tuples: (streaming - call Result.Size() to materialize)\n")
 	}
 
 	// Group events by type for summary
@@ -969,8 +969,8 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 	// Identity is a pointer type alias and goes through scalar path automatically
 	if elemType.Kind() == reflect.Struct && !isScalarStructType(elemType) {
 		// Struct path - use mapper
-		findColumns := extractFindColumnStrings(q.Find)
-		mapper, err := dlreflect.NewQueryResultMapper(elemType, findColumns)
+		findSymbols := extractFindSymbolStrings(q.Find)
+		mapper, err := dlreflect.NewQueryResultMapper(elemType, findSymbols)
 		if err != nil {
 			return err
 		}
@@ -987,7 +987,7 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 		return nil
 	}
 
-	// Scalar path - single column queries only
+	// Scalar path - single symbol queries only
 	if len(q.Find) != 1 {
 		return fmt.Errorf("scalar QueryInto requires exactly 1 find element, got %d", len(q.Find))
 	}
@@ -1024,7 +1024,7 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 
 // QueryOneInto executes a Datalog query expecting at most one result and populates a value.
 // The query can be either an EDN string or a *query.Query from the query builder.
-// Supports both struct destinations (multi-column) and scalar destinations (single-column).
+// Supports both struct destinations (multi-symbol) and scalar destinations (single-symbol).
 // Returns (true, nil) if a result was found and mapped successfully.
 // Returns (false, nil) if the query returns no results (empty result is valid, not an error).
 // Returns (false, ErrMultipleResults) if more than one result exists.
@@ -1077,8 +1077,8 @@ func (d *Database) QueryOneInto(dest interface{}, queryInput interface{}, inputs
 	isStruct := elemType.Kind() == reflect.Struct && !isScalarStructType(elemType)
 
 	if isStruct {
-		findColumns := extractFindColumnStrings(q.Find)
-		mapper, err := dlreflect.NewQueryResultMapper(elemType, findColumns)
+		findSymbols := extractFindSymbolStrings(q.Find)
+		mapper, err := dlreflect.NewQueryResultMapper(elemType, findSymbols)
 		if err != nil {
 			return false, err
 		}
@@ -1088,7 +1088,7 @@ func (d *Database) QueryOneInto(dest interface{}, queryInput interface{}, inputs
 		return true, nil
 	}
 
-	// Scalar path - single column queries only
+	// Scalar path - single symbol queries only
 	if len(q.Find) != 1 {
 		return false, fmt.Errorf("scalar QueryOneInto requires exactly 1 find element, got %d", len(q.Find))
 	}
@@ -1102,14 +1102,14 @@ func (d *Database) QueryOneInto(dest interface{}, queryInput interface{}, inputs
 	return true, nil
 }
 
-// extractFindColumnStrings extracts column names from :find clause as strings.
+// extractFindSymbolStrings extracts symbol names from :find clause as strings.
 // For variables, returns "?name". For aggregates, returns "(sum ?x)".
-func extractFindColumnStrings(find []query.FindElement) []string {
-	columns := make([]string, len(find))
+func extractFindSymbolStrings(find []query.FindElement) []string {
+	symbols := make([]string, len(find))
 	for i, elem := range find {
-		columns[i] = elem.String()
+		symbols[i] = elem.String()
 	}
-	return columns
+	return symbols
 }
 
 // Scalar struct types - these are structs but treated as scalar values
@@ -1124,7 +1124,7 @@ func isScalarStructType(t reflect.Type) bool {
 	return t == timeType || t == identityType || t == keywordType
 }
 
-// mapScalarResults maps single-column query results to a scalar slice.
+// mapScalarResults maps single-symbol query results to a scalar slice.
 func mapScalarResults(results [][]interface{}, sliceVal reflect.Value, elemIsPtr bool) error {
 	elemType := sliceVal.Type().Elem()
 	if elemIsPtr {
@@ -1147,7 +1147,7 @@ func mapScalarResults(results [][]interface{}, sliceVal reflect.Value, elemIsPtr
 		}
 
 		if err := setScalarValue(elemVal, val); err != nil {
-			return fmt.Errorf("row %d: %w", i, err)
+			return fmt.Errorf("tuple %d: %w", i, err)
 		}
 
 		if elemIsPtr {
@@ -2130,17 +2130,17 @@ func (t *Transaction) validateUniqueness() error {
 			return fmt.Errorf("failed to check uniqueness for %s: %w", d.A.String(), err)
 		}
 
-		// Find the index of ?e in the result columns
-		columns := results.Columns()
+		// Find the index of ?e in the result symbols
+		symbols := results.Symbols()
 		eIndex := -1
-		for i, col := range columns {
-			if col == datalog.NewSymbol("?e") {
+		for i, sym := range symbols {
+			if sym == datalog.NewSymbol("?e") {
 				eIndex = i
 				break
 			}
 		}
 		if eIndex < 0 {
-			continue // No entity column in results (shouldn't happen)
+			continue // No entity symbol in results (shouldn't happen)
 		}
 
 		// Check if any existing datoms have a different entity
@@ -2319,26 +2319,26 @@ func relationToSlice(rel executor.Relation) [][]interface{} {
 	}
 	// Don't preallocate if size is unknown (-1)
 	size := rel.Size()
-	var rows [][]interface{}
+	var tuples [][]interface{}
 	if size >= 0 {
-		rows = make([][]interface{}, 0, size)
+		tuples = make([][]interface{}, 0, size)
 	} else {
-		rows = make([][]interface{}, 0)
+		tuples = make([][]interface{}, 0)
 	}
 
 	it := rel.Iterator()
 	defer it.Close()
 
 	for it.Next() {
-		tuple := it.Tuple()
-		row := make([]interface{}, len(tuple))
-		for i, v := range tuple {
-			row[i] = v
+		src := it.Tuple()
+		t := make([]interface{}, len(src))
+		for i, v := range src {
+			t[i] = v
 		}
-		rows = append(rows, row)
+		tuples = append(tuples, t)
 	}
 
-	return rows
+	return tuples
 }
 
 // Pull retrieves entity data according to a pull pattern

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -956,6 +956,14 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 		return fmt.Errorf("failed to resolve query: %w", err)
 	}
 
+	// Execute query as streaming relation
+	rel, err := d.ExecuteQueryRelation(q, inputs...)
+	if err != nil {
+		return err
+	}
+	iter := rel.Iterator()
+	defer iter.Close()
+
 	// Check if element type is a struct or scalar
 	// time.Time and Keyword are structs but treated as scalars
 	// Identity is a pointer type alias and goes through scalar path automatically
@@ -967,12 +975,16 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 			return err
 		}
 
-		results, err := d.ExecuteQueryWithInputs(q, inputs...)
-		if err != nil {
-			return err
+		newSlice := reflect.MakeSlice(sliceVal.Type(), 0, 0)
+		for iter.Next() {
+			elem := reflect.New(elemType).Elem()
+			if err := mapper.MapTuple(iter.Tuple(), elem); err != nil {
+				return err
+			}
+			newSlice = reflect.Append(newSlice, elem)
 		}
-
-		return mapper.MapAll(results, sliceVal)
+		sliceVal.Set(newSlice)
+		return nil
 	}
 
 	// Scalar path - single column queries only
@@ -980,13 +992,34 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 		return fmt.Errorf("scalar QueryInto requires exactly 1 find element, got %d", len(q.Find))
 	}
 
-	results, err := d.ExecuteQueryWithInputs(q, inputs...)
-	if err != nil {
-		return err
-	}
+	newSlice := reflect.MakeSlice(sliceVal.Type(), 0, 0)
+	for iter.Next() {
+		tuple := iter.Tuple()
+		if len(tuple) == 0 {
+			continue
+		}
 
-	// Map scalar results directly
-	return mapScalarResults(results, sliceVal, elemIsPtr)
+		var elemVal reflect.Value
+		if elemIsPtr {
+			elemVal = reflect.New(elemType).Elem()
+		} else {
+			elemVal = reflect.New(elemType).Elem()
+		}
+
+		if err := setScalarValue(elemVal, tuple[0]); err != nil {
+			return err
+		}
+
+		if elemIsPtr {
+			ptr := reflect.New(elemType)
+			ptr.Elem().Set(elemVal)
+			newSlice = reflect.Append(newSlice, ptr)
+		} else {
+			newSlice = reflect.Append(newSlice, elemVal)
+		}
+	}
+	sliceVal.Set(newSlice)
+	return nil
 }
 
 // QueryOneInto executes a Datalog query expecting at most one result and populates a value.
@@ -1020,30 +1053,36 @@ func (d *Database) QueryOneInto(dest interface{}, queryInput interface{}, inputs
 		return false, fmt.Errorf("failed to resolve query: %w", err)
 	}
 
+	// Execute query as streaming relation
+	rel, err := d.ExecuteQueryRelation(q, inputs...)
+	if err != nil {
+		return false, err
+	}
+	iter := rel.Iterator()
+	defer iter.Close()
+
+	// Read first tuple
+	if !iter.Next() {
+		return false, nil
+	}
+	firstTuple := make([]interface{}, len(iter.Tuple()))
+	copy(firstTuple, iter.Tuple())
+
+	// Check for multiple results
+	if iter.Next() {
+		return false, dlreflect.ErrMultipleResults
+	}
+
 	// Check if destination is a struct (but not time.Time, Identity, Keyword which are scalars)
 	isStruct := elemType.Kind() == reflect.Struct && !isScalarStructType(elemType)
 
 	if isStruct {
-		// Struct path - use mapper
 		findColumns := extractFindColumnStrings(q.Find)
 		mapper, err := dlreflect.NewQueryResultMapper(elemType, findColumns)
 		if err != nil {
 			return false, err
 		}
-
-		results, err := d.ExecuteQueryWithInputs(q, inputs...)
-		if err != nil {
-			return false, err
-		}
-
-		if len(results) == 0 {
-			return false, nil
-		}
-		if len(results) > 1 {
-			return false, dlreflect.ErrMultipleResults
-		}
-
-		if err := mapper.MapTuple(results[0], elemVal); err != nil {
+		if err := mapper.MapTuple(firstTuple, elemVal); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -1054,23 +1093,10 @@ func (d *Database) QueryOneInto(dest interface{}, queryInput interface{}, inputs
 		return false, fmt.Errorf("scalar QueryOneInto requires exactly 1 find element, got %d", len(q.Find))
 	}
 
-	results, err := d.ExecuteQueryWithInputs(q, inputs...)
-	if err != nil {
-		return false, err
-	}
-
-	if len(results) == 0 {
-		return false, nil
-	}
-	if len(results) > 1 {
-		return false, dlreflect.ErrMultipleResults
-	}
-
-	// Map single scalar result
-	if len(results[0]) == 0 {
+	if len(firstTuple) == 0 {
 		return false, fmt.Errorf("query returned empty tuple")
 	}
-	if err := setScalarValue(elemVal, results[0][0]); err != nil {
+	if err := setScalarValue(elemVal, firstTuple[0]); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/datalog/storage/database_function_integration_test.go
+++ b/datalog/storage/database_function_integration_test.go
@@ -57,9 +57,9 @@ func TestGetElseBasic(t *testing.T) {
 			wantCount: 3,
 			checkResult: func(t *testing.T, results [][]interface{}) {
 				nameToNick := make(map[string]string)
-				for _, row := range results {
-					name := row[0].(string)
-					nick := row[1].(string)
+				for _, tuple := range results {
+					name := tuple[0].(string)
+					nick := tuple[1].(string)
 					nameToNick[name] = nick
 				}
 				if nameToNick["Alice Smith"] != "Ali" {
@@ -79,9 +79,9 @@ func TestGetElseBasic(t *testing.T) {
 			wantCount: 3,
 			checkResult: func(t *testing.T, results [][]interface{}) {
 				nameToNick := make(map[string]string)
-				for _, row := range results {
-					name := row[0].(string)
-					nick := row[1].(string)
+				for _, tuple := range results {
+					name := tuple[0].(string)
+					nick := tuple[1].(string)
 					nameToNick[name] = nick
 				}
 				if nameToNick["Alice Smith"] != "Ali" {
@@ -102,8 +102,8 @@ func TestGetElseBasic(t *testing.T) {
 			}
 			if len(results) != tt.wantCount {
 				t.Errorf("Expected %d results, got %d", tt.wantCount, len(results))
-				for i, row := range results {
-					t.Logf("  Row %d: %v", i, row)
+				for i, tuple := range results {
+					t.Logf("  Tuple %d: %v", i, tuple)
 				}
 			}
 			if tt.checkResult != nil {
@@ -152,11 +152,11 @@ func TestGetElseNumericDefault(t *testing.T) {
 	}
 
 	nameToDiscount := make(map[string]int64)
-	for _, row := range results {
-		name := row[0].(string)
-		discount, ok := row[1].(int64)
+	for _, tuple := range results {
+		name := tuple[0].(string)
+		discount, ok := tuple[1].(int64)
 		if !ok {
-			t.Errorf("Expected int64 for discount, got %T: %v", row[1], row[1])
+			t.Errorf("Expected int64 for discount, got %T: %v", tuple[1], tuple[1])
 			continue
 		}
 		nameToDiscount[name] = discount
@@ -216,8 +216,8 @@ func TestMissingAsPredicate(t *testing.T) {
 
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result (Bob), got %d", len(results))
-		for i, row := range results {
-			t.Logf("  Row %d: %v", i, row)
+		for i, tuple := range results {
+			t.Logf("  Tuple %d: %v", i, tuple)
 		}
 		return
 	}
@@ -255,7 +255,7 @@ func TestMissingAsExpression(t *testing.T) {
 		t.Fatalf("Failed to commit: %v", err)
 	}
 
-	// Get missing status as a boolean column
+	// Get missing status as a boolean symbol
 	results, err := db.ExecuteQuery(`[:find ?name ?needs_verification :where [?e :user/name ?name] [(missing? $ ?e :user/verified) ?needs_verification]]`)
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
@@ -263,18 +263,18 @@ func TestMissingAsExpression(t *testing.T) {
 
 	if len(results) != 2 {
 		t.Errorf("Expected 2 results, got %d", len(results))
-		for i, row := range results {
-			t.Logf("  Row %d: %v", i, row)
+		for i, tuple := range results {
+			t.Logf("  Tuple %d: %v", i, tuple)
 		}
 		return
 	}
 
 	nameToMissing := make(map[string]bool)
-	for _, row := range results {
-		name := row[0].(string)
-		missing, ok := row[1].(bool)
+	for _, tuple := range results {
+		name := tuple[0].(string)
+		missing, ok := tuple[1].(bool)
 		if !ok {
-			t.Errorf("Expected bool for missing status, got %T: %v", row[1], row[1])
+			t.Errorf("Expected bool for missing status, got %T: %v", tuple[1], tuple[1])
 			continue
 		}
 		nameToMissing[name] = missing
@@ -336,8 +336,8 @@ func TestMissingMultipleAttributes(t *testing.T) {
 
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result (Person4), got %d", len(results))
-		for i, row := range results {
-			t.Logf("  Row %d: %v", i, row)
+		for i, tuple := range results {
+			t.Logf("  Tuple %d: %v", i, tuple)
 		}
 		return
 	}
@@ -397,20 +397,20 @@ func TestGetSomeBasic(t *testing.T) {
 
 	if len(results) != 3 {
 		t.Errorf("Expected 3 results, got %d", len(results))
-		for i, row := range results {
-			t.Logf("  Row %d: %v", i, row)
+		for i, tuple := range results {
+			t.Logf("  Tuple %d: %v", i, tuple)
 		}
 		return
 	}
 
 	idToDisplay := make(map[string]string)
-	for _, row := range results {
-		id := row[0].(string)
+	for _, tuple := range results {
+		id := tuple[0].(string)
 		// get-some returns a GetSomeResult struct, which contains the value
 		// The executor should extract just the value for the binding
-		display, ok := row[1].(string)
+		display, ok := tuple[1].(string)
 		if !ok {
-			t.Logf("Row for id %s has display type %T: %v", id, row[1], row[1])
+			t.Logf("Tuple for id %s has display type %T: %v", id, tuple[1], tuple[1])
 			continue
 		}
 		idToDisplay[id] = display
@@ -466,8 +466,8 @@ func TestGetSomeNoMatch(t *testing.T) {
 	// Should only return User1
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result (only User1), got %d", len(results))
-		for i, row := range results {
-			t.Logf("  Row %d: %v", i, row)
+		for i, tuple := range results {
+			t.Logf("  Tuple %d: %v", i, tuple)
 		}
 		return
 	}
@@ -521,16 +521,16 @@ func TestCombinedDatabaseFunctions(t *testing.T) {
 
 	if len(results) != 2 {
 		t.Errorf("Expected 2 results, got %d", len(results))
-		for i, row := range results {
-			t.Logf("  Row %d: %v", i, row)
+		for i, tuple := range results {
+			t.Logf("  Tuple %d: %v", i, tuple)
 		}
 		return
 	}
 
-	for _, row := range results {
-		name := row[0].(string)
-		phone := row[1].(string)
-		emailMissing := row[2].(bool)
+	for _, tuple := range results {
+		name := tuple[0].(string)
+		phone := tuple[1].(string)
+		emailMissing := tuple[2].(bool)
 
 		switch name {
 		case "Alice":
@@ -653,8 +653,8 @@ func TestDatabaseFunctionWithOrderBy(t *testing.T) {
 
 	// Order should be: Charlie (95), Alice (85), Bob (0)
 	expected := []string{"Charlie", "Alice", "Bob"}
-	for i, row := range results {
-		name := row[0].(string)
+	for i, tuple := range results {
+		name := tuple[0].(string)
 		if name != expected[i] {
 			t.Errorf("Position %d: expected %s, got %s", i, expected[i], name)
 		}
@@ -704,9 +704,9 @@ func TestGetElseWithNullishValues(t *testing.T) {
 		t.Fatalf("Expected 2 results, got %d", len(results))
 	}
 
-	for _, row := range results {
-		name := row[0].(string)
-		desc := row[1].(string)
+	for _, tuple := range results {
+		name := tuple[0].(string)
+		desc := tuple[1].(string)
 		switch name {
 		case "Entity1":
 			if desc != "" {
@@ -762,8 +762,8 @@ func TestDatabaseFunctionWithInputParameters(t *testing.T) {
 
 	// If it succeeds, check results
 	t.Logf("Query with variable default succeeded (results: %d)", len(results))
-	for _, row := range results {
-		t.Logf("  %v", row)
+	for _, tuple := range results {
+		t.Logf("  %v", tuple)
 	}
 }
 

--- a/datalog/storage/database_function_integration_test.go
+++ b/datalog/storage/database_function_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 )
 
 // =============================================================================
@@ -96,7 +97,7 @@ func TestGetElseBasic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results, err := db.ExecuteQuery(tt.query)
+			results, err := executor.CollectTuples(db.Query(tt.query))
 			if err != nil {
 				t.Fatalf("Query failed: %v", err)
 			}
@@ -142,7 +143,7 @@ func TestGetElseNumericDefault(t *testing.T) {
 		t.Fatalf("Failed to commit: %v", err)
 	}
 
-	results, err := db.ExecuteQuery(`[:find ?name ?discount :where [?e :product/name ?name] [(get-else $ ?e :product/discount 0) ?discount]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name ?discount :where [?e :product/name ?name] [(get-else $ ?e :product/discount 0) ?discount]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -209,7 +210,7 @@ func TestMissingAsPredicate(t *testing.T) {
 	}
 
 	// Find users WITHOUT email - should only return Bob
-	results, err := db.ExecuteQuery(`[:find ?name :where [?e :user/name ?name] [(missing? $ ?e :user/email)]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name :where [?e :user/name ?name] [(missing? $ ?e :user/email)]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -256,7 +257,7 @@ func TestMissingAsExpression(t *testing.T) {
 	}
 
 	// Get missing status as a boolean symbol
-	results, err := db.ExecuteQuery(`[:find ?name ?needs_verification :where [?e :user/name ?name] [(missing? $ ?e :user/verified) ?needs_verification]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name ?needs_verification :where [?e :user/name ?name] [(missing? $ ?e :user/verified) ?needs_verification]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -329,7 +330,7 @@ func TestMissingMultipleAttributes(t *testing.T) {
 	}
 
 	// Find contacts missing BOTH phone AND email
-	results, err := db.ExecuteQuery(`[:find ?name :where [?e :contact/name ?name] [(missing? $ ?e :contact/phone)] [(missing? $ ?e :contact/email)]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name :where [?e :contact/name ?name] [(missing? $ ?e :contact/phone)] [(missing? $ ?e :contact/email)]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -390,7 +391,7 @@ func TestGetSomeBasic(t *testing.T) {
 	}
 
 	// get-some with three fallback options: nickname -> fullname -> email
-	results, err := db.ExecuteQuery(`[:find ?id ?display :where [?e :user/id ?id] [(get-some $ ?e :user/nickname :user/fullname :user/email) ?display]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?id ?display :where [?e :user/id ?id] [(get-some $ ?e :user/nickname :user/fullname :user/email) ?display]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -458,7 +459,7 @@ func TestGetSomeNoMatch(t *testing.T) {
 	}
 
 	// get-some should filter out User2 since none of the attrs exist
-	results, err := db.ExecuteQuery(`[:find ?id ?display :where [?e :user/id ?id] [(get-some $ ?e :user/nickname :user/fullname :user/displayname) ?display]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?id ?display :where [?e :user/id ?id] [(get-some $ ?e :user/nickname :user/fullname :user/displayname) ?display]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -514,7 +515,7 @@ func TestCombinedDatabaseFunctions(t *testing.T) {
 
 	// Use get-else to get phone with default "N/A"
 	// AND check if email is missing
-	results, err := db.ExecuteQuery(`[:find ?name ?phone ?email_missing :where [?e :person/name ?name] [(get-else $ ?e :person/phone "N/A") ?phone] [(missing? $ ?e :person/email) ?email_missing]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name ?phone ?email_missing :where [?e :person/name ?name] [(get-else $ ?e :person/phone "N/A") ?phone] [(missing? $ ?e :person/email) ?email_missing]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -582,7 +583,7 @@ func TestDatabaseFunctionWithAggregation(t *testing.T) {
 	}
 
 	// Sum of discounts, with 0 as default for items without discount
-	results, err := db.ExecuteQuery(`[:find (sum ?discount) :where [?e :item/name ?name] [(get-else $ ?e :item/discount 0) ?discount]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find (sum ?discount) :where [?e :item/name ?name] [(get-else $ ?e :item/discount 0) ?discount]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -642,7 +643,7 @@ func TestDatabaseFunctionWithOrderBy(t *testing.T) {
 	}
 
 	// Order by score descending (Bob gets 0 as default)
-	results, err := db.ExecuteQuery(`[:find ?name ?score :where [?e :person/name ?name] [(get-else $ ?e :person/score 0) ?score] :order-by [[?score :desc]]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name ?score :where [?e :person/name ?name] [(get-else $ ?e :person/score 0) ?score] :order-by [[?score :desc]]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -695,7 +696,7 @@ func TestGetElseWithNullishValues(t *testing.T) {
 	}
 
 	// The empty string should be returned (not the default)
-	results, err := db.ExecuteQuery(`[:find ?name ?desc :where [?e :entity/name ?name] [(get-else $ ?e :entity/description "DEFAULT") ?desc]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name ?desc :where [?e :entity/name ?name] [(get-else $ ?e :entity/description "DEFAULT") ?desc]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -749,10 +750,10 @@ func TestDatabaseFunctionWithInputParameters(t *testing.T) {
 	}
 
 	// Use input parameter for default value
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name ?status :in $ ?default-status :where [?e :user/name ?name] [(get-else $ ?e :user/status ?default-status) ?status]]`,
 		"pending",
-	)
+	))
 	if err != nil {
 		// This might fail because get-else expects a constant default, not a variable
 		// Let's verify this is the expected behavior

--- a/datalog/storage/database_schema_test.go
+++ b/datalog/storage/database_schema_test.go
@@ -140,7 +140,7 @@ func TestSchemaUniquenessValue(t *testing.T) {
 	}
 	results, err := matcher.Match(pattern, nil)
 	require.NoError(t, err, "matcher.Match should succeed")
-	t.Logf("Result columns: %v", results.Columns())
+	t.Logf("Result symbols: %v", results.Symbols())
 
 	iter := results.Iterator()
 	count := 0

--- a/datalog/storage/datom_decoder.go
+++ b/datalog/storage/datom_decoder.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/wbrown/janus-datalog/datalog"
@@ -71,15 +72,17 @@ func NewKeyOnlyIterator(store *BadgerStore, index IndexType, start, end []byte) 
 
 	it := txn.NewIterator(opts)
 
+	bi := &BadgerIterator{
+		txn:   txn,
+		it:    it,
+		start: start,
+		end:   end,
+		index: index,
+	}
+	runtime.SetFinalizer(bi, (*BadgerIterator).Close)
 	return &KeyOnlyIterator{
-		BadgerIterator: &BadgerIterator{
-			txn:   txn,
-			it:    it,
-			start: start,
-			end:   end,
-			index: index,
-		},
-		encoder: store.encoder,
+		BadgerIterator: bi,
+		encoder:        store.encoder,
 	}, nil
 }
 

--- a/datalog/storage/ea_cache_bypass_test.go
+++ b/datalog/storage/ea_cache_bypass_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -94,9 +95,9 @@ func TestEACacheBypass_Reproduction(t *testing.T) {
 		})
 		defer db.SetAnnotationHandler(nil)
 
-		results, err := db.ExecuteQueryWithInputs(
+		results, err := executor.CollectTuples(db.Query(
 			`[:find ?v :in $ ?e :where [?e :person/name ?v]]`,
-			personID)
+			personID))
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		assert.Equal(t, "Charlie", results[0][0])
@@ -112,9 +113,9 @@ func TestEACacheBypass_Reproduction(t *testing.T) {
 		})
 		defer db.SetAnnotationHandler(nil)
 
-		results, err := db.ExecuteQueryWithInputs(
+		results, err := executor.CollectTuples(db.Query(
 			`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-			personID, nameAttr)
+			personID, nameAttr))
 		require.NoError(t, err)
 		require.Len(t, results, 1, "Should return 1 result (LWW winner)")
 		assert.Equal(t, "Charlie", results[0][0])
@@ -145,15 +146,15 @@ func TestEACacheBypass_CardinalityOne(t *testing.T) {
 			}
 
 			// A as constant
-			constantResults, err := db.ExecuteQueryWithInputs(
+			constantResults, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e :where [?e :person/name ?v]]`,
-				personID)
+				personID))
 			require.NoError(t, err)
 
 			// A as scalar input
-			inputResults, err := db.ExecuteQueryWithInputs(
+			inputResults, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-				personID, nameAttr)
+				personID, nameAttr))
 			require.NoError(t, err)
 
 			require.Len(t, constantResults, 1, "[%s] A-as-constant: should return 1 result", mode.name)
@@ -186,15 +187,15 @@ func TestEACacheBypass_CardinalityMany(t *testing.T) {
 			require.NoError(t, err)
 
 			// A as constant
-			constantResults, err := db.ExecuteQueryWithInputs(
+			constantResults, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e :where [?e :person/tags ?v]]`,
-				personID)
+				personID))
 			require.NoError(t, err)
 
 			// A as scalar input
-			inputResults, err := db.ExecuteQueryWithInputs(
+			inputResults, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-				personID, tagsAttr)
+				personID, tagsAttr))
 			require.NoError(t, err)
 
 			require.Len(t, constantResults, 1, "[%s] A-as-constant: should return 1 result (add-wins)", mode.name)
@@ -220,15 +221,15 @@ func TestEACacheBypass_CardinalityVector(t *testing.T) {
 			require.NoError(t, err)
 
 			// A as constant
-			constantResults, err := db.ExecuteQueryWithInputs(
+			constantResults, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e :where [?e :doc/content ?v]]`,
-				docID)
+				docID))
 			require.NoError(t, err)
 
 			// A as scalar input
-			inputResults, err := db.ExecuteQueryWithInputs(
+			inputResults, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-				docID, contentAttr)
+				docID, contentAttr))
 			require.NoError(t, err)
 
 			require.Len(t, constantResults, 1, "[%s] A-as-constant: should return 1 result (resolved vector)", mode.name)
@@ -259,9 +260,9 @@ func TestEACacheBypass_TupleInput(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ [[?e ?a]] :where [?e ?a ?v]]`,
-				[]any{personID, nameAttr})
+				[]any{personID, nameAttr}))
 			require.NoError(t, err)
 			require.Len(t, results, 1, "[%s] Tuple input should return 1 result", mode.name)
 			assert.Equal(t, "Charlie", results[0][0])
@@ -286,12 +287,12 @@ func TestEACacheBypass_RelationInput(t *testing.T) {
 			_, err := tx.Commit()
 			require.NoError(t, err)
 
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
 				[][]any{
 					{person1, nameAttr},
 					{person2, ageAttr},
-				})
+				}))
 			require.NoError(t, err)
 			require.Len(t, results, 2, "[%s] Relation input should return 2 results", mode.name)
 		})
@@ -317,10 +318,10 @@ func TestEACacheBypass_CollectionEWithScalarA(t *testing.T) {
 				}
 			}
 
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?v :in $ [?e ...] ?a :where [?e ?a ?v]]`,
 				[]datalog.Identity{entities[0], entities[1], entities[2]},
-				nameAttr)
+				nameAttr))
 			require.NoError(t, err)
 			require.Len(t, results, 3, "[%s] Should return 3 results (one LWW winner per entity)", mode.name)
 		})
@@ -346,9 +347,9 @@ func TestEACacheBypass_NonexistentAttribute(t *testing.T) {
 			_, err := tx.Commit()
 			require.NoError(t, err)
 
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-				personID, ageAttr)
+				personID, ageAttr))
 			require.NoError(t, err)
 			assert.Len(t, results, 0, "[%s] Nonexistent attribute should return 0 results", mode.name)
 		})
@@ -369,9 +370,9 @@ func TestEACacheBypass_CacheInvalidation(t *testing.T) {
 			_, err := tx.Commit()
 			require.NoError(t, err)
 
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-				personID, nameAttr)
+				personID, nameAttr))
 			require.NoError(t, err)
 			require.Len(t, results, 1)
 			assert.Equal(t, "Alice", results[0][0])
@@ -381,9 +382,9 @@ func TestEACacheBypass_CacheInvalidation(t *testing.T) {
 			_, err = tx2.Commit()
 			require.NoError(t, err)
 
-			results, err = db.ExecuteQueryWithInputs(
+			results, err = executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`,
-				personID, nameAttr)
+				personID, nameAttr))
 			require.NoError(t, err)
 			require.Len(t, results, 1)
 			assert.Equal(t, "Bob", results[0][0], "[%s] Should see new value after write", mode.name)
@@ -412,12 +413,12 @@ func TestEACacheBypass_MixedCardinalities_RelationInput(t *testing.T) {
 			_, err = tx2.Commit()
 			require.NoError(t, err)
 
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
 				[][]any{
 					{person1, nameAttr},
 					{person1, tagsAttr},
-				})
+				}))
 			require.NoError(t, err)
 			assert.Len(t, results, 3,
 				"[%s] Mixed cardinalities: 1 name + 2 tags = 3 results, got %d", mode.name, len(results))
@@ -485,11 +486,11 @@ func TestEACacheBypass_PerRowA_UsesCache(t *testing.T) {
 
 	// Query: for each entity in the collection, look up its config/attr to get ?a,
 	// then look up [?e ?a ?v]. After pattern 1, binding has 2 tuples with varying A.
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?a ?v :in $ [?e ...] :where
 		  [?e :config/attr ?a]
 		  [?e ?a ?v]]`,
-		[]interface{}{entity1, entity2})
+		[]interface{}{entity1, entity2}))
 	require.NoError(t, err)
 	require.Len(t, results, 2, "Should get 2 results (one per entity)")
 
@@ -525,12 +526,12 @@ func TestEACacheBypass_PerRowVector_RelationInput(t *testing.T) {
 				events = append(events, e)
 			})
 
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
 				[][]any{
 					{person1, nameAttr},
 					{person1, contentAttr},
-				})
+				}))
 			require.NoError(t, err)
 
 			db.SetAnnotationHandler(nil)
@@ -562,12 +563,12 @@ func TestEACacheBypass_CacheMissFallback(t *testing.T) {
 			_, err := tx.Commit()
 			require.NoError(t, err)
 
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
 				[][]any{
 					{person1, nameAttr},
 					{person2, nameAttr},
-				})
+				}))
 			require.NoError(t, err)
 			assert.Len(t, results, 1,
 				"[%s] Should return 1 result (Alice only, nonexistent entity skipped)", mode.name)
@@ -610,11 +611,11 @@ func TestEACacheBypass_JoinBoundA(t *testing.T) {
 			_, err = tx.Commit()
 			require.NoError(t, err)
 
-			results, err := db.ExecuteQueryWithInputs(
+			results, err := executor.CollectTuples(db.Query(
 				`[:find ?v :in $ ?meta :where
 				  [?meta :meta/target-attr ?a]
 				  [?person ?a ?v]]`,
-				metaID)
+				metaID))
 			require.NoError(t, err)
 			require.Len(t, results, 1,
 				"[%s] Join-bound A should return 1 result", mode.name)
@@ -673,8 +674,8 @@ func BenchmarkEACacheBypass(b *testing.B) {
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
 					e := entities[i%100]
-					results, err := db.ExecuteQueryWithInputs(
-						`[:find ?v :in $ ?e :where [?e :person/name ?v]]`, e)
+					results, err := executor.CollectTuples(db.Query(
+						`[:find ?v :in $ ?e :where [?e :person/name ?v]]`, e))
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -688,8 +689,8 @@ func BenchmarkEACacheBypass(b *testing.B) {
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
 					e := entities[i%100]
-					results, err := db.ExecuteQueryWithInputs(
-						`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`, e, nameAttr)
+					results, err := executor.CollectTuples(db.Query(
+						`[:find ?v :in $ ?e ?a :where [?e ?a ?v]]`, e, nameAttr))
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -703,9 +704,9 @@ func BenchmarkEACacheBypass(b *testing.B) {
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
 					e := entities[i%100]
-					results, err := db.ExecuteQueryWithInputs(
+					results, err := executor.CollectTuples(db.Query(
 						`[:find ?v :in $ [[?e ?a]] :where [?e ?a ?v]]`,
-						[]any{e, nameAttr})
+						[]any{e, nameAttr}))
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -723,9 +724,9 @@ func BenchmarkEACacheBypass(b *testing.B) {
 				}
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					results, err := db.ExecuteQueryWithInputs(
+					results, err := executor.CollectTuples(db.Query(
 						`[:find ?e ?a ?v :in $ [[?e ?a] ...] :where [?e ?a ?v]]`,
-						relInput)
+						relInput))
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/datalog/storage/ea_cache_bypass_test.go
+++ b/datalog/storage/ea_cache_bypass_test.go
@@ -426,16 +426,16 @@ func TestEACacheBypass_MixedCardinalities_RelationInput(t *testing.T) {
 }
 
 // =============================================================================
-// Phase 2 Tests: Per-row A from relation/join bindings
+// Phase 2 Tests: Per-tuple A from relation/join bindings
 // =============================================================================
 
 // TestEACacheBypass_PerRowA_UsesCache tests that the cache is used when both E and A
-// are columns in the binding relation with multiple rows (per-row A from join results).
+// are symbols in the binding relation with multiple tuples (per-tuple A from join results).
 // This is the Phase 2 optimization target.
 //
 // Setup: Each entity has a :config/attr that names its own value attribute.
 // Pattern 1 resolves the attribute name. Pattern 2 looks up the value.
-// After pattern 1, the binding for pattern 2 has multiple rows with varying (E, A).
+// After pattern 1, the binding for pattern 2 has multiple tuples with varying (E, A).
 func TestEACacheBypass_PerRowA_UsesCache(t *testing.T) {
 	dir := t.TempDir()
 	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
@@ -484,7 +484,7 @@ func TestEACacheBypass_PerRowA_UsesCache(t *testing.T) {
 	defer db.SetAnnotationHandler(nil)
 
 	// Query: for each entity in the collection, look up its config/attr to get ?a,
-	// then look up [?e ?a ?v]. After pattern 1, binding has 2 rows with varying A.
+	// then look up [?e ?a ?v]. After pattern 1, binding has 2 tuples with varying A.
 	results, err := db.ExecuteQueryWithInputs(
 		`[:find ?e ?a ?v :in $ [?e ...] :where
 		  [?e :config/attr ?a]
@@ -495,9 +495,9 @@ func TestEACacheBypass_PerRowA_UsesCache(t *testing.T) {
 
 	// Check that storage/reuse-strategy is NOT used for pattern 2
 	// Before Phase 2 fix: FAILS — reuse-strategy IS present (cache bypassed)
-	// After Phase 2 fix: passes — per-row A uses cache
+	// After Phase 2 fix: passes — per-tuple A uses cache
 	assert.False(t, hasReuseStrategyEvent(events),
-		"Per-row A from join should use cache path, not storage/reuse-strategy scans")
+		"Per-tuple A from join should use cache path, not storage/reuse-strategy scans")
 }
 
 func TestEACacheBypass_PerRowVector_RelationInput(t *testing.T) {
@@ -542,7 +542,7 @@ func TestEACacheBypass_PerRowVector_RelationInput(t *testing.T) {
 				}
 			}
 			assert.Len(t, results, 2,
-				"[%s] Per-row vector: 1 name + 1 resolved vector = 2 results, got %d", mode.name, len(results))
+				"[%s] Per-tuple vector: 1 name + 1 resolved vector = 2 results, got %d", mode.name, len(results))
 		})
 	}
 }

--- a/datalog/storage/eatv_vector_transition_test.go
+++ b/datalog/storage/eatv_vector_transition_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 )
 
 // TestEATV_VectorTransitionDropsDatom reproduces the CRDT vector group
@@ -47,9 +48,9 @@ func TestEATV_VectorTransitionDropsDatom(t *testing.T) {
 
 	// Collection input [?e ...] — only E is bound, A is free → forces EATV
 	entitySlice := []any{entities[0], entities[1], entities[2]}
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?a ?v :in $ [?e ...] :where [?e ?a ?v]]`,
-		entitySlice)
+		entitySlice))
 	require.NoError(t, err)
 
 	db.SetAnnotationHandler(nil)

--- a/datalog/storage/elementid_binding_test.go
+++ b/datalog/storage/elementid_binding_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -57,8 +58,8 @@ func TestElementIDBinding_ScalarInput(t *testing.T) {
 	require.NoError(t, err)
 
 	// Step 1: Query all (entity, value, tx) to discover the ElementIDs
-	allResults, err := db.ExecuteQueryWithInputs(
-		`[:find ?e ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	allResults, err := executor.CollectTuples(db.Query(
+		`[:find ?e ?v ?tx :where [?e :person/name ?v ?tx]]`))
 	require.NoError(t, err)
 	t.Logf("All results: %d", len(allResults))
 	require.Len(t, allResults, 2, "Should have 2 datoms (one per entity)")
@@ -86,9 +87,9 @@ func TestElementIDBinding_ScalarInput(t *testing.T) {
 
 	// Step 2: Use Alice's ElementID as a scalar binding to filter by tx.
 	// This should return only Alice's datom — not Bob's.
-	filteredResults, err := db.ExecuteQueryWithInputs(
+	filteredResults, err := executor.CollectTuples(db.Query(
 		`[:find ?e ?v :in $ ?tx :where [?e :person/name ?v ?tx]]`,
-		aliceTx)
+		aliceTx))
 	require.NoError(t, err)
 
 	t.Logf("Filtered results (tx=%v): %v", aliceTx, filteredResults)
@@ -134,8 +135,8 @@ func TestElementIDBinding_CollectionInput(t *testing.T) {
 	require.NoError(t, err)
 
 	// Discover all ElementIDs
-	allResults, err := db.ExecuteQueryWithInputs(
-		`[:find ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	allResults, err := executor.CollectTuples(db.Query(
+		`[:find ?v ?tx :where [?e :person/name ?v ?tx]]`))
 	require.NoError(t, err)
 	require.Len(t, allResults, 3)
 
@@ -146,9 +147,9 @@ func TestElementIDBinding_CollectionInput(t *testing.T) {
 	}
 
 	// Pass Alice's and Bob's tx as a collection — should return 2 results
-	filteredResults, err := db.ExecuteQueryWithInputs(
+	filteredResults, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ [?tx ...] :where [?e :person/name ?v ?tx]]`,
-		[]datalog.ElementID{txByName["Alice"], txByName["Bob"]})
+		[]datalog.ElementID{txByName["Alice"], txByName["Bob"]}))
 	require.NoError(t, err)
 
 	t.Logf("Collection results: %v", filteredResults)
@@ -190,8 +191,8 @@ func TestElementIDBinding_RelationInput(t *testing.T) {
 	require.NoError(t, err)
 
 	// Discover ElementIDs
-	allResults, err := db.ExecuteQueryWithInputs(
-		`[:find ?e ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	allResults, err := executor.CollectTuples(db.Query(
+		`[:find ?e ?v ?tx :where [?e :person/name ?v ?tx]]`))
 	require.NoError(t, err)
 	require.Len(t, allResults, 2)
 
@@ -208,12 +209,12 @@ func TestElementIDBinding_RelationInput(t *testing.T) {
 	}
 
 	// Pass as relation binding [[?e ?tx] ...]
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?v :in $ [[?e ?tx] ...] :where [?e :person/name ?v ?tx]]`,
 		[][]interface{}{
 			{aliceIdentity, aliceTx},
 			{bobIdentity, bobTx},
-		})
+		}))
 	require.NoError(t, err)
 
 	t.Logf("Relation results: %v", results)
@@ -268,10 +269,10 @@ func TestElementIDBinding_TxJoin(t *testing.T) {
 	// Join on ?e: find name/age pairs for the same entity.
 	// Each attribute's datom has a unique Tx (CRDT per-operation Lamport),
 	// so we use separate ?tx1, ?tx2 variables.
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name ?age ?tx1 ?tx2
 		  :where [?e :person/name ?name ?tx1]
-		         [?e :person/age ?age ?tx2]]`)
+		         [?e :person/age ?age ?tx2]]`))
 	require.NoError(t, err)
 
 	t.Logf("TxJoin results: %v", results)
@@ -329,8 +330,8 @@ func TestElementIDBinding_ComparisonPredicate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get Alice's tx
-	allResults, err := db.ExecuteQueryWithInputs(
-		`[:find ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	allResults, err := executor.CollectTuples(db.Query(
+		`[:find ?v ?tx :where [?e :person/name ?v ?tx]]`))
 	require.NoError(t, err)
 	require.Len(t, allResults, 2)
 
@@ -342,12 +343,12 @@ func TestElementIDBinding_ComparisonPredicate(t *testing.T) {
 	}
 
 	// Filter with equality predicate
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?v
 		  :in $ ?target-tx
 		  :where [?e :person/name ?v ?tx]
 		         [(= ?tx ?target-tx)]]`,
-		aliceTx)
+		aliceTx))
 	require.NoError(t, err)
 
 	t.Logf("Comparison predicate results: %v", results)
@@ -392,8 +393,8 @@ func TestElementIDBinding_MultipleEntitiesSameTx(t *testing.T) {
 	require.NoError(t, err)
 
 	// Discover all Tx values — each entity has its own unique Tx
-	allResults, err := db.ExecuteQueryWithInputs(
-		`[:find ?v ?tx :where [?e :person/name ?v ?tx]]`)
+	allResults, err := executor.CollectTuples(db.Query(
+		`[:find ?v ?tx :where [?e :person/name ?v ?tx]]`))
 	require.NoError(t, err)
 	require.Len(t, allResults, 3)
 
@@ -410,9 +411,9 @@ func TestElementIDBinding_MultipleEntitiesSameTx(t *testing.T) {
 		"Bob and Charlie should have different Tx values")
 
 	// Filter by Alice's Tx — should return exactly Alice, not Bob or Charlie
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name :in $ ?tx :where [?e :person/name ?name ?tx]]`,
-		txByName["Alice"])
+		txByName["Alice"]))
 	require.NoError(t, err)
 
 	t.Logf("Alice-tx results: %v", results)
@@ -420,9 +421,9 @@ func TestElementIDBinding_MultipleEntitiesSameTx(t *testing.T) {
 	assert.Equal(t, "Alice", results[0][0].(string))
 
 	// Filter by Bob's Tx — should return exactly Bob
-	results, err = db.ExecuteQueryWithInputs(
+	results, err = executor.CollectTuples(db.Query(
 		`[:find ?name :in $ ?tx :where [?e :person/name ?name ?tx]]`,
-		txByName["Bob"])
+		txByName["Bob"]))
 	require.NoError(t, err)
 
 	t.Logf("Bob-tx results: %v", results)

--- a/datalog/storage/elementid_binding_test.go
+++ b/datalog/storage/elementid_binding_test.go
@@ -225,7 +225,7 @@ func TestElementIDBinding_RelationInput(t *testing.T) {
 }
 
 // TestElementIDBinding_TxJoin verifies that two patterns joined on ?e correctly
-// return *ElementID Tx values as distinct columns. In CRDT storage, each Set()
+// return *ElementID Tx values as distinct symbols. In CRDT storage, each Set()
 // gets a unique ElementID, so ?tx1 != ?tx2 even for the same entity.
 func TestElementIDBinding_TxJoin(t *testing.T) {
 	dir := t.TempDir()
@@ -277,7 +277,7 @@ func TestElementIDBinding_TxJoin(t *testing.T) {
 	t.Logf("TxJoin results: %v", results)
 	require.Len(t, results, 2, "Should return 2 name/age pairs joined on entity")
 
-	// Verify results contain correct name/age pairs and that Tx columns are ElementIDs
+	// Verify results contain correct name/age pairs and that Tx symbols are ElementIDs
 	for _, r := range results {
 		name := r[0].(string)
 		age := r[1].(int64)

--- a/datalog/storage/empty_data_subquery_bug_test.go
+++ b/datalog/storage/empty_data_subquery_bug_test.go
@@ -48,7 +48,7 @@ func TestEmptyDataSubqueryBug(t *testing.T) {
 	            $ ?s ?year ?month ?day) [[?open-price]]]]`
 
 	// Execute with default options (EnableFineGrainedPhases=true)
-	results, err := db.ExecuteQueryWithInputs(query, "AAPL")
+	results, err := executor.CollectTuples(db.Query(query, "AAPL"))
 
 	// Should succeed with empty results, NOT fail with projection error
 	if err != nil {
@@ -156,7 +156,7 @@ func TestEmptyDataSubqueryBug_FullGopherStreetQuery(t *testing.T) {
 	            $ ?s ?year ?month ?day) [[?total-volume]]]]`
 
 	// Execute with default options (EnableFineGrainedPhases=true)
-	results, err := db.ExecuteQueryWithInputs(query, "AAPL")
+	results, err := executor.CollectTuples(db.Query(query, "AAPL"))
 
 	if err != nil {
 		t.Logf("BUG REPRODUCED! Error: %v", err)

--- a/datalog/storage/empty_data_subquery_bug_test.go
+++ b/datalog/storage/empty_data_subquery_bug_test.go
@@ -221,7 +221,7 @@ func TestEmptyDataSubqueryBug_WithOptions(t *testing.T) {
 			t.Fatalf("Should succeed with empty results: %v", err)
 		}
 
-		// Convert to rows
+		// Convert to tuples
 		it := result.Iterator()
 		defer it.Close()
 		count := 0
@@ -247,7 +247,7 @@ func TestEmptyDataSubqueryBug_WithOptions(t *testing.T) {
 
 		assert.NoError(t, err, "Should succeed regardless of EnableFineGrainedPhases setting")
 
-		// Convert to rows
+		// Convert to tuples
 		it := result.Iterator()
 		defer it.Close()
 		count := 0

--- a/datalog/storage/export_test.go
+++ b/datalog/storage/export_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/codec"
 	"github.com/wbrown/janus-datalog/datalog/edn"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -1194,8 +1195,8 @@ func TestDatabaseRoundTrip_CRDTSemantics(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query original: should see "veteran" and "leader" but not "warrior"
-	results1, err := db1.ExecuteQueryWithInputs(
-		`[:find ?tag :in $ ?e :where [?e :person/tags ?tag]]`, id)
+	results1, err := executor.CollectTuples(db1.Query(
+		`[:find ?tag :in $ ?e :where [?e :person/tags ?tag]]`, id))
 	require.NoError(t, err)
 	tags1 := extractStringValues(results1)
 	assert.Contains(t, tags1, "veteran")
@@ -1215,8 +1216,8 @@ func TestDatabaseRoundTrip_CRDTSemantics(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query imported DB: same semantic result — "warrior" must still be dead
-	results2, err := db2.ExecuteQueryWithInputs(
-		`[:find ?tag :in $ ?e :where [?e :person/tags ?tag]]`, id)
+	results2, err := executor.CollectTuples(db2.Query(
+		`[:find ?tag :in $ ?e :where [?e :person/tags ?tag]]`, id))
 	require.NoError(t, err)
 	tags2 := extractStringValues(results2)
 	assert.Contains(t, tags2, "veteran")

--- a/datalog/storage/export_test.go
+++ b/datalog/storage/export_test.go
@@ -1281,12 +1281,12 @@ func TestDatabaseRoundTrip_RGA(t *testing.T) {
 // Helper functions
 // =============================================================================
 
-// extractStringValues extracts string values from query result tuples (first column)
+// extractStringValues extracts string values from query result tuples (first symbol)
 func extractStringValues(results [][]interface{}) []string {
 	var vals []string
-	for _, row := range results {
-		if len(row) > 0 {
-			if s, ok := row[0].(string); ok {
+	for _, tuple := range results {
+		if len(tuple) > 0 {
+			if s, ok := tuple[0].(string); ok {
 				vals = append(vals, s)
 			}
 		}

--- a/datalog/storage/get_else_constant_entity_test.go
+++ b/datalog/storage/get_else_constant_entity_test.go
@@ -162,13 +162,13 @@ func TestGetElseWithConstantEntity(t *testing.T) {
 			t.Fatalf("Query failed: %v", err)
 		}
 
-		// Should return 2 rows (one per item), each with Alice's nickname
+		// Should return 2 tuples (one per item), each with Alice's nickname
 		if len(results) != 2 {
 			t.Fatalf("Expected 2 results, got %d", len(results))
 		}
 
-		for _, row := range results {
-			nick := row[1].(string)
+		for _, tuple := range results {
+			nick := tuple[1].(string)
 			if nick != "Ali" {
 				t.Errorf("Expected 'Ali', got %q", nick)
 			}
@@ -192,8 +192,8 @@ func TestGetElseWithConstantEntity(t *testing.T) {
 			t.Fatalf("Expected 2 results, got %d", len(results))
 		}
 
-		for _, row := range results {
-			isMissing := row[1].(bool)
+		for _, tuple := range results {
+			isMissing := tuple[1].(bool)
 			if !isMissing {
 				t.Errorf("Expected true, got %v", isMissing)
 			}

--- a/datalog/storage/get_else_constant_entity_test.go
+++ b/datalog/storage/get_else_constant_entity_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 )
 
 // TestGetElseWithConstantEntity reproduces a bug where get-else fails when
@@ -52,13 +53,13 @@ func TestGetElseWithConstantEntity(t *testing.T) {
 	t.Run("entity from input parameter", func(t *testing.T) {
 		// Pass entity as input parameter - get-else should still work
 		// The entity is constant-bound via :in clause, not from a pattern
-		results, err := db.ExecuteQueryWithInputs(
+		results, err := executor.CollectTuples(db.Query(
 			`[:find ?nick
 			  :in $ ?entity
 			  :where
 			  [(get-else $ ?entity :person/nickname "No Nickname") ?nick]]`,
 			alice,
-		)
+		))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}
@@ -76,13 +77,13 @@ func TestGetElseWithConstantEntity(t *testing.T) {
 	t.Run("entity from input with default value", func(t *testing.T) {
 		charlie := datalog.NewIdentity("charlie")
 		// Charlie doesn't exist - should return default
-		results, err := db.ExecuteQueryWithInputs(
+		results, err := executor.CollectTuples(db.Query(
 			`[:find ?nick
 			  :in $ ?entity
 			  :where
 			  [(get-else $ ?entity :person/nickname "Unknown") ?nick]]`,
 			charlie,
-		)
+		))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}
@@ -99,13 +100,13 @@ func TestGetElseWithConstantEntity(t *testing.T) {
 
 	t.Run("missing? with constant entity", func(t *testing.T) {
 		// Similar bug for missing? with constant entity
-		results, err := db.ExecuteQueryWithInputs(
+		results, err := executor.CollectTuples(db.Query(
 			`[:find ?is-missing
 			  :in $ ?entity
 			  :where
 			  [(missing? $ ?entity :person/email) ?is-missing]]`,
 			alice,
-		)
+		))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}
@@ -122,13 +123,13 @@ func TestGetElseWithConstantEntity(t *testing.T) {
 
 	t.Run("get-else with no patterns at all", func(t *testing.T) {
 		// Edge case: query with ONLY get-else, no patterns
-		results, err := db.ExecuteQueryWithInputs(
+		results, err := executor.CollectTuples(db.Query(
 			`[:find ?name
 			  :in $ ?entity
 			  :where
 			  [(get-else $ ?entity :person/name "Anon") ?name]]`,
 			alice,
-		)
+		))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}
@@ -150,14 +151,14 @@ func TestGetElseWithConstantEntity(t *testing.T) {
 		// Query has a pattern [?i :item/name ?item-name] which creates groups
 		// But get-else uses ?entity which is constant-bound from input
 		// This triggers: len(groups) > 0 && len(unresolvedExprSyms) == 0
-		results, err := db.ExecuteQueryWithInputs(
+		results, err := executor.CollectTuples(db.Query(
 			`[:find ?item-name ?nick
 			  :in $ ?entity
 			  :where
 			  [?i :item/name ?item-name]
 			  [(get-else $ ?entity :person/nickname "No Nickname") ?nick]]`,
 			alice,
-		)
+		))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}
@@ -176,14 +177,14 @@ func TestGetElseWithConstantEntity(t *testing.T) {
 	})
 
 	t.Run("missing? with unrelated pattern - BUG CASE", func(t *testing.T) {
-		results, err := db.ExecuteQueryWithInputs(
+		results, err := executor.CollectTuples(db.Query(
 			`[:find ?item-name ?is-missing
 			  :in $ ?entity
 			  :where
 			  [?i :item/name ?item-name]
 			  [(missing? $ ?entity :person/email) ?is-missing]]`,
 			alice,
-		)
+		))
 		if err != nil {
 			t.Fatalf("Query failed: %v", err)
 		}

--- a/datalog/storage/get_some_input_test.go
+++ b/datalog/storage/get_some_input_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 )
 
 // TestGetSome_WithScalarInput reproduces a bug where a query using get-some
@@ -44,10 +45,10 @@ func TestGetSome_WithScalarInput(t *testing.T) {
 	}
 
 	// Query: get-some should return :entity/code value since entity has it
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?id :in $ ?e :where [(get-some $ ?e :entity/code :entity/name) ?id]]`,
 		entity,
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -69,10 +70,10 @@ func TestGetSome_WithScalarInput(t *testing.T) {
 		t.Fatalf("Failed to commit: %v", err)
 	}
 
-	results2, err := db.ExecuteQueryWithInputs(
+	results2, err := executor.CollectTuples(db.Query(
 		`[:find ?id :in $ ?e :where [(get-some $ ?e :entity/code :entity/name) ?id]]`,
 		entity2,
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed for entity2: %v", err)
 	}
@@ -113,10 +114,10 @@ func TestGetSome_WithScalarInput_NoMatch(t *testing.T) {
 	}
 
 	// Query: get-some should return empty (entity has neither requested attr)
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?id :in $ ?e :where [(get-some $ ?e :entity/code :entity/name) ?id]]`,
 		entity,
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -121,13 +121,13 @@ func (m *BadgerMatcher) estimatePatternCardinality(pattern *query.DataPattern) i
 func (m *BadgerMatcher) matchWithHashJoin(
 	pattern *query.DataPattern,
 	bindingRel executor.Relation,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	position int, // Datom position (0=E, 1=A, 2=V, 3=T)
 	index IndexType,
 	constraints []executor.StorageConstraint,
 ) (executor.Relation, error) {
 	// PHASE 1: Build hash set from binding relation
-	// Find which variable is at the datom position, then find its column index
+	// Find which variable is at the datom position, then find its symbol index
 	var joinSymbol query.Symbol
 	switch position {
 	case 0:
@@ -150,27 +150,27 @@ func (m *BadgerMatcher) matchWithHashJoin(
 		}
 	}
 
-	// Find the column index of joinSymbol in bindingRel
-	bindingCols := bindingRel.Columns()
-	columnIndex := -1
-	for i, col := range bindingCols {
-		if col == joinSymbol {
-			columnIndex = i
+	// Find the symbol index of joinSymbol in bindingRel
+	bindingSyms := bindingRel.Symbols()
+	symbolIndex := -1
+	for i, sym := range bindingSyms {
+		if sym == joinSymbol {
+			symbolIndex = i
 			break
 		}
 	}
 
-	if columnIndex == -1 {
+	if symbolIndex == -1 {
 		// Variable not in binding relation - shouldn't happen if strategy is correct
-		return executor.NewMaterializedRelationNoDedupeWithOptions(columns, nil, m.options), nil
+		return executor.NewMaterializedRelationNoDedupeWithOptions(symbols, nil, m.options), nil
 	}
 
-	// Build hash set using column index (not datom position)
-	hashSet := m.buildHashSet(bindingRel, columnIndex)
+	// Build hash set using symbol index (not datom position)
+	hashSet := m.buildHashSet(bindingRel, symbolIndex)
 
 	if len(hashSet) == 0 {
 		// No bindings - return empty result
-		return executor.NewMaterializedRelationNoDedupeWithOptions(columns, nil, m.options), nil
+		return executor.NewMaterializedRelationNoDedupeWithOptions(symbols, nil, m.options), nil
 	}
 
 	// PHASE 2: Determine scan range for the pattern
@@ -179,8 +179,8 @@ func (m *BadgerMatcher) matchWithHashJoin(
 	if len(hashSet) == 1 {
 		// Extract the single bound value from the hash set
 		for _, tuples := range hashSet {
-			if len(tuples) > 0 && columnIndex < len(tuples[0]) {
-				boundValue = tuples[0][columnIndex]
+			if len(tuples) > 0 && symbolIndex < len(tuples[0]) {
+				boundValue = tuples[0][symbolIndex]
 			}
 			break
 		}
@@ -206,18 +206,18 @@ func (m *BadgerMatcher) matchWithHashJoin(
 		matcher:      m,
 		pattern:      pattern,
 		bindingRel:   bindingRel,
-		columns:      columns,
+		symbols:      symbols,
 		position:     position,
 		index:        index,
 		constraints:  constraints,
 		hashSet:      hashSet,
 		iter:         resolvedIter,
-		workspace:    make(executor.Tuple, len(columns)),
-		tupleBuilder: m.getTupleBuilder(pattern, columns),
+		workspace:    make(executor.Tuple, len(symbols)),
+		tupleBuilder: m.getTupleBuilder(pattern, symbols),
 	}
 
 	// Return streaming relation
-	return executor.NewStreamingRelationWithOptions(columns, iter, m.options), nil
+	return executor.NewStreamingRelationWithOptions(symbols, iter, m.options), nil
 }
 
 // scanRange holds start and end keys for a storage scan
@@ -421,7 +421,7 @@ func (m *BadgerMatcher) chooseIndexForValues(index IndexType, e, a, v, tx interf
 }
 
 // buildHashSet creates a hash set from binding relation for O(1) lookup
-// Returns map from key to ALL tuples with that key value (supporting multi-column bindings)
+// Returns map from key to ALL tuples with that key value (supporting multi-symbol bindings)
 func (m *BadgerMatcher) buildHashSet(bindingRel executor.Relation, position int) map[string][]executor.Tuple {
 	hashSet := make(map[string][]executor.Tuple)
 
@@ -500,11 +500,11 @@ func (m *BadgerMatcher) matchesWithBindingTuple(
 	bindingRel executor.Relation,
 	bindingTuple executor.Tuple,
 ) bool {
-	// Build column index for binding relation
-	columns := bindingRel.Columns()
-	colIndex := make(map[query.Symbol]int)
-	for i, col := range columns {
-		colIndex[col] = i
+	// Build symbol index for binding relation
+	symbols := bindingRel.Symbols()
+	symIndex := make(map[query.Symbol]int)
+	for i, sym := range symbols {
+		symIndex[sym] = i
 	}
 
 	// Extract bound values for E, A, V, T
@@ -514,7 +514,7 @@ func (m *BadgerMatcher) matchesWithBindingTuple(
 	if c, ok := pattern.GetE().(query.Constant); ok {
 		e = c.Value
 	} else if sym, ok := pattern.GetE().(query.Variable); ok {
-		if idx, found := colIndex[sym.Name]; found && idx < len(bindingTuple) {
+		if idx, found := symIndex[sym.Name]; found && idx < len(bindingTuple) {
 			e = bindingTuple[idx]
 		}
 	}
@@ -523,7 +523,7 @@ func (m *BadgerMatcher) matchesWithBindingTuple(
 	if c, ok := pattern.GetA().(query.Constant); ok {
 		a = c.Value
 	} else if sym, ok := pattern.GetA().(query.Variable); ok {
-		if idx, found := colIndex[sym.Name]; found && idx < len(bindingTuple) {
+		if idx, found := symIndex[sym.Name]; found && idx < len(bindingTuple) {
 			a = bindingTuple[idx]
 		}
 	}
@@ -532,7 +532,7 @@ func (m *BadgerMatcher) matchesWithBindingTuple(
 	if c, ok := pattern.GetV().(query.Constant); ok {
 		v = c.Value
 	} else if sym, ok := pattern.GetV().(query.Variable); ok {
-		if idx, found := colIndex[sym.Name]; found && idx < len(bindingTuple) {
+		if idx, found := symIndex[sym.Name]; found && idx < len(bindingTuple) {
 			v = bindingTuple[idx]
 		}
 	}
@@ -542,7 +542,7 @@ func (m *BadgerMatcher) matchesWithBindingTuple(
 		if c, ok := pattern.GetT().(query.Constant); ok {
 			tx = c.Value
 		} else if sym, ok := pattern.GetT().(query.Variable); ok {
-			if idx, found := colIndex[sym.Name]; found && idx < len(bindingTuple) {
+			if idx, found := symIndex[sym.Name]; found && idx < len(bindingTuple) {
 				tx = bindingTuple[idx]
 			}
 		}
@@ -558,7 +558,7 @@ func (m *BadgerMatcher) matchesWithBindingTuple(
 func (m *BadgerMatcher) matchWithMergeJoin(
 	pattern *query.DataPattern,
 	bindingRel executor.Relation,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	position int,
 	index IndexType,
 	constraints []executor.StorageConstraint,
@@ -569,7 +569,7 @@ func (m *BadgerMatcher) matchWithMergeJoin(
 
 	if len(sortedTuples) == 0 {
 		// No bindings - return empty result
-		return executor.NewMaterializedRelationNoDedupeWithOptions(columns, nil, m.options), nil
+		return executor.NewMaterializedRelationNoDedupeWithOptions(symbols, nil, m.options), nil
 	}
 
 	// PHASE 2: Determine scan range for the pattern
@@ -594,19 +594,19 @@ func (m *BadgerMatcher) matchWithMergeJoin(
 		matcher:      m,
 		pattern:      pattern,
 		bindingRel:   bindingRel,
-		columns:      columns,
+		symbols:      symbols,
 		position:     position,
 		index:        index,
 		constraints:  constraints,
 		sortedTuples: sortedTuples,
 		bindingIdx:   0,
 		iter:         resolvedIterMerge,
-		workspace:    make(executor.Tuple, len(columns)),
-		tupleBuilder: m.getTupleBuilder(pattern, columns),
+		workspace:    make(executor.Tuple, len(symbols)),
+		tupleBuilder: m.getTupleBuilder(pattern, symbols),
 	}
 
 	// Return streaming relation
-	return executor.NewStreamingRelationWithOptions(columns, iter, m.options), nil
+	return executor.NewStreamingRelationWithOptions(symbols, iter, m.options), nil
 }
 
 // extractBindingKey extracts the join key from a binding tuple at the specified position
@@ -737,7 +737,7 @@ type hashJoinIterator struct {
 	matcher       *BadgerMatcher
 	pattern       *query.DataPattern
 	bindingRel    executor.Relation
-	columns       []query.Symbol
+	symbols       []query.Symbol
 	position      int
 	index         IndexType
 	constraints   []executor.StorageConstraint
@@ -772,7 +772,7 @@ func (it *hashJoinIterator) Next() bool {
 		// Probe hash set (O(1) lookup)
 		if bindingTuples, found := it.hashSet[probeKeyStr]; found {
 			// Check against ALL binding tuples with this key
-			// (for multi-column bindings, there may be multiple tuples per key)
+			// (for multi-symbol bindings, there may be multiple tuples per key)
 			for _, bindingTuple := range bindingTuples {
 				// Verify full pattern match
 				if it.matcher.matchesWithBindingTuple(datom, it.pattern, it.bindingRel, bindingTuple) {
@@ -829,7 +829,7 @@ type mergeJoinIterator struct {
 	matcher      *BadgerMatcher
 	pattern      *query.DataPattern
 	bindingRel   executor.Relation
-	columns      []query.Symbol
+	symbols      []query.Symbol
 	position     int
 	index        IndexType
 	constraints  []executor.StorageConstraint

--- a/datalog/storage/hash_join_symbol_index_test.go
+++ b/datalog/storage/hash_join_symbol_index_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 // TestHashJoinColumnIndexBug tests the bug where HashJoinScan confused
-// datom position with column index in the binding relation.
+// datom position with symbol index in the binding relation.
 //
 // Bug scenario:
 // - Pattern: [?e :attr ?ref] where ?ref comes from a binding relation
 // - ?ref is at datom position 2 (V position)
-// - But ?ref is at column index 0 in the binding relation (first/only column)
+// - But ?ref is at symbol index 0 in the binding relation (first/only symbol)
 // - buildHashSet was using position=2 instead of columnIndex=0
 // - Tried to access tuple[2] when tuple only had length 1
 // - Result: Empty hash set → no matches
@@ -24,7 +24,7 @@ import (
 // This bug was hidden because:
 // - With threshold ≤2, IndexNestedLoop was used for small binding sets
 // - Only appeared when we changed threshold to 0, making HashJoinScan the default
-// - Most benchmarks had patterns where datom position == column index
+// - Most benchmarks had patterns where datom position == symbol index
 func TestHashJoinColumnIndexBug(t *testing.T) {
 	tempDir := t.TempDir()
 	db, err := NewDatabase(tempDir)
@@ -56,10 +56,10 @@ func TestHashJoinColumnIndexBug(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Query that triggers the bug:
-	// 1. [?s :symbol/ticker "AAPL"] returns binding with columns=[?s]
+	// 1. [?s :symbol/ticker "AAPL"] returns binding with symbols=[?s]
 	// 2. [?e :price/symbol ?s] joins on ?s
 	//    - ?s is at datom position 2 (V position in the pattern)
-	//    - But ?s is at column index 0 in the binding relation
+	//    - But ?s is at symbol index 0 in the binding relation
 	//    - Bug: used position=2 to access tuple[2], but tuple only has length 1
 	queryStr := `[:find ?e ?value
 	              :where [?s :symbol/ticker "AAPL"]
@@ -77,7 +77,7 @@ func TestHashJoinColumnIndexBug(t *testing.T) {
 
 	result, err := exec.Execute(q)
 	assert.NoError(t, err)
-	assert.False(t, result.IsEmpty(), "Should have results when HashJoinScan correctly uses column index")
+	assert.False(t, result.IsEmpty(), "Should have results when HashJoinScan correctly uses symbol index")
 
 	// Should find all 5 price entities
 	assert.Equal(t, 5, result.Size(), "Should find 5 price entities")
@@ -88,17 +88,17 @@ func TestHashJoinColumnIndexBug(t *testing.T) {
 	count := 0
 	for it.Next() {
 		tuple := it.Tuple()
-		assert.Len(t, tuple, 2, "Should have 2 columns: ?e and ?value")
+		assert.Len(t, tuple, 2, "Should have 2 symbols: ?e and ?value")
 		// Verify entity is an Identity
 		switch v := tuple[0].(type) {
 		case datalog.Identity:
 			// Valid Identity type
 		default:
-			t.Errorf("First column should be Identity, got %T: %v", v, v)
+			t.Errorf("First symbol should be Identity, got %T: %v", v, v)
 		}
 		// Verify value is a float64
 		value, ok := tuple[1].(float64)
-		assert.True(t, ok, "Second column should be float64, got %T", tuple[1])
+		assert.True(t, ok, "Second symbol should be float64, got %T", tuple[1])
 		assert.GreaterOrEqual(t, value, 100.0)
 		assert.LessOrEqual(t, value, 104.0)
 		count++
@@ -106,8 +106,8 @@ func TestHashJoinColumnIndexBug(t *testing.T) {
 	assert.Equal(t, 5, count, "Iterator should return 5 tuples")
 }
 
-// TestHashJoinColumnIndexMultiColumn tests the fix works with multiple columns
-// where the join variable is not the first column.
+// TestHashJoinColumnIndexMultiColumn tests the fix works with multiple symbols
+// where the join variable is not the first symbol.
 func TestHashJoinColumnIndexMultiColumn(t *testing.T) {
 	tempDir := t.TempDir()
 	db, err := NewDatabase(tempDir)
@@ -133,12 +133,12 @@ func TestHashJoinColumnIndexMultiColumn(t *testing.T) {
 	_, err = tx.Commit()
 	assert.NoError(t, err)
 
-	// Query where join variable is the second column:
-	// 1. [?e1 :attr1 ?x] [?e1 :attr2 ?y] returns columns=[?e1, ?x, ?y]
-	//    (assuming phases separate these, second might be columns=[?y])
+	// Query where join variable is the second symbol:
+	// 1. [?e1 :attr1 ?x] [?e1 :attr2 ?y] returns symbols=[?e1, ?x, ?y]
+	//    (assuming phases separate these, second might be symbols=[?y])
 	// 2. [?e2 :attr3 ?y] joins on ?y
 	//    - ?y is at datom position 2 (V)
-	//    - ?y's column index depends on result of first patterns
+	//    - ?y's symbol index depends on result of first patterns
 	queryStr := `[:find ?e1 ?e2
 	              :where [?e1 :attr1 "X"]
 	                     [?e1 :attr2 ?y]
@@ -167,13 +167,13 @@ func TestHashJoinColumnIndexMultiColumn(t *testing.T) {
 	case datalog.Identity:
 		// Valid Identity type
 	default:
-		t.Fatalf("Expected Identity for first column, got %T", v)
+		t.Fatalf("Expected Identity for first symbol, got %T", v)
 	}
 	switch v := tuple[1].(type) {
 	case datalog.Identity:
 		// Valid Identity type
 	default:
-		t.Fatalf("Expected Identity for second column, got %T", v)
+		t.Fatalf("Expected Identity for second symbol, got %T", v)
 	}
 
 	// Both entities should be present and different

--- a/datalog/storage/iterator_reuse_regression_test.go
+++ b/datalog/storage/iterator_reuse_regression_test.go
@@ -427,7 +427,7 @@ func (m *instrumentedMatcher) Match(pattern *query.DataPattern, bindings executo
 		for _, elem := range pattern.Elements {
 			if v, ok := elem.(query.Variable); ok {
 				for _, rel := range bindings {
-					for _, col := range rel.Columns() {
+					for _, col := range rel.Symbols() {
 						if v.Name == col {
 							hasBindingVar = true
 							break

--- a/datalog/storage/join_e2e_test.go
+++ b/datalog/storage/join_e2e_test.go
@@ -88,7 +88,7 @@ func TestStorageBackedJoinE2E(t *testing.T) {
 				// Verify join correctness: name and age must match
 				for _, tuple := range results {
 					if len(tuple) != 2 {
-						t.Errorf("Expected 2 columns, got %d", len(tuple))
+						t.Errorf("Expected 2 symbols, got %d", len(tuple))
 						continue
 					}
 

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -125,7 +125,7 @@ func (m *BadgerMatcher) WithTimeRanges(ranges []executor.TimeRange) executor.Tim
 }
 
 // getTupleBuilder returns a cached tuple builder or creates a new one
-func (m *BadgerMatcher) getTupleBuilder(pattern *query.DataPattern, columns []query.Symbol) *query.InternedTupleBuilder {
+func (m *BadgerMatcher) getTupleBuilder(pattern *query.DataPattern, symbols []query.Symbol) *query.InternedTupleBuilder {
 	// Initialize cache exactly once (for tests or code paths that don't use NewBadgerMatcher)
 	m.builderCacheOnce.Do(func() {
 		if m.builderCache == nil {
@@ -134,15 +134,15 @@ func (m *BadgerMatcher) getTupleBuilder(pattern *query.DataPattern, columns []qu
 	})
 
 	key := pattern.String()
-	for _, col := range columns {
-		key += "|" + col.String()
+	for _, sym := range symbols {
+		key += "|" + sym.String()
 	}
 
 	if val, ok := m.builderCache.Load(key); ok {
 		return val.(*query.InternedTupleBuilder)
 	}
 
-	builder := query.NewInternedTupleBuilder(pattern, columns)
+	builder := query.NewInternedTupleBuilder(pattern, symbols)
 	actual, _ := m.builderCache.LoadOrStore(key, builder)
 	return actual.(*query.InternedTupleBuilder)
 }
@@ -158,7 +158,7 @@ func (m *BadgerMatcher) ForceJoinStrategy(strategy *JoinStrategy) {
 // bindPattern creates a new pattern with variables replaced by tuple values
 func (m *BadgerMatcher) bindPattern(pattern *query.DataPattern, tuple executor.Tuple, rel executor.Relation) *query.DataPattern {
 	// Get symbol positions in the relation
-	symbols := rel.Columns()
+	symbols := rel.Symbols()
 	symbolIndex := make(map[query.Symbol]int)
 	for i, sym := range symbols {
 		symbolIndex[sym] = i

--- a/datalog/storage/matcher_cache_test.go
+++ b/datalog/storage/matcher_cache_test.go
@@ -512,7 +512,7 @@ func BenchmarkCachePathWithBindings(b *testing.B) {
 			query.Variable{Name: datalog.NewSymbol("?age")},
 		},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?age")}
+	symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?age")}
 
 	b.Run("MatcherMatch_WithBindings", func(b *testing.B) {
 		b.ReportAllocs()
@@ -535,5 +535,5 @@ func BenchmarkCachePathWithBindings(b *testing.B) {
 		}
 	})
 
-	_ = columns // Used in pattern setup
+	_ = symbols // Used in pattern setup
 }

--- a/datalog/storage/matcher_cache_test.go
+++ b/datalog/storage/matcher_cache_test.go
@@ -379,7 +379,7 @@ func BenchmarkCachePathTupleBuilding(b *testing.B) {
 	b.Run("Query_CacheHit", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			result, _ := db.ExecuteQuery(`[:find ?e ?name :where [?e :person/name ?name]]`)
+			result, _ := executor.CollectTuples(db.Query(`[:find ?e ?name :where [?e :person/name ?name]]`))
 			if len(result) != 100 {
 				b.Fatalf("expected 100 results, got %d", len(result))
 			}
@@ -478,7 +478,7 @@ func BenchmarkCachePathWithBindings(b *testing.B) {
 	b.Run("JoinQuery_CachePath", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			result, err := db.ExecuteQuery(`[:find ?e ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`)
+			result, err := executor.CollectTuples(db.Query(`[:find ?e ?name ?age :where [?e :person/name ?name] [?e :person/age ?age]]`))
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/datalog/storage/matcher_concurrency_test.go
+++ b/datalog/storage/matcher_concurrency_test.go
@@ -18,7 +18,7 @@ func TestTupleBuilderCacheConcurrency(t *testing.T) {
 
 	matcher := NewBadgerMatcher(db.Store())
 
-	// Create test pattern and columns
+	// Create test pattern and symbols
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
 			query.Variable{Name: datalog.NewSymbol("?e")},
@@ -26,7 +26,7 @@ func TestTupleBuilderCacheConcurrency(t *testing.T) {
 			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+	symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 	// Spawn 1000 goroutines accessing cache concurrently
 	// This should trigger the concurrent map access bug if not fixed
@@ -38,7 +38,7 @@ func TestTupleBuilderCacheConcurrency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
-				builder := matcher.getTupleBuilder(pattern, columns)
+				builder := matcher.getTupleBuilder(pattern, symbols)
 				if builder == nil {
 					select {
 					case errorChan <- nil:
@@ -74,13 +74,13 @@ func TestTupleBuilderCacheSharing(t *testing.T) {
 			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+	symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 	// Get builder from base matcher
-	builder1 := baseMatcher.getTupleBuilder(pattern, columns)
+	builder1 := baseMatcher.getTupleBuilder(pattern, symbols)
 
 	// Get builder from AsOf matcher - should be the same instance (shared cache)
-	builder2 := asOfMatcher.getTupleBuilder(pattern, columns)
+	builder2 := asOfMatcher.getTupleBuilder(pattern, symbols)
 
 	if builder1 != builder2 {
 		t.Error("AsOf matcher should share cache with base matcher")

--- a/datalog/storage/matcher_iterator_nonreusing.go
+++ b/datalog/storage/matcher_iterator_nonreusing.go
@@ -12,7 +12,7 @@ type nonReusingIterator struct {
 	pattern       *query.DataPattern
 	bindingRel    executor.Relation
 	bindingTuples []executor.Tuple
-	columns       []query.Symbol
+	symbols       []query.Symbol
 	constraints   []executor.StorageConstraint
 
 	// Iterator state

--- a/datalog/storage/matcher_iterator_reusing.go
+++ b/datalog/storage/matcher_iterator_reusing.go
@@ -14,7 +14,7 @@ type reusingIterator struct {
 	tuples      []executor.Tuple
 	position    int       // Which position is changing (0=E, 1=A, 2=V)
 	index       IndexType // Which index to use
-	columns     []query.Symbol
+	symbols     []query.Symbol
 	constraints []executor.StorageConstraint
 
 	// Iterator state
@@ -250,11 +250,11 @@ func (it *reusingIterator) Close() error {
 	return nil
 }
 
-// getColumnIndex returns the index of a symbol in the binding relation columns
-func (it *reusingIterator) getColumnIndex(variable query.Variable) int {
-	columns := it.bindingRel.Columns()
-	for i, col := range columns {
-		if col == variable.Name {
+// getSymbolIndex returns the index of a symbol in the binding relation symbols
+func (it *reusingIterator) getSymbolIndex(variable query.Variable) int {
+	symbols := it.bindingRel.Symbols()
+	for i, sym := range symbols {
+		if sym == variable.Name {
 			return i
 		}
 	}
@@ -273,11 +273,11 @@ func (it *reusingIterator) updateBoundPattern(bindingTuple executor.Tuple) {
 
 // calculateSeekKey calculates the key to seek to based on binding tuple and position
 func (it *reusingIterator) calculateSeekKey(bindingTuple executor.Tuple) ([]byte, []byte) {
-	// Get column mapping
-	columns := it.bindingRel.Columns()
-	colIndex := make(map[query.Symbol]int)
-	for i, col := range columns {
-		colIndex[col] = i
+	// Get symbol mapping
+	symbols := it.bindingRel.Symbols()
+	symIndex := make(map[query.Symbol]int)
+	for i, sym := range symbols {
+		symIndex[sym] = i
 	}
 
 	// Extract values based on pattern
@@ -287,7 +287,7 @@ func (it *reusingIterator) calculateSeekKey(bindingTuple executor.Tuple) ([]byte
 	if c, ok := it.pattern.GetE().(query.Constant); ok {
 		e = c.Value
 	} else if sym, ok := it.pattern.GetE().(query.Variable); ok {
-		if idx, found := colIndex[sym.Name]; found && idx < len(bindingTuple) {
+		if idx, found := symIndex[sym.Name]; found && idx < len(bindingTuple) {
 			e = bindingTuple[idx]
 		}
 	}
@@ -303,7 +303,7 @@ func (it *reusingIterator) calculateSeekKey(bindingTuple executor.Tuple) ([]byte
 	if c, ok := it.pattern.GetV().(query.Constant); ok {
 		v = c.Value
 	} else if sym, ok := it.pattern.GetV().(query.Variable); ok {
-		if idx, found := colIndex[sym.Name]; found && idx < len(bindingTuple) {
+		if idx, found := symIndex[sym.Name]; found && idx < len(bindingTuple) {
 			v = bindingTuple[idx]
 		}
 	}
@@ -313,7 +313,7 @@ func (it *reusingIterator) calculateSeekKey(bindingTuple executor.Tuple) ([]byte
 		if c, ok := it.pattern.GetT().(query.Constant); ok {
 			tx = c.Value
 		} else if sym, ok := it.pattern.GetT().(query.Variable); ok {
-			if idx, found := colIndex[sym.Name]; found && idx < len(bindingTuple) {
+			if idx, found := symIndex[sym.Name]; found && idx < len(bindingTuple) {
 				tx = bindingTuple[idx]
 			}
 		}

--- a/datalog/storage/matcher_iterator_unbound.go
+++ b/datalog/storage/matcher_iterator_unbound.go
@@ -11,7 +11,7 @@ type unboundIterator struct {
 	index       IndexType
 	start, end  []byte
 	pattern     *query.DataPattern
-	columns     []query.Symbol
+	symbols     []query.Symbol
 	e, a, v, tx interface{}
 	constraints []executor.StorageConstraint
 
@@ -89,7 +89,7 @@ type unboundMaskIterator struct {
 	index       IndexType
 	start, end  []byte
 	pattern     *query.DataPattern
-	columns     []query.Symbol
+	symbols     []query.Symbol
 	e, a, v, tx interface{}
 	keyMask     *KeyMaskConstraint
 	constraints []executor.StorageConstraint // For non-mask constraints

--- a/datalog/storage/matcher_multi_position_debug_test.go
+++ b/datalog/storage/matcher_multi_position_debug_test.go
@@ -47,7 +47,7 @@ func TestMultiPositionDebug(t *testing.T) {
 			{entity1, "A"},
 		},
 	)
-	t.Logf("Binding columns: %v", bindingRel.Columns())
+	t.Logf("Binding symbols: %v", bindingRel.Symbols())
 
 	it := bindingRel.Iterator()
 	for it.Next() {
@@ -56,7 +56,7 @@ func TestMultiPositionDebug(t *testing.T) {
 	it.Close()
 
 	// Test the pattern extractor
-	extractor := query.NewPatternExtractor(pattern, bindingRel.Columns())
+	extractor := query.NewPatternExtractor(pattern, bindingRel.Symbols())
 	bindingTuple := executor.Tuple{entity1, "A"}
 	values := extractor.Extract(bindingTuple)
 	t.Logf("Extracted values:")

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -52,19 +52,19 @@ func (m *BadgerMatcher) MatchWithConstraints(
 	bindings executor.Relations,
 	constraints []executor.StorageConstraint,
 ) (executor.Relation, error) {
-	// Determine pattern columns
-	columns := pattern.ExtractColumns()
+	// Determine pattern symbols
+	symbols := pattern.ExtractColumns()
 
 	if bindings == nil || len(bindings) == 0 {
 		// Simple case - no bindings
-		return m.matchUnboundAsRelation(pattern, columns, constraints)
+		return m.matchUnboundAsRelation(pattern, symbols, constraints)
 	}
 
 	// Find best binding relation for this pattern
 	bindingRel := bindings.FindBestForPattern(pattern)
 	if bindingRel == nil {
 		// No relation binds any pattern variables
-		return m.matchUnboundAsRelation(pattern, columns, constraints)
+		return m.matchUnboundAsRelation(pattern, symbols, constraints)
 	}
 
 	// CRITICAL FIX: Don't call IsEmpty() on StreamingRelations - it consumes first tuple!
@@ -72,11 +72,11 @@ func (m *BadgerMatcher) MatchWithConstraints(
 	// If relation is empty, subsequent iteration will discover that naturally.
 	if _, isStreaming := bindingRel.(*executor.StreamingRelation); !isStreaming {
 		if bindingRel.IsEmpty() {
-			return m.matchUnboundAsRelation(pattern, columns, constraints)
+			return m.matchUnboundAsRelation(pattern, symbols, constraints)
 		}
 	}
 
-	// Project the binding relation to only include columns used in the pattern
+	// Project the binding relation to only include symbols used in the pattern
 	bindingRel = bindingRel.ProjectFromPattern(pattern)
 
 	// Check for vector cardinality - requires special handling with bound E from bindings
@@ -95,7 +95,7 @@ func (m *BadgerMatcher) MatchWithConstraints(
 			if kw, ok := aResolved.(datalog.Keyword); ok {
 				if attr := m.schema.GetAttribute(kw); attr != nil {
 					if attr.Cardinality == schema.CardinalityVector {
-						return m.matchVectorWithBindings(pattern, bindingRel, columns, kw)
+						return m.matchVectorWithBindings(pattern, bindingRel, symbols, kw)
 					}
 				}
 			}
@@ -106,22 +106,22 @@ func (m *BadgerMatcher) MatchWithConstraints(
 	// use the cache for each E value instead of storage scans.
 	if m.cache != nil && m.txID == nil {
 		if aResolved != nil {
-			// Phase 1: A has a single known value (from constant or single-row binding)
+			// Phase 1: A has a single known value (from constant or single-tuple binding)
 			if aKw, ok := aResolved.(datalog.Keyword); ok {
-				cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw, -1)
+				cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, symbols, aKw, -1)
 				if handled {
 					return cacheResult, nil
 				}
 			}
 		} else if aVar, ok := pattern.GetA().(query.Variable); ok {
-			// Phase 2: A varies per row in bindingRel (e.g., from join results)
-			aIdx := findVariableColumn(aVar.Name, bindingRel)
+			// Phase 2: A varies per tuple in bindingRel (e.g., from join results)
+			aIdx := findVariableSymbol(aVar.Name, bindingRel)
 			eVar, eIsVar := pattern.GetE().(query.Variable)
 			if aIdx >= 0 && eIsVar {
-				eIdx := findVariableColumn(eVar.Name, bindingRel)
+				eIdx := findVariableSymbol(eVar.Name, bindingRel)
 				if eIdx >= 0 {
 					cacheResult, handled := m.matchWithBindingsFromCache(
-						pattern, bindingRel, columns, nil, aIdx)
+						pattern, bindingRel, symbols, nil, aIdx)
 					if handled {
 						return cacheResult, nil
 					}
@@ -176,7 +176,7 @@ func (m *BadgerMatcher) MatchWithConstraints(
 		// For V-bound cardinality-one queries, use candidate + validate pattern
 		// See docs/reference/INDEX_SELECTION_PROOF.md Theorem 4
 		if strategy.NeedsValidation {
-			return m.matchWithVValidation(pattern, bindingRel, columns, strategy, constraints)
+			return m.matchWithVValidation(pattern, bindingRel, symbols, strategy, constraints)
 		}
 
 		// Choose join strategy based on selectivity
@@ -199,31 +199,31 @@ func (m *BadgerMatcher) MatchWithConstraints(
 		switch joinStrategy {
 		case HashJoinScan:
 			// Use hash join for medium selectivity (1-50%)
-			return m.matchWithHashJoin(pattern, bindingRel, columns, strategy.Position, strategy.Index, constraints)
+			return m.matchWithHashJoin(pattern, bindingRel, symbols, strategy.Position, strategy.Index, constraints)
 
 		case MergeJoin:
 			// Use merge join for high selectivity (>50%) with large binding sets
-			return m.matchWithMergeJoin(pattern, bindingRel, columns, strategy.Position, strategy.Index, constraints)
+			return m.matchWithMergeJoin(pattern, bindingRel, symbols, strategy.Position, strategy.Index, constraints)
 
 		case IndexNestedLoop:
 			// Use iterator reuse for small sets or high selectivity
-			return m.matchWithIteratorReuse(pattern, bindingRel, columns, strategy, constraints)
+			return m.matchWithIteratorReuse(pattern, bindingRel, symbols, strategy, constraints)
 
 		default:
 			// Fall back to iterator reuse
-			return m.matchWithIteratorReuse(pattern, bindingRel, columns, strategy, constraints)
+			return m.matchWithIteratorReuse(pattern, bindingRel, symbols, strategy, constraints)
 		}
 
 	case NoReuse:
 		fallthrough
 	default:
 		// Fall back to opening/closing iterator for each tuple
-		return m.matchWithoutIteratorReuse(pattern, bindingRel, columns, constraints)
+		return m.matchWithoutIteratorReuse(pattern, bindingRel, symbols, constraints)
 	}
 }
 
 // matchUnboundAsRelation matches a pattern without bindings and returns a Relation
-func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, columns []query.Symbol, constraints []executor.StorageConstraint) (executor.Relation, error) {
+func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, symbols []query.Symbol, constraints []executor.StorageConstraint) (executor.Relation, error) {
 	// Extract constant values from pattern
 	var e, a, v, tx interface{}
 
@@ -270,7 +270,7 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 	if m.cache != nil && m.txID == nil && e != nil && a != nil {
 		if eIdent, ok := e.(datalog.Identity); ok {
 			if aKw, ok := a.(datalog.Keyword); ok {
-				cacheResult, handled := m.matchFromCache(pattern, columns, eIdent, aKw, v, card)
+				cacheResult, handled := m.matchFromCache(pattern, symbols, eIdent, aKw, v, card)
 				if handled {
 					return cacheResult, nil
 				}
@@ -305,9 +305,9 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 		// V-bound scan (AVET) only sees datoms with this V, but the LWW winner
 		// may have a different V. Use candidate + validate pattern.
 		// See docs/reference/INDEX_SELECTION_PROOF.md Theorem 2 & 5.
-		dummyCol := datalog.NewSymbol("__v_bound_dummy__")
+		dummySym := datalog.NewSymbol("__v_bound_dummy__")
 		bindingRel := executor.NewMaterializedRelation(
-			[]query.Symbol{dummyCol},
+			[]query.Symbol{dummySym},
 			[]executor.Tuple{{v}},
 		)
 		strategy := ReuseStrategy{
@@ -318,7 +318,7 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			BoundA:          a,
 			BoundV:          v,
 		}
-		return m.matchWithVValidation(pattern, bindingRel, columns, strategy, nil)
+		return m.matchWithVValidation(pattern, bindingRel, symbols, strategy, nil)
 	} else if e == nil && a != nil && card == schema.CardinalityMany {
 		// E is unbound, A is bound, cardinality-many
 		// Need to scan all entities with this attribute and apply add-wins resolution
@@ -343,27 +343,27 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 
 	// For cardinality-vector with E+A bound: use vector resolution
 	if useVectorResolution {
-		return m.matchCardinalityVectorAsRelation(pattern, columns, e, a)
+		return m.matchCardinalityVectorAsRelation(pattern, symbols, e, a)
 	}
 
 	// For cardinality-many with E+A bound, V unbound: use add-wins resolution
 	if useAddWinsResolution {
-		return m.matchCardinalityManyAsRelation(pattern, columns, e, a)
+		return m.matchCardinalityManyAsRelation(pattern, symbols, e, a)
 	}
 
 	// For cardinality-many with E+A+V bound: use membership check
 	if useMembershipCheck {
-		return m.matchCardinalityManyMembership(pattern, columns, e, a, v)
+		return m.matchCardinalityManyMembership(pattern, symbols, e, a, v)
 	}
 
 	// For cardinality-many with A bound, E unbound, V unbound: scan all entities
 	if useAddWinsScanAllEntities {
-		return m.matchCardinalityManyScanAllEntities(pattern, columns, a)
+		return m.matchCardinalityManyScanAllEntities(pattern, symbols, a)
 	}
 
 	// For cardinality-many with A bound, E unbound, V bound: find entities with value
 	if useAddWinsScanAllEntitiesWithValue {
-		return m.matchCardinalityManyFindEntitiesWithValue(pattern, columns, a, v)
+		return m.matchCardinalityManyFindEntitiesWithValue(pattern, symbols, a, v)
 	}
 
 	// Choose index and create scan range
@@ -411,15 +411,15 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			start:           start,
 			end:             end,
 			pattern:         pattern,
-			columns:         columns,
+			symbols:         symbols,
 			e:               e,
 			a:               a,
 			v:               v,
 			tx:              tx,
 			keyMask:         keyMask,
 			constraints:     constraints, // Still need for non-mask constraints
-			workspace:       make(executor.Tuple, len(columns)),
-			tupleBuilder:    m.getTupleBuilder(pattern, columns),
+			workspace:       make(executor.Tuple, len(symbols)),
+			tupleBuilder:    m.getTupleBuilder(pattern, symbols),
 			returnOnlyFirst: returnOnlyFirst, // CRDT cardinality-one support
 		}
 
@@ -444,14 +444,14 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 			start:           start,
 			end:             end,
 			pattern:         pattern,
-			columns:         columns,
+			symbols:         symbols,
 			e:               e,
 			a:               a,
 			v:               v,
 			tx:              tx,
 			constraints:     constraints,
-			workspace:       make(executor.Tuple, len(columns)),
-			tupleBuilder:    m.getTupleBuilder(pattern, columns),
+			workspace:       make(executor.Tuple, len(symbols)),
+			tupleBuilder:    m.getTupleBuilder(pattern, symbols),
 			returnOnlyFirst: returnOnlyFirst, // CRDT cardinality-one support
 		}
 
@@ -473,12 +473,12 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, colum
 	// Return streaming relation with lazy materialization
 	// The iterator will be consumed and cached on first call to Iterator(),
 	// eliminating the 6.3 GB of upfront allocations while maintaining correctness
-	rel := executor.NewStreamingRelationWithOptions(columns, iter, m.options)
+	rel := executor.NewStreamingRelationWithOptions(symbols, iter, m.options)
 	return rel, nil
 }
 
 // matchWithoutIteratorReuse uses separate scan for each binding tuple
-func (m *BadgerMatcher) matchWithoutIteratorReuse(pattern *query.DataPattern, bindingRel executor.Relation, columns []query.Symbol, constraints []executor.StorageConstraint) (executor.Relation, error) {
+func (m *BadgerMatcher) matchWithoutIteratorReuse(pattern *query.DataPattern, bindingRel executor.Relation, symbols []query.Symbol, constraints []executor.StorageConstraint) (executor.Relation, error) {
 	// Emit no-reuse path event
 	if m.handler != nil {
 		m.handler(annotations.Event{
@@ -509,23 +509,23 @@ func (m *BadgerMatcher) matchWithoutIteratorReuse(pattern *query.DataPattern, bi
 		pattern:          pattern,
 		bindingRel:       bindingRel,
 		bindingTuples:    bindingTuples,
-		columns:          columns,
+		symbols:          symbols,
 		constraints:      constraints,
 		currentIdx:       -1,
-		workspace:        make(executor.Tuple, len(columns)),
-		patternExtractor: query.NewPatternExtractor(pattern, bindingRel.Columns()),
-		tupleBuilder:     m.getTupleBuilder(pattern, columns),
+		workspace:        make(executor.Tuple, len(symbols)),
+		patternExtractor: query.NewPatternExtractor(pattern, bindingRel.Symbols()),
+		tupleBuilder:     m.getTupleBuilder(pattern, symbols),
 	}
 
 	// Return streaming relation with the iterator
-	return executor.NewStreamingRelationWithOptions(columns, iter, m.options), nil
+	return executor.NewStreamingRelationWithOptions(symbols, iter, m.options), nil
 }
 
 // matchWithIteratorReuse implements the optimized iterator reuse strategy
 func (m *BadgerMatcher) matchWithIteratorReuse(
 	pattern *query.DataPattern,
 	bindingRel executor.Relation,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	strategy ReuseStrategy,
 	constraints []executor.StorageConstraint,
 ) (executor.Relation, error) {
@@ -542,16 +542,16 @@ func (m *BadgerMatcher) matchWithIteratorReuse(
 		tuples:           sortedTuples,
 		position:         strategy.Position,
 		index:            strategy.Index,
-		columns:          columns,
+		symbols:          symbols,
 		constraints:      constraints,
 		currentIdx:       -1,
-		workspace:        make(executor.Tuple, len(columns)),
-		patternExtractor: query.NewPatternExtractor(pattern, bindingRel.Columns()),
-		tupleBuilder:     m.getTupleBuilder(pattern, columns),
+		workspace:        make(executor.Tuple, len(symbols)),
+		patternExtractor: query.NewPatternExtractor(pattern, bindingRel.Symbols()),
+		tupleBuilder:     m.getTupleBuilder(pattern, symbols),
 	}
 
 	// Return streaming relation with the iterator
-	return executor.NewStreamingRelationWithOptions(columns, iter, m.options), nil
+	return executor.NewStreamingRelationWithOptions(symbols, iter, m.options), nil
 }
 
 // matchWithVValidation implements the candidate + validate pattern for V-bound
@@ -564,7 +564,7 @@ func (m *BadgerMatcher) matchWithIteratorReuse(
 func (m *BadgerMatcher) matchWithVValidation(
 	pattern *query.DataPattern,
 	bindingRel executor.Relation,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	strategy ReuseStrategy,
 	constraints []executor.StorageConstraint,
 ) (executor.Relation, error) {
@@ -576,7 +576,7 @@ func (m *BadgerMatcher) matchWithVValidation(
 				"pattern":     pattern.String(),
 				"index":       indexName(strategy.Index),
 				"bound_a":     fmt.Sprintf("%v", strategy.BoundA),
-				"binding_rel": bindingRel.Columns(),
+				"binding_rel": bindingRel.Symbols(),
 			},
 		})
 	}
@@ -592,15 +592,15 @@ func (m *BadgerMatcher) matchWithVValidation(
 		candidateIndex:   strategy.Index,           // AVET or VAET for candidates
 		validationIndex:  strategy.ValidationIndex, // EATV for validation
 		boundA:           strategy.BoundA,          // Constant A value if any
-		columns:          columns,
+		symbols:          symbols,
 		constraints:      constraints,
 		currentTupleIdx:  -1,
-		workspace:        make(executor.Tuple, len(columns)),
-		patternExtractor: query.NewPatternExtractor(pattern, bindingRel.Columns()),
-		tupleBuilder:     m.getTupleBuilder(pattern, columns),
+		workspace:        make(executor.Tuple, len(symbols)),
+		patternExtractor: query.NewPatternExtractor(pattern, bindingRel.Symbols()),
+		tupleBuilder:     m.getTupleBuilder(pattern, symbols),
 	}
 
-	return executor.NewStreamingRelationWithOptions(columns, iter, m.options), nil
+	return executor.NewStreamingRelationWithOptions(symbols, iter, m.options), nil
 }
 
 // validatingVBoundIterator implements the semi-join pattern for V-bound queries.
@@ -617,7 +617,7 @@ type validatingVBoundIterator struct {
 	pattern     *query.DataPattern
 	bindingRel  executor.Relation
 	tuples      []executor.Tuple
-	columns     []query.Symbol
+	symbols     []query.Symbol
 	constraints []executor.StorageConstraint
 
 	// Index configuration
@@ -923,23 +923,23 @@ func (it *validatingVBoundIterator) encodeValue(v any) []byte {
 
 // buildTuple creates a result tuple from a validated datom
 func (it *validatingVBoundIterator) buildTuple(datom *datalog.Datom) executor.Tuple {
-	tuple := make(executor.Tuple, len(it.columns))
-	for i, col := range it.columns {
+	tuple := make(executor.Tuple, len(it.symbols))
+	for i, sym := range it.symbols {
 		// Check each pattern element - might be Variable or Constant
-		if v, ok := it.pattern.GetE().(query.Variable); ok && col == v.Name {
+		if v, ok := it.pattern.GetE().(query.Variable); ok && sym == v.Name {
 			tuple[i] = datom.E
 			continue
 		}
-		if v, ok := it.pattern.GetA().(query.Variable); ok && col == v.Name {
+		if v, ok := it.pattern.GetA().(query.Variable); ok && sym == v.Name {
 			tuple[i] = datom.A
 			continue
 		}
-		if v, ok := it.pattern.GetV().(query.Variable); ok && col == v.Name {
+		if v, ok := it.pattern.GetV().(query.Variable); ok && sym == v.Name {
 			tuple[i] = datom.V
 			continue
 		}
 		if len(it.pattern.Elements) > 3 {
-			if v, ok := it.pattern.GetT().(query.Variable); ok && col == v.Name {
+			if v, ok := it.pattern.GetT().(query.Variable); ok && sym == v.Name {
 				tuple[i] = datom.Tx
 			}
 		}
@@ -967,7 +967,7 @@ func (it *validatingVBoundIterator) Close() error {
 func (m *BadgerMatcher) matchWithSimpleBatchScanning(
 	pattern *query.DataPattern,
 	bindingRel executor.Relation,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	strategy ReuseStrategy,
 	constraints []executor.StorageConstraint,
 ) (executor.Relation, error) {
@@ -982,7 +982,7 @@ func (m *BadgerMatcher) matchWithSimpleBatchScanning(
 		bindingRel,
 		position,
 		IndexType(index),
-		columns,
+		symbols,
 		constraints,
 	)
 
@@ -993,14 +993,14 @@ func (m *BadgerMatcher) matchWithSimpleBatchScanning(
 
 	// Return streaming relation wrapping the scanner
 	// Note: scanner materializes internally but we avoid secondary materialization
-	return executor.NewStreamingRelationWithOptions(columns, scanner, m.options), nil
+	return executor.NewStreamingRelationWithOptions(symbols, scanner, m.options), nil
 }
 
 // matchWithBatchScanning uses batch scanning to process large binding sets efficiently
 func (m *BadgerMatcher) matchWithBatchScanning(
 	pattern *query.DataPattern,
 	bindingRel executor.Relation,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	strategy ReuseStrategy,
 	constraints []executor.StorageConstraint,
 ) (executor.Relation, error) {
@@ -1011,7 +1011,7 @@ func (m *BadgerMatcher) matchWithBatchScanning(
 		bindingRel,
 		strategy.Position,
 		strategy.Index,
-		columns,
+		symbols,
 		constraints,
 	)
 
@@ -1022,7 +1022,7 @@ func (m *BadgerMatcher) matchWithBatchScanning(
 
 	// Return streaming relation wrapping the scanner
 	// Note: scanner materializes internally but we avoid secondary materialization
-	return executor.NewStreamingRelationWithOptions(columns, scanner, m.options), nil
+	return executor.NewStreamingRelationWithOptions(symbols, scanner, m.options), nil
 }
 
 // matchFromCache attempts to resolve a pattern using the cache.
@@ -1030,7 +1030,7 @@ func (m *BadgerMatcher) matchWithBatchScanning(
 // This provides O(1) access for patterns with E and A bound when querying latest state.
 func (m *BadgerMatcher) matchFromCache(
 	pattern *query.DataPattern,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	e datalog.Identity,
 	a datalog.Keyword,
 	v interface{}, // nil if V is unbound
@@ -1050,7 +1050,7 @@ func (m *BadgerMatcher) matchFromCache(
 	}
 
 	// Get tuple builder for building tuples
-	tupleBuilder := m.getTupleBuilder(pattern, columns)
+	tupleBuilder := m.getTupleBuilder(pattern, symbols)
 
 	// Pre-allocate datom buffer with constant E and A
 	var datomBuf datalog.Datom
@@ -1069,30 +1069,30 @@ func (m *BadgerMatcher) matchFromCache(
 		val := entry.OneValue()
 		if val == nil {
 			// No value - return empty relation
-			return executor.NewMaterializedRelationWithOptions(columns, nil, m.options), true
+			return executor.NewMaterializedRelationWithOptions(symbols, nil, m.options), true
 		}
 		if v != nil {
 			// V is bound - check if it matches
 			if !valuesEqual(val, v) {
-				return executor.NewMaterializedRelationWithOptions(columns, nil, m.options), true
+				return executor.NewMaterializedRelationWithOptions(symbols, nil, m.options), true
 			}
 		}
 		// Build tuple with the cached value
 		tuple := buildTuple(val, entry.Version())
-		return executor.NewMaterializedRelationWithOptions(columns, []executor.Tuple{tuple}, m.options), true
+		return executor.NewMaterializedRelationWithOptions(symbols, []executor.Tuple{tuple}, m.options), true
 
 	case schema.CardinalityMany:
 		set := entry.ManySet()
 		if len(set) == 0 {
-			return executor.NewMaterializedRelationWithOptions(columns, nil, m.options), true
+			return executor.NewMaterializedRelationWithOptions(symbols, nil, m.options), true
 		}
 		if v != nil {
 			// V is bound - membership check
 			if set[v] {
 				tuple := buildTuple(v, entry.Version())
-				return executor.NewMaterializedRelationWithOptions(columns, []executor.Tuple{tuple}, m.options), true
+				return executor.NewMaterializedRelationWithOptions(symbols, []executor.Tuple{tuple}, m.options), true
 			}
-			return executor.NewMaterializedRelationWithOptions(columns, nil, m.options), true
+			return executor.NewMaterializedRelationWithOptions(symbols, nil, m.options), true
 		}
 		// V is unbound - return all set members
 		tuples := make([]executor.Tuple, 0, len(set))
@@ -1100,12 +1100,12 @@ func (m *BadgerMatcher) matchFromCache(
 			tuple := buildTuple(val, entry.Version())
 			tuples = append(tuples, tuple)
 		}
-		return executor.NewMaterializedRelationWithOptions(columns, tuples, m.options), true
+		return executor.NewMaterializedRelationWithOptions(symbols, tuples, m.options), true
 
 	case schema.CardinalityVector:
 		list := entry.VectorList()
 		if len(list) == 0 {
-			return executor.NewMaterializedRelationWithOptions(columns, nil, m.options), true
+			return executor.NewMaterializedRelationWithOptions(symbols, nil, m.options), true
 		}
 		if v != nil {
 			// V is bound - check if vector equals (for vector, V is the whole list)
@@ -1114,33 +1114,33 @@ func (m *BadgerMatcher) matchFromCache(
 		}
 		// V is unbound - return the vector as a single value
 		tuple := buildTuple(list, entry.Version())
-		return executor.NewMaterializedRelationWithOptions(columns, []executor.Tuple{tuple}, m.options), true
+		return executor.NewMaterializedRelationWithOptions(symbols, []executor.Tuple{tuple}, m.options), true
 	}
 
 	return nil, false // Unknown cardinality, fallback to storage
 }
 
-// findVariableColumn returns the column index for a variable in a relation, or -1.
-func findVariableColumn(sym query.Symbol, rel executor.Relation) int {
-	for i, col := range rel.Columns() {
-		if col == sym {
+// findVariableSymbol returns the symbol index for a variable in a relation, or -1.
+func findVariableSymbol(sym query.Symbol, rel executor.Relation) int {
+	for i, s := range rel.Symbols() {
+		if s == sym {
 			return i
 		}
 	}
 	return -1
 }
 
-// resolveKeywordFromBindings searches all binding relations for a single-row relation
+// resolveKeywordFromBindings searches all binding relations for a single-tuple relation
 // containing the given variable and returns its value as a Keyword. This covers scalar
-// inputs and single-row tuple inputs where A has exactly one known value.
+// inputs and single-tuple tuple inputs where A has exactly one known value.
 func resolveKeywordFromBindings(aVar query.Variable, bindings executor.Relations) (datalog.Keyword, bool) {
 	for _, rel := range bindings {
-		idx := findVariableColumn(aVar.Name, rel)
+		idx := findVariableSymbol(aVar.Name, rel)
 		if idx < 0 {
 			continue
 		}
 		if rel.Size() != 1 {
-			return nil, false // multi-row — can't extract single value
+			return nil, false // multi-tuple — can't extract single value
 		}
 		iter := rel.Iterator()
 		defer iter.Close()
@@ -1158,38 +1158,38 @@ func resolveKeywordFromBindings(aVar query.Variable, bindings executor.Relations
 // Uses cache for O(1) lookup per bound E value instead of storage scans.
 // Returns (relation, true) if cache was used, (nil, false) if fallback to storage is needed.
 //
-// When aColIdx >= 0, A is extracted per-row from bindingRel[aColIdx] instead of using
-// the fixed `a` parameter. This handles the case where both E and A are columns in the
-// binding relation (e.g., from join results with varying attributes per row).
+// When aSymIdx >= 0, A is extracted per-tuple from bindingRel[aSymIdx] instead of using
+// the fixed `a` parameter. This handles the case where both E and A are symbols in the
+// binding relation (e.g., from join results with varying attributes per tuple).
 func (m *BadgerMatcher) matchWithBindingsFromCache(
 	pattern *query.DataPattern,
 	bindingRel executor.Relation,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	a datalog.Keyword,
-	aColIdx int,
+	aSymIdx int,
 ) (executor.Relation, bool) {
-	// Find which column in the binding relation has E
+	// Find which symbol in the binding relation has E
 	eVar, isVar := pattern.GetE().(query.Variable)
 	if !isVar {
 		return nil, false // E is not a variable, can't get it from bindings
 	}
 
-	bindingColumns := bindingRel.Columns()
-	eColIdx := -1
-	for i, col := range bindingColumns {
-		if col == eVar.Name {
-			eColIdx = i
+	bindingSymbols := bindingRel.Symbols()
+	eSymIdx := -1
+	for i, sym := range bindingSymbols {
+		if sym == eVar.Name {
+			eSymIdx = i
 			break
 		}
 	}
-	if eColIdx < 0 {
+	if eSymIdx < 0 {
 		return nil, false // E variable not in bindings
 	}
 
-	// Pre-compute fixed-A values when A is constant across all rows
+	// Pre-compute fixed-A values when A is constant across all tuples
 	var fixedCard schema.Cardinality
 	var fixedAAttr Attribute
-	if aColIdx < 0 {
+	if aSymIdx < 0 {
 		fixedCard = schema.CardinalityOne
 		if m.schema != nil {
 			if def := m.schema.GetAttribute(a); def != nil {
@@ -1207,12 +1207,12 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 	}
 
 	// Get tuple builder
-	tupleBuilder := m.getTupleBuilder(pattern, columns)
+	tupleBuilder := m.getTupleBuilder(pattern, symbols)
 
 	// Pre-allocate datom buffer
 	var datomBuf datalog.Datom
-	if aColIdx < 0 {
-		datomBuf.A = a // constant A across all rows
+	if aSymIdx < 0 {
+		datomBuf.A = a // constant A across all tuples
 	}
 
 	buildTuple := func(e datalog.Identity, val interface{}, tx datalog.ElementID) executor.Tuple {
@@ -1229,12 +1229,12 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 
 	for iter.Next() {
 		tuple := iter.Tuple()
-		if eColIdx >= len(tuple) {
+		if eSymIdx >= len(tuple) {
 			continue
 		}
 
 		// Get E value from binding
-		eVal := tuple[eColIdx]
+		eVal := tuple[eSymIdx]
 		eIdent, ok := eVal.(datalog.Identity)
 		if !ok {
 			// Try to convert if it's a different type
@@ -1245,15 +1245,15 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 			}
 		}
 
-		// Determine A and cardinality for this row
+		// Determine A and cardinality for this tuple
 		var rowCard schema.Cardinality
 		var rowAAttr Attribute
-		if aColIdx >= 0 {
-			// Per-row A: extract from binding tuple
-			if aColIdx >= len(tuple) {
+		if aSymIdx >= 0 {
+			// Per-tuple A: extract from binding tuple
+			if aSymIdx >= len(tuple) {
 				continue
 			}
-			aKw, ok := tuple[aColIdx].(datalog.Keyword)
+			aKw, ok := tuple[aSymIdx].(datalog.Keyword)
 			if !ok {
 				continue
 			}
@@ -1324,7 +1324,7 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 		}
 	}
 
-	return executor.NewMaterializedRelationWithOptions(columns, resultTuples, m.options), true
+	return executor.NewMaterializedRelationWithOptions(symbols, resultTuples, m.options), true
 }
 
 // valuesEqual compares two values for equality
@@ -1363,7 +1363,7 @@ func valuesEqual(a, b interface{}) bool {
 // matchCardinalityManyAsRelation handles cardinality-many patterns using add-wins resolution
 func (m *BadgerMatcher) matchCardinalityManyAsRelation(
 	pattern *query.DataPattern,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	e, a interface{},
 ) (executor.Relation, error) {
 	// Get entity and attribute bytes
@@ -1384,24 +1384,24 @@ func (m *BadgerMatcher) matchCardinalityManyAsRelation(
 	}
 
 	// Build tuples from resolved members
-	// We need to map the values to the correct column positions
+	// We need to map the values to the correct symbol positions
 	tuples := make([]executor.Tuple, 0, len(result.Members))
 
 	for member := range result.Members {
-		tuple := make(executor.Tuple, len(columns))
-		for i, col := range columns {
+		tuple := make(executor.Tuple, len(symbols))
+		for i, sym := range symbols {
 			switch {
 			case pattern.GetE() != nil && pattern.GetE().IsVariable() &&
-				pattern.GetE().(query.Variable).Name == col:
+				pattern.GetE().(query.Variable).Name == sym:
 				tuple[i] = e
 			case pattern.GetA() != nil && pattern.GetA().IsVariable() &&
-				pattern.GetA().(query.Variable).Name == col:
+				pattern.GetA().(query.Variable).Name == sym:
 				tuple[i] = a
 			case pattern.GetV() != nil && pattern.GetV().IsVariable() &&
-				pattern.GetV().(query.Variable).Name == col:
+				pattern.GetV().(query.Variable).Name == sym:
 				tuple[i] = member
 			case pattern.GetT() != nil && pattern.GetT().IsVariable() &&
-				pattern.GetT().(query.Variable).Name == col:
+				pattern.GetT().(query.Variable).Name == sym:
 				// For cardinality-many, we don't have a single Tx
 				// Use the max ElementID as the "current" transaction
 				tuple[i] = result.MaxElementID
@@ -1411,14 +1411,14 @@ func (m *BadgerMatcher) matchCardinalityManyAsRelation(
 	}
 
 	// Return materialized relation with the resolved set members
-	return executor.NewMaterializedRelation(columns, tuples), nil
+	return executor.NewMaterializedRelation(symbols, tuples), nil
 }
 
 // matchCardinalityVectorAsRelation handles cardinality-vector patterns using RGA resolution.
 // Returns the entire reconstructed vector as a single value bound to the V variable.
 func (m *BadgerMatcher) matchCardinalityVectorAsRelation(
 	pattern *query.DataPattern,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	e, a interface{},
 ) (executor.Relation, error) {
 	// Get entity and attribute bytes
@@ -1440,32 +1440,32 @@ func (m *BadgerMatcher) matchCardinalityVectorAsRelation(
 
 	// If empty vector, return empty relation
 	if len(result.Elements) == 0 {
-		return executor.NewMaterializedRelation(columns, nil), nil
+		return executor.NewMaterializedRelation(symbols, nil), nil
 	}
 
 	// Build a single tuple with the entire vector as the V value
-	tuple := make(executor.Tuple, len(columns))
-	for i, col := range columns {
+	tuple := make(executor.Tuple, len(symbols))
+	for i, sym := range symbols {
 		switch {
 		case pattern.GetE() != nil && pattern.GetE().IsVariable() &&
-			pattern.GetE().(query.Variable).Name == col:
+			pattern.GetE().(query.Variable).Name == sym:
 			tuple[i] = e
 		case pattern.GetA() != nil && pattern.GetA().IsVariable() &&
-			pattern.GetA().(query.Variable).Name == col:
+			pattern.GetA().(query.Variable).Name == sym:
 			tuple[i] = a
 		case pattern.GetV() != nil && pattern.GetV().IsVariable() &&
-			pattern.GetV().(query.Variable).Name == col:
+			pattern.GetV().(query.Variable).Name == sym:
 			// Return the entire vector as a []any
 			tuple[i] = result.Elements
 		case pattern.GetT() != nil && pattern.GetT().IsVariable() &&
-			pattern.GetT().(query.Variable).Name == col:
+			pattern.GetT().(query.Variable).Name == sym:
 			// Use the max ElementID as the "current" transaction
 			tuple[i] = result.MaxElementID
 		}
 	}
 
-	// Return single-row relation with the vector
-	return executor.NewMaterializedRelation(columns, []executor.Tuple{tuple}), nil
+	// Return single-tuple relation with the vector
+	return executor.NewMaterializedRelation(symbols, []executor.Tuple{tuple}), nil
 }
 
 // matchVectorWithBindings handles vector patterns when E is bound via join bindings.
@@ -1474,28 +1474,28 @@ func (m *BadgerMatcher) matchCardinalityVectorAsRelation(
 func (m *BadgerMatcher) matchVectorWithBindings(
 	pattern *query.DataPattern,
 	bindingRel executor.Relation,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	attr datalog.Keyword,
 ) (executor.Relation, error) {
-	// Find which column in bindings provides the entity
-	var eColIdx int = -1
-	bindingCols := bindingRel.Columns()
+	// Find which symbol in bindings provides the entity
+	var eSymIdx int = -1
+	bindingSyms := bindingRel.Symbols()
 
-	// Find the entity variable in the pattern and match it to binding columns
+	// Find the entity variable in the pattern and match it to binding symbols
 	if pattern.GetE() != nil && pattern.GetE().IsVariable() {
 		eVar := pattern.GetE().(query.Variable).Name
-		for i, col := range bindingCols {
-			if col == eVar {
-				eColIdx = i
+		for i, sym := range bindingSyms {
+			if sym == eVar {
+				eSymIdx = i
 				break
 			}
 		}
 	}
 
-	if eColIdx == -1 {
+	if eSymIdx == -1 {
 		// E is not bound from bindings - fall back to normal path
 		// This shouldn't happen if we got here, but be safe
-		return executor.NewMaterializedRelation(columns, nil), nil
+		return executor.NewMaterializedRelation(symbols, nil), nil
 	}
 
 	// Get attribute bytes once
@@ -1509,7 +1509,7 @@ func (m *BadgerMatcher) matchVectorWithBindings(
 
 	for it.Next() {
 		bindingTuple := it.Tuple()
-		eVal := bindingTuple[eColIdx]
+		eVal := bindingTuple[eSymIdx]
 
 		// Get entity bytes
 		var eBytes [20]byte
@@ -1531,26 +1531,26 @@ func (m *BadgerMatcher) matchVectorWithBindings(
 		}
 
 		// Build output tuple
-		tuple := make(executor.Tuple, len(columns))
-		for i, col := range columns {
+		tuple := make(executor.Tuple, len(symbols))
+		for i, sym := range symbols {
 			switch {
 			case pattern.GetE() != nil && pattern.GetE().IsVariable() &&
-				pattern.GetE().(query.Variable).Name == col:
+				pattern.GetE().(query.Variable).Name == sym:
 				tuple[i] = eVal
 			case pattern.GetA() != nil && pattern.GetA().IsVariable() &&
-				pattern.GetA().(query.Variable).Name == col:
+				pattern.GetA().(query.Variable).Name == sym:
 				tuple[i] = attr
 			case pattern.GetV() != nil && pattern.GetV().IsVariable() &&
-				pattern.GetV().(query.Variable).Name == col:
+				pattern.GetV().(query.Variable).Name == sym:
 				// Return the entire vector as []any
 				tuple[i] = result.Elements
 			case pattern.GetT() != nil && pattern.GetT().IsVariable() &&
-				pattern.GetT().(query.Variable).Name == col:
+				pattern.GetT().(query.Variable).Name == sym:
 				tuple[i] = result.MaxElementID
 			default:
-				// Check if this column comes from bindings (pass through)
-				for j, bindCol := range bindingCols {
-					if bindCol == col && j < len(bindingTuple) {
+				// Check if this symbol comes from bindings (pass through)
+				for j, bindSym := range bindingSyms {
+					if bindSym == sym && j < len(bindingTuple) {
 						tuple[i] = bindingTuple[j]
 						break
 					}
@@ -1561,13 +1561,13 @@ func (m *BadgerMatcher) matchVectorWithBindings(
 		tuples = append(tuples, tuple)
 	}
 
-	return executor.NewMaterializedRelation(columns, tuples), nil
+	return executor.NewMaterializedRelation(symbols, tuples), nil
 }
 
 // matchCardinalityManyMembership checks if a specific value is in a cardinality-many set
 func (m *BadgerMatcher) matchCardinalityManyMembership(
 	pattern *query.DataPattern,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	e, a, v interface{},
 ) (executor.Relation, error) {
 	// Get entity and attribute bytes
@@ -1589,30 +1589,30 @@ func (m *BadgerMatcher) matchCardinalityManyMembership(
 
 	// If not a member, return empty relation
 	if !isMember {
-		return executor.NewMaterializedRelation(columns, nil), nil
+		return executor.NewMaterializedRelation(symbols, nil), nil
 	}
 
 	// Value is in set - build result tuple
-	tuple := make(executor.Tuple, len(columns))
-	for i, col := range columns {
+	tuple := make(executor.Tuple, len(symbols))
+	for i, sym := range symbols {
 		switch {
 		case pattern.GetE() != nil && pattern.GetE().IsVariable() &&
-			pattern.GetE().(query.Variable).Name == col:
+			pattern.GetE().(query.Variable).Name == sym:
 			tuple[i] = e
 		case pattern.GetA() != nil && pattern.GetA().IsVariable() &&
-			pattern.GetA().(query.Variable).Name == col:
+			pattern.GetA().(query.Variable).Name == sym:
 			tuple[i] = a
 		case pattern.GetV() != nil && pattern.GetV().IsVariable() &&
-			pattern.GetV().(query.Variable).Name == col:
+			pattern.GetV().(query.Variable).Name == sym:
 			tuple[i] = v
 		case pattern.GetT() != nil && pattern.GetT().IsVariable() &&
-			pattern.GetT().(query.Variable).Name == col:
+			pattern.GetT().(query.Variable).Name == sym:
 			// For membership queries, we don't have a specific Tx
 			tuple[i] = datalog.ElementID{}
 		}
 	}
 
-	return executor.NewMaterializedRelation(columns, []executor.Tuple{tuple}), nil
+	return executor.NewMaterializedRelation(symbols, []executor.Tuple{tuple}), nil
 }
 
 // cardinalityManyScanAllEntitiesIterator streams results for [?e :attr ?v] patterns
@@ -1621,7 +1621,7 @@ func (m *BadgerMatcher) matchCardinalityManyMembership(
 type cardinalityManyScanAllEntitiesIterator struct {
 	matcher      *BadgerMatcher
 	pattern      *query.DataPattern
-	columns      []query.Symbol
+	symbols      []query.Symbol
 	a            interface{}
 	aBytes       [32]byte
 	storageIter  Iterator
@@ -1643,20 +1643,20 @@ func (it *cardinalityManyScanAllEntitiesIterator) Next() bool {
 			it.currentMemberIdx++
 
 			// Build tuple
-			tuple := make(executor.Tuple, len(it.columns))
-			for i, col := range it.columns {
+			tuple := make(executor.Tuple, len(it.symbols))
+			for i, sym := range it.symbols {
 				switch {
 				case it.pattern.GetE() != nil && it.pattern.GetE().IsVariable() &&
-					it.pattern.GetE().(query.Variable).Name == col:
+					it.pattern.GetE().(query.Variable).Name == sym:
 					tuple[i] = it.currentEntity
 				case it.pattern.GetA() != nil && it.pattern.GetA().IsVariable() &&
-					it.pattern.GetA().(query.Variable).Name == col:
+					it.pattern.GetA().(query.Variable).Name == sym:
 					tuple[i] = it.a
 				case it.pattern.GetV() != nil && it.pattern.GetV().IsVariable() &&
-					it.pattern.GetV().(query.Variable).Name == col:
+					it.pattern.GetV().(query.Variable).Name == sym:
 					tuple[i] = member
 				case it.pattern.GetT() != nil && it.pattern.GetT().IsVariable() &&
-					it.pattern.GetT().(query.Variable).Name == col:
+					it.pattern.GetT().(query.Variable).Name == sym:
 					tuple[i] = it.currentMaxElementID
 				}
 			}
@@ -1724,7 +1724,7 @@ func (it *cardinalityManyScanAllEntitiesIterator) Close() error {
 // Scans all entities with the attribute and resolves each set using add-wins
 func (m *BadgerMatcher) matchCardinalityManyScanAllEntities(
 	pattern *query.DataPattern,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	a interface{},
 ) (executor.Relation, error) {
 	// Get attribute bytes
@@ -1748,14 +1748,14 @@ func (m *BadgerMatcher) matchCardinalityManyScanAllEntities(
 	iter := &cardinalityManyScanAllEntitiesIterator{
 		matcher:      m,
 		pattern:      pattern,
-		columns:      columns,
+		symbols:      symbols,
 		a:            a,
 		aBytes:       aBytes,
 		storageIter:  storageIter,
 		seenEntities: make(map[[20]byte]bool),
 	}
 
-	return executor.NewStreamingRelationWithOptions(columns, iter, m.options), nil
+	return executor.NewStreamingRelationWithOptions(symbols, iter, m.options), nil
 }
 
 // cardinalityManyAVETValueIterator streams results for [?e :attr "value"] patterns
@@ -1769,7 +1769,7 @@ func (m *BadgerMatcher) matchCardinalityManyScanAllEntities(
 type cardinalityManyAVETValueIterator struct {
 	matcher     *BadgerMatcher
 	pattern     *query.DataPattern
-	columns     []query.Symbol
+	symbols     []query.Symbol
 	a, v        interface{}
 	aBytes      [32]byte
 	storageIter Iterator
@@ -1876,20 +1876,20 @@ func (it *cardinalityManyAVETValueIterator) isCurrentEntityMember() bool {
 }
 
 func (it *cardinalityManyAVETValueIterator) buildTuple() {
-	tuple := make(executor.Tuple, len(it.columns))
-	for i, col := range it.columns {
+	tuple := make(executor.Tuple, len(it.symbols))
+	for i, sym := range it.symbols {
 		switch {
 		case it.pattern.GetE() != nil && it.pattern.GetE().IsVariable() &&
-			it.pattern.GetE().(query.Variable).Name == col:
+			it.pattern.GetE().(query.Variable).Name == sym:
 			tuple[i] = it.currentEntity
 		case it.pattern.GetA() != nil && it.pattern.GetA().IsVariable() &&
-			it.pattern.GetA().(query.Variable).Name == col:
+			it.pattern.GetA().(query.Variable).Name == sym:
 			tuple[i] = it.a
 		case it.pattern.GetV() != nil && it.pattern.GetV().IsVariable() &&
-			it.pattern.GetV().(query.Variable).Name == col:
+			it.pattern.GetV().(query.Variable).Name == sym:
 			tuple[i] = it.v
 		case it.pattern.GetT() != nil && it.pattern.GetT().IsVariable() &&
-			it.pattern.GetT().(query.Variable).Name == col:
+			it.pattern.GetT().(query.Variable).Name == sym:
 			tuple[i] = datalog.ElementID{}
 		}
 	}
@@ -1916,7 +1916,7 @@ func (it *cardinalityManyAVETValueIterator) Close() error {
 type cardinalityManyFindEntitiesWithValueIterator struct {
 	matcher      *BadgerMatcher
 	pattern      *query.DataPattern
-	columns      []query.Symbol
+	symbols      []query.Symbol
 	a, v         interface{}
 	aBytes       [32]byte
 	storageIter  Iterator
@@ -1951,20 +1951,20 @@ func (it *cardinalityManyFindEntitiesWithValueIterator) Next() bool {
 		}
 
 		// Value is in the set - build tuple
-		tuple := make(executor.Tuple, len(it.columns))
-		for i, col := range it.columns {
+		tuple := make(executor.Tuple, len(it.symbols))
+		for i, sym := range it.symbols {
 			switch {
 			case it.pattern.GetE() != nil && it.pattern.GetE().IsVariable() &&
-				it.pattern.GetE().(query.Variable).Name == col:
+				it.pattern.GetE().(query.Variable).Name == sym:
 				tuple[i] = datom.E
 			case it.pattern.GetA() != nil && it.pattern.GetA().IsVariable() &&
-				it.pattern.GetA().(query.Variable).Name == col:
+				it.pattern.GetA().(query.Variable).Name == sym:
 				tuple[i] = it.a
 			case it.pattern.GetV() != nil && it.pattern.GetV().IsVariable() &&
-				it.pattern.GetV().(query.Variable).Name == col:
+				it.pattern.GetV().(query.Variable).Name == sym:
 				tuple[i] = it.v
 			case it.pattern.GetT() != nil && it.pattern.GetT().IsVariable() &&
-				it.pattern.GetT().(query.Variable).Name == col:
+				it.pattern.GetT().(query.Variable).Name == sym:
 				tuple[i] = datalog.ElementID{}
 			}
 		}
@@ -1992,7 +1992,7 @@ func (it *cardinalityManyFindEntitiesWithValueIterator) Close() error {
 // instead of O(n) where n = all entities with the attribute.
 func (m *BadgerMatcher) matchCardinalityManyFindEntitiesWithValue(
 	pattern *query.DataPattern,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	a, v interface{},
 ) (executor.Relation, error) {
 	// Get attribute bytes
@@ -2022,12 +2022,12 @@ func (m *BadgerMatcher) matchCardinalityManyFindEntitiesWithValue(
 	iter := &cardinalityManyAVETValueIterator{
 		matcher:     m,
 		pattern:     pattern,
-		columns:     columns,
+		symbols:     symbols,
 		a:           a,
 		v:           v,
 		aBytes:      aBytes,
 		storageIter: storageIter,
 	}
 
-	return executor.NewStreamingRelationWithOptions(columns, iter, m.options), nil
+	return executor.NewStreamingRelationWithOptions(symbols, iter, m.options), nil
 }

--- a/datalog/storage/matcher_strategy.go
+++ b/datalog/storage/matcher_strategy.go
@@ -73,10 +73,10 @@ func analyzeReuseStrategy(pattern *query.DataPattern, bindingRel executor.Relati
 	// but that's okay - the overhead of reuse with one binding is negligible
 
 	// Count which positions have variables that are bound
-	bindingCols := bindingRel.Columns()
+	bindingSyms := bindingRel.Symbols()
 	bindingSet := make(map[query.Symbol]bool)
-	for _, col := range bindingCols {
-		bindingSet[col] = true
+	for _, sym := range bindingSyms {
+		bindingSet[sym] = true
 	}
 
 	// Track which positions have bound variables
@@ -211,17 +211,17 @@ func chooseBestMultiPositionStrategy(
 		bindingRel = streamRel.Materialize()
 	}
 
-	// Track column index and distinct count per bound position.
+	// Track symbol index and distinct count per bound position.
 	// Uses a slice parallel to boundPositions for deterministic iteration
 	// (maps cause nondeterministic tiebreaking via random iteration order).
 	type posInfo struct {
 		pos      int // datom position (0=E, 1=A, 2=V, 3=T)
-		colIdx   int // column index in binding relation (-1 if not found)
+		symIdx   int // symbol index in binding relation (-1 if not found)
 		distinct int // count of distinct values
 	}
 	info := make([]posInfo, 0, len(boundPositions))
 
-	// Build position-to-column-index mapping
+	// Build position-to-symbol-index mapping
 	for _, pos := range boundPositions {
 		var varName query.Symbol
 		switch pos {
@@ -249,14 +249,14 @@ func chooseBestMultiPositionStrategy(
 			continue
 		}
 
-		colIdx := -1
-		for ci, col := range bindingRel.Columns() {
-			if col == varName {
-				colIdx = ci
+		symIdx := -1
+		for si, sym := range bindingRel.Symbols() {
+			if sym == varName {
+				symIdx = si
 				break
 			}
 		}
-		info = append(info, posInfo{pos: pos, colIdx: colIdx})
+		info = append(info, posInfo{pos: pos, symIdx: symIdx})
 	}
 
 	// Count distinct values for each position
@@ -269,8 +269,8 @@ func chooseBestMultiPositionStrategy(
 	for it.Next() {
 		tuple := it.Tuple()
 		for i, pi := range info {
-			if pi.colIdx >= 0 && pi.colIdx < len(tuple) {
-				sets[i][tuple[pi.colIdx]] = true
+			if pi.symIdx >= 0 && pi.symIdx < len(tuple) {
+				sets[i][tuple[pi.symIdx]] = true
 			}
 		}
 	}

--- a/datalog/storage/merge_join_test.go
+++ b/datalog/storage/merge_join_test.go
@@ -234,13 +234,13 @@ func TestMergeJoinCorrectness(t *testing.T) {
 				},
 			}
 
-			columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+			symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 			// Call merge join directly
 			result, err := matcher.matchWithMergeJoin(
 				pattern,
 				bindingRel,
-				columns,
+				symbols,
 				0, // position 0 = entity
 				EAVT,
 				nil, // no constraints
@@ -257,7 +257,7 @@ func TestMergeJoinCorrectness(t *testing.T) {
 				resultCount++
 				tuple := iter.Tuple()
 				if len(tuple) != 2 {
-					t.Errorf("expected 2 columns, got %d", len(tuple))
+					t.Errorf("expected 2 symbols, got %d", len(tuple))
 				}
 				// Verify entity is in binding set
 				entity, ok := tuple[0].(datalog.Identity)
@@ -341,13 +341,13 @@ func TestMergeJoinVsHashJoin(t *testing.T) {
 					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			}
-			columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+			symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 			// Call hash join
 			hashResult, err := matcher.matchWithHashJoin(
 				pattern,
 				bindingRel,
-				columns,
+				symbols,
 				0, // position 0 = entity
 				EAVT,
 				nil,
@@ -360,7 +360,7 @@ func TestMergeJoinVsHashJoin(t *testing.T) {
 			mergeResult, err := matcher.matchWithMergeJoin(
 				pattern,
 				bindingRel,
-				columns,
+				symbols,
 				0, // position 0 = entity
 				EAVT,
 				nil,
@@ -454,13 +454,13 @@ func TestMergeJoinPerformance(t *testing.T) {
 			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+	symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
 
 	start := time.Now()
 	result, err := matcher.matchWithMergeJoin(
 		pattern,
 		bindingRel,
-		columns,
+		symbols,
 		0,
 		EAVT,
 		nil,
@@ -573,12 +573,12 @@ func TestCompareJoinKeys(t *testing.T) {
 
 // Helper functions
 
-func createMockRelation(size int, columns []query.Symbol) executor.Relation {
+func createMockRelation(size int, symbols []query.Symbol) executor.Relation {
 	tuples := make([]executor.Tuple, size)
 	for i := 0; i < size; i++ {
 		tuples[i] = executor.Tuple{datalog.NewIdentity(fmt.Sprintf("entity:%d", i))}
 	}
-	return executor.NewMaterializedRelationNoDedupe(columns, tuples)
+	return executor.NewMaterializedRelationNoDedupe(symbols, tuples)
 }
 
 func resultToMap(rel executor.Relation) map[string]int64 {

--- a/datalog/storage/multi_source_integration_test.go
+++ b/datalog/storage/multi_source_integration_test.go
@@ -36,7 +36,7 @@ func TestMultiSource_MemorySourceWithDatabase(t *testing.T) {
 	cache := executor.NewMemoryPatternMatcher(cacheDatoms)
 
 	// Query joining database and memory source
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name ?score
 		  :in $ $cache
 		  :where [?e :user/name ?name]
@@ -46,7 +46,7 @@ func TestMultiSource_MemorySourceWithDatabase(t *testing.T) {
 		WithSources(map[query.Symbol]executor.PatternMatcher{
 			datalog.NewSymbol("$cache"): cache,
 		}),
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -79,14 +79,14 @@ func TestMultiSource_MemorySourceOnly(t *testing.T) {
 	}
 	items := executor.NewMemoryPatternMatcher(facts)
 
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name
 		  :in $items
 		  :where [$items ?e :item/name ?name]]`,
 		WithSources(map[query.Symbol]executor.PatternMatcher{
 			datalog.NewSymbol("$items"): items,
 		}),
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -135,11 +135,11 @@ func TestMultiSource_SliceSourceWithQueryBuilder(t *testing.T) {
 		Where(qb.PatFrom(rs, r, qb.Kw(":rule/key"), key)).
 		MustBuild()
 
-	results, err := db.ExecuteQueryWithInputs(q,
+	results, err := executor.CollectTuples(db.Query(q,
 		WithSources(map[query.Symbol]executor.PatternMatcher{
 			datalog.NewSymbol("$rules"): ruleSource,
 		}),
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestMultiSource_SliceSourceDependencyQuery(t *testing.T) {
 	})
 
 	// Query dependencies for a specific rule
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?dep
 		  :in $rules ?key
 		  :where [$rules ?r :rule/key ?key]
@@ -188,7 +188,7 @@ func TestMultiSource_SliceSourceDependencyQuery(t *testing.T) {
 			datalog.NewSymbol("$rules"): ruleSource,
 		}),
 		"region-lore",
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -213,9 +213,9 @@ func TestMultiSource_SourceValidation(t *testing.T) {
 	db := createTestDB(t)
 
 	// Query declares $users in :in but doesn't provide it
-	_, err := db.ExecuteQueryWithInputs(
+	_, err := executor.CollectTuples(db.Query(
 		`[:find ?e :in $users :where [$users ?e :attr ?v]]`,
-	)
+	))
 	if err == nil {
 		t.Fatal("expected error for missing source, got nil")
 	}
@@ -233,7 +233,7 @@ func TestMultiSource_DefaultSourceAlwaysAvailable(t *testing.T) {
 	}
 
 	// Standard query without any :in clause - default $ source
-	results, err := db.ExecuteQuery(`[:find ?name :where [?e :thing/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name :where [?e :thing/name ?name]]`))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestMultiSource_CrossDatabaseJoin(t *testing.T) {
 	}
 
 	// Cross-database join: find user names and their roles
-	results, err := usersDB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(usersDB.Query(
 		`[:find ?name ?role
 		  :in $users $perms
 		  :where [$users ?u :user/name ?name]
@@ -279,7 +279,7 @@ func TestMultiSource_CrossDatabaseJoin(t *testing.T) {
 			datalog.NewSymbol("$users"): usersDB,
 			datalog.NewSymbol("$perms"): permsDB,
 		}),
-	)
+	))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}

--- a/datalog/storage/multi_source_integration_test.go
+++ b/datalog/storage/multi_source_integration_test.go
@@ -96,8 +96,8 @@ func TestMultiSource_MemorySourceOnly(t *testing.T) {
 	}
 
 	names := make(map[string]bool)
-	for _, row := range results {
-		names[row[0].(string)] = true
+	for _, tuple := range results {
+		names[tuple[0].(string)] = true
 	}
 	for _, expected := range []string{"Sword", "Shield", "Potion"} {
 		if !names[expected] {
@@ -149,8 +149,8 @@ func TestMultiSource_SliceSourceWithQueryBuilder(t *testing.T) {
 	}
 
 	keys := make(map[string]bool)
-	for _, row := range results {
-		keys[row[0].(string)] = true
+	for _, tuple := range results {
+		keys[tuple[0].(string)] = true
 	}
 	if !keys["region-lore"] {
 		t.Error("expected region-lore in results")
@@ -198,8 +198,8 @@ func TestMultiSource_SliceSourceDependencyQuery(t *testing.T) {
 	}
 
 	deps := make(map[string]bool)
-	for _, row := range results {
-		deps[row[0].(string)] = true
+	for _, tuple := range results {
+		deps[tuple[0].(string)] = true
 	}
 	if !deps["world-lore"] {
 		t.Error("expected world-lore dependency")

--- a/datalog/storage/ohlc_bug_reproduction_test.go
+++ b/datalog/storage/ohlc_bug_reproduction_test.go
@@ -97,8 +97,8 @@ func TestOHLCQueryBug(t *testing.T) {
 		}
 		it.Close()
 
-		// Should have 1 row (grouped by year/month/day)
-		// If bug exists, might get 0 rows or hang
+		// Should have 1 tuple (grouped by year/month/day)
+		// If bug exists, might get 0 tuples or hang
 		require.Greater(t, count, 0, "Query returned 0 results - tuple copying bug in matcher_relations.go:241")
 
 	case <-time.After(30 * time.Second):

--- a/datalog/storage/ohlc_realistic_test.go
+++ b/datalog/storage/ohlc_realistic_test.go
@@ -159,7 +159,7 @@ func TestOHLCRealisticQueries(t *testing.T) {
 		// Debug output
 		t.Logf("Result IsEmpty: %v", result.IsEmpty())
 		t.Logf("Result Size: %d", result.Size())
-		t.Logf("Result Columns: %v", result.Columns())
+		t.Logf("Result Symbols: %v", result.Symbols())
 
 		assert.False(t, result.IsEmpty(), "Should have aggregation results")
 

--- a/datalog/storage/or_clause_bug_test.go
+++ b/datalog/storage/or_clause_bug_test.go
@@ -16,10 +16,10 @@ import (
 // results as expected.
 //
 // Expected behavior: (or [?t :task/type :type/a] [?t :task/type :type/b])
-// should only return rows where ?t has type :type/a OR :type/b.
+// should only return tuples where ?t has type :type/a OR :type/b.
 //
 // Actual behavior: The `or` clause appears to be ignored entirely, returning
-// all rows regardless of whether they match either branch.
+// all tuples regardless of whether they match either branch.
 func TestOrClauseBug(t *testing.T) {
 	dbPath := "/tmp/test-or-clause-bug-" + t.Name()
 	defer os.RemoveAll(dbPath)

--- a/datalog/storage/or_clause_bug_test.go
+++ b/datalog/storage/or_clause_bug_test.go
@@ -59,7 +59,7 @@ func TestOrClauseBug(t *testing.T) {
 	 [?t :task/type ?type]
 	 [?t :task/type :type/a]]`
 
-	results, err := db.ExecuteQuery(queryWithoutOr)
+	results, err := executor.CollectTuples(db.Query(queryWithoutOr))
 	assert.NoError(t, err)
 	t.Logf("Without or (expect 1 result with :type/a): %d results", len(results))
 	for _, r := range results {
@@ -77,7 +77,7 @@ func TestOrClauseBug(t *testing.T) {
 	 (or [?t :task/type :type/a]
 	     [?t :task/type :type/b])]`
 
-	results, err = db.ExecuteQuery(queryWithOr)
+	results, err = executor.CollectTuples(db.Query(queryWithOr))
 	assert.NoError(t, err)
 	t.Logf("With or (expect 2 results with :type/a or :type/b): %d results", len(results))
 	for _, r := range results {

--- a/datalog/storage/or_fallback_copy_test.go
+++ b/datalog/storage/or_fallback_copy_test.go
@@ -71,8 +71,8 @@ func TestOrClauseTupleStability(t *testing.T) {
                         (or [?e :entity/status "active"]
                             [?e :entity/status "pending"])]`
 
-	// Use ExecuteQueryRelation to get streaming results WITHOUT materialization
-	rel, err := db.ExecuteQueryRelation(queryStr)
+	// Use Query to get streaming results WITHOUT materialization
+	rel, err := db.Query(queryStr)
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -137,8 +137,8 @@ func TestOrClauseMultipleBranches(t *testing.T) {
                             [?e :product/category "books"]
                             [?e :product/category "clothing"])]`
 
-	// Use ExecuteQueryRelation for streaming WITHOUT materialization
-	rel, err := db.ExecuteQueryRelation(queryStr)
+	// Use Query for streaming WITHOUT materialization
+	rel, err := db.Query(queryStr)
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}

--- a/datalog/storage/or_subquery_regression_test.go
+++ b/datalog/storage/or_subquery_regression_test.go
@@ -21,7 +21,7 @@ func TestOrClauseWithCorrelatedSubquery_E2E(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dbPath,
+		Path: dbPath,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -60,18 +60,18 @@ func TestOrClauseWithCorrelatedSubquery_E2E(t *testing.T) {
 	                             $ ?scenario) [[?count]]]
 	                         [(ground 0) ?count])]`
 
-	rows, err := db.ExecuteQuery(queryStr)
+	tuples, err := db.ExecuteQuery(queryStr)
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
 
 	// Collect results
 	results := make(map[string]int64)
-	for _, row := range rows {
-		t.Logf("Result row: %v", row)
+	for _, tuple := range tuples {
+		t.Logf("Result tuple: %v", tuple)
 		// scenario is an Identity, count is int64
-		scenarioID := row[0].(datalog.Identity)
-		count := row[1].(int64)
+		scenarioID := tuple[0].(datalog.Identity)
+		count := tuple[1].(int64)
 		results[scenarioID.String()] = count
 	}
 
@@ -90,7 +90,7 @@ func TestScenarioSummaryQuery_E2E(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dbPath,
+		Path: dbPath,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -124,17 +124,17 @@ func TestScenarioSummaryQuery_E2E(t *testing.T) {
 	                      $ ?scenario) [[?taskCount]]]
 	                  [(ground 0) ?taskCount])]`
 
-	rows, err := db.ExecuteQuery(queryStr)
+	tuples, err := db.ExecuteQuery(queryStr)
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
 
-	t.Logf("Got %d results", len(rows))
-	for _, row := range rows {
-		t.Logf("Row: %v", row)
+	t.Logf("Got %d results", len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("Tuple: %v", tuple)
 	}
 
-	require.Len(t, rows, 1, "Should have 1 scenario")
+	require.Len(t, tuples, 1, "Should have 1 scenario")
 }
 
 // scenarioSummaryQueryFull is the EXACT production query from user's code
@@ -204,7 +204,7 @@ func TestNestedSubqueryInOr_E2E(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dbPath,
+		Path: dbPath,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -248,16 +248,16 @@ func TestNestedSubqueryInOr_E2E(t *testing.T) {
 	                      $ ?scenario) [[?lastKey]]]
 	                  [(ground :none) ?lastKey])]`
 
-	rows, err := db.ExecuteQuery(queryStr)
+	tuples, err := db.ExecuteQuery(queryStr)
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
 
-	t.Logf("Got %d results", len(rows))
-	for _, row := range rows {
-		t.Logf("Row: %v", row)
+	t.Logf("Got %d results", len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("Tuple: %v", tuple)
 	}
-	require.Len(t, rows, 1)
+	require.Len(t, tuples, 1)
 }
 
 // TestProductionQueryStructure_E2E incrementally builds toward the production query
@@ -266,7 +266,7 @@ func TestProductionQueryStructure_E2E(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dbPath,
+		Path: dbPath,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -319,16 +319,16 @@ func TestProductionQueryStructure_E2E(t *testing.T) {
 	              ;; Comparison binding
 	              [(> ?openingCount 0) ?complete]]`
 
-	rows, err := db.ExecuteQuery(queryStr)
+	tuples, err := db.ExecuteQuery(queryStr)
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
 
-	t.Logf("Got %d results", len(rows))
-	for _, row := range rows {
-		t.Logf("Row: %v", row)
+	t.Logf("Got %d results", len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("Tuple: %v", tuple)
 	}
-	require.Len(t, rows, 2)
+	require.Len(t, tuples, 2)
 }
 
 // TestGetElseBeforeOrClause_E2E tests get-else BEFORE the OR clause
@@ -337,7 +337,7 @@ func TestGetElseBeforeOrClause_E2E(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dbPath,
+		Path: dbPath,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -370,16 +370,16 @@ func TestGetElseBeforeOrClause_E2E(t *testing.T) {
 	                      $ ?scenario) [[?taskCount]]]
 	                  [(ground 0) ?taskCount])]`
 
-	rows, err := db.ExecuteQuery(queryStr)
+	tuples, err := db.ExecuteQuery(queryStr)
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
 
-	t.Logf("Got %d results", len(rows))
-	for _, row := range rows {
-		t.Logf("Row: %v", row)
+	t.Logf("Got %d results", len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("Tuple: %v", tuple)
 	}
-	require.Len(t, rows, 2)
+	require.Len(t, tuples, 2)
 }
 
 // TestMultipleSequentialOrClauses_E2E tests MULTIPLE sequential OR clauses
@@ -388,7 +388,7 @@ func TestMultipleSequentialOrClauses_E2E(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dbPath,
+		Path: dbPath,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -427,16 +427,16 @@ func TestMultipleSequentialOrClauses_E2E(t *testing.T) {
 	                      $ ?scenario) [[?count2]]]
 	                  [(ground 0) ?count2])]`
 
-	rows, err := db.ExecuteQuery(queryStr)
+	tuples, err := db.ExecuteQuery(queryStr)
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
 
-	t.Logf("Got %d results", len(rows))
-	for _, row := range rows {
-		t.Logf("Row: %v", row)
+	t.Logf("Got %d results", len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("Tuple: %v", tuple)
 	}
-	require.Len(t, rows, 2)
+	require.Len(t, tuples, 2)
 }
 
 // TestOrWithGetElseInsideSubquery_E2E tests OR with get-else inside the subquery
@@ -445,7 +445,7 @@ func TestOrWithGetElseInsideSubquery_E2E(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dbPath,
+		Path: dbPath,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -476,16 +476,16 @@ func TestOrWithGetElseInsideSubquery_E2E(t *testing.T) {
 	                  (and [(ground 0) ?taskCount]
 	                       [(ground 0) ?totalTokens]))]`
 
-	rows, err := db.ExecuteQuery(queryStr)
+	tuples, err := db.ExecuteQuery(queryStr)
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
 
-	t.Logf("Got %d results", len(rows))
-	for _, row := range rows {
-		t.Logf("Row: %v", row)
+	t.Logf("Got %d results", len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("Tuple: %v", tuple)
 	}
-	require.Len(t, rows, 2)
+	require.Len(t, tuples, 2)
 }
 
 // TestOrWithMultipleAggregations_E2E tests OR with multiple aggregations in subquery
@@ -494,7 +494,7 @@ func TestOrWithMultipleAggregations_E2E(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dbPath,
+		Path: dbPath,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -526,16 +526,16 @@ func TestOrWithMultipleAggregations_E2E(t *testing.T) {
 	                  (and [(ground 0) ?taskCount]
 	                       [(ground 0) ?totalTokens]))]`
 
-	rows, err := db.ExecuteQuery(queryStr)
+	tuples, err := db.ExecuteQuery(queryStr)
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
 
-	t.Logf("Got %d results", len(rows))
-	for _, row := range rows {
-		t.Logf("Row: %v", row)
+	t.Logf("Got %d results", len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("Tuple: %v", tuple)
 	}
-	require.Len(t, rows, 2)
+	require.Len(t, tuples, 2)
 }
 
 // TestFullScenarioSummaryQuery_E2E tests the EXACT production query
@@ -544,7 +544,7 @@ func TestFullScenarioSummaryQuery_E2E(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path:      dbPath,
+		Path: dbPath,
 	})
 	require.NoError(t, err)
 	defer db.Close()
@@ -575,15 +575,15 @@ func TestFullScenarioSummaryQuery_E2E(t *testing.T) {
 	_, err = tx.Commit()
 	require.NoError(t, err)
 
-	rows, err := db.ExecuteQuery(scenarioSummaryQueryFull)
+	tuples, err := db.ExecuteQuery(scenarioSummaryQueryFull)
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
 
-	t.Logf("Got %d results", len(rows))
-	for _, row := range rows {
-		t.Logf("Row: %v", row)
+	t.Logf("Got %d results", len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("Tuple: %v", tuple)
 	}
 
-	require.Len(t, rows, 2, "Should have 2 scenarios")
+	require.Len(t, tuples, 2, "Should have 2 scenarios")
 }

--- a/datalog/storage/or_subquery_regression_test.go
+++ b/datalog/storage/or_subquery_regression_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 )
 
 // TestOrClauseWithCorrelatedSubquery_E2E reproduces the bug where
@@ -60,7 +61,7 @@ func TestOrClauseWithCorrelatedSubquery_E2E(t *testing.T) {
 	                             $ ?scenario) [[?count]]]
 	                         [(ground 0) ?count])]`
 
-	tuples, err := db.ExecuteQuery(queryStr)
+	tuples, err := executor.CollectTuples(db.Query(queryStr))
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
@@ -124,7 +125,7 @@ func TestScenarioSummaryQuery_E2E(t *testing.T) {
 	                      $ ?scenario) [[?taskCount]]]
 	                  [(ground 0) ?taskCount])]`
 
-	tuples, err := db.ExecuteQuery(queryStr)
+	tuples, err := executor.CollectTuples(db.Query(queryStr))
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
@@ -248,7 +249,7 @@ func TestNestedSubqueryInOr_E2E(t *testing.T) {
 	                      $ ?scenario) [[?lastKey]]]
 	                  [(ground :none) ?lastKey])]`
 
-	tuples, err := db.ExecuteQuery(queryStr)
+	tuples, err := executor.CollectTuples(db.Query(queryStr))
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
@@ -319,7 +320,7 @@ func TestProductionQueryStructure_E2E(t *testing.T) {
 	              ;; Comparison binding
 	              [(> ?openingCount 0) ?complete]]`
 
-	tuples, err := db.ExecuteQuery(queryStr)
+	tuples, err := executor.CollectTuples(db.Query(queryStr))
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
@@ -370,7 +371,7 @@ func TestGetElseBeforeOrClause_E2E(t *testing.T) {
 	                      $ ?scenario) [[?taskCount]]]
 	                  [(ground 0) ?taskCount])]`
 
-	tuples, err := db.ExecuteQuery(queryStr)
+	tuples, err := executor.CollectTuples(db.Query(queryStr))
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
@@ -427,7 +428,7 @@ func TestMultipleSequentialOrClauses_E2E(t *testing.T) {
 	                      $ ?scenario) [[?count2]]]
 	                  [(ground 0) ?count2])]`
 
-	tuples, err := db.ExecuteQuery(queryStr)
+	tuples, err := executor.CollectTuples(db.Query(queryStr))
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
@@ -476,7 +477,7 @@ func TestOrWithGetElseInsideSubquery_E2E(t *testing.T) {
 	                  (and [(ground 0) ?taskCount]
 	                       [(ground 0) ?totalTokens]))]`
 
-	tuples, err := db.ExecuteQuery(queryStr)
+	tuples, err := executor.CollectTuples(db.Query(queryStr))
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
@@ -526,7 +527,7 @@ func TestOrWithMultipleAggregations_E2E(t *testing.T) {
 	                  (and [(ground 0) ?taskCount]
 	                       [(ground 0) ?totalTokens]))]`
 
-	tuples, err := db.ExecuteQuery(queryStr)
+	tuples, err := executor.CollectTuples(db.Query(queryStr))
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}
@@ -575,7 +576,7 @@ func TestFullScenarioSummaryQuery_E2E(t *testing.T) {
 	_, err = tx.Commit()
 	require.NoError(t, err)
 
-	tuples, err := db.ExecuteQuery(scenarioSummaryQueryFull)
+	tuples, err := executor.CollectTuples(db.Query(scenarioSummaryQueryFull))
 	if err != nil {
 		t.Fatalf("Query execution failed: %v", err)
 	}

--- a/datalog/storage/parallel_decorrelation_symbol_order_test.go
+++ b/datalog/storage/parallel_decorrelation_symbol_order_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/planner"
 )
 
-// TestParallelDecorrelationColumnOrderBadger tests parallel decorrelation column ordering with BadgerDB
+// TestParallelDecorrelationColumnOrderBadger tests parallel decorrelation symbol ordering with BadgerDB
 // This reproduces the gopher-street bug where BadgerMatcher + parallel decorrelation
-// scrambles column order due to inconsistent transaction snapshots across goroutines
+// scrambles symbol order due to inconsistent transaction snapshots across goroutines
 func TestParallelDecorrelationColumnOrderBadger(t *testing.T) {
 	// Create temporary BadgerDB
-	tmpDir, err := os.MkdirTemp("", "badger-column-order-test-*")
+	tmpDir, err := os.MkdirTemp("", "badger-symbol-order-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
@@ -166,34 +166,34 @@ func TestParallelDecorrelationColumnOrderBadger(t *testing.T) {
 			t.Logf("  [%d] = %v (%T)", i, val, val)
 		}
 
-		// Verify correct column ordering: [?date, ?open-price, ?daily-high, ?daily-low, ?close-price, ?total-volume]
+		// Verify correct symbol ordering: [?date, ?open-price, ?daily-high, ?daily-low, ?close-price, ?total-volume]
 		if len(tuple) != 6 {
-			t.Fatalf("Expected 6 columns, got %d", len(tuple))
+			t.Fatalf("Expected 6 symbols, got %d", len(tuple))
 		}
 
-		// Column 1: ?open-price should be 100.00
+		// Symbol 1: ?open-price should be 100.00
 		if val, ok := tuple[1].(float64); !ok || val != 100.0 {
-			t.Errorf("Column 1 (?open-price) should be 100.0, got %v (%T)", tuple[1], tuple[1])
+			t.Errorf("Symbol 1 (?open-price) should be 100.0, got %v (%T)", tuple[1], tuple[1])
 		}
 
-		// Column 2: ?daily-high should be 103.00
+		// Symbol 2: ?daily-high should be 103.00
 		if val, ok := tuple[2].(float64); !ok || val != 103.0 {
-			t.Errorf("Column 2 (?daily-high) should be 103.0, got %v (%T)", tuple[2], tuple[2])
+			t.Errorf("Symbol 2 (?daily-high) should be 103.0, got %v (%T)", tuple[2], tuple[2])
 		}
 
-		// Column 3: ?daily-low should be 99.50
+		// Symbol 3: ?daily-low should be 99.50
 		if val, ok := tuple[3].(float64); !ok || val != 99.5 {
-			t.Errorf("Column 3 (?daily-low) should be 99.5, got %v (%T)", tuple[3], tuple[3])
+			t.Errorf("Symbol 3 (?daily-low) should be 99.5, got %v (%T)", tuple[3], tuple[3])
 		}
 
-		// Column 4: ?close-price should be 102.50
+		// Symbol 4: ?close-price should be 102.50
 		if val, ok := tuple[4].(float64); !ok || val != 102.5 {
-			t.Errorf("Column 4 (?close-price) should be 102.5, got %v (%T)", tuple[4], tuple[4])
+			t.Errorf("Symbol 4 (?close-price) should be 102.5, got %v (%T)", tuple[4], tuple[4])
 		}
 
-		// Column 5: ?total-volume should be 3050000
+		// Symbol 5: ?total-volume should be 3050000
 		if val, ok := tuple[5].(float64); !ok || val != 3050000 {
-			t.Errorf("Column 5 (?total-volume) should be 3050000, got %v (%T)", tuple[5], tuple[5])
+			t.Errorf("Symbol 5 (?total-volume) should be 3050000, got %v (%T)", tuple[5], tuple[5])
 		}
 	})
 
@@ -227,23 +227,23 @@ func TestParallelDecorrelationColumnOrderBadger(t *testing.T) {
 
 		// Same verification as parallel
 		if len(tuple) != 6 {
-			t.Fatalf("Expected 6 columns, got %d", len(tuple))
+			t.Fatalf("Expected 6 symbols, got %d", len(tuple))
 		}
 
 		if val, ok := tuple[1].(float64); !ok || val != 100.0 {
-			t.Errorf("Column 1 (?open-price) should be 100.0, got %v (%T)", tuple[1], tuple[1])
+			t.Errorf("Symbol 1 (?open-price) should be 100.0, got %v (%T)", tuple[1], tuple[1])
 		}
 		if val, ok := tuple[2].(float64); !ok || val != 103.0 {
-			t.Errorf("Column 2 (?daily-high) should be 103.0, got %v (%T)", tuple[2], tuple[2])
+			t.Errorf("Symbol 2 (?daily-high) should be 103.0, got %v (%T)", tuple[2], tuple[2])
 		}
 		if val, ok := tuple[3].(float64); !ok || val != 99.5 {
-			t.Errorf("Column 3 (?daily-low) should be 99.5, got %v (%T)", tuple[3], tuple[3])
+			t.Errorf("Symbol 3 (?daily-low) should be 99.5, got %v (%T)", tuple[3], tuple[3])
 		}
 		if val, ok := tuple[4].(float64); !ok || val != 102.5 {
-			t.Errorf("Column 4 (?close-price) should be 102.5, got %v (%T)", tuple[4], tuple[4])
+			t.Errorf("Symbol 4 (?close-price) should be 102.5, got %v (%T)", tuple[4], tuple[4])
 		}
 		if val, ok := tuple[5].(float64); !ok || val != 3050000 {
-			t.Errorf("Column 5 (?total-volume) should be 3050000, got %v (%T)", tuple[5], tuple[5])
+			t.Errorf("Symbol 5 (?total-volume) should be 3050000, got %v (%T)", tuple[5], tuple[5])
 		}
 	})
 }

--- a/datalog/storage/perf_diagnostic_test.go
+++ b/datalog/storage/perf_diagnostic_test.go
@@ -77,7 +77,7 @@ func BenchmarkHashJoinIteration(b *testing.B) {
 	_, _ = tx.Commit()
 
 	// Warm up
-	_, _ = db.ExecuteQuery(`[:find ?e :where [?e :task/scenario ?s]]`)
+	_, _ = executor.CollectTuples(db.Query(`[:find ?e :where [?e :task/scenario ?s]]`))
 
 	matcher := db.Matcher().(*BadgerMatcher)
 	pattern := &query.DataPattern{

--- a/datalog/storage/perf_diagnostic_test.go
+++ b/datalog/storage/perf_diagnostic_test.go
@@ -188,8 +188,8 @@ func BenchmarkDatomFromKeyToTuple(b *testing.B) {
 			query.Variable{Name: datalog.NewSymbol("?v")},
 		},
 	}
-	columns := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
-	tupleBuilder := query.NewInternedTupleBuilder(pattern, columns)
+	symbols := []query.Symbol{datalog.NewSymbol("?e"), datalog.NewSymbol("?v")}
+	tupleBuilder := query.NewInternedTupleBuilder(pattern, symbols)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/datalog/storage/predicate_product_test.go
+++ b/datalog/storage/predicate_product_test.go
@@ -82,12 +82,12 @@ func (tdb *bridgeTestDB) cleanup() {
 	os.RemoveAll(tdb.Dir)
 }
 
-// collectStrings extracts the first column as strings from query results.
+// collectStrings extracts the first symbol as strings from query results.
 func collectStrings(results [][]interface{}) []string {
 	var out []string
-	for _, row := range results {
-		if len(row) > 0 {
-			if s, ok := row[0].(string); ok {
+	for _, tuple := range results {
+		if len(tuple) > 0 {
+			if s, ok := tuple[0].(string); ok {
 				out = append(out, s)
 			}
 		}
@@ -249,9 +249,9 @@ func TestScalarInput_ExpressionBridge(t *testing.T) {
 
 	// Collect name -> adjusted age
 	adjusted := make(map[string]int64)
-	for _, row := range results {
-		name, _ := row[0].(string)
-		age, _ := row[1].(int64)
+	for _, tuple := range results {
+		name, _ := tuple[0].(string)
+		age, _ := tuple[1].(int64)
 		adjusted[name] = age
 	}
 
@@ -304,7 +304,7 @@ func TestScalarInput_InPatternNotConstantBindable(t *testing.T) {
 
 // TestCollectionInput_BridgingPredicate tests a collection input where each
 // excluded name must be checked against all people. This is NOT constant-bindable
-// because it's a collection (multi-row), not a scalar.
+// because it's a collection (multi-tuple), not a scalar.
 //
 // IMPORTANT semantic note: The predicate [(not= ?name ?excluded-name)] performs
 // PAIRWISE comparison, not set membership testing. So:
@@ -345,7 +345,7 @@ func TestCollectionInput_BridgingPredicate(t *testing.T) {
 
 // TestCollectionInput_ComparisonBridge tests a collection of thresholds compared
 // against ages. The theta-join produces all valid (person, threshold) combinations,
-// then projection to :find columns deduplicates.
+// then projection to :find symbols deduplicates.
 func TestCollectionInput_ComparisonBridge(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
@@ -372,31 +372,31 @@ func TestCollectionInput_ComparisonBridge(t *testing.T) {
 	// Total: 5 combinations.
 	//
 	// But :find ?name ?age projects away ?threshold, and Eve(40) appears twice
-	// (once for threshold 25, once for 35). After deduplication: 4 unique rows.
+	// (once for threshold 25, once for 35). After deduplication: 4 unique tuples.
 	if len(results) != 4 {
 		t.Fatalf("Expected 4 results (Eve deduplicated), got %d: %v", len(results), results)
 	}
 
 	// Verify the specific (name, age) pairs we expect
-	type row struct {
+	type tuple struct {
 		name string
 		age  int64
 	}
-	got := make(map[row]bool)
+	got := make(map[tuple]bool)
 	for _, r := range results {
 		name, _ := r[0].(string)
 		age, _ := r[1].(int64)
-		got[row{name, age}] = true
+		got[tuple{name, age}] = true
 	}
 
-	for _, expected := range []row{
+	for _, expected := range []tuple{
 		{"Alice", 30},   // > 25
 		{"Charlie", 35}, // > 25
 		{"Diana", 28},   // > 25
 		{"Eve", 40},     // > 25 and > 35, but deduplicated
 	} {
 		if !got[expected] {
-			t.Errorf("Missing expected row: (%s, %d)", expected.name, expected.age)
+			t.Errorf("Missing expected tuple: (%s, %d)", expected.name, expected.age)
 		}
 	}
 }
@@ -421,16 +421,16 @@ func TestDisjointPatterns_BridgedByPredicate(t *testing.T) {
 
 	// alpha = {Alice, Bob}, beta = {Charlie, Diana}
 	// not= always true since different entities
-	// Expect 2×2 = 4 rows
+	// Expect 2×2 = 4 tuples
 	if len(results) != 4 {
 		t.Fatalf("Expected 4 results, got %d: %v", len(results), results)
 	}
 
 	type pair struct{ n1, n2 string }
 	got := make(map[pair]bool)
-	for _, row := range results {
-		n1, _ := row[0].(string)
-		n2, _ := row[1].(string)
+	for _, tuple := range results {
+		n1, _ := tuple[0].(string)
+		n2, _ := tuple[1].(string)
 		got[pair{n1, n2}] = true
 	}
 
@@ -468,23 +468,23 @@ func TestDisjointGroups_ExpressionBridge(t *testing.T) {
 		t.Fatalf("Expected 4 results, got %d: %v", len(results), results)
 	}
 
-	type row struct{ n1, n2, combined string }
-	got := make(map[row]bool)
+	type tuple struct{ n1, n2, combined string }
+	got := make(map[tuple]bool)
 	for _, r := range results {
 		n1, _ := r[0].(string)
 		n2, _ := r[1].(string)
 		combined, _ := r[2].(string)
-		got[row{n1, n2, combined}] = true
+		got[tuple{n1, n2, combined}] = true
 	}
 
-	for _, expected := range []row{
+	for _, expected := range []tuple{
 		{"Alice", "Charlie", "Alice & Charlie"},
 		{"Alice", "Diana", "Alice & Diana"},
 		{"Bob", "Charlie", "Bob & Charlie"},
 		{"Bob", "Diana", "Bob & Diana"},
 	} {
 		if !got[expected] {
-			t.Errorf("Missing expected row: %v", expected)
+			t.Errorf("Missing expected tuple: %v", expected)
 		}
 	}
 }

--- a/datalog/storage/predicate_product_test.go
+++ b/datalog/storage/predicate_product_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -105,14 +106,14 @@ func TestScalarInput_InequalityPredicate(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?name
 		  :in $ ?self
 		  :where
 		  [?e :person/name ?name]
 		  [(not= ?e ?self)]]`,
 		tdb.Alice,
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -135,7 +136,7 @@ func TestScalarInput_ComparisonPredicate(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?name
 		  :in $ ?min-age
 		  :where
@@ -143,7 +144,7 @@ func TestScalarInput_ComparisonPredicate(t *testing.T) {
 		  [?e :person/age ?age]
 		  [(> ?age ?min-age)]]`,
 		int64(30),
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -167,14 +168,14 @@ func TestScalarInput_EqualityPredicate(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?name
 		  :in $ ?target-team
 		  :where
 		  [?e :person/name ?name]
 		  [?e :person/team ?target-team]]`,
 		"alpha",
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -197,7 +198,7 @@ func TestScalarInput_MultipleBridgingPredicates(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?name
 		  :in $ ?self ?min-age
 		  :where
@@ -206,7 +207,7 @@ func TestScalarInput_MultipleBridgingPredicates(t *testing.T) {
 		  [(not= ?e ?self)]
 		  [(> ?age ?min-age)]]`,
 		tdb.Alice, int64(28),
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -230,7 +231,7 @@ func TestScalarInput_ExpressionBridge(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?name ?adjusted
 		  :in $ ?bonus
 		  :where
@@ -238,7 +239,7 @@ func TestScalarInput_ExpressionBridge(t *testing.T) {
 		  [?e :person/age ?age]
 		  [(+ ?age ?bonus) ?adjusted]]`,
 		int64(10),
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -274,7 +275,7 @@ func TestScalarInput_InPatternNotConstantBindable(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?other-name
 		  :in $ ?target-name
 		  :where
@@ -284,7 +285,7 @@ func TestScalarInput_InPatternNotConstantBindable(t *testing.T) {
 		  [?other :person/name ?other-name]
 		  [(not= ?other ?e)]]`,
 		"Alice",
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -317,14 +318,14 @@ func TestCollectionInput_BridgingPredicate(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?name
 		  :in $ [?excluded-name ...]
 		  :where
 		  [?e :person/name ?name]
 		  [(not= ?name ?excluded-name)]]`,
 		[]string{"Alice", "Bob"},
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -350,7 +351,7 @@ func TestCollectionInput_ComparisonBridge(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?name ?age
 		  :in $ [?threshold ...]
 		  :where
@@ -358,7 +359,7 @@ func TestCollectionInput_ComparisonBridge(t *testing.T) {
 		  [?e :person/age ?age]
 		  [(> ?age ?threshold)]]`,
 		[]interface{}{int64(25), int64(35)},
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -408,13 +409,13 @@ func TestDisjointPatterns_BridgedByPredicate(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?n1 ?n2
 		  :where
 		  [?e1 :person/name ?n1] [?e1 :person/team "alpha"]
 		  [?e2 :person/name ?n2] [?e2 :person/team "beta"]
 		  [(not= ?e1 ?e2)]]`,
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -452,13 +453,13 @@ func TestDisjointGroups_ExpressionBridge(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?n1 ?n2 ?combined
 		  :where
 		  [?e1 :person/name ?n1] [?e1 :person/team "alpha"]
 		  [?e2 :person/name ?n2] [?e2 :person/team "beta"]
 		  [(str ?n1 " & " ?n2) ?combined]]`,
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -497,7 +498,7 @@ func TestScalarInput_AllExcluded(t *testing.T) {
 	tdb := setupBridgeTestDB(t)
 	defer tdb.cleanup()
 
-	results, err := tdb.DB.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(tdb.DB.Query(
 		`[:find ?name
 		  :in $ ?min-age
 		  :where
@@ -505,7 +506,7 @@ func TestScalarInput_AllExcluded(t *testing.T) {
 		  [?e :person/age ?age]
 		  [(> ?age ?min-age)]]`,
 		int64(100),
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -538,14 +539,14 @@ func TestScalarInput_SingleEntitySelfExclusion(t *testing.T) {
 		t.Fatalf("Failed to commit: %v", err)
 	}
 
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name
 		  :in $ ?self
 		  :where
 		  [?e :person/name ?name]
 		  [(not= ?e ?self)]]`,
 		alice,
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}

--- a/datalog/storage/predicate_pushdown_benchmark_test.go
+++ b/datalog/storage/predicate_pushdown_benchmark_test.go
@@ -106,7 +106,7 @@ func BenchmarkPredicatePushdown(b *testing.B) {
 			for it.Next() {
 				tuple := it.Tuple()
 				// Find the time value
-				for i, col := range timeRel.Columns() {
+				for i, col := range timeRel.Symbols() {
 					if col == datalog.NewSymbol("?t") {
 						if t, ok := tuple[i].(time.Time); ok {
 							if t.Day() == 5 {
@@ -189,7 +189,7 @@ func BenchmarkPredicatePushdown(b *testing.B) {
 				it := timeRel.Iterator()
 				for it.Next() {
 					tuple := it.Tuple()
-					for i, col := range timeRel.Columns() {
+					for i, col := range timeRel.Symbols() {
 						if col == datalog.NewSymbol("?t") {
 							if t, ok := tuple[i].(time.Time); ok {
 								if t.Day() == 5 {
@@ -300,7 +300,7 @@ func BenchmarkPredicatePushdownAllocs(b *testing.B) {
 			it := timeRel.Iterator()
 			for it.Next() {
 				tuple := it.Tuple()
-				for i, col := range timeRel.Columns() {
+				for i, col := range timeRel.Symbols() {
 					if col == datalog.NewSymbol("?t") {
 						if t, ok := tuple[i].(time.Time); ok {
 							_ = t.Day() == 5

--- a/datalog/storage/pull_benchmark_test.go
+++ b/datalog/storage/pull_benchmark_test.go
@@ -242,7 +242,7 @@ func BenchmarkPullBadger_VsQuery(b *testing.B) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, _ = db.ExecuteQueryWithInputs(queryStr, entity)
+			_, _ = executor.CollectTuples(db.Query(queryStr, entity))
 		}
 	})
 }

--- a/datalog/storage/pull_integration_test.go
+++ b/datalog/storage/pull_integration_test.go
@@ -281,7 +281,7 @@ func TestPullWildcardPatternMatching(t *testing.T) {
 		}
 	})
 
-	// Test the same pattern matching but with column extraction as pull does
+	// Test the same pattern matching but with symbol extraction as pull does
 	t.Run("PatternMatchWithColumnExtraction", func(t *testing.T) {
 		matcher := db.Matcher()
 
@@ -302,11 +302,11 @@ func TestPullWildcardPatternMatching(t *testing.T) {
 			t.Fatal("expected non-nil relation")
 		}
 
-		// Check columns
-		cols := rel.Columns()
-		t.Logf("Columns: %v", cols)
+		// Check symbols
+		cols := rel.Symbols()
+		t.Logf("Symbols: %v", cols)
 
-		// Find column indices like pull.go does
+		// Find symbol indices like pull.go does
 		aIdx := -1
 		vIdx := -1
 		for i, col := range cols {
@@ -319,7 +319,7 @@ func TestPullWildcardPatternMatching(t *testing.T) {
 		t.Logf("aIdx=%d, vIdx=%d", aIdx, vIdx)
 
 		if aIdx < 0 || vIdx < 0 {
-			t.Fatalf("missing expected columns: aIdx=%d, vIdx=%d", aIdx, vIdx)
+			t.Fatalf("missing expected symbols: aIdx=%d, vIdx=%d", aIdx, vIdx)
 		}
 
 		// Iterate and build datoms like pull.go does
@@ -410,14 +410,14 @@ func TestPullIntegration_InQuery(t *testing.T) {
 		// Results should be pulled maps
 		foundAlice := false
 		foundBob := false
-		for _, row := range results {
-			if len(row) != 1 {
-				t.Errorf("expected 1 column per row, got %d", len(row))
+		for _, tuple := range results {
+			if len(tuple) != 1 {
+				t.Errorf("expected 1 symbol per tuple, got %d", len(tuple))
 				continue
 			}
-			pulled, ok := row[0].(map[string]interface{})
+			pulled, ok := tuple[0].(map[string]interface{})
 			if !ok {
-				t.Errorf("expected map[string]interface{}, got %T", row[0])
+				t.Errorf("expected map[string]interface{}, got %T", tuple[0])
 				continue
 			}
 			name := pulled["person/name"]
@@ -455,25 +455,25 @@ func TestPullIntegration_InQuery(t *testing.T) {
 			t.Fatalf("expected 2 results, got %d", len(results))
 		}
 
-		// Each row should have [type, pulled_map]
-		for _, row := range results {
-			if len(row) != 2 {
-				t.Errorf("expected 2 columns, got %d", len(row))
+		// Each tuple should have [type, pulled_map]
+		for _, tuple := range results {
+			if len(tuple) != 2 {
+				t.Errorf("expected 2 symbols, got %d", len(tuple))
 				continue
 			}
 
-			// First column should be the type keyword
-			typeKw, ok := row[0].(datalog.Keyword)
+			// First symbol should be the type keyword
+			typeKw, ok := tuple[0].(datalog.Keyword)
 			if !ok {
-				t.Errorf("expected Keyword for type, got %T", row[0])
+				t.Errorf("expected Keyword for type, got %T", tuple[0])
 			} else if typeKw.String() != ":type/person" {
 				t.Errorf("expected type=:type/person, got %s", typeKw.String())
 			}
 
-			// Second column should be pulled map
-			pulled, ok := row[1].(map[string]interface{})
+			// Second symbol should be pulled map
+			pulled, ok := tuple[1].(map[string]interface{})
 			if !ok {
-				t.Errorf("expected map for pull, got %T", row[1])
+				t.Errorf("expected map for pull, got %T", tuple[1])
 			} else {
 				name := pulled["person/name"]
 				if name != "Alice" && name != "Bob" {

--- a/datalog/storage/pull_integration_test.go
+++ b/datalog/storage/pull_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/query"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
@@ -231,11 +232,11 @@ func TestPullWildcardPatternMatching(t *testing.T) {
 
 	// Test that we can query for all attributes of alice via standard query
 	t.Run("QueryAllAttributes", func(t *testing.T) {
-		results, err := db.ExecuteQueryWithInputs(`
+		results, err := executor.CollectTuples(db.Query(`
 			[:find ?a ?v
 			 :in $ ?e
 			 :where [?e ?a ?v]]
-		`, alice)
+		`, alice))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -395,10 +396,10 @@ func TestPullIntegration_InQuery(t *testing.T) {
 
 	// Test pull in query
 	t.Run("PullInFindClause", func(t *testing.T) {
-		results, err := db.ExecuteQuery(`
+		results, err := executor.CollectTuples(db.Query(`
 			[:find (pull ?e [:person/name :person/age])
 			 :where [?e :entity/type :type/person]]
-		`)
+		`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -443,10 +444,10 @@ func TestPullIntegration_InQuery(t *testing.T) {
 
 	// Test mixed find clause (pull + regular variable)
 	t.Run("MixedFindClause", func(t *testing.T) {
-		results, err := db.ExecuteQuery(`
+		results, err := executor.CollectTuples(db.Query(`
 			[:find ?type (pull ?e [:person/name])
 			 :where [?e :entity/type ?type]]
-		`)
+		`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}

--- a/datalog/storage/pure_aggregation_badger_test.go
+++ b/datalog/storage/pure_aggregation_badger_test.go
@@ -138,12 +138,12 @@ func TestPureAggregationWithBadgerDB(t *testing.T) {
 			}
 			if aggregationMode != "streaming" {
 				t.Fatalf("TEST CONFIGURATION ERROR: This test must use streaming aggregation to reproduce the bug, but used '%s'. "+
-					"Either increase test data size (currently 500 rows) or decrease StreamingAggregationThreshold (currently 100).",
+					"Either increase test data size (currently 500 tuples) or decrease StreamingAggregationThreshold (currently 100).",
 					aggregationMode)
 			}
 		}
 
-		assert.Equal(t, 1, result.Size(), "Pure aggregation should return 1 row")
+		assert.Equal(t, 1, result.Size(), "Pure aggregation should return 1 tuple")
 
 		// Check the max value
 		tuple := result.Get(0)
@@ -183,12 +183,12 @@ func TestPureAggregationWithBadgerDB(t *testing.T) {
 			}
 			if aggregationMode != "streaming" {
 				t.Fatalf("TEST CONFIGURATION ERROR: This test must use streaming aggregation to reproduce the bug, but used '%s'. "+
-					"Either increase test data size (currently 500 rows) or decrease StreamingAggregationThreshold (currently 100).",
+					"Either increase test data size (currently 500 tuples) or decrease StreamingAggregationThreshold (currently 100).",
 					aggregationMode)
 			}
 		}
 
-		assert.Equal(t, 1, result.Size(), "Pure aggregation should return 1 row")
+		assert.Equal(t, 1, result.Size(), "Pure aggregation should return 1 tuple")
 
 		// Check the min value
 		tuple := result.Get(0)
@@ -208,7 +208,7 @@ func TestPureAggregationWithBadgerDB(t *testing.T) {
 		result, err := exec.Execute(q)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
-		assert.Equal(t, 1, result.Size(), "Pure aggregation should return 1 row")
+		assert.Equal(t, 1, result.Size(), "Pure aggregation should return 1 tuple")
 
 		// Check the count
 		tuple := result.Get(0)

--- a/datalog/storage/query_inputs_test.go
+++ b/datalog/storage/query_inputs_test.go
@@ -51,12 +51,12 @@ func TestExecuteQuery(t *testing.T) {
 
 	// Verify we got both names
 	names := make(map[string]bool)
-	for _, row := range results {
-		if len(row) != 1 {
-			t.Errorf("Expected 1 column, got %d", len(row))
+	for _, tuple := range results {
+		if len(tuple) != 1 {
+			t.Errorf("Expected 1 symbol, got %d", len(tuple))
 			continue
 		}
-		if name, ok := row[0].(string); ok {
+		if name, ok := tuple[0].(string); ok {
 			names[name] = true
 		}
 	}
@@ -115,7 +115,7 @@ func TestExecuteQueryWithScalarInput(t *testing.T) {
 		// The actual entity ID value doesn't matter as long as we found one match
 		t.Logf("Found entity: %v (type: %T)", results[0][0], results[0][0])
 	} else {
-		t.Error("Expected 1 result with 1 column")
+		t.Error("Expected 1 result with 1 symbol")
 	}
 }
 
@@ -404,8 +404,8 @@ func TestExecuteQueryWithTimeInput(t *testing.T) {
 
 	// Verify we have prices for all dates
 	prices := make(map[float64]bool)
-	for _, row := range results {
-		if close, ok := row[1].(float64); ok {
+	for _, tuple := range results {
+		if close, ok := tuple[1].(float64); ok {
 			prices[close] = true
 		}
 	}

--- a/datalog/storage/query_inputs_test.go
+++ b/datalog/storage/query_inputs_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -40,7 +41,7 @@ func TestExecuteQuery(t *testing.T) {
 	}
 
 	// Execute simple query
-	results, err := db.ExecuteQuery(`[:find ?name :where [?e :person/name ?name]]`)
+	results, err := executor.CollectTuples(db.Query(`[:find ?name :where [?e :person/name ?name]]`))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -96,12 +97,12 @@ func TestExecuteQueryWithScalarInput(t *testing.T) {
 	}
 
 	// Execute query with scalar input
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e
 		  :in $ ?name
 		  :where [?e :person/name ?name]]`,
 		"Alice",
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -152,14 +153,14 @@ func TestExecuteQueryWithMultipleScalarInputs(t *testing.T) {
 	}
 
 	// Execute query with name filter (simpler test - the age range query hits disjoint groups)
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name ?age
 		  :in $ ?target-name
 		  :where [?e :person/name ?target-name]
 		         [?e :person/name ?name]
 		         [?e :person/age ?age]]`,
 		"Alice",
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -224,13 +225,13 @@ func TestExecuteQueryWithCollectionInput(t *testing.T) {
 	}
 
 	// Query with collection input
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name ?food
 		  :in $ [?food ...]
 		  :where [?e :person/name ?name]
 		         [?e :person/likes ?food]]`,
 		[]string{"pizza", "pasta"},
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -271,14 +272,14 @@ func TestExecuteQueryWithTupleInput(t *testing.T) {
 	}
 
 	// Query with tuple input - simplified
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e
 		  :in $ ?name ?target-age
 		  :where [?e :person/name ?name]
 		         [?e :person/age ?target-age]]`,
 		"Alice",
 		int64(30),
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -321,7 +322,7 @@ func TestExecuteQueryWithRelationInput(t *testing.T) {
 	}
 
 	// Query with relation input - find entities matching name/age pairs
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?e
 		  :in $ [[?name ?target-age] ...]
 		  :where [?e :person/name ?name]
@@ -330,7 +331,7 @@ func TestExecuteQueryWithRelationInput(t *testing.T) {
 			{"Alice", int64(30)},
 			{"Bob", int64(25)},
 		},
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -384,7 +385,7 @@ func TestExecuteQueryWithTimeInput(t *testing.T) {
 	}
 
 	// Query with just symbol input (time range comparisons hit unassigned predicate issue)
-	results, err := db.ExecuteQueryWithInputs(
+	results, err := executor.CollectTuples(db.Query(
 		`[:find ?time ?close
 		  :in $ ?symbol
 		  :where [?s :symbol/ticker ?symbol]
@@ -392,7 +393,7 @@ func TestExecuteQueryWithTimeInput(t *testing.T) {
 		         [?p :price/time ?time]
 		         [?p :price/close ?close]]`,
 		"CRWV",
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -461,7 +462,7 @@ func TestExecuteQueryInputErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := db.ExecuteQueryWithInputs(tt.query, tt.inputs...)
+			_, err := executor.CollectTuples(db.Query(tt.query, tt.inputs...))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Expected error=%v, got err=%v", tt.wantErr, err)
 			}

--- a/datalog/storage/query_into_test.go
+++ b/datalog/storage/query_into_test.go
@@ -613,7 +613,7 @@ func TestQueryInto_ScalarMultiColumnError(t *testing.T) {
 	`)
 
 	if err == nil {
-		t.Fatal("expected error for multi-column query with scalar slice")
+		t.Fatal("expected error for multi-symbol query with scalar slice")
 	}
 }
 
@@ -689,7 +689,7 @@ func TestQueryOneInto_ScalarMultiColumnError(t *testing.T) {
 	`)
 
 	if err == nil {
-		t.Fatal("expected error for multi-column query with scalar destination")
+		t.Fatal("expected error for multi-symbol query with scalar destination")
 	}
 }
 
@@ -727,7 +727,7 @@ type PullResult struct {
 
 // MixedModeResult combines query variables with pull attributes
 type MixedModeResult struct {
-	// Query variable - comes from tuple column
+	// Query variable - comes from tuple symbol
 	PersonName string `datalog:"?name"`
 	// Attribute tags - come from pull result map in tuple
 	ID  datalog.Identity `datalog:"db/id"`

--- a/datalog/storage/queryexecutor_in_param_subquery_bug_test.go
+++ b/datalog/storage/queryexecutor_in_param_subquery_bug_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestQueryExecutorInParamWithCorrelatedSubquery reproduces the gopher-street bug:
 // Top-level :in parameter combined with correlated subqueries fails with
-// "cannot project: column ?open-price not found in relation"
+// "cannot project: symbol ?open-price not found in relation"
 func TestQueryExecutorInParamWithCorrelatedSubquery(t *testing.T) {
 	// Create temporary database
 	dbPath := "/tmp/test-in-param-subquery-" + t.Name()
@@ -46,7 +46,7 @@ func TestQueryExecutorInParamWithCorrelatedSubquery(t *testing.T) {
 	assert.NoError(t, tx.Add(bar2, datalog.NewKeyword(":bar/day"), int64(1)))
 	assert.NoError(t, tx.Add(bar2, datalog.NewKeyword(":bar/open"), 105.0))
 
-	// Day 2 bars (so anchor pattern returns multiple rows)
+	// Day 2 bars (so anchor pattern returns multiple tuples)
 	assert.NoError(t, tx.Add(bar3, datalog.NewKeyword(":bar/symbol"), aapl))
 	assert.NoError(t, tx.Add(bar3, datalog.NewKeyword(":bar/year"), int64(2025)))
 	assert.NoError(t, tx.Add(bar3, datalog.NewKeyword(":bar/month"), int64(1)))
@@ -62,8 +62,8 @@ func TestQueryExecutorInParamWithCorrelatedSubquery(t *testing.T) {
 	_, err = tx.Commit()
 	assert.NoError(t, err)
 
-	// Query matching gopher-street EXACTLY - RelationBinding with MULTIPLE columns
-	// THIS IS THE KEY: [[?daily-high ?daily-low]] returns TWO columns in one binding
+	// Query matching gopher-street EXACTLY - RelationBinding with MULTIPLE symbols
+	// THIS IS THE KEY: [[?daily-high ?daily-low]] returns TWO symbols in one binding
 	queryStr := `[:find ?date ?daily-high ?daily-low ?open-price
 	              :in $ ?ticker
 	              :where [?s :symbol/ticker ?ticker]
@@ -132,8 +132,8 @@ func TestQueryExecutorInParamWithCorrelatedSubquery(t *testing.T) {
 	// If we get here, the bug is fixed
 	t.Logf("Bug NOT reproduced - test PASSES")
 	assert.Len(t, results, 2, "Should have 2 results (one per day)")
-	for _, row := range results {
-		assert.Len(t, row, 4, "Each result should have 4 columns")
-		t.Logf("Result: date=%v, high=%v, low=%v, open=%v", row[0], row[1], row[2], row[3])
+	for _, tuple := range results {
+		assert.Len(t, tuple, 4, "Each result should have 4 symbols")
+		t.Logf("Result: date=%v, high=%v, low=%v, open=%v", tuple[0], tuple[1], tuple[2], tuple[3])
 	}
 }

--- a/datalog/storage/set_semantics_storage_test.go
+++ b/datalog/storage/set_semantics_storage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 )
 
 // =============================================================================
@@ -67,7 +68,7 @@ func TestSetSemantics_StorageQuery(t *testing.T) {
 	}
 
 	t.Run("Query projecting to value only - [:find ?v :where [_ :test/value ?v]]", func(t *testing.T) {
-		result, err := db.ExecuteQuery(`[:find ?v :where [_ :test/value ?v]]`)
+		result, err := executor.CollectTuples(db.Query(`[:find ?v :where [_ :test/value ?v]]`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -80,7 +81,7 @@ func TestSetSemantics_StorageQuery(t *testing.T) {
 	})
 
 	t.Run("Query projecting entity and value - [:find ?e ?v :where [?e :test/value ?v]]", func(t *testing.T) {
-		result, err := db.ExecuteQuery(`[:find ?e ?v :where [?e :test/value ?v]]`)
+		result, err := executor.CollectTuples(db.Query(`[:find ?e ?v :where [?e :test/value ?v]]`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -129,11 +130,11 @@ func TestSetSemantics_StorageQuery_MultipleAttributes(t *testing.T) {
 
 	t.Run("Join then project to overlapping values", func(t *testing.T) {
 		// This query joins on entity, producing tuples that might duplicate after projection
-		result, err := db.ExecuteQuery(`
+		result, err := executor.CollectTuples(db.Query(`
 			[:find ?city
 			 :where [?e :person/name ?name]
 			        [?e :person/city ?city]]
-		`)
+		`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -146,11 +147,11 @@ func TestSetSemantics_StorageQuery_MultipleAttributes(t *testing.T) {
 	})
 
 	t.Run("Multiple projection symbols", func(t *testing.T) {
-		result, err := db.ExecuteQuery(`
+		result, err := executor.CollectTuples(db.Query(`
 			[:find ?name ?city
 			 :where [?e :person/name ?name]
 			        [?e :person/city ?city]]
-		`)
+		`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -193,11 +194,11 @@ func TestSetSemantics_StorageQuery_WithPredicates(t *testing.T) {
 	}
 
 	t.Run("Filter then project to repeated values", func(t *testing.T) {
-		result, err := db.ExecuteQuery(`
+		result, err := executor.CollectTuples(db.Query(`
 			[:find ?age
 			 :where [?e :person/age ?age]
 			        [(>= ?age 25)]]
-		`)
+		`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -250,11 +251,11 @@ func TestSetSemantics_StorageQuery_Aggregation(t *testing.T) {
 
 	t.Run("Count with potential duplicates", func(t *testing.T) {
 		// Count employees per department
-		result, err := db.ExecuteQuery(`
+		result, err := executor.CollectTuples(db.Query(`
 			[:find ?dept (count ?e)
 			 :where [?e :employee/dept ?dept]
 			        [?e :employee/salary ?salary]]
-		`)
+		`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -303,11 +304,11 @@ func TestSetSemantics_StorageQuery_NotClause(t *testing.T) {
 	}
 
 	t.Run("NOT clause with projection", func(t *testing.T) {
-		result, err := db.ExecuteQuery(`
+		result, err := executor.CollectTuples(db.Query(`
 			[:find ?role
 			 :where [?e :user/role ?role]
 			        (not [?e :user/status "inactive"])]
-		`)
+		`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}
@@ -360,12 +361,12 @@ func TestSetSemantics_StorageQuery_OrClause(t *testing.T) {
 	t.Run("OR clause with overlapping results", func(t *testing.T) {
 		// Items that are either pending OR high priority
 		// e1, e2, e3, e4 match - but projecting to priority should dedupe
-		result, err := db.ExecuteQuery(`
+		result, err := executor.CollectTuples(db.Query(`
 			[:find ?priority
 			 :where [?e :item/priority ?priority]
 			        (or [?e :item/status "pending"]
 			            [?e :item/priority "high"])]
-		`)
+		`))
 		if err != nil {
 			t.Fatalf("query failed: %v", err)
 		}

--- a/datalog/storage/set_semantics_storage_test.go
+++ b/datalog/storage/set_semantics_storage_test.go
@@ -22,10 +22,10 @@ func assertResultNoDuplicates(t *testing.T, name string, results [][]interface{}
 	t.Helper()
 	seen := make(map[string]int)
 
-	for idx, row := range results {
-		key := fmt.Sprintf("%v", row)
+	for idx, tuple := range results {
+		key := fmt.Sprintf("%v", tuple)
 		if firstIdx, exists := seen[key]; exists {
-			t.Errorf("%s: duplicate row at index %d (first seen at %d): %v", name, idx, firstIdx, row)
+			t.Errorf("%s: duplicate tuple at index %d (first seen at %d): %v", name, idx, firstIdx, tuple)
 		}
 		seen[key] = idx
 	}
@@ -128,7 +128,7 @@ func TestSetSemantics_StorageQuery_MultipleAttributes(t *testing.T) {
 	}
 
 	t.Run("Join then project to overlapping values", func(t *testing.T) {
-		// This query joins on entity, producing rows that might duplicate after projection
+		// This query joins on entity, producing tuples that might duplicate after projection
 		result, err := db.ExecuteQuery(`
 			[:find ?city
 			 :where [?e :person/name ?name]
@@ -145,7 +145,7 @@ func TestSetSemantics_StorageQuery_MultipleAttributes(t *testing.T) {
 		assertResultNoDuplicates(t, "City projection after join", result)
 	})
 
-	t.Run("Multiple projection columns", func(t *testing.T) {
+	t.Run("Multiple projection symbols", func(t *testing.T) {
 		result, err := db.ExecuteQuery(`
 			[:find ?name ?city
 			 :where [?e :person/name ?name]

--- a/datalog/storage/simple_batch_scanner.go
+++ b/datalog/storage/simple_batch_scanner.go
@@ -17,7 +17,7 @@ type simpleBatchScanner struct {
 	bindingRel  executor.Relation
 	position    int // Which position has bindings (0=E, 1=A, 2=V, 3=T)
 	index       IndexType
-	columns     []query.Symbol
+	symbols     []query.Symbol
 	constraints []executor.StorageConstraint
 
 	// Results
@@ -35,7 +35,7 @@ func newSimpleBatchScanner(
 	bindingRel executor.Relation,
 	position int,
 	index IndexType,
-	columns []query.Symbol,
+	symbols []query.Symbol,
 	constraints []executor.StorageConstraint,
 ) *simpleBatchScanner {
 	return &simpleBatchScanner{
@@ -44,10 +44,10 @@ func newSimpleBatchScanner(
 		bindingRel:   bindingRel,
 		position:     position,
 		index:        index,
-		columns:      columns,
+		symbols:      symbols,
 		constraints:  constraints,
 		resultIndex:  -1,
-		tupleBuilder: matcher.getTupleBuilder(pattern, columns),
+		tupleBuilder: matcher.getTupleBuilder(pattern, symbols),
 	}
 }
 

--- a/datalog/storage/tuple_builder_bench_test.go
+++ b/datalog/storage/tuple_builder_bench_test.go
@@ -26,7 +26,7 @@ func BenchmarkTupleBuilding(b *testing.B) {
 		},
 	}
 
-	columns := []query.Symbol{
+	symbols := []query.Symbol{
 		datalog.NewSymbol("?e"),
 		datalog.NewSymbol("?a"),
 		datalog.NewSymbol("?v"),
@@ -36,12 +36,12 @@ func BenchmarkTupleBuilding(b *testing.B) {
 	b.Run("DatomToTuple", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_ = query.DatomToTuple(*datom, pattern, columns)
+			_ = query.DatomToTuple(*datom, pattern, symbols)
 		}
 	})
 
 	b.Run("TupleBuilder", func(b *testing.B) {
-		tb := query.NewTupleBuilder(pattern, columns)
+		tb := query.NewTupleBuilder(pattern, symbols)
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -50,7 +50,7 @@ func BenchmarkTupleBuilding(b *testing.B) {
 	})
 
 	b.Run("OptimizedTupleBuilder", func(b *testing.B) {
-		tb := query.NewOptimizedTupleBuilder(pattern, columns)
+		tb := query.NewOptimizedTupleBuilder(pattern, symbols)
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -59,7 +59,7 @@ func BenchmarkTupleBuilding(b *testing.B) {
 	})
 
 	b.Run("OptimizedTupleBuilder_Pooled", func(b *testing.B) {
-		tb := query.NewOptimizedTupleBuilder(pattern, columns)
+		tb := query.NewOptimizedTupleBuilder(pattern, symbols)
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -70,9 +70,9 @@ func BenchmarkTupleBuilding(b *testing.B) {
 	})
 
 	b.Run("OptimizedTupleBuilder_Into", func(b *testing.B) {
-		tb := query.NewOptimizedTupleBuilder(pattern, columns)
+		tb := query.NewOptimizedTupleBuilder(pattern, symbols)
 		// Pre-allocate workspace
-		workspace := make(query.Tuple, len(columns))
+		workspace := make(query.Tuple, len(symbols))
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -81,7 +81,7 @@ func BenchmarkTupleBuilding(b *testing.B) {
 	})
 
 	b.Run("InternedTupleBuilder", func(b *testing.B) {
-		tb := query.NewInternedTupleBuilder(pattern, columns)
+		tb := query.NewInternedTupleBuilder(pattern, symbols)
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -90,9 +90,9 @@ func BenchmarkTupleBuilding(b *testing.B) {
 	})
 
 	b.Run("InternedTupleBuilder_Into", func(b *testing.B) {
-		tb := query.NewInternedTupleBuilder(pattern, columns)
+		tb := query.NewInternedTupleBuilder(pattern, symbols)
 		// Pre-allocate workspace
-		workspace := make(query.Tuple, len(columns))
+		workspace := make(query.Tuple, len(symbols))
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -106,7 +106,7 @@ func BenchmarkTupleBuildingScenarios(b *testing.B) {
 	scenarios := []struct {
 		name    string
 		pattern *query.DataPattern
-		columns []query.Symbol
+		symbols []query.Symbol
 	}{
 		{
 			name: "2_vars",
@@ -117,7 +117,7 @@ func BenchmarkTupleBuildingScenarios(b *testing.B) {
 					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
-			columns: []query.Symbol{
+			symbols: []query.Symbol{
 				datalog.NewSymbol("?e"),
 				datalog.NewSymbol("?v"),
 			},
@@ -131,7 +131,7 @@ func BenchmarkTupleBuildingScenarios(b *testing.B) {
 					query.Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
-			columns: []query.Symbol{
+			symbols: []query.Symbol{
 				datalog.NewSymbol("?e"),
 				datalog.NewSymbol("?a"),
 				datalog.NewSymbol("?v"),
@@ -147,7 +147,7 @@ func BenchmarkTupleBuildingScenarios(b *testing.B) {
 					query.Variable{Name: datalog.NewSymbol("?t")},
 				},
 			},
-			columns: []query.Symbol{
+			symbols: []query.Symbol{
 				datalog.NewSymbol("?e"),
 				datalog.NewSymbol("?a"),
 				datalog.NewSymbol("?v"),
@@ -168,12 +168,12 @@ func BenchmarkTupleBuildingScenarios(b *testing.B) {
 			b.Run("DatomToTuple", func(b *testing.B) {
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
-					_ = query.DatomToTuple(*datom, scenario.pattern, scenario.columns)
+					_ = query.DatomToTuple(*datom, scenario.pattern, scenario.symbols)
 				}
 			})
 
 			b.Run("OptimizedTupleBuilder", func(b *testing.B) {
-				tb := query.NewOptimizedTupleBuilder(scenario.pattern, scenario.columns)
+				tb := query.NewOptimizedTupleBuilder(scenario.pattern, scenario.symbols)
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {

--- a/datalog/storage/workspace_regression_test.go
+++ b/datalog/storage/workspace_regression_test.go
@@ -215,11 +215,11 @@ func TestWorkspaceRegression_PredicateFilter(t *testing.T) {
 	defer cleanup()
 
 	// Query with predicate
-	results, err := db.ExecuteQuery(`
+	results, err := executor.CollectTuples(db.Query(`
 		[:find ?e ?age
 		 :where [?e :person/age ?age]
 		        [(>= ?age 25)]]
-	`)
+	`))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -253,10 +253,10 @@ func TestWorkspaceRegression_Projection(t *testing.T) {
 	defer cleanup()
 
 	// Query projecting only age
-	results, err := db.ExecuteQuery(`
+	results, err := executor.CollectTuples(db.Query(`
 		[:find ?age
 		 :where [?e :person/age ?age]]
-	`)
+	`))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -292,11 +292,11 @@ func TestWorkspaceRegression_FilterThenProject(t *testing.T) {
 	db, cleanup := createWorkspaceTestDB(t)
 	defer cleanup()
 
-	results, err := db.ExecuteQuery(`
+	results, err := executor.CollectTuples(db.Query(`
 		[:find ?age
 		 :where [?e :person/age ?age]
 		        [(>= ?age 25)]]
-	`)
+	`))
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}

--- a/datalog/storage/workspace_regression_test.go
+++ b/datalog/storage/workspace_regression_test.go
@@ -232,22 +232,22 @@ func TestWorkspaceRegression_PredicateFilter(t *testing.T) {
 	}
 
 	// Check that all ages are >= 25
-	for i, row := range results {
-		if len(row) >= 2 {
-			age, ok := row[1].(int64)
+	for i, tuple := range results {
+		if len(tuple) >= 2 {
+			age, ok := tuple[1].(int64)
 			if !ok {
-				t.Errorf("row %d: unexpected age type %T", i, row[1])
+				t.Errorf("tuple %d: unexpected age type %T", i, tuple[1])
 				continue
 			}
 			if age < 25 {
-				t.Errorf("row %d: age %d should not pass filter >= 25", i, age)
+				t.Errorf("tuple %d: age %d should not pass filter >= 25", i, age)
 			}
-			t.Logf("Row %d: age=%d", i, age)
+			t.Logf("Tuple %d: age=%d", i, age)
 		}
 	}
 }
 
-// Test 4: Projection to single column
+// Test 4: Projection to single symbol
 func TestWorkspaceRegression_Projection(t *testing.T) {
 	db, cleanup := createWorkspaceTestDB(t)
 	defer cleanup()
@@ -270,9 +270,9 @@ func TestWorkspaceRegression_Projection(t *testing.T) {
 
 	// Collect ages
 	ageSet := make(map[int64]bool)
-	for _, row := range results {
-		if len(row) >= 1 {
-			if age, ok := row[0].(int64); ok {
+	for _, tuple := range results {
+		if len(tuple) >= 1 {
+			if age, ok := tuple[0].(int64); ok {
 				ageSet[age] = true
 				t.Logf("Age: %d", age)
 			}
@@ -310,9 +310,9 @@ func TestWorkspaceRegression_FilterThenProject(t *testing.T) {
 
 	// Verify the ages are correct
 	ageSet := make(map[int64]bool)
-	for _, row := range results {
-		if len(row) >= 1 {
-			if age, ok := row[0].(int64); ok {
+	for _, tuple := range results {
+		if len(tuple) >= 1 {
+			if age, ok := tuple[0].(int64); ok {
 				ageSet[age] = true
 				if age < 25 {
 					t.Errorf("age %d should not be in results (filter >= 25)", age)

--- a/docs/INPUT_PARAMETER_SEMANTICS.md
+++ b/docs/INPUT_PARAMETER_SEMANTICS.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Input parameters (from `:in` clause) have specific semantics in query planning and execution that differ from both pattern-derived variables and relation columns. Understanding these semantics is critical for correct query planning.
+Input parameters (from `:in` clause) have specific semantics in query planning and execution that differ from both pattern-derived variables and relation symbols. Understanding these semantics is critical for correct query planning.
 
 ## The Three-Level Type System
 
@@ -26,8 +26,8 @@ Janus Datalog maintains a clear separation between three different "levels" of s
 - **Location**: Both `Phase.Provides` (where produced) and subsequent `Phase.Available`
 - **Analogy**: Local variables that persist through computation
 
-### 3. Relation Columns (Data Level)
-- **Actual data**: Columns in the physical relations produced by phases
+### 3. Relation Symbols (Data Level)
+- **Actual data**: Symbols in the physical relations produced by phases
 - **Scope**: Only exist in specific phase outputs
 - **Purpose**: Carry actual query results
 - **Location**: `Phase.Provides` only (what the relation actually contains)
@@ -38,7 +38,7 @@ Janus Datalog maintains a clear separation between three different "levels" of s
 ### Invariant 1: Available ≠ Provides
 ```
 Available = Environment symbols (inputs + previous outputs)
-Provides = Relation columns (what THIS phase produces)
+Provides = Relation symbols (what THIS phase produces)
 ```
 
 Input parameters are in `Available` (can be used) but NOT in `Provides` (not in result).
@@ -93,15 +93,15 @@ Keep:      [?time ?s]                  ← What's needed for find clause
 
 ## Common Pitfalls
 
-### Pitfall 1: Treating Input Parameters as Relation Columns
+### Pitfall 1: Treating Input Parameters as Relation Symbols
 ```go
 // WRONG: Try to keep input parameter
 Keep: [?time ?close ?symbol]  // ?symbol not in Provides!
 ```
 
-**Error**: "cannot project: column ?symbol not found in relation"
+**Error**: "cannot project: symbol ?symbol not found in relation"
 
-**Why**: Input parameters are environment symbols, not data columns.
+**Why**: Input parameters are environment symbols, not data symbols.
 
 **Fix**: Only keep symbols that are in `Provides`:
 ```go
@@ -238,11 +238,11 @@ for i := range phases {
 This is the core insight that resolves confusion:
 
 - **Metadata**: Information ABOUT the query execution (input parameters)
-- **Data**: Information IN the query result (relation columns)
+- **Data**: Information IN the query result (relation symbols)
 
-Just as SQL prepared statements have parameters that don't appear in result columns:
+Just as SQL prepared statements have parameters that don't appear in result symbols:
 ```sql
--- ?symbol is a parameter, not a column
+-- ?symbol is a parameter, not a symbol
 SELECT time, close
 FROM prices
 WHERE symbol = ?  -- ?symbol filters but doesn't appear in output

--- a/docs/PHASE_FIND_AND_SYMBOL_ORDERING.md
+++ b/docs/PHASE_FIND_AND_SYMBOL_ORDERING.md
@@ -1,14 +1,14 @@
-# Phase Find and Column Ordering
+# Phase Find and Symbol Ordering
 
 ## Discovery
 
-While implementing phase reordering, we discovered a subtle but important architectural consideration regarding how phases handle column ordering.
+While implementing phase reordering, we discovered a subtle but important architectural consideration regarding how phases handle symbol ordering.
 
 ## Order-Preserving Phases: An Alternative Approach
 
 In some distributed Datalog planners, each phase has a `:find` field that specifies:
-1. **Which columns** the phase should output
-2. **In what order** those columns should appear
+1. **Which symbols** the phase should output
+2. **In what order** those symbols should appear
 
 ```clojure
 find (if-let [find? (not-empty (intersection keep referred))]
@@ -23,14 +23,14 @@ The `:find` is calculated as:
 
 ### Why Order Matters
 
-Some implementations maintain **consistent column ordering** throughout query execution:
-- All phases output columns in an order aligned with the final query's find clause
-- Additional columns (needed for joins but not in final result) appear after the find columns
+Some implementations maintain **consistent symbol ordering** throughout query execution:
+- All phases output symbols in an order aligned with the final query's find clause
+- Additional symbols (needed for joins but not in final result) appear after the find symbols
 - This means **no reordering is needed at the end** - the final result is already in the correct order
 
 ## Go's Current Approach: Project Without Order
 
-In our Go implementation, phases use `Keep` to specify which columns to retain, but don't specify order:
+In our Go implementation, phases use `Keep` to specify which symbols to retain, but don't specify order:
 
 ```go
 phases[i].Find = findVars  // Same for all phases (global find clause)
@@ -42,38 +42,38 @@ We project to `phase.Keep` at phase boundaries (line 236-244 in `expressions_and
 projected, err := result.Project(phase.Keep)
 ```
 
-But `Project()` doesn't guarantee any particular column order - columns end up in whatever order the relation operations naturally produce.
+But `Project()` doesn't guarantee any particular symbol order - symbols end up in whatever order the relation operations naturally produce.
 
 ## The Positional Nature of Tuples
 
-While we use **named columns** (`[]query.Symbol`), the underlying data is **positional**:
+While we use **named symbols** (`[]query.Symbol`), the underlying data is **positional**:
 
 ```go
 type MaterializedRelation struct {
-    columns []query.Symbol    // Named columns
+    symbols []query.Symbol    // Named symbols
     tuples  []Tuple           // [][]interface{} - positional arrays!
 }
 ```
 
 This means:
-- Looking up a column by name finds its **index position**
+- Looking up a symbol by name finds its **index position**
 - Accessing values requires `tuple[columnIndex]`
-- **Reordering columns means creating new tuple arrays** with values copied to new positions
+- **Reordering symbols means creating new tuple arrays** with values copied to new positions
 
 ## Performance Implications
 
-### With Arbitrary Column Order (Current Go):
-1. Join two relations → create new tuples with merged column order
-2. Project to `Keep` → create new tuples with subset of columns (arbitrary order)
+### With Arbitrary Symbol Order (Current Go):
+1. Join two relations → create new tuples with merged symbol order
+2. Project to `Keep` → create new tuples with subset of symbols (arbitrary order)
 3. Pass to next phase → repeat
 4. Final projection to `query.Find` → **reorder tuples again** to match find clause
 
 **Cost**: Multiple tuple array allocations and memory copies per phase.
 
-### With Consistent Column Order (Clojure):
-1. All phases maintain same column order (find clause order + extras)
-2. Joins naturally align (same columns in same positions)
-3. Projecting to `Keep` = dropping trailing columns (cheap)
+### With Consistent Symbol Order (Clojure):
+1. All phases maintain same symbol order (find clause order + extras)
+2. Joins naturally align (same symbols in same positions)
+3. Projecting to `Keep` = dropping trailing symbols (cheap)
 4. Final projection to `query.Find` = **free** (already in right order)
 
 **Cost**: Minimal - mostly just slice operations, no tuple copying.
@@ -89,9 +89,9 @@ This means:
 - `phase.Find` is **never read** by the executor
 
 **Impact**:
-- Code works correctly (named columns ensure we get right values)
+- Code works correctly (named symbols ensure we get right values)
 - But potentially less efficient due to tuple reordering overhead
-- May not matter much with named column lookups and modern allocators
+- May not matter much with named symbol lookups and modern allocators
 
 ## Decision: Do We Need Phase-Specific Find?
 
@@ -103,7 +103,7 @@ This means:
 
 ### Arguments AGAINST:
 - Current approach works and is simpler
-- Named columns already incur lookup overhead
+- Named symbols already incur lookup overhead
 - Modern allocators are fast
 - Optimization may be premature
 - Would require changes throughout projection/join code
@@ -120,8 +120,8 @@ This means:
 
 **If we implement it later**:
 - Calculate `phase.Find` as ordered subset of `phase.Keep` matching query find clause order
-- Modify `Project()` to accept target column order
-- Modify join operations to maintain consistent column ordering
+- Modify `Project()` to accept target symbol order
+- Modify join operations to maintain consistent symbol ordering
 - Benchmark to verify the optimization actually helps
 
 ## Key Insight for Phase Reordering

--- a/docs/QUERY_SYSTEM_TLDR.md
+++ b/docs/QUERY_SYSTEM_TLDR.md
@@ -157,7 +157,7 @@ func Collapse(relations []Relation) []Relation {
         merged := false
         for i, group := range groups {
             if shareColumns(rel, group) {
-                groups[i] = hashJoin(group, rel)  // Join on shared columns
+                groups[i] = hashJoin(group, rel)  // Join on shared symbols
                 merged = true
                 break
             }
@@ -170,7 +170,7 @@ func Collapse(relations []Relation) []Relation {
 }
 ```
 
-**Result**: Multiple "disjoint groups" if relations don't share columns.
+**Result**: Multiple "disjoint groups" if relations don't share symbols.
 
 **Error case**: If disjoint groups remain at the end → query would require Cartesian product → reject with error.
 
@@ -178,21 +178,21 @@ func Collapse(relations []Relation) []Relation {
 
 ## Join Strategy: Hash Join
 
-When joining two relations on shared columns:
+When joining two relations on shared symbols:
 
 ```
-Relation A: [?e, ?name]     (10,000 rows)
-Relation B: [?e, ?age]      (10,000 rows)
+Relation A: [?e, ?name]     (10,000 tuples)
+Relation B: [?e, ?age]      (10,000 tuples)
 Join on: ?e
 
 Algorithm:
 1. Build hash table from SMALLER relation
-   hash[?e] → [?name rows...]
+   hash[?e] → [?name tuples...]
 
 2. Probe with LARGER relation
    for each (?e, ?age) in B:
        lookup hash[?e]
-       emit combined rows
+       emit combined tuples
 
 Complexity: O(n + m) instead of O(n × m)
 ```
@@ -212,8 +212,8 @@ Pattern 2: [?e :salary ?s]       → Now works on pre-filtered set
 ```
 
 **Why not wait?**
-- Filtering 10K rows to 1K is cheap
-- Subsequent patterns only process 1K rows instead of 10K
+- Filtering 10K tuples to 1K is cheap
+- Subsequent patterns only process 1K tuples instead of 10K
 - Memory stays bounded
 
 **Game analogy**: Like early-out in raymarching. Check cheap bounds before expensive SDF evaluation.
@@ -255,7 +255,7 @@ Step 1: [?player :player/weapon ?weapon]
 
 Step 2: [?weapon :weapon/damage ?damage]
 
-        For each row from Step 1:
+        For each tuple from Step 1:
           Execute pattern with ?weapon = sword_5
           Execute pattern with ?weapon = axe_3
           ...
@@ -339,13 +339,13 @@ Round 4:
 ```
 Step 1: [?player :player/weapon ?weapon]
         Index: AEVT (attribute bound)
-        Result: Relation([?player, ?weapon], 10000 rows)
+        Result: Relation([?player, ?weapon], 10000 tuples)
         Groups: [Rel1]
 
 Step 2: [?weapon :weapon/damage ?damage]
         Binding: Use Rel1's ?weapon values
         Index: EAVT per weapon (entity bound)
-        Result: Relation([?weapon, ?damage], 10000 rows)
+        Result: Relation([?weapon, ?damage], 10000 tuples)
         Groups: [Rel1, Rel2]
         Collapse: Rel1 ∩ Rel2 on ?weapon → Rel3([?player, ?weapon, ?damage])
         Groups: [Rel3]
@@ -353,17 +353,17 @@ Step 2: [?weapon :weapon/damage ?damage]
 Step 3: [?player :player/name ?name]
         Binding: Use Rel3's ?player values
         Index: EAVT per player
-        Result: Relation([?player, ?name], 10000 rows)
+        Result: Relation([?player, ?name], 10000 tuples)
         Collapse: Rel3 ∩ Rel4 on ?player → Rel5([?player, ?weapon, ?damage, ?name])
         Groups: [Rel5]
 
 Step 4: [(> ?damage 50)]
         Filter Rel5 where ?damage > 50
-        Result: Rel6 (maybe 2000 rows)
+        Result: Rel6 (maybe 2000 tuples)
         Groups: [Rel6]
 
 Project: Keep only [?name, ?damage]
-Return: 2000 rows
+Return: 2000 tuples
 ```
 
 ---
@@ -374,7 +374,7 @@ Return: 2000 rows
 |----------|--------|-----------------|
 | **Clause order** | Score by type, respect dependencies | Task priority + job graph |
 | **When to join** | After every clause (collapse) | Incremental scene merging |
-| **Join algorithm** | Hash join on shared columns | Spatial hashing |
+| **Join algorithm** | Hash join on shared symbols | Spatial hashing |
 | **Index selection** | Based on bound variables | Choosing accel structure |
 | **Binding strategy** | Score by selectivity position | Instance culling |
 | **Predicate timing** | ASAP when symbols available | Early-out optimization |

--- a/docs/STREAMING_ARCHITECTURE_DECISION.md
+++ b/docs/STREAMING_ARCHITECTURE_DECISION.md
@@ -16,7 +16,7 @@ We implemented a complete streaming preservation pipeline:
 
 ### 1. Iterator Composition
 - `FilterIterator`: Lazy filtering without materialization
-- `ProjectIterator`: Lazy projection to subset of columns
+- `ProjectIterator`: Lazy projection to subset of symbols
 - `TransformIterator`: Lazy tuple transformation
 - `PredicateFilterIterator`: Lazy predicate evaluation
 - `FunctionEvaluatorIterator`: Lazy function evaluation

--- a/docs/TALE_AND_LESSONS_OF_CORRECTNESS_BUGS.md
+++ b/docs/TALE_AND_LESSONS_OF_CORRECTNESS_BUGS.md
@@ -353,7 +353,7 @@ TestComprehensiveExecutorValidation/all_features_combined
 
 The errors:
 ```
-Legacy error: projection failed: cannot project: column ?total not found
+Legacy error: projection failed: cannot project: symbol ?total not found
 New error: <nil>
 ```
 

--- a/docs/archive/2025-10/AGGREGATE_SUBQUERY_BUG_ANALYSIS.md
+++ b/docs/archive/2025-10/AGGREGATE_SUBQUERY_BUG_ANALYSIS.md
@@ -29,7 +29,7 @@ Original subquery (high/low example):
 Should execute as:
 - **Find clause**: `[:find (max ?h) (min ?l)]` - pure aggregation, no group-by
 - **Aggregation type**: Single aggregation over all matching tuples
-- **Expected result**: One row with two aggregate values
+- **Expected result**: One tuple with two aggregate values
 
 ### Actual Behavior
 
@@ -46,7 +46,7 @@ Debug output shows the subquery executes with:
 This is treated as:
 - **Find clause**: `[:find ?sym ?py ?pm ?pd (max ?h) (min ?l)]` - mixed variables and aggregates
 - **Aggregation type**: Grouped aggregation by `[?sym ?py ?pm ?pd]`
-- **Problem**: Input variables `?sym`, `?py`, `?pm`, `?pd` are treated as group-by columns
+- **Problem**: Input variables `?sym`, `?py`, `?pm`, `?pd` are treated as group-by symbols
 
 ## Why This Causes nil Values
 
@@ -55,13 +55,13 @@ With grouped aggregation:
 1. **First subquery execution** (for a specific date):
    - Groups by `[?sym=<identity> ?py=2025 ?pm=7 ?pd=31]`
    - Computes aggregates for that group
-   - Returns result with those grouping columns
+   - Returns result with those grouping symbols
 
 2. **Join with outer query**:
-   - Outer query doesn't have columns `?py`, `?pm`, `?pd`
-   - Join tries to match on these non-existent columns
-   - **Result**: Empty join or mismatched columns
-   - Aggregate columns end up as `nil`
+   - Outer query doesn't have symbols `?py`, `?pm`, `?pd`
+   - Join tries to match on these non-existent symbols
+   - **Result**: Empty join or mismatched symbols
+   - Aggregate symbols end up as `nil`
 
 3. **Last subquery** (volume) works because:
    - It's the final operation

--- a/docs/archive/2025-10/AGGREGATION_BEHAVIOR_CHANGES.md
+++ b/docs/archive/2025-10/AGGREGATION_BEHAVIOR_CHANGES.md
@@ -105,7 +105,7 @@ The fix preserves the fundamental difference between aggregation types:
 
 **Why this matters**: Adding input variables as grouping keys changes semantics:
 - Pure → Grouped changes from "global max" to "max per input"
-- Join conditions expect specific column structure
+- Join conditions expect specific symbol structure
 - Wrong structure → join failures → `nil` values
 
 ### 4. 📊 Test Suite Changes

--- a/docs/archive/2025-10/BRANCH_REPORT_FIX_BUFFERED_ITERATOR_ARCHITECTURE.md
+++ b/docs/archive/2025-10/BRANCH_REPORT_FIX_BUFFERED_ITERATOR_ARCHITECTURE.md
@@ -96,8 +96,8 @@ The branch transformed the executor from a fragile, materializing-by-default sys
 - Removed both from executePhasesWithInputs
 - Empty results now handled naturally
 
-**Commit 12** (`3ea82c9`): Add Keep column projection
-- **Critical Bug**: Legacy executor wasn't projecting to Keep columns
+**Commit 12** (`3ea82c9`): Add Keep symbol projection
+- **Critical Bug**: Legacy executor wasn't projecting to Keep symbols
 - Breaking phase-to-phase data flow
 - Added Keep projection after each non-final phase
 

--- a/docs/archive/2025-10/CONCURRENT_MAP_BUG_REPORT.md
+++ b/docs/archive/2025-10/CONCURRENT_MAP_BUG_REPORT.md
@@ -67,12 +67,12 @@ type BadgerMatcher struct {
     // ...
 }
 
-func (m *BadgerMatcher) getTupleBuilder(pattern, columns) *InternedTupleBuilder {
-    key := computeKey(pattern, columns)
+func (m *BadgerMatcher) getTupleBuilder(pattern, symbols) *InternedTupleBuilder {
+    key := computeKey(pattern, symbols)
     if builder, exists := m.tupleBuilderCache[key] {  // Line 68: CONCURRENT READ
         return builder
     }
-    builder := createBuilder(pattern, columns)
+    builder := createBuilder(pattern, symbols)
     m.tupleBuilderCache[key] = builder  // CONCURRENT WRITE
     return builder
 }
@@ -118,8 +118,8 @@ type BadgerMatcher struct {
     // ...
 }
 
-func (m *BadgerMatcher) getTupleBuilder(pattern, columns) *InternedTupleBuilder {
-    key := computeKey(pattern, columns)
+func (m *BadgerMatcher) getTupleBuilder(pattern, symbols) *InternedTupleBuilder {
+    key := computeKey(pattern, symbols)
 
     // Try read lock first (fast path)
     m.tupleBuilderCacheMu.RLock()
@@ -138,7 +138,7 @@ func (m *BadgerMatcher) getTupleBuilder(pattern, columns) *InternedTupleBuilder 
         return builder
     }
 
-    builder := createBuilder(pattern, columns)
+    builder := createBuilder(pattern, symbols)
     m.tupleBuilderCache[key] = builder
     return builder
 }
@@ -155,14 +155,14 @@ type BadgerMatcher struct {
     // ...
 }
 
-func (m *BadgerMatcher) getTupleBuilder(pattern, columns) *InternedTupleBuilder {
-    key := computeKey(pattern, columns)
+func (m *BadgerMatcher) getTupleBuilder(pattern, symbols) *InternedTupleBuilder {
+    key := computeKey(pattern, symbols)
 
     if builder, ok := m.tupleBuilderCache.Load(key); ok {
         return builder.(*InternedTupleBuilder)
     }
 
-    builder := createBuilder(pattern, columns)
+    builder := createBuilder(pattern, symbols)
     actual, loaded := m.tupleBuilderCache.LoadOrStore(key, builder)
     return actual.(*InternedTupleBuilder)
 }
@@ -195,7 +195,7 @@ Move cache from `BadgerMatcher` to `Executor` with goroutine-local access.
 func TestTupleBuilderCacheConcurrency(t *testing.T) {
     matcher := NewBadgerMatcher(/* ... */)
     pattern := &Pattern{/* ... */}
-    columns := []Symbol{/* ... */}
+    symbols := []Symbol{/* ... */}
 
     // Spawn 1000 goroutines accessing cache concurrently
     var wg sync.WaitGroup
@@ -204,7 +204,7 @@ func TestTupleBuilderCacheConcurrency(t *testing.T) {
         go func() {
             defer wg.Done()
             for j := 0; j < 100; j++ {
-                builder := matcher.getTupleBuilder(pattern, columns)
+                builder := matcher.getTupleBuilder(pattern, symbols)
                 if builder == nil {
                     t.Error("getTupleBuilder returned nil")
                 }
@@ -248,7 +248,7 @@ The optimization report (`OPTIMIZATION_REPORT_2025_10_08.md`) mentions:
 
 > **Tuple Builder Caching** (commit `ff1cecb`) - **15% reduction**
 > - Problem: Creating new `InternedTupleBuilder` for every pattern match
-> - Solution: Cache builders per `(pattern, columns)` combination
+> - Solution: Cache builders per `(pattern, symbols)` combination
 
 The solution is correct, but the implementation missed thread-safety requirements for parallel execution.
 

--- a/docs/archive/2025-10/DRY_OPPORTUNITIES.md
+++ b/docs/archive/2025-10/DRY_OPPORTUNITIES.md
@@ -4,7 +4,7 @@
 **Codebase Size**: ~60,000 lines of Go code
 **Initial Duplication Identified**: ~1,900 lines
 **Completed Refactoring**: 445 lines eliminated
-**Investigated & Found Consolidated**: ~330-400 lines (Column Indexing, Value Comparison)
+**Investigated & Found Consolidated**: ~330-400 lines (Symbol Indexing, Value Comparison)
 **Actual Remaining Opportunities**: ~100-200 lines (Test Infrastructure only)
 **Total Actual Duplication**: ~545-645 lines (**0.9-1.1%** - exceptionally clean)
 
@@ -32,7 +32,7 @@ A comprehensive analysis of the janus-datalog codebase revealed **exceptionally 
 
 | Area | Estimated Lines | Investigation Result | Status |
 |------|----------------|---------------------|---------|
-| Column Indexing | 80-100 | Already exists as `TupleIndexer.ColIndex` | ✅ Consolidated |
+| Symbol Indexing | 80-100 | Already exists as `TupleIndexer.ColIndex` | ✅ Consolidated |
 | Value Comparison | 150-200 | Already exists in `datalog/compare.go` | ✅ Consolidated |
 | Value Hashing | 100-150 | Intentionally different: hashing vs equality | ⚠️ Not duplication |
 
@@ -122,7 +122,7 @@ This codebase is **exceptionally clean** at 1.5-1.7% duplication.
 ```go
 // 50+ lines of pattern extraction in reusingIterator
 colIndex := make(map[Symbol]int)
-for i, col := range columns {
+for i, col := range symbols {
     colIndex[col] = i
 }
 if c, ok := pattern.GetE().(query.Constant); ok {
@@ -137,7 +137,7 @@ if c, ok := pattern.GetE().(query.Constant); ok {
 
 **After:**
 ```go
-extractor := query.NewPatternExtractor(pattern, columns)
+extractor := query.NewPatternExtractor(pattern, symbols)
 values := extractor.Extract(bindingTuple)
 // Access via values.E, values.A, values.V, values.T
 ```
@@ -195,8 +195,8 @@ func emitIteratorStatistics(
 **Before (repeated in 3 files):**
 ```go
 // ~80 lines in each builder's constructor
-colIndex := make(map[Symbol]int, len(columns))
-for i, col := range columns {
+colIndex := make(map[Symbol]int, len(symbols))
+for i, col := range symbols {
     colIndex[col] = i
 }
 
@@ -211,7 +211,7 @@ if v, ok := pattern.GetE().(Variable); ok {
 
 **After:**
 ```go
-indexer := NewTupleIndexer(pattern, columns)
+indexer := NewTupleIndexer(pattern, symbols)
 return &InternedTupleBuilder{
     eIndex: indexer.EIndex,
     aIndex: indexer.AIndex,
@@ -237,7 +237,7 @@ return &InternedTupleBuilder{
 
 After completing the initial three phases, we investigated the remaining "opportunities" from the original analysis. **Result**: Most were already consolidated or not actual duplication.
 
-### Column Indexing Helper - Already Exists ✅
+### Symbol Indexing Helper - Already Exists ✅
 
 **Original Claim**: 38+ call sites building `map[Symbol]int`, ~80-100 lines of duplication
 
@@ -484,7 +484,7 @@ func TestQueryExecution(t *testing.T) {
 4. Add helpers incrementally as patterns emerge
 5. Don't force-fit - only use where it improves clarity
 
-**Note**: Sections 2 and 3 (Value Comparison and Column Indexing) were originally listed here but removed after investigation revealed they were already consolidated (see "Investigation Results" section above).
+**Note**: Sections 2 and 3 (Value Comparison and Symbol Indexing) were originally listed here but removed after investigation revealed they were already consolidated (see "Investigation Results" section above).
 
 ---
 
@@ -536,7 +536,7 @@ Three iterator implementations (`reusingIterator`, `nonReusingIterator`, `unboun
 - ✅ Explicit delegation makes it obvious what each type does
 
 **Methods that look duplicated but aren't:**
-- `Columns()`, `Options()` - Trivial accessors (1-2 lines, embedding wouldn't help)
+- `Symbols()`, `Options()` - Trivial accessors (1-2 lines, embedding wouldn't help)
 - `Project()`, `Filter()` - Different implementations for materialized vs streaming
 - `Join()` - Completely different strategies based on data representation
 
@@ -606,7 +606,7 @@ After investigation, only **one item** has actual duplication worth consolidatin
 
 ### Investigated & Found Already Consolidated ✅
 
-- ✅ **Column Indexing** - Already exists as `TupleIndexer.ColIndex` and `ColumnIndex()` helper
+- ✅ **Symbol Indexing** - Already exists as `TupleIndexer.ColIndex` and `ColumnIndex()` helper
 - ✅ **Value Comparison** - Already consolidated in `datalog/compare.go` (280 lines)
 - ⚠️ **Value Hashing** - Intentionally different operations (hashing vs equality), not duplication
 
@@ -685,7 +685,7 @@ These were initially identified as duplication (~700-1,200 lines) but represent 
 - ✅ **Helper functions** preferred over base classes (Go idioms)
 
 ### For Remaining Opportunities
-**If implementing test infrastructure, value comparison, or column indexing:**
+**If implementing test infrastructure, value comparison, or symbol indexing:**
 - Lines of code eliminated vs code added
 - Test coverage maintained or improved
 - Performance impact <5% in hot paths
@@ -701,14 +701,14 @@ After comprehensive analysis, investigation, and Go idioms review, the janus-dat
 
 - **Total actual duplication**: ~545-645 lines out of 60,000 = **0.9-1.1%** ✨
 - **Completed refactoring**: 445 lines eliminated (3 phases)
-- **Already consolidated**: ~330-400 lines (column indexing, value comparison)
+- **Already consolidated**: ~330-400 lines (symbol indexing, value comparison)
 - **Remaining true DRY**: ~100-200 lines (test infrastructure only)
 - **Reclassified as intentional**: ~700-1,200 lines (iterator types, relation delegation, etc.)
 
 ### Investigation Findings
 
 **What we discovered**:
-1. **Column Indexing** - Already exists as `TupleIndexer.ColIndex` ✅
+1. **Symbol Indexing** - Already exists as `TupleIndexer.ColIndex` ✅
 2. **Value Comparison** - Already consolidated in `datalog/compare.go` (280 lines) ✅
 3. **Value Hashing** - Intentionally different operations (hashing vs equality) ⚠️
 
@@ -739,7 +739,7 @@ After comprehensive analysis, investigation, and Go idioms review, the janus-dat
   - **Not urgent** - consider only if test maintenance becomes a pain point
 
 **Already Done ✅:**
-- ✅ Column Indexing - Use existing `TupleIndexer.ColIndex` and `ColumnIndex()` helper
+- ✅ Symbol Indexing - Use existing `TupleIndexer.ColIndex` and `ColumnIndex()` helper
 - ✅ Value Comparison - Use existing `datalog.ValuesEqual()` and `datalog.CompareValues()`
 
 **NOT Recommended:**

--- a/docs/archive/2025-10/FAILING_TESTS.md
+++ b/docs/archive/2025-10/FAILING_TESTS.md
@@ -17,7 +17,7 @@
 
 ### ✅ TestMultipleAggregateSubqueriesNilBug - FIXED
 - **File**: Root package test
-- **Issue**: Was returning 0 rows instead of 1 due to entity join bug
+- **Issue**: Was returning 0 tuples instead of 1 due to entity join bug
 - **Fix**: Fixed StreamingRelation.IsEmpty() consuming first tuple (see BUG_ENTITY_JOIN_LOSES_FIRST_TUPLE.md)
 
 ---
@@ -113,7 +113,7 @@
 
 **Tests Fixed**:
 - ✅ TestEntityJoinBug - Returns 5/5 results (was 4/5)
-- ✅ TestMultipleAggregateSubqueriesNilBug - Returns correct aggregates (was 0 rows)
+- ✅ TestMultipleAggregateSubqueriesNilBug - Returns correct aggregates (was 0 tuples)
 
 ---
 

--- a/docs/archive/2025-10/FIXES_2025_10_10.md
+++ b/docs/archive/2025-10/FIXES_2025_10_10.md
@@ -153,7 +153,7 @@ github.com/wbrown/gopher-street.ExtractDailyFromDatalogAccurate(0xc000ee6500)
     /Users/wbrown/go/src/github.com/wbrown/gopher-street/extract_datalog.go:930 +0x730
 ```
 
-Line 930: `High: row[2].(float64)` - panics because `row[2]` is nil
+Line 930: `High: tuple[2].(float64)` - panics because `tuple[2]` is nil
 
 ### Trigger Conditions
 Subquery with aggregate function returns empty result:
@@ -201,10 +201,10 @@ case query.TupleBinding:
     // EMPTY RESULT = PATTERN FAILS TO MATCH
     // Return empty relation instead of error (datalog semantics)
     if result.Size() == 0 {
-        columns := make([]query.Symbol, len(inputSymbols)+len(b.Variables))
-        copy(columns, inputSymbols)
-        copy(columns[len(inputSymbols):], b.Variables)
-        return NewMaterializedRelation(columns, []Tuple{}), nil
+        symbols := make([]query.Symbol, len(inputSymbols)+len(b.Variables))
+        copy(symbols, inputSymbols)
+        copy(symbols[len(inputSymbols):], b.Variables)
+        return NewMaterializedRelation(symbols, []Tuple{}), nil
     }
 
     if result.Size() != 1 {
@@ -336,16 +336,16 @@ Alice is correctly excluded because the pattern failed to match (no orders → e
 
 ```go
 // BEFORE (defensive code)
-for _, row := range results {
-    if row[1] == nil {
+for _, tuple := range results {
+    if tuple[1] == nil {
         continue  // Skip nil aggregations
     }
-    high := row[1].(float64)
+    high := tuple[1].(float64)
 }
 
 // AFTER (no longer needed)
-for _, row := range results {
-    high := row[1].(float64)  // Safe - never nil
+for _, tuple := range results {
+    high := tuple[1].(float64)  // Safe - never nil
 }
 ```
 
@@ -429,14 +429,14 @@ These fixes are:
 
 ## Clarification: Streaming Aggregation Bug
 
-**IMPORTANT**: During testing, a separate bug was discovered in streaming aggregation that returned nil values for max/min/avg/sum when processing >100 rows. This was initially misattributed to the October 10 fixes.
+**IMPORTANT**: During testing, a separate bug was discovered in streaming aggregation that returned nil values for max/min/avg/sum when processing >100 tuples. This was initially misattributed to the October 10 fixes.
 
 **Actual Status**:
 - ✅ **October 10 subquery fixes are CORRECT** - No regression, working as intended
 - ❌ **Streaming aggregation bug was PRE-EXISTING** - Unrelated to October 10 fixes
 
 The streaming bug has been **fixed separately** with two changes to `datalog/executor/aggregation.go`:
-1. Initialize column indices to -1 instead of 0 (lines 723-758)
+1. Initialize symbol indices to -1 instead of 0 (lines 723-758)
 2. Increment count for min/max in `AggregateState.Update()` (lines 501-511)
 
 See `STREAMING_AGGREGATION_NIL_BUG.md` for full details of the streaming bug investigation and fix.
@@ -444,7 +444,7 @@ See `STREAMING_AGGREGATION_NIL_BUG.md` for full details of the streaming bug inv
 **Verification**: All tests pass including:
 - Subquery empty aggregation tests (October 10 fixes)
 - Streaming aggregation tests (streaming bug fix)
-- BadgerDB pure aggregation tests (streaming with >100 rows)
+- BadgerDB pure aggregation tests (streaming with >100 tuples)
 - Decorrelation tests (pure aggregations not decorrelated)
 
 ---

--- a/docs/archive/2025-10/GOPHER_STREET_RESPONSE.md
+++ b/docs/archive/2025-10/GOPHER_STREET_RESPONSE.md
@@ -90,7 +90,7 @@ Your report mentioned parallel execution being disabled, but investigation showe
 
 2. **Input Parameter in Keep Bug** (phase_reordering.go:358-383)
    - Problem: Join symbol logic added input parameters to projection
-   - Symptom: "cannot project: column ?symbol not found"
+   - Symptom: "cannot project: symbol ?symbol not found"
    - Fix: Only keep symbols in `Keep ⊆ Provides ∩ Available`
    - Test: `TestExecuteQueryWithTimeInput`
 
@@ -129,7 +129,7 @@ Your report mentioned parallel execution being disabled, but investigation showe
 
 **Previous fixes** (already completed in October):
 - Concurrent map access (commit `ce789af`) - Fixed with sync.Map
-- Tuple order violation (commits `d2c74cd`, `1dc21a7`) - Fixed with column mapping
+- Tuple order violation (commits `d2c74cd`, `1dc21a7`) - Fixed with symbol mapping
 
 ### 3. Comprehensive Documentation
 

--- a/docs/archive/2025-10/HASHJOIN_CACHE_LOCALITY_DISCOVERY.md
+++ b/docs/archive/2025-10/HASHJOIN_CACHE_LOCALITY_DISCOVERY.md
@@ -205,7 +205,7 @@ result := rel.Join(other)
 ### 2. Size Hints May Not Be Worth The Cost
 
 If getting size information requires:
-- Counting rows (O(n) scan)
+- Counting tuples (O(n) scan)
 - Materializing a relation
 - Waiting for async operation
 

--- a/docs/archive/2025-10/LARGE_BINDING_SET_DIAGNOSIS.md
+++ b/docs/archive/2025-10/LARGE_BINDING_SET_DIAGNOSIS.md
@@ -31,7 +31,7 @@ Queries with large binding sets (>1000 entities) were extremely slow, timing out
 **Performance Results**:
 ```
 Test 2 (aggregation):  timeout → 523ms
-Test 3 (79 rows):      61+ sec → 69ms (880x speedup!)
+Test 3 (79 tuples):      61+ sec → 69ms (880x speedup!)
 Test 5 (complex OHLC): 27 sec  → 210ms (128x speedup!)
 ```
 
@@ -118,7 +118,7 @@ The implementation validates classic database join algorithm theory:
 All gopher-street queries now perform well:
 - Test 1 (count datoms): 181ms ✅
 - Test 2 (aggregation with filters): 523ms ✅ (was timeout)
-- Test 3 (79 rows with filters): 69ms ✅ (was 61+ seconds)
+- Test 3 (79 tuples with filters): 69ms ✅ (was 61+ seconds)
 - Test 4 (simple subquery): 35ms ✅ (already fast)
 - Test 5 (complex OHLC): 210ms ✅ (was 27 seconds)
 

--- a/docs/archive/2025-10/PERFORMANCE_ISSUE.md
+++ b/docs/archive/2025-10/PERFORMANCE_ISSUE.md
@@ -63,10 +63,10 @@ The proper fix requires:
 1. **Query optimization**: Reorder patterns to use available constraints early
 2. **Constraint propagation**: Understand relationships between attributes and constraints
 3. **Index support**: Add composite indices for common query patterns (symbol+date)
-4. **Single-row optimization**: Special handling for single-row binding relations
+4. **Single-tuple optimization**: Special handling for single-tuple binding relations
 
 ## Impact
 
-Current: Fetching 7088 rows per subquery execution (37 times = 261,256 rows)
-Optimal: Fetching ~200 rows per subquery execution (37 times = 7,400 rows)
+Current: Fetching 7088 tuples per subquery execution (37 times = 261,256 tuples)
+Optimal: Fetching ~200 tuples per subquery execution (37 times = 7,400 tuples)
 Performance impact: ~35x more data fetched than necessary

--- a/docs/archive/2025-10/PURE_AGGREGATION_NIL_BUG.md
+++ b/docs/archive/2025-10/PURE_AGGREGATION_NIL_BUG.md
@@ -30,7 +30,7 @@ All pure aggregation queries return `nil` instead of computed values, even when 
 | ...    |
 ```
 
-8256 rows exist in database.
+8256 tuples exist in database.
 
 ### Query 2: Pure aggregation (BROKEN)
 ```clojure
@@ -89,7 +89,7 @@ cd /Users/wbrown/go/src/github.com/wbrown/gopher-street
 
 # Verify data exists
 ./datalog-cli -db datalog-db -query '[:find (count ?p) :where [?s :symbol/ticker "CRWV"] [?p :price/symbol ?s]]'
-# Returns: 8256 rows
+# Returns: 8256 tuples
 
 # Try simple aggregation - FAILS
 ./datalog-cli -db datalog-db -query '[:find (max ?h) :where [?s :symbol/ticker "CRWV"] [?p :price/symbol ?s] [?p :price/high ?h]]'
@@ -120,10 +120,10 @@ case query.TupleBinding:
     // EMPTY RESULT = PATTERN FAILS TO MATCH
     // Return empty relation instead of error (datalog semantics)
     if result.Size() == 0 {
-        columns := make([]query.Symbol, len(inputSymbols)+len(b.Variables))
-        copy(columns, inputSymbols)
-        copy(columns[len(inputSymbols):], b.Variables)
-        return NewMaterializedRelation(columns, []Tuple{}), nil
+        symbols := make([]query.Symbol, len(inputSymbols)+len(b.Variables))
+        copy(symbols, inputSymbols)
+        copy(symbols[len(inputSymbols):], b.Variables)
+        return NewMaterializedRelation(symbols, []Tuple{}), nil
     }
 
     // ... proceed with binding
@@ -230,22 +230,22 @@ case query.TupleBinding:
 [:find (max ?h) :where [?p :price/high ?h]]
 ```
 
-**Expected**: `| (max ?h) |` → `| 119.59 |` (single row with computed value)
+**Expected**: `| (max ?h) |` → `| 119.59 |` (single tuple with computed value)
 
 ### Pure Aggregation Without Data
 ```clojure
 [:find (max ?h) :where [?p :price/high ?h] [?p :price/symbol ?no-such-symbol]]
 ```
 
-**Expected**: 0 rows (pattern fails to match, per Datalog semantics)
-**NOT**: 1 row with nil value
+**Expected**: 0 tuples (pattern fails to match, per Datalog semantics)
+**NOT**: 1 tuple with nil value
 
 ### Grouped Aggregation With Data
 ```clojure
 [:find ?s (max ?h) :where [?p :price/symbol ?s] [?p :price/high ?h]]
 ```
 
-**Expected**: Multiple rows, one per symbol, with computed max values
+**Expected**: Multiple tuples, one per symbol, with computed max values
 
 ### Grouped Aggregation With Some Empty Groups
 ```clojure
@@ -254,7 +254,7 @@ case query.TupleBinding:
         [(q [:find (max ?p) :in $ ?person :where [?o :order/person ?person] [?o :price ?p]] $ ?person) [[?max-price]]]]
 ```
 
-**Expected**: Only rows for people with orders (people without orders excluded)
+**Expected**: Only tuples for people with orders (people without orders excluded)
 
 ## Proposed Fix Strategy
 
@@ -280,7 +280,7 @@ The fix for empty subqueries should NOT affect aggregations that have data:
 // CORRECT LOGIC:
 if result.Size() == 0 {
     // No results from subquery - pattern fails to match
-    return NewMaterializedRelation(columns, []Tuple{}), nil
+    return NewMaterializedRelation(symbols, []Tuple{}), nil
 }
 
 if result.Size() == 1 {
@@ -335,7 +335,7 @@ func TestPureAggregationWithData(t *testing.T) {
     results := db.ExecuteQuery(query)
 
     // Assertions
-    assert.Equal(t, 1, len(results), "Pure aggregation should return 1 row")
+    assert.Equal(t, 1, len(results), "Pure aggregation should return 1 tuple")
     assert.NotNil(t, results[0][0], "Aggregation value must not be nil")
     assert.Equal(t, 200.0, results[0][0].(float64), "Max should be 200.0")
 }
@@ -350,7 +350,7 @@ func TestPureAggregationWithoutData(t *testing.T) {
     results := db.ExecuteQuery(query)
 
     // Assertions
-    assert.Equal(t, 0, len(results), "Empty aggregation should return 0 rows")
+    assert.Equal(t, 0, len(results), "Empty aggregation should return 0 tuples")
 }
 ```
 
@@ -359,13 +359,13 @@ func TestPureAggregationWithoutData(t *testing.T) {
 ```bash
 # After fix, all these should work:
 ./datalog-cli -db datalog-db -query '[:find (max ?h) :where [?s :symbol/ticker "CRWV"] [?p :price/symbol ?s] [?p :price/high ?h]]'
-# Expected: Single row with numeric value
+# Expected: Single tuple with numeric value
 
 ./datalog-cli -db datalog-db -query '[:find (min ?t) (max ?t) :where [?s :symbol/ticker "CRWV"] [?p :price/symbol ?s] [?p :price/time ?t]]'
-# Expected: Single row with two timestamp values
+# Expected: Single tuple with two timestamp values
 
 ./datalog-cli -db datalog-db -query '[:find (max ?h) :where [?s :symbol/ticker "NOSUCHSYMBOL"] [?p :price/symbol ?s] [?p :price/high ?h]]'
-# Expected: Zero rows (not one row with nil)
+# Expected: Zero tuples (not one tuple with nil)
 ```
 
 ## Urgency
@@ -376,7 +376,7 @@ func TestPureAggregationWithoutData(t *testing.T) {
 1. Revert October 10 subquery nil fixes temporarily
 2. Investigate and fix properly with comprehensive test coverage
 3. Ensure fix handles BOTH cases:
-   - Empty aggregations → 0 rows (not nil)
+   - Empty aggregations → 0 tuples (not nil)
    - Non-empty aggregations → computed values (not nil)
 
 ## Related Files

--- a/docs/archive/2025-10/QUERY_OPTIMIZATION_FINDINGS.md
+++ b/docs/archive/2025-10/QUERY_OPTIMIZATION_FINDINGS.md
@@ -96,7 +96,7 @@ CSE would provide measurable benefits in scenarios with:
    - Measured: 1-3% improvement in sequential mode
 
 2. **Expensive filter predicates**
-   - Complex computations applied to each row
+   - Complex computations applied to each tuple
    - CSE would compute once instead of N times
    - Our test: simple pattern scans (cheap)
 

--- a/docs/archive/2025-10/SEMI_JOIN_PUSHDOWN_FAILED_ATTEMPT.md
+++ b/docs/archive/2025-10/SEMI_JOIN_PUSHDOWN_FAILED_ATTEMPT.md
@@ -139,10 +139,10 @@ Merged query **cross-joined** input relation with patterns, creating massive exp
 
 When we bypassed `executeWithRelationInputIteration`:
 - Input relation went to `BindQueryInputs`
-- Created a relation with correlation key columns: `Relation([?sym ?py ?pm ?pd ?ph], 260 tuples)`
+- Created a relation with correlation key symbols: `Relation([?sym ?py ?pm ?pd ?ph], 260 tuples)`
 - This relation entered the phase as **just another relation**
 - Phase executor naturally **joined** it with pattern results
-- Since `?sym` is the ONLY shared column, got a cross-product on the other columns
+- Since `?sym` is the ONLY shared symbol, got a cross-product on the other symbols
 
 ### What We Actually Need
 
@@ -161,7 +161,7 @@ But we don't have `contains-tuple?` predicate!
 
 **Option 2: Predicate pushdown**
 Transform equality predicates `[(= ?py ?y)]` into range scans BEFORE pattern execution.
-But this requires index support for multi-column constraints.
+But this requires index support for multi-symbol constraints.
 
 **Option 3: Iteration IS correct (current approach)**
 Execute query once per distinct group. This IS semantically correct - each tuple represents one aggregation group to compute.
@@ -223,7 +223,7 @@ All semi-join pushdown code has been reverted:
 
 **2. Predicate Pushdown (Real)**
 - Push `[(= ?py ?y)]` predicates into storage layer as range scans
-- Requires multi-column index support
+- Requires multi-symbol index support
 - Much more complex than our failed attempt
 
 **3. Parallel Iteration** ✅ ALREADY EXISTS

--- a/docs/archive/2025-10/SESSION_SUMMARY_2025_10_05.md
+++ b/docs/archive/2025-10/SESSION_SUMMARY_2025_10_05.md
@@ -19,7 +19,7 @@ Implement hash join strategy to fix large binding set performance issues.
 **Performance Results**:
 ```
 Test 2 (aggregation with date filters):  timeout → 523ms
-Test 3 (79 rows with filters):           61+ sec → 69ms (880x speedup!)
+Test 3 (79 tuples with filters):           61+ sec → 69ms (880x speedup!)
 Test 4 (simple subquery):                fast    → 35ms (already optimal)
 Test 5 (complex OHLC 4 subqueries):      27 sec  → 210ms (128x speedup!)
 ```

--- a/docs/archive/2025-10/STREAMING_AGGREGATION_NIL_BUG.md
+++ b/docs/archive/2025-10/STREAMING_AGGREGATION_NIL_BUG.md
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-Pure aggregations (max, min, avg, sum) return `nil` values instead of computed results when using **streaming aggregation** (>100 rows). The bug does NOT occur with **batch aggregation** (<100 rows).
+Pure aggregations (max, min, avg, sum) return `nil` values instead of computed results when using **streaming aggregation** (>100 tuples). The bug does NOT occur with **batch aggregation** (<100 tuples).
 
 **Key Finding**: This is a pre-existing bug in `StreamingAggregateRelation`, NOT a regression from today's subquery nil fixes. The subquery fixes are correct and working as intended.
 
@@ -21,8 +21,8 @@ Pure aggregations (max, min, avg, sum) return `nil` values instead of computed r
 2. **Investigation**: Created test with BadgerDB - all aggregations PASSED (used batch mode)
 3. **Confusion**: gopher-street queries returned nil, but tests passed
 4. **Root Cause**: Discovered streaming vs batch aggregation difference
-   - Test used 3 rows → batch aggregation → ✅ works
-   - gopher-street used 2456 rows → streaming aggregation → ❌ returns nil
+   - Test used 3 tuples → batch aggregation → ✅ works
+   - gopher-street used 2456 tuples → streaming aggregation → ❌ returns nil
 5. **Confirmation**: Disabled streaming in gopher-street → aggregations work perfectly
 
 ---
@@ -31,7 +31,7 @@ Pure aggregations (max, min, avg, sum) return `nil` values instead of computed r
 
 ### Test Case
 
-Created `datalog/storage/pure_aggregation_badger_test.go` with 150 rows to trigger streaming:
+Created `datalog/storage/pure_aggregation_badger_test.go` with 150 tuples to trigger streaming:
 
 ```bash
 cd /Users/wbrown/go/src/github.com/wbrown/janus-datalog
@@ -40,7 +40,7 @@ go test -v ./datalog/storage -run TestPureAggregationWithBadgerDB
 
 **Results with StreamingAggregation = true:**
 ```
-NonAggregated:        ✅ PASS (150 rows returned)
+NonAggregated:        ✅ PASS (150 tuples returned)
 PureMaxAggregation:   ❌ FAIL (returns nil, expected 249.0)
 PureMinAggregation:   ❌ FAIL (returns nil, expected 100.0)
 PureCountAggregation: ✅ PASS (returns 150)
@@ -50,7 +50,7 @@ PureCountAggregation: ✅ PASS (returns 150)
 
 ```
 TEST CONFIGURATION ERROR: This test must use streaming aggregation to reproduce the bug, but used 'batch'.
-Either increase test data size (currently 150 rows) or decrease StreamingAggregationThreshold (currently 100).
+Either increase test data size (currently 150 tuples) or decrease StreamingAggregationThreshold (currently 100).
 ```
 
 This ensures the test continues to reproduce the streaming bug even if implementation details change.
@@ -89,7 +89,7 @@ useStreaming := EnableStreamingAggregation &&
 
 ### Affected Aggregations
 
-| Function | Batch (<100 rows) | Streaming (≥100 rows) |
+| Function | Batch (<100 tuples) | Streaming (≥100 tuples) |
 |----------|-------------------|----------------------|
 | count    | ✅ Works          | ✅ Works             |
 | sum      | ✅ Works          | ❌ Returns nil       |
@@ -97,21 +97,21 @@ useStreaming := EnableStreamingAggregation &&
 | min      | ✅ Works          | ❌ Returns nil       |
 | max      | ✅ Works          | ❌ Returns nil       |
 
-**Pattern**: `count` works because it doesn't require column matching. All value-based aggregations fail.
+**Pattern**: `count` works because it doesn't require symbol matching. All value-based aggregations fail.
 
 ### Debug Output
 
 With `debugAggregation = true` and `EnableStreamingAggregationDebug = true`:
 
 ```
-[ExecuteAggregations] Called with 1 find elements, rel columns: [?h ?s]
+[ExecuteAggregations] Called with 1 find elements, rel symbols: [?h ?s]
 [ExecuteAggregations] Element 0: FindAggregate - Function=max, Arg=?h
 [ExecuteAggregations] Extracted 1 aggregates, 0 groupByVars: []
 [ExecuteAggregations] aggregates=1, eligible=true, shouldUse=true, useStreaming=true, relType=*executor.MaterializedRelation, relSize=2456
 [ExecuteAggregations] Using STREAMING aggregation (groupByVars=[])
 ```
 
-Note: Relation has correct columns `[?h ?s]`, but streaming aggregation returns nil.
+Note: Relation has correct symbols `[?h ?s]`, but streaming aggregation returns nil.
 
 ---
 
@@ -120,18 +120,18 @@ Note: Relation has correct columns `[?h ?s]`, but streaming aggregation returns 
 ### Hypothesis
 
 `StreamingAggregateRelation` has a bug in how it:
-1. Matches aggregate argument variables (?h) to relation columns
+1. Matches aggregate argument variables (?h) to relation symbols
 2. Extracts values from tuples during iteration
 3. Computes final aggregate results
 
 The bug is likely in one of these methods:
 - `StreamingAggregateRelation.Iterator()` - Creates iterator for streaming computation
-- `StreamingAggregateRelation.Columns()` - Returns result columns
+- `StreamingAggregateRelation.Symbols()` - Returns result symbols
 - Internal aggregation accumulator logic
 
 ### Why Count Works
 
-`count` doesn't need to extract column values - it just counts tuples:
+`count` doesn't need to extract symbol values - it just counts tuples:
 
 ```go
 case "count":
@@ -139,11 +139,11 @@ case "count":
 ```
 
 But `max`, `min`, `avg`, `sum` all need to:
-1. Find the column index for the aggregate argument
-2. Extract values from that column
+1. Find the symbol index for the aggregate argument
+2. Extract values from that symbol
 3. Compute the aggregate
 
-The column matching or value extraction is failing in streaming mode.
+The symbol matching or value extraction is failing in streaming mode.
 
 ---
 
@@ -156,7 +156,7 @@ The column matching or value extraction is failing in streaming mode.
 
 ### What Still Works
 - ✅ Queries with <100 results (uses batch aggregation)
-- ✅ Count aggregations (doesn't need column matching)
+- ✅ Count aggregations (doesn't need symbol matching)
 - ✅ Grouped aggregations (may use different code path)
 - ✅ All October 10 subquery fixes (NOT related to this bug)
 
@@ -218,7 +218,7 @@ type StreamingAggregateRelation struct {
 
 func (r *StreamingAggregateRelation) Iterator() Iterator {
     // BUG IS LIKELY HERE
-    // Check column matching logic
+    // Check symbol matching logic
     // Check value extraction from tuples
     // Check aggregate computation
 }
@@ -227,8 +227,8 @@ func (r *StreamingAggregateRelation) Iterator() Iterator {
 ### 2. Add Comprehensive Tests
 
 Tests needed:
-- ✅ Pure aggregations with <100 rows (batch mode) - EXISTS
-- ✅ Pure aggregations with >100 rows (streaming mode) - EXISTS (now fails correctly)
+- ✅ Pure aggregations with <100 tuples (batch mode) - EXISTS
+- ✅ Pure aggregations with >100 tuples (streaming mode) - EXISTS (now fails correctly)
 - ⏳ Grouped aggregations with streaming
 - ⏳ Multiple aggregates in one query with streaming
 - ⏳ Conditional aggregates with streaming
@@ -240,7 +240,7 @@ Compare streaming vs batch implementations to find divergence:
 - `StreamingAggregateRelation` (streaming) - ❌ broken
 
 Look for differences in:
-- Column index lookup
+- Symbol index lookup
 - Tuple value extraction
 - Nil value handling
 
@@ -269,7 +269,7 @@ go test -v -run TestToolCalculateISOStrategy
 
 After fix, verify streaming still provides benefits:
 - Memory usage: O(groups) not O(tuples) for large datasets
-- Speed: Similar or faster than batch for >1000 rows
+- Speed: Similar or faster than batch for >1000 tuples
 - Correctness: Exact same results as batch aggregation
 
 ---
@@ -277,7 +277,7 @@ After fix, verify streaming still provides benefits:
 ## Related Files
 
 - `datalog/executor/aggregation.go` - Contains bug in StreamingAggregateRelation
-- `datalog/storage/pure_aggregation_badger_test.go` - Reproduces bug with >100 rows
+- `datalog/storage/pure_aggregation_badger_test.go` - Reproduces bug with >100 tuples
 - `datalog/executor/executor_aggregate_test.go` - Tests that use batch aggregation (pass)
 - `PURE_AGGREGATION_NIL_BUG.md` - Incorrect bug report (blamed wrong component)
 - `FIXES_2025_10_10.md` - Subquery fixes (unrelated, working correctly)
@@ -287,14 +287,14 @@ After fix, verify streaming still provides benefits:
 ## Conclusions
 
 1. **October 10 subquery fixes are correct** - No regression, working as intended
-2. **Streaming aggregation has pre-existing bug** - Affects max/min/avg/sum with >100 rows
+2. **Streaming aggregation has pre-existing bug** - Affects max/min/avg/sum with >100 tuples
 3. **Batch aggregation works perfectly** - Can be used as temporary workaround
 4. **Bug is isolated and reproducible** - Test case exists, root cause identified
 5. **Fix is straightforward** - Compare streaming vs batch implementations
 
 **Priority**: HIGH - Affects all large-dataset analytics in gopher-street
 
-**Recommended Action**: Fix `StreamingAggregateRelation` iterator logic to match batch aggregation behavior for column matching and value extraction.
+**Recommended Action**: Fix `StreamingAggregateRelation` iterator logic to match batch aggregation behavior for symbol matching and value extraction.
 
 ---
 
@@ -304,25 +304,25 @@ After fix, verify streaming still provides benefits:
 
 The bug was actually **TWO separate bugs** in `StreamingAggregateRelation.materialize()`:
 
-#### Bug 1: Column Index Initialization
+#### Bug 1: Symbol Index Initialization
 
-Lines 732-743 initialized column index arrays to 0 (default int value) instead of -1:
+Lines 732-743 initialized symbol index arrays to 0 (default int value) instead of -1:
 
 ```go
 // BEFORE (BROKEN):
 aggIndices := make([]int, len(r.aggregates))
 for i, agg := range r.aggregates {
-    for j, col := range columns {
+    for j, col := range symbols {
         if col == agg.Arg {
             aggIndices[i] = j
             break
         }
     }
 }
-// If column not found, aggIndices[i] remains 0 (WRONG - uses first column)
+// If symbol not found, aggIndices[i] remains 0 (WRONG - uses first symbol)
 ```
 
-**Impact**: When aggregate argument column was not found, index 0 was used, causing wrong column data to be aggregated.
+**Impact**: When aggregate argument symbol was not found, index 0 was used, causing wrong symbol data to be aggregated.
 
 **Fix**: Initialize indices to -1 and check for >= 0 before use:
 
@@ -333,7 +333,7 @@ for i := range aggIndices {
     aggIndices[i] = -1 // Initialize to -1 (not found)
 }
 for i, agg := range r.aggregates {
-    for j, col := range columns {
+    for j, col := range symbols {
         if col == agg.Arg {
             aggIndices[i] = j
             break
@@ -416,7 +416,7 @@ case "max":
 All tests pass after fix:
 
 ```bash
-# BadgerDB test with 150 rows (streaming mode)
+# BadgerDB test with 150 tuples (streaming mode)
 go test -v ./datalog/storage -run TestPureAggregationWithBadgerDB
 # Result: ✅ PASS - All aggregations return correct values
 
@@ -437,7 +437,7 @@ go test -v ./datalog/executor -run TestDecorrelation
 
 Added temporary debug logging to diagnose the issue:
 
-- Lines 723-727: Log source columns, group-by vars, and aggregates
+- Lines 723-727: Log source symbols, group-by vars, and aggregates
 - Lines 755-758: Log computed indices
 - Lines 787-789: Log tuples being processed
 - Lines 836-838: Log aggregate updates
@@ -456,7 +456,7 @@ None - the fixes are purely correctness fixes:
 The streaming aggregation performance characteristics remain unchanged:
 - Memory: O(groups) instead of O(tuples)
 - Time: Single pass over data
-- Threshold: 100 rows (unchanged)
+- Threshold: 100 tuples (unchanged)
 
 ### Status
 

--- a/docs/archive/2025-10/STREAMING_ARCHITECTURE_COMPLETE.md
+++ b/docs/archive/2025-10/STREAMING_ARCHITECTURE_COMPLETE.md
@@ -162,7 +162,7 @@ type FilterIterator struct {
 
 type ProjectIterator struct {
     source Iterator
-    indices []int  // Column indices to keep
+    indices []int  // Symbol indices to keep
 }
 
 type TransformIterator struct {
@@ -213,7 +213,7 @@ Now truly streams with composition support:
 ```go
 func (r *StreamingRelation) Filter(filter Filter) Relation {
     if r.options.EnableIteratorComposition {
-        return NewStreamingRelation(r.columns,
+        return NewStreamingRelation(r.symbols,
             NewFilterIterator(r.iterator, filter))
     }
     // Fallback to materialized

--- a/docs/archive/2025-10/SUBQUERY_DECORRELATION_IMPLEMENTATION.md
+++ b/docs/archive/2025-10/SUBQUERY_DECORRELATION_IMPLEMENTATION.md
@@ -308,13 +308,13 @@ type DecorrelatedSubqueryPlan struct {
     FilterGroups       []FilterGroup      // Groups of subqueries by filter
     MergedPlans        []*QueryPlan       // One plan per filter group
     CorrelationKeys    []query.Symbol     // Keys to join on (e.g., ?year, ?month, ?day, ?hour)
-    ColumnMapping      map[int]ResultMap  // Original subquery -> result columns
+    ColumnMapping      map[int]ResultMap  // Original subquery -> result symbols
 }
 
-// ResultMap maps original subquery to columns in merged result
+// ResultMap maps original subquery to symbols in merged result
 type ResultMap struct {
     FilterGroupIdx int   // Which merged query produced this result
-    ColumnIndices  []int // Which columns in that result
+    ColumnIndices  []int // Which symbols in that result
 }
 ```
 
@@ -328,10 +328,10 @@ plan := DecorrelatedSubqueryPlan{
     MergedPlans: [3 query plans],
     CorrelationKeys: []query.Symbol{"?year", "?month", "?day", "?hour"},
     ColumnMapping: map[int]ResultMap{
-        0: {FilterGroupIdx: 0, ColumnIndices: []int{4, 5}},    // SubQ1 -> columns 4,5 of Group A (high, low)
-        1: {FilterGroupIdx: 1, ColumnIndices: []int{4}},       // SubQ2 -> column 4 of Group B (open)
-        2: {FilterGroupIdx: 2, ColumnIndices: []int{4}},       // SubQ3 -> column 4 of Group C (close)
-        3: {FilterGroupIdx: 0, ColumnIndices: []int{6}},       // SubQ4 -> column 6 of Group A (volume)
+        0: {FilterGroupIdx: 0, ColumnIndices: []int{4, 5}},    // SubQ1 -> symbols 4,5 of Group A (high, low)
+        1: {FilterGroupIdx: 1, ColumnIndices: []int{4}},       // SubQ2 -> symbol 4 of Group B (open)
+        2: {FilterGroupIdx: 2, ColumnIndices: []int{4}},       // SubQ3 -> symbol 4 of Group C (close)
+        3: {FilterGroupIdx: 0, ColumnIndices: []int{6}},       // SubQ4 -> symbol 6 of Group A (volume)
     },
 }
 ```
@@ -555,7 +555,7 @@ func createDecorrelatedPlan(phase *Phase, group DecorrelationGroup) (*Decorrelat
 
         mergedPlans = append(mergedPlans, mergedPlan)
 
-        // Update column mapping
+        // Update symbol mapping
         for subqIdx, cols := range colMap {
             columnMapping[subqIdx] = ResultMap{
                 FilterGroupIdx: groupIdx,
@@ -733,9 +733,9 @@ func joinDecorrelatedResults(results []Relation, keys []query.Symbol) (Relation,
     return combined, nil
 }
 
-// hashJoinOnKeys performs hash join on specified key columns
+// hashJoinOnKeys performs hash join on specified key symbols
 func hashJoinOnKeys(left, right Relation, keys []query.Symbol) Relation {
-    // Find key column indices in both relations
+    // Find key symbol indices in both relations
     leftIndices := make([]int, len(keys))
     rightIndices := make([]int, len(keys))
 
@@ -773,7 +773,7 @@ func hashJoinOnKeys(left, right Relation, keys []query.Symbol) Relation {
 
     // Probe and build result
     var resultTuples []Tuple
-    resultColumns := append(left.Columns(), filterColumns(right.Columns(), keys)...)
+    resultColumns := append(left.Symbols(), filterColumns(right.Symbols(), keys)...)
 
     it = probeRel.Iterator()
     for it.Next() {
@@ -809,15 +809,15 @@ func makeJoinKey(tuple Tuple, indices []int) string {
     return strings.Join(parts, "|")
 }
 
-// filterColumns removes key columns from column list
-func filterColumns(columns []query.Symbol, keys []query.Symbol) []query.Symbol {
+// filterColumns removes key symbols from symbol list
+func filterColumns(symbols []query.Symbol, keys []query.Symbol) []query.Symbol {
     keySet := make(map[query.Symbol]bool)
     for _, key := range keys {
         keySet[key] = true
     }
 
     var result []query.Symbol
-    for _, col := range columns {
+    for _, col := range symbols {
         if !keySet[col] {
             result = append(result, col)
         }

--- a/docs/archive/2025-10/SUBQUERY_NIL_AGGREGATION_BUG.md
+++ b/docs/archive/2025-10/SUBQUERY_NIL_AGGREGATION_BUG.md
@@ -25,7 +25,7 @@ github.com/wbrown/gopher-street.ExtractDailyFromDatalogAccurate(0xc000ee6500)
 	/Users/wbrown/go/src/github.com/wbrown/gopher-street/extract_datalog.go:930 +0x730
 ```
 
-Line 930: `High: row[2].(float64)` - panics because `row[2]` is nil
+Line 930: `High: tuple[2].(float64)` - panics because `tuple[2]` is nil
 
 ## Reproduction
 

--- a/docs/archive/2025-10/SYMMETRIC_HASH_JOIN_EVALUATION.md
+++ b/docs/archive/2025-10/SYMMETRIC_HASH_JOIN_EVALUATION.md
@@ -196,7 +196,7 @@ For interactive use, **43µs matters more than 7.1ms**.
 ```sql
 SELECT * FROM big_table JOIN other_table LIMIT 10
 ```
-- Processes ALL rows from big_table
+- Processes ALL tuples from big_table
 - Builds complete hash table
 - Returns first 10
 - **Wasteful**
@@ -205,7 +205,7 @@ SELECT * FROM big_table JOIN other_table LIMIT 10
 ```sql
 SELECT * FROM big_table JOIN other_table LIMIT 10
 ```
-- Processes ~100-200 rows
+- Processes ~100-200 tuples
 - Produces 10 results
 - Stops iteration
 - **44× faster**

--- a/docs/archive/STREAMING_QUERY_API_PLAN.md
+++ b/docs/archive/STREAMING_QUERY_API_PLAN.md
@@ -1,0 +1,114 @@
+# Plan: Streaming `Query()` — Return `executor.Relation`
+
+## Context
+
+`Query()` should never have materialized. The engine streams throughout — hash joins, predicate pushdown, phase execution all operate on `Iterator` chains. Then `Query()` calls `relationToSlice()` which copies everything into `[][]any`. `QueryInto` is worse — double materialization.
+
+`ExecuteQueryRelation()` already exists and returns `executor.Relation`. `Query()` is just `ExecuteQueryWithInputs()` + `relationToSlice()`. Remove the materialization.
+
+## Changes
+
+### 1. `storage/badger_store.go` — Finalizer safety net on `BadgerIterator`
+
+Add `runtime.SetFinalizer` at creation, clear on explicit `Close()`. This covers both `Scan()` (line 155) and `KeyOnlyIterator` (embeds `*BadgerIterator`, `datom_decoder.go:57`).
+
+**`BadgerIterator.Close()`** (line 471) — make idempotent + clear finalizer:
+```go
+func (i *BadgerIterator) Close() error {
+    if i.txn == nil {
+        return nil
+    }
+    runtime.SetFinalizer(i, nil)
+    i.it.Close()
+    i.txn.Discard()
+    i.txn = nil
+    return nil
+}
+```
+
+**`Scan()`** (line 155) — set finalizer after creating `BadgerIterator`:
+```go
+iter := &BadgerIterator{...}
+runtime.SetFinalizer(iter, (*BadgerIterator).Close)
+return iter, nil
+```
+
+**`NewKeyOnlyIterator()`** (`datom_decoder.go:74`) — same, set finalizer on the embedded `*BadgerIterator`:
+```go
+bi := &BadgerIterator{...}
+runtime.SetFinalizer(bi, (*BadgerIterator).Close)
+return &KeyOnlyIterator{BadgerIterator: bi, ...}, nil
+```
+
+### 2. `storage/convenience.go` — `Query()` returns `executor.Relation`
+
+```go
+func (d *Database) Query(queryInput interface{}, inputs ...interface{}) (executor.Relation, error) {
+    return d.ExecuteQueryRelation(queryInput, inputs...)
+}
+```
+
+`Query()` becomes an alias for `ExecuteQueryRelation()`.
+
+### 3. `storage/database.go` — `QueryInto` and `QueryOneInto` use streaming
+
+Both currently call `ExecuteQueryWithInputs()` (materialize), then map. Change to `ExecuteQueryRelation()` + iterate with `MapTuple()` per tuple.
+
+**`QueryInto` struct path** (line 962):
+```go
+rel, err := d.ExecuteQueryRelation(q, inputs...)
+iter := rel.Iterator()
+defer iter.Close()
+for iter.Next() {
+    elem := reflect.New(m.elemType).Elem()
+    mapper.MapTuple(iter.Tuple(), elem)
+    newSlice = reflect.Append(newSlice, elem)
+}
+```
+
+**`QueryOneInto`** (line 1026): open iterator, read one tuple, close. No full materialization.
+
+### 4. `db/interfaces.go` — Update `Querier` interface
+
+```go
+type Querier interface {
+    Query(q any, inputs ...any) (executor.Relation, error)
+    // rest unchanged
+}
+```
+
+### 5. `db/db_test.go` — Update callers
+
+Tests that did `results, err := d.Query(...)` become:
+```go
+rel, err := d.Query(...)
+require.NoError(t, err)
+iter := rel.Iterator()
+defer iter.Close()
+// iterate or materialize as needed
+```
+
+Add streaming-specific tests: iterate without materializing, verify `Close()` releases resources.
+
+### 6. Other callers of `d.Query()`
+
+Only 5 call sites (all in `db/db_test.go`). No `cmd/` or `tests/` callers — they use `ExecuteQueryWithInputs()`.
+
+## What does NOT change
+
+- `ExecuteQueryWithInputs()` — stays as materializing `[][]any` path for ~100 internal test files
+- `ExecuteQueryRelation()` — stays as-is
+- `executor.Relation`, `executor.Iterator` — no changes, no new types
+- `relationToSlice()` — stays, used by `ExecuteQueryWithInputs()`
+- Typed accessors (`GetString`, etc.) — signatures unchanged, internally use streaming `QueryOneInto`
+
+## No new files, no new types
+
+## Verification
+
+```bash
+go build ./...
+go test -count=1 ./datalog/db/
+go test -count=1 ./datalog/storage/
+go test -count=1 ./...
+```

--- a/docs/archive/completed/EXECUTOR_REFACTORING_PLAN.md
+++ b/docs/archive/completed/EXECUTOR_REFACTORING_PLAN.md
@@ -28,7 +28,7 @@ These methods don't use any Executor fields - they're pure data transformations.
 
 ### 1.2 MaterializeResult  
 **Current**: `func (e *Executor) materializeResult(rel Relation, find []query.Symbol) Relation`
-**Target**: `func MaterializeResult(rel Relation, columns []query.Symbol) Relation`
+**Target**: `func MaterializeResult(rel Relation, symbols []query.Symbol) Relation`
 **Steps**:
 1. Create standalone function `MaterializeResult`
 2. Update method to call standalone function

--- a/docs/archive/completed/FEATURE_REQUEST_STORAGE_INPUT_PARAMS.md
+++ b/docs/archive/completed/FEATURE_REQUEST_STORAGE_INPUT_PARAMS.md
@@ -226,17 +226,17 @@ func (ds *DatalogStorage) ExecuteQueryWithInputs(
 }
 
 func relationToSlice(rel executor.Relation) [][]interface{} {
-    rows := make([][]interface{}, 0, rel.Size())
+    tuples := make([][]interface{}, 0, rel.Size())
     it := rel.Iterator()
     for it.Next() {
         tuple := it.Tuple()
-        row := make([]interface{}, len(tuple))
+        tuple := make([]interface{}, len(tuple))
         for i, v := range tuple {
-            row[i] = v
+            tuple[i] = v
         }
-        rows = append(rows, row)
+        tuples = append(tuples, tuple)
     }
-    return rows
+    return tuples
 }
 ```
 

--- a/docs/archive/completed/LAZY_MATERIALIZATION_IDEAS.md
+++ b/docs/archive/completed/LAZY_MATERIALIZATION_IDEAS.md
@@ -22,7 +22,7 @@ for _, rel := range allResults {
     }
     it.Close()
 }
-result := NewMaterializedRelation(columns, allTuples)
+result := NewMaterializedRelation(symbols, allTuples)
 ```
 
 ## The Clojure/Lazy Approach
@@ -39,7 +39,7 @@ Input Combinations (lazy seq)
 ```
 
 ### Benefits
-1. **Memory Efficiency**: Process millions of rows without loading all into memory
+1. **Memory Efficiency**: Process millions of tuples without loading all into memory
 2. **Early Termination**: If parent only needs first N results, don't compute rest
 3. **Pipeline Parallelism**: Different stages could run concurrently
 4. **Composability**: Operations naturally compose without intermediate collections
@@ -153,10 +153,10 @@ func (it *lazyUnionIterator) Next() bool {
 
 ### 3. Streaming Transformations
 ```go
-// Project columns without materializing
+// Project symbols without materializing
 type ProjectedRelation struct {
     source      Relation
-    projection  []int  // Column indices to keep
+    projection  []int  // Symbol indices to keep
 }
 
 func (r *ProjectedRelation) Iterator() RelationIterator {
@@ -216,11 +216,11 @@ A practical approach might be:
 ```go
 type Relation interface {
     Iterator() RelationIterator
-    Columns() []Symbol
+    Symbols() []Symbol
     
     // Lazy operations return lazy relations
     Filter(predicate) Relation
-    Project(columns) Relation
+    Project(symbols) Relation
     
     // Operations that might materialize
     Join(other Relation) Relation  // Might materialize build side

--- a/docs/archive/completed/QUERY_INTO_PROPOSAL.md
+++ b/docs/archive/completed/QUERY_INTO_PROPOSAL.md
@@ -24,12 +24,12 @@ if err != nil {
 
 // Every. Single. Consumer. Writes. This.
 trades := make([]Trade, 0, len(results))
-for _, row := range results {
+for _, tuple := range results {
     trade := Trade{
-        Symbol: row[0].(string),
-        Price:  row[1].(float64),
-        Volume: row[2].(int64),
-        Date:   row[3].(time.Time),
+        Symbol: tuple[0].(string),
+        Price:  tuple[1].(float64),
+        Volume: tuple[2].(int64),
+        Date:   tuple[3].(time.Time),
     }
     trades = append(trades, trade)
 }
@@ -38,7 +38,7 @@ for _, row := range results {
 Problems with this approach:
 - **Duplicated code** - Same iteration logic at every call site
 - **Runtime panics** - Type assertions fail at runtime, not compile time
-- **Index errors** - Easy to get column order wrong (`row[2]` vs `row[3]`)
+- **Index errors** - Easy to get symbol order wrong (`tuple[2]` vs `tuple[3]`)
 - **Type mismatches** - Was it `int` or `int64`? `float32` or `float64`?
 - **No IDE support** - Magic indices, no autocomplete
 
@@ -225,10 +225,10 @@ func (db *Database) QueryInto(ctx context.Context, dest interface{}, query strin
 
     // 5. Populate slice
     newSlice := reflect.MakeSlice(sliceVal.Type(), 0, len(results))
-    for _, row := range results {
+    for _, tuple := range results {
         elem := reflect.New(elemType).Elem()
-        if err := populateStruct(elem, row, fieldMap); err != nil {
-            return fmt.Errorf("row %d: %w", i, err)
+        if err := populateStruct(elem, tuple, fieldMap); err != nil {
+            return fmt.Errorf("tuple %d: %w", i, err)
         }
         newSlice = reflect.Append(newSlice, elem)
     }
@@ -246,7 +246,7 @@ var (
     ErrMultipleResults = errors.New("query returned multiple results")
     ErrTypeMismatch    = errors.New("cannot convert query result to field type")
     ErrMissingField    = errors.New("required field has no value")
-    ErrUnmappedColumn  = errors.New("query column has no matching struct field")
+    ErrUnmappedColumn  = errors.New("query symbol has no matching struct field")
 )
 ```
 
@@ -347,7 +347,7 @@ err := db.QueryInto(ctx, &results, query)
 
 ## Open Questions
 
-1. Should unmapped query columns be an error or silently ignored?
+1. Should unmapped query symbols be an error or silently ignored?
    - Recommendation: Warning log, not error (allows SELECT * style flexibility)
 
 2. Should we support maps as dest (`[]map[string]interface{}`)?

--- a/docs/archive/completed/README.md
+++ b/docs/archive/completed/README.md
@@ -6,7 +6,7 @@ Documentation for features that have been fully implemented and are now part of 
 
 ### Query Features
 - **subquery-implementation-plan.md** - Datomic-style subqueries with proper scoping (June 2025)
-- **order-by-implementation-plan.md** - Multi-column sorting with direction control (June 2025)
+- **order-by-implementation-plan.md** - Multi-symbol sorting with direction control (June 2025)
 - **expunge_bindings_plan.md** - Migration from Bindings to Relations (June 2025)
 - **expression_phase_plan.md** - Expression evaluation within query phases (June 2025)
 

--- a/docs/archive/completed/expression_phase_plan.md
+++ b/docs/archive/completed/expression_phase_plan.md
@@ -78,8 +78,8 @@ Update the planner to assign expressions to phases:
 
 2. **Expression evaluation within phase**:
    - Only evaluate expressions whose inputs are available
-   - Add new columns to the relation for expression bindings
-   - Can project out intermediate columns immediately after use
+   - Add new symbols to the relation for expression bindings
+   - Can project out intermediate symbols immediately after use
 
 ### Phase 4: Optimization Opportunities
 
@@ -92,7 +92,7 @@ Update the planner to assign expressions to phases:
    - Reduces data volume before expensive joins
 
 3. **Expression Ordering**:
-   - Within a phase, order expressions to minimize intermediate columns
+   - Within a phase, order expressions to minimize intermediate symbols
    - Evaluate expressions that enable projections first
 
 ## Implementation Steps
@@ -118,7 +118,7 @@ Update the planner to assign expressions to phases:
 ### Step 5: Implement Phase Expression Evaluation
 - [ ] Add `evaluateExpressionInPhase()` to executor
 - [ ] Modify executePhase to call expression evaluation
-- [ ] Ensure proper column tracking
+- [ ] Ensure proper symbol tracking
 
 ### Step 6: Implement Equality Filtering
 - [ ] Convert equality expressions to filters

--- a/docs/archive/completed/expunge_bindings_plan.md
+++ b/docs/archive/completed/expunge_bindings_plan.md
@@ -2,13 +2,13 @@
 
 ## Core Insight
 
-Bindings are a flawed abstraction. They're just Relations with a single row, but by converting them to maps, we lose critical capabilities:
+Bindings are a flawed abstraction. They're just Relations with a single tuple, but by converting them to maps, we lose critical capabilities:
 - Tuple relationships are destroyed
 - Ordering information is lost  
 - We need constant conversion between data structures
 - The code is more complex than necessary
 
-**The Solution: Use Relations everywhere. A Binding is just a single-row Relation.**
+**The Solution: Use Relations everywhere. A Binding is just a single-tuple Relation.**
 
 ## Why Bindings Must Go
 
@@ -97,7 +97,7 @@ for _, entity := range entities {
 
 #### After (with Relations)
 ```go
-// Creating a single-row relation for a constant
+// Creating a single-tuple relation for a constant
 rel := NewRelation([]Symbol{"?x"}, [][]interface{}{{42}})
 results := matcher.MatchWithRelation(pattern, rel)
 
@@ -177,7 +177,7 @@ joined := leftRel.NaturalJoin(rightResults)
 
 ### Step 3: Migrate Existing Code
 - Update executor to use Relations
-- Convert binding creation to single-row Relations
+- Convert binding creation to single-tuple Relations
 - Replace binding extraction with projection
 
 ### Step 4: Remove Binding Code
@@ -227,4 +227,4 @@ By expunging Bindings and using Relations everywhere, we:
 - Create a more elegant and performant system
 - Align better with relational/Datalog semantics
 
-The key insight: **A Binding is just a single-row Relation. Use Relations everywhere.**
+The key insight: **A Binding is just a single-tuple Relation. Use Relations everywhere.**

--- a/docs/archive/completed/order-by-implementation-plan.md
+++ b/docs/archive/completed/order-by-implementation-plan.md
@@ -109,7 +109,7 @@ func sortRelation(rel Relation, orderBy []query.OrderByClause) Relation {
     // Materialize if streaming
     mat := materializeIfNeeded(rel)
     
-    // Get column indices for sort variables
+    // Get symbol indices for sort variables
     sortIndices := make([]int, len(orderBy))
     for i, clause := range orderBy {
         idx := mat.ColumnIndex(clause.Variable)
@@ -143,7 +143,7 @@ func sortRelation(rel Relation, orderBy []query.OrderByClause) Relation {
         return false
     })
     
-    return NewMaterializedRelation(mat.Columns(), tuples)
+    return NewMaterializedRelation(mat.Symbols(), tuples)
 }
 ```
 
@@ -234,8 +234,8 @@ if len(q.OrderBy) > 0 {
 ## Testing
 
 Test cases should include:
-1. Single column ascending/descending
-2. Multiple columns with mixed directions
+1. Single symbol ascending/descending
+2. Multiple symbols with mixed directions
 3. Sorting different data types (strings, numbers, dates, identities)
 4. Handling nil/missing values
 5. Variables not in find clause (should be ignored)

--- a/docs/archive/completed/subquery-implementation-plan.md
+++ b/docs/archive/completed/subquery-implementation-plan.md
@@ -48,7 +48,7 @@ Where:
             [?p-close :price/close ?close]]
     ?s ?d) [[?o ?c]]]
 
-;; Subquery returning multiple rows (collection)
+;; Subquery returning multiple tuples (collection)
 [(q [:find ?price ?time
      :in $ ?sym
      :where [?p :price/symbol ?sym]
@@ -102,12 +102,12 @@ type BindingForm interface {
     isBindingForm()
 }
 
-// TupleBinding binds a single row: [[?a ?b]]
+// TupleBinding binds a single tuple: [[?a ?b]]
 type TupleBinding struct {
     Variables []Variable
 }
 
-// CollectionBinding binds all rows: ?coll
+// CollectionBinding binds all tuples: ?coll
 type CollectionBinding struct {
     Variable Variable
 }
@@ -212,7 +212,7 @@ type Context interface {
 
 1. **OHLC query** - The motivating example should work correctly
 2. **Nested aggregations** - Subqueries within subqueries
-3. **Multiple row returns** - Collection and relation bindings
+3. **Multiple tuple returns** - Collection and relation bindings
 4. **Performance tests** - Ensure subqueries don't create performance issues
 
 ### Example Test Case
@@ -248,7 +248,7 @@ func TestSubqueryOHLC(t *testing.T) {
                 [?p-close :price/minute-of-day 960]
                 [?p-close :price/close ?close]]`
     
-    // Should return exactly 1 row with correct values
+    // Should return exactly 1 tuple with correct values
     result, err := executor.Execute(parseQuery(query))
     assert.NoError(t, err)
     assert.Equal(t, 1, result.Size())

--- a/docs/archive/early-design/DATALOG_GO_NOTES_HISTORICAL_INSIGHTS.md
+++ b/docs/archive/early-design/DATALOG_GO_NOTES_HISTORICAL_INSIGHTS.md
@@ -22,7 +22,7 @@ If executed left-to-right with 1M follows relationships, the first join produces
 
 **Dynamic join ordering with early termination**:
 
-1. Group relations by shared columns (connectivity)
+1. Group relations by shared symbols (connectivity)
 2. Join progressively as relations become available
 3. Terminate immediately on empty results
 4. Keep disjoint relation groups separate

--- a/docs/archive/optimization-attempts/BADGERDB_OPTIMIZATION_COMPLETE.md
+++ b/docs/archive/optimization-attempts/BADGERDB_OPTIMIZATION_COMPLETE.md
@@ -35,8 +35,8 @@ type BadgerMatcher struct {
     builderMutex sync.RWMutex
 }
 
-func (m *BadgerMatcher) getTupleBuilder(pattern *query.DataPattern, columns []query.Symbol) *InternedTupleBuilder {
-    key := builderCacheKey{pattern: pattern, columns: columns}
+func (m *BadgerMatcher) getTupleBuilder(pattern *query.DataPattern, symbols []query.Symbol) *InternedTupleBuilder {
+    key := builderCacheKey{pattern: pattern, symbols: symbols}
 
     m.builderMutex.RLock()
     builder, exists := m.builderCache[key]
@@ -47,7 +47,7 @@ func (m *BadgerMatcher) getTupleBuilder(pattern *query.DataPattern, columns []qu
     }
 
     // Create new builder and cache it
-    builder = NewInternedTupleBuilder(columns)
+    builder = NewInternedTupleBuilder(symbols)
     m.builderMutex.Lock()
     m.builderCache[key] = builder
     m.builderMutex.Unlock()
@@ -58,7 +58,7 @@ func (m *BadgerMatcher) getTupleBuilder(pattern *query.DataPattern, columns []qu
 
 ### Key Design Decisions
 
-1. **Cache key**: (pattern, columns) uniquely identifies builder configuration
+1. **Cache key**: (pattern, symbols) uniquely identifies builder configuration
 2. **Thread-safe**: RWMutex allows concurrent reads, serialized writes
 3. **Lifetime**: Builders cached for matcher lifetime (acceptable memory)
 4. **Reuse**: Same builder instance used for all matches with same pattern

--- a/docs/archive/optimization-attempts/OCTOBER_2025_OPTIMIZATION_SUMMARY.md
+++ b/docs/archive/optimization-attempts/OCTOBER_2025_OPTIMIZATION_SUMMARY.md
@@ -97,7 +97,7 @@ All optimizations production-ready with full test coverage.
 
 #### B. Tuple Builder Caching (15% reduction)
 **Problem**: Creating new InternedTupleBuilder per match
-**Solution**: Cache builders per (pattern, columns) combination
+**Solution**: Cache builders per (pattern, symbols) combination
 **Result**: 28.6 GB → 24.2 GB
 
 #### C. Bindings Map Reuse (53% reduction)

--- a/docs/archive/optimization-attempts/PARALLEL_SUBQUERY_COMPLETE.md
+++ b/docs/archive/optimization-attempts/PARALLEL_SUBQUERY_COMPLETE.md
@@ -73,7 +73,7 @@ type SubqueryExecutionOptions struct {
 | Execution Time | 18.23s | 3.49s | **5.22× faster** |
 | Time per Hour | 124.03 ms | 23.69 ms | **5.24× faster** |
 | Memory | ~19.6 GB | ~19.3 GB | Comparable |
-| Correctness | 147 rows | 147 rows | ✅ Identical |
+| Correctness | 147 tuples | 147 tuples | ✅ Identical |
 
 **Why 5.2× on 10-core CPU?**
 - Workload is CPU-bound (joins, aggregations)

--- a/docs/archive/optimization-attempts/STREAMING_AGGREGATION_IMPLEMENTATION.md
+++ b/docs/archive/optimization-attempts/STREAMING_AGGREGATION_IMPLEMENTATION.md
@@ -63,7 +63,7 @@ Implemented streaming aggregation that computes aggregates incrementally in a si
 - `TestStreamingAggregationThreshold`: Verifies heuristic behavior
 
 **gopher-street OHLC tests**:
-- ✅ Pass with correct results (147 rows)
+- ✅ Pass with correct results (147 tuples)
 - ⏱️ Time: 17.5s (unchanged from 17.4s baseline)
 - 💾 Memory: 19.5 GB (minimal change from 19.6 GB)
 

--- a/docs/archive/optimization-attempts/TIME_RANGE_OPTIMIZATION_STATUS.md
+++ b/docs/archive/optimization-attempts/TIME_RANGE_OPTIMIZATION_STATUS.md
@@ -31,7 +31,7 @@ Implemented semi-join pushdown via time range constraints to optimize hourly OHL
 func extractTimeRanges(inputRelation Relation, correlationKeys []query.Symbol) ([]TimeRange, error)
 ```
 
-- Detects `?year`, `?month`, `?day`, `?hour` columns in input relation
+- Detects `?year`, `?month`, `?day`, `?hour` symbols in input relation
 - Converts tuples to `time.Time` ranges: `[start, end)`
 - Granularity detection:
   - Has `?hour` → hourly ranges (1 hour duration)

--- a/docs/bugs/BUG_CACHE_CARDINALIY_ONE_TOMBSTONE.md
+++ b/docs/bugs/BUG_CACHE_CARDINALIY_ONE_TOMBSTONE.md
@@ -41,7 +41,7 @@ Three reproduction scenarios:
 --- FAIL
 
 === RUN   TestCacheRemove_JoinBoundE_RoundTrip
-    Matched rows after Remove(): 1 (expected 0)
+    Matched tuples after Remove(): 1 (expected 0)
     BUG: Query returns stale data after Remove() on CardinalityOne.
 --- FAIL
 
@@ -210,7 +210,7 @@ affected resolution path.
 ### 2. Test matrix
 
 Every scenario must be tested through every resolution path. The scenarios
-are the rows; the resolution paths are the columns.
+are the tuples; the resolution paths are the symbols.
 
 **Scenarios** (operation sequences):
 
@@ -224,7 +224,7 @@ are the rows; the resolution paths are the columns.
 | S6 | Two entities, remove one | Removed entity absent, other unaffected |
 | S7 | Set() → Remove (uses Set not Add) | Attribute absent |
 
-**Resolution paths** (columns):
+**Resolution paths** (symbols):
 
 | Path | How exercised | File |
 |------|---------------|------|
@@ -829,7 +829,7 @@ To trigger the V-bound validation path, we need V as a Variable in the
 pattern, bound via a binding relation. The test needs:
 1. Create an as-of matcher: `matcher.AsOf(tx1Lamport)`
 2. Create a pattern: `[?e :person/name ?name _]` (V is variable)
-3. Create a binding relation with column `?name` containing the test value
+3. Create a binding relation with symbol `?name` containing the test value
 4. Call `asOfMatcher.Match(pattern, bindingRel)`
 5. Count results
 
@@ -853,7 +853,7 @@ func vBoundMatchCountAsOf(t *testing.T, db *Database, a datalog.Keyword,
     }
 
     // Binding relation: single tuple with ?name = v
-    bindingRel := <create relation with column ?name, single row [v]>
+    bindingRel := <create relation with symbol ?name, single tuple [v]>
 
     results, err := asOfMatcher.Match(pattern, bindingRel)
     // ... count and return
@@ -1263,7 +1263,7 @@ Constant and nil input, the code path is:
 
 ```
 Match(pattern, nil)
-  → matchUnboundAsRelation(pattern, columns, constraints)
+  → matchUnboundAsRelation(pattern, symbols, constraints)
     → chooseIndex(e=nil, a=constant, v=constant, tx=nil)
       → returns AVET
     → regular scan + CRDTResolvingIterator
@@ -1301,10 +1301,10 @@ The actual fix was **12 lines** in `matchUnboundAsRelation`.
 
 The key insight (from the user, not Claude): `matchWithVValidation` already
 implements candidate+validate. It takes a binding relation. A constant V
-is just... a single-row binding relation. So:
+is just... a single-tuple binding relation. So:
 
 1. Detect: `e == nil && a != nil && v != nil && card == CardinalityOne`
-2. Create a one-row `MaterializedRelation` containing the V constant
+2. Create a one-tuple `MaterializedRelation` containing the V constant
 3. Call `matchWithVValidation` with it
 4. Done
 
@@ -1342,7 +1342,7 @@ When the fix requires behavior that already exists on a different code
 path, the right question is: "what's the minimal adapter to reach that
 path?" Not: "how do I reimplement that behavior from scratch?"
 
-Here, the adapter was a single-row `MaterializedRelation`. The entire
+Here, the adapter was a single-tuple `MaterializedRelation`. The entire
 `matchWithVValidation` → `validatingVBoundIterator` → `validateCandidate`
 pipeline was already correct. It just needed to be reachable from the
 constant-V code path.

--- a/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
+++ b/docs/bugs/BUG_CRDT_QUERY_RESOLUTION_NOT_APPLIED.md
@@ -225,13 +225,13 @@ If A is unbound (`a == nil`), **no CRDT resolution is applied**. This is wrong -
 
 ### Single-Value Bindings Are Just One Case
 
-The system already detects single-row bindings for scan optimization (`hash_join_matcher.go:177-188`), but this is just an optimization opportunity, not the core fix. The core fix must handle ALL cases:
+The system already detects single-tuple bindings for scan optimization (`hash_join_matcher.go:177-188`), but this is just an optimization opportunity, not the core fix. The core fix must handle ALL cases:
 
 | Scenario | What A Is | Resolution Strategy |
 |----------|-----------|---------------------|
 | Constant in pattern | Known at compile time | Look up cardinality, resolve |
-| Single-row binding | Known at runtime | Look up cardinality, resolve |
-| Multi-row binding | Multiple known values | Resolve per (E, A) group |
+| Single-tuple binding | Known at runtime | Look up cardinality, resolve |
+| Multi-tuple binding | Multiple known values | Resolve per (E, A) group |
 | Completely unbound | Unknown until scan | Resolve per (E, A) group |
 
 **All scenarios reduce to the same solution**: group by (E, A) and resolve each group based on that attribute's schema-defined cardinality.
@@ -699,8 +699,8 @@ if iter.Next() {
 
 ### Why Not "Extract A from Bindings"?
 
-Extracting A from bindings only works for the single-row binding case. It fails for:
-- Multi-row bindings: `[:find ?v :in $ [?a ...] :where [?e ?a ?v]]`
+Extracting A from bindings only works for the single-tuple binding case. It fails for:
+- Multi-tuple bindings: `[:find ?v :in $ [?a ...] :where [?e ?a ?v]]`
 - Unbound A: `[:find ?e ?a ?v :where [?e ?a ?v]]`
 - A bound via join from another pattern
 

--- a/docs/bugs/BUG_EATV_SCAN_RANGE_AND_CRDT_VECTOR_TRANSITION.md
+++ b/docs/bugs/BUG_EATV_SCAN_RANGE_AND_CRDT_VECTOR_TRANSITION.md
@@ -115,7 +115,7 @@ This bug only manifests when:
 
 In this test, EATV sorts by E then A. Alphabetically `:doc/content` < `:person/name`, so the vector group comes first, triggering the bug.
 
-**Why AETV doesn't hit this**: With AETV (A-primary), each per-row call scans only one attribute's datoms. There's no group transition within a single scan, so the bug never triggers.
+**Why AETV doesn't hit this**: With AETV (A-primary), each per-tuple call scans only one attribute's datoms. There's no group transition within a single scan, so the bug never triggers.
 
 **Fix**: Save the boundary datom as a pending datom and process it before the next `source.Next()` call:
 
@@ -132,7 +132,7 @@ When emitting a Vector group at a boundary, save the boundary datom. On the next
 
 **File**: `datalog/storage/matcher_strategy.go`, `chooseBestMultiPositionStrategy`
 
-`chooseBestMultiPositionStrategy` iterated `positionCardinalities` (a `map[int]int`) to find the position with the most distinct values. When both E and A have equal cardinality (1 distinct value each from a single-row binding), Go's randomized map iteration determined which position "won":
+`chooseBestMultiPositionStrategy` iterated `positionCardinalities` (a `map[int]int`) to find the position with the most distinct values. When both E and A have equal cardinality (1 distinct value each from a single-tuple binding), Go's randomized map iteration determined which position "won":
 
 - Position 0 (E) wins → EATV → triggers bugs 1+2 → **FAIL**
 - Position 1 (A) wins → AETV → neither bug triggered → **PASS**
@@ -146,7 +146,7 @@ With EATV selected (failing case):
 storage/reuse-strategy  index:EATV position:0
 storage/join-strategy   index:EATV join_strategy:hash-join-scan
 matches->relations      binding.size:1 match.count:-1          # vector intercept (streaming)
-pattern/hash-join-complete  datoms.scanned:3 matches.found:0   # name row: 3 scanned, 0 matched
+pattern/hash-join-complete  datoms.scanned:3 matches.found:0   # name tuple: 3 scanned, 0 matched
 matches->relations      binding.size:1 match.count:1           # vector result materialized
 ```
 

--- a/docs/bugs/BUG_EA_CACHE_BYPASS_VARIABLE_ATTRIBUTE.md
+++ b/docs/bugs/BUG_EA_CACHE_BYPASS_VARIABLE_ATTRIBUTE.md
@@ -36,7 +36,7 @@ The cache is checked in two places in `MatchWithConstraints` (`matcher_relations
 if m.cache != nil && m.txID == 0 {
     if a := m.extractValue(pattern.GetA()); a != nil {   // ← nil for Variables
         if aKw, ok := a.(datalog.Keyword); ok {
-            cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw)
+            cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, symbols, aKw)
             if handled {
                 return cacheResult, nil
             }
@@ -52,7 +52,7 @@ if m.cache != nil && m.txID == 0 {
 if m.cache != nil && m.txID == 0 && e != nil && a != nil {
     if eIdent, ok := e.(datalog.Identity); ok {
         if aKw, ok := a.(datalog.Keyword); ok {
-            cacheResult, handled := m.matchFromCache(pattern, columns, eIdent, aKw, v, card)
+            cacheResult, handled := m.matchFromCache(pattern, symbols, eIdent, aKw, v, card)
             if handled {
                 return cacheResult, nil
             }
@@ -178,7 +178,7 @@ if aValue == nil && bindingRel != nil {
 }
 if aValue != nil {
     if aKw, ok := aValue.(datalog.Keyword); ok {
-        cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw)
+        cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, symbols, aKw)
         if handled {
             return cacheResult, nil
         }
@@ -186,7 +186,7 @@ if aValue != nil {
 }
 ```
 
-For scalar inputs (single-row binding), `extractSingleValueFromBindings` returns the value directly. For collection/relation inputs (multi-row bindings), this gets more complex — each row may have a different A value. The simplest initial fix handles the single-value case (which covers the `HasAttribute` pattern) and falls through to storage scans for multi-value A bindings.
+For scalar inputs (single-tuple binding), `extractSingleValueFromBindings` returns the value directly. For collection/relation inputs (multi-tuple bindings), this gets more complex — each tuple may have a different A value. The simplest initial fix handles the single-value case (which covers the `HasAttribute` pattern) and falls through to storage scans for multi-value A bindings.
 
 ### What NOT to do
 
@@ -196,9 +196,9 @@ For scalar inputs (single-row binding), `extractSingleValueFromBindings` returns
 
 ### Optimization phases
 
-**Phase 1** (high impact, simple): Handle single-value A from bindings. This covers `HasAttribute` (`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`) which is the dominant pattern in downstream applications. Extract A from a single-row binding, use the existing `matchWithBindingsFromCache`.
+**Phase 1** (high impact, simple): Handle single-value A from bindings. This covers `HasAttribute` (`[:find ?v :in $ ?e ?attr :where [?e ?attr ?v]]`) which is the dominant pattern in downstream applications. Extract A from a single-tuple binding, use the existing `matchWithBindingsFromCache`.
 
-**Phase 2** (medium impact): Handle collection/relation A inputs. For each row in the binding relation, extract the (E, A) pair and do a cache lookup. This is a loop over `cache.GetOrResolve` calls with tuple building per hit.
+**Phase 2** (medium impact): Handle collection/relation A inputs. For each tuple in the binding relation, extract the (E, A) pair and do a cache lookup. This is a loop over `cache.GetOrResolve` calls with tuple building per hit.
 
 **Phase 3** (low impact, complex): Handle join-bound A. When A gets its value from a prior join (not from `:in`), the binding relation passed to the matcher already contains A's value. The same Phase 1/2 logic applies — the binding relation is the binding relation regardless of where it came from.
 

--- a/docs/bugs/BUG_ELEMENTID_NOT_FIRST_CLASS.md
+++ b/docs/bugs/BUG_ELEMENTID_NOT_FIRST_CLASS.md
@@ -274,14 +274,14 @@ All tests follow the same data setup pattern as the existing `TestElementIDBindi
 - **Query**: `[:find ?v :in $ [[?e ?tx] ...] :where [?e :person/name ?v ?tx]]`
 - **Input**: `[][]interface{}{{aliceIdentity, aliceTx}, {bobIdentity, bobTx}}`
 - **Assert**: Returns 2 results with correct names
-- **Exercises**: Multi-column hash join with ElementID, `valueToHashKey(ElementID)`, `compareJoinKeys(ElementID)`
+- **Exercises**: Multi-symbol hash join with ElementID, `valueToHashKey(ElementID)`, `compareJoinKeys(ElementID)`
 
 #### `TestElementIDBinding_TxJoin`
-- **Purpose**: Two patterns joined on `?tx` where Tx column holds `*ElementID`
+- **Purpose**: Two patterns joined on `?tx` where Tx symbol holds `*ElementID`
 - **Setup**: 2 entities with 2 attributes each, written in separate transactions
 - **Query**: `[:find ?name ?age :where [?e1 :person/name ?name ?tx] [?e2 :person/age ?age ?tx]]`
 - **Assert**: Each transaction's name/age pairs are joined correctly
-- **Exercises**: Hash join on `*ElementID` column (both sides from storage), `TupleKey` hashing
+- **Exercises**: Hash join on `*ElementID` symbol (both sides from storage), `TupleKey` hashing
 
 #### `TestElementIDBinding_ComparisonPredicate`
 - **Purpose**: `[(= ?tx ?target-tx)]` predicate with ElementID binding

--- a/docs/bugs/BUG_ENUMERATE_MULTIROW_EXPANSION.md
+++ b/docs/bugs/BUG_ENUMERATE_MULTIROW_EXPANSION.md
@@ -1,4 +1,4 @@
-# Bug: Enumerate Multi-Row Expansion Not Handled by Expression Evaluator
+# Bug: Enumerate Multi-Tuple Expansion Not Handled by Expression Evaluator
 
 **Status:** Fixed
 **Fix:** `datalog/executor/helpers.go` — added `[][]interface{}` handler before existing `[]interface{}` path
@@ -32,30 +32,30 @@ if tb, ok := expr.Binding.(query.TupleBinding); ok {
 newTuples = append(newTuples, newTuple)  // Tuple appended with nil binding values
 ```
 
-In Go, `[][]interface{}` does not satisfy a `[]interface{}` type assertion. The assertion returns `ok=false`, the binding block is skipped, and the tuple is appended with zero values in the `?idx` and `?item` columns.
+In Go, `[][]interface{}` does not satisfy a `[]interface{}` type assertion. The assertion returns `ok=false`, the binding block is skipped, and the tuple is appended with zero values in the `?idx` and `?item` symbols.
 
 ## Consequence
 
 For a vector `["a", "b", "c"]` with binding `[(enumerate ?vec) [?idx ?item]]`:
 
 **Expected:** 3 output tuples: `[0, "a"]`, `[1, "b"]`, `[2, "c"]`
-**Actual:** 1 output tuple with nil values in ?idx and ?item columns
+**Actual:** 1 output tuple with nil values in ?idx and ?item symbols
 
-The query would either return wrong results (nil values passing through) or return zero rows (if subsequent patterns tried to join on the nil values).
+The query would either return wrong results (nil values passing through) or return zero tuples (if subsequent patterns tried to join on the nil values).
 
 ## Fix
 
-Added a `[][]interface{}` type check before the existing `[]interface{}` path (helpers.go:214-246). For each sub-tuple in the multi-row result:
+Added a `[][]interface{}` type check before the existing `[]interface{}` path (helpers.go:214-246). For each sub-tuple in the multi-tuple result:
 
 1. Creates a new output tuple (copy of the input tuple)
 2. Populates binding variables from the sub-tuple
 3. Appends to result — one output tuple per vector element
 
 Handles both cases:
-- **`hasAllBindings`** (binding variables already exist as columns): overwrites existing column positions
-- **new columns** (binding variables are new): fills positions in the extended column list
+- **`hasAllBindings`** (binding variables already exist as symbols): overwrites existing symbol positions
+- **new symbols** (binding variables are new): fills positions in the extended symbol list
 
-This is the one-input-row-to-many-output-rows expansion that enumerate requires. All other expressions remain 1:1 (one input row produces one output row).
+This is the one-input-tuple-to-many-output-tuples expansion that enumerate requires. All other expressions remain 1:1 (one input tuple produces one output tuple).
 
 ## Related
 

--- a/docs/bugs/BUG_ITERATOR_LEAK_BUILTIN_EVALUATION.md
+++ b/docs/bugs/BUG_ITERATOR_LEAK_BUILTIN_EVALUATION.md
@@ -107,7 +107,7 @@ for iter.Next() {
 // Line 329: iterator opened, closed at line 338
 iter := rel.Iterator()
 for iter.Next() {
-    // ... project columns ...
+    // ... project symbols ...
 }
 iter.Close()  // ← correctly closed
 ```

--- a/docs/bugs/BUG_PLANNER_REORDERS_PATTERN_BEFORE_ENUMERATE.md
+++ b/docs/bugs/BUG_PLANNER_REORDERS_PATTERN_BEFORE_ENUMERATE.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-The greedy clause planner reorders data patterns before enumerate expressions that provide variables those patterns need. This causes incorrect query results: a cross-product join on the wrong column instead of a filtered join on the enumerate-provided variable.
+The greedy clause planner reorders data patterns before enumerate expressions that provide variables those patterns need. This causes incorrect query results: a cross-product join on the wrong symbol instead of a filtered join on the enumerate-provided variable.
 
 ## Reproduction
 
@@ -52,8 +52,8 @@ After the planner reorders, execution proceeds:
 1. `:in` params create relation `{?room, ?color}` (both in one group)
 2. Room/name/items patterns build up `{?room, ?color, ?c, ?name, ?vec}`
 3. **Color pattern runs next** (before enumerate): scans all items with color=red, gets `{?item=redItem, ?color=:color/red}`
-4. Joins with accumulated relation on `?color` -- the only shared column
-5. Cross-product: every container row gets `?item=redItem`
+4. Joins with accumulated relation on `?color` -- the only shared symbol
+5. Cross-product: every container tuple gets `?item=redItem`
 6. Enumerate finally runs, but `?item` is already bound -- damage done
 
 Annotation trace confirming the join:
@@ -73,7 +73,7 @@ The bug requires **two `:in` parameters** where:
 1. One (e.g. `?room`) is consumed by early data patterns
 2. The other (e.g. `?color`) is consumed by a data pattern that should run AFTER enumerate
 
-With a single `:in ?color` and no room-anchoring patterns, the bug still causes reordering but the final result may be accidentally correct (enumerate filters the cross-product when checking consistency of already-bound `?item`). With two `:in` params, `?color` enters the accumulated relation early via the shared input group, so the color-pattern join has a shared column (`?color`) and produces a real cross-product that enumerate can't undo.
+With a single `:in ?color` and no room-anchoring patterns, the bug still causes reordering but the final result may be accidentally correct (enumerate filters the cross-product when checking consistency of already-bound `?item`). With two `:in` params, `?color` enters the accumulated relation early via the shared input group, so the color-pattern join has a shared symbol (`?color`) and produces a real cross-product that enumerate can't undo.
 
 ### Verified non-triggers
 

--- a/docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md
+++ b/docs/bugs/BUG_SCHEMALESS_ATTR_BOUND_QUERY.md
@@ -25,7 +25,7 @@ tx.Commit() // succeeds
 // Unbound query — FINDS the data
 db.ExecuteQueryWithInputs(
     `[:find ?e ?a ?v :where [?e ?a ?v]]`,
-) // returns row with :module/input ✓
+) // returns tuple with :module/input ✓
 
 // Bound query — FAILS to find the data
 db.ExecuteQueryWithInputs(

--- a/docs/bugs/BUG_STREAMING_RELATION_PREMATURE_MATERIALIZATION.md
+++ b/docs/bugs/BUG_STREAMING_RELATION_PREMATURE_MATERIALIZATION.md
@@ -36,7 +36,7 @@ func (r *StreamingRelation) Iterator() Iterator {
             tuples = append(tuples, it.Tuple())  // ❌ BUG: Line 864 - No copy!
         }
         it.Close()
-        r.materialized = NewMaterializedRelationWithOptions(r.columns, tuples, r.options)
+        r.materialized = NewMaterializedRelationWithOptions(r.symbols, tuples, r.options)
     })
     return r.materialized.Iterator()
 }
@@ -74,7 +74,7 @@ DEBUG materializeRelationsForPattern: After Materialize, type=*executor.Material
 ```
 
 **Timeline**:
-1. First pattern creates StreamingRelation with `[?s]` columns
+1. First pattern creates StreamingRelation with `[?s]` symbols
 2. **Iterator() is called** with `shouldCache=false` (before Materialize())
 3. StreamingRelation enters fallback materialization path (lines 843-869)
 4. Line 864: `tuples = append(tuples, it.Tuple())` - NO COPY

--- a/docs/bugs/BUG_STREAMING_TUPLE_COPYING.md
+++ b/docs/bugs/BUG_STREAMING_TUPLE_COPYING.md
@@ -171,14 +171,14 @@ The streaming optimizations (commits 4a394cb, 4f3b742, 15d196d, 78c930a) enabled
 ```go
 // TestStreamingTupleCopying verifies tuple copying works with streaming
 func TestStreamingTupleCopying(t *testing.T) {
-    columns := []query.Symbol{"x", "y", "z"}
+    symbols := []query.Symbol{"x", "y", "z"}
     tuples := []Tuple{
         {int64(1), int64(10), int64(100)},
         {int64(2), int64(20), int64(200)},
         {int64(3), int64(30), int64(300)},
     }
 
-    rel := NewMaterializedRelationWithOptions(columns, tuples, ExecutorOptions{
+    rel := NewMaterializedRelationWithOptions(symbols, tuples, ExecutorOptions{
         EnableTrueStreaming: true,
     })
 

--- a/docs/bugs/SUBQUERY_MISSING_DB.md
+++ b/docs/bugs/SUBQUERY_MISSING_DB.md
@@ -30,7 +30,7 @@ The query builder generates:
 ;; ^ missing $ - only variable passed
 ```
 
-This causes the subquery to misinterpret `?scenario` as the database, breaking correlation entirely. The subquery runs uncorrelated, returning global aggregates instead of per-row values.
+This causes the subquery to misinterpret `?scenario` as the database, breaking correlation entirely. The subquery runs uncorrelated, returning global aggregates instead of per-tuple values.
 
 ## Reproduction
 

--- a/docs/bugs/WHY_TESTS_MISSED_TUPLE_COPYING_BUG.md
+++ b/docs/bugs/WHY_TESTS_MISSED_TUPLE_COPYING_BUG.md
@@ -64,8 +64,8 @@ But if the test only checks `len(tuples) == 3`, it passes! The test might not in
 ### 3. Tests Don't Verify All Tuple Values
 
 Many tests check:
-- Row count (`assert.Equal(t, 3, result.Size())`)
-- First row only (`if it.Next() { ... }`)
+- Tuple count (`assert.Equal(t, 3, result.Size())`)
+- First tuple only (`if it.Next() { ... }`)
 - Specific values extracted immediately
 
 They **don't** collect all tuples into a slice and verify each one is different.
@@ -111,7 +111,7 @@ The gopher-street tests succeeded where our tests failed because:
 ### 2. CLI Tool (Not Test Framework)
 - CLI calls `result.Table()` which collects ALL tuples
 - Verifies displayed output contains actual data
-- Human can visually see "0 rows" vs expected output
+- Human can visually see "0 tuples" vs expected output
 
 ### 3. Complex Multi-Pattern Queries
 ```sql
@@ -142,7 +142,7 @@ The verbose output made it obvious: data goes in, nothing comes out.
 ### Missing Test Pattern #1: Tuple Collection Verification
 ```go
 func TestTupleCollectionWithStreaming(t *testing.T) {
-    rel := NewMaterializedRelationWithOptions(columns, tuples, ExecutorOptions{
+    rel := NewMaterializedRelationWithOptions(symbols, tuples, ExecutorOptions{
         EnableTrueStreaming: true,  // CRITICAL!
     })
 
@@ -176,7 +176,7 @@ func TestLargeDatasetStreaming(t *testing.T) {
     }
 
     // Test with streaming enabled
-    rel := NewMaterializedRelationWithOptions(columns, largeTuples, ExecutorOptions{
+    rel := NewMaterializedRelationWithOptions(symbols, largeTuples, ExecutorOptions{
         EnableTrueStreaming: true,
     })
 

--- a/docs/bugs/active/CONDITIONAL_AGGREGATE_STREAMING_DEPENDENCY.md
+++ b/docs/bugs/active/CONDITIONAL_AGGREGATE_STREAMING_DEPENDENCY.md
@@ -15,7 +15,7 @@ Conditional aggregate rewriting exhibits non-deterministic failures when streami
 
 Running `BenchmarkConditionalAggregateWithStreaming/Rewriting_only_(no_streaming)` multiple times:
 - Run 1: ✅ PASS (1.77ms)
-- Run 2: ❌ FAIL - `projection failed: cannot project: column ?__cond_?pd not found`
+- Run 2: ❌ FAIL - `projection failed: cannot project: symbol ?__cond_?pd not found`
 - Run 3: ✅ PASS (1.72ms)
 - Run 4: ✅ PASS (1.70ms)
 - Run 5: ✅ PASS (1.71ms)
@@ -44,7 +44,7 @@ opts := planner.PlannerOptions{
 
 ## Root Cause (Hypothesis)
 
-The error message `?__cond_?pd not found in relation (has columns: [?p ?name ?ev ?t ?v ?pd])` suggests that:
+The error message `?__cond_?pd not found in relation (has symbols: [?p ?name ?ev ?t ?v ?pd])` suggests that:
 
 1. The condition variable `?__cond_?pd` was created during planning
 2. But somehow didn't make it into the relation at execution time
@@ -113,7 +113,7 @@ To reproduce (run multiple times until failure):
 go test -bench BenchmarkConditionalAggregateWithStreaming/Rewriting_only -benchtime=1x -count=10 ./tests
 ```
 
-Look for `projection failed: cannot project: column ?__cond_?pd not found`
+Look for `projection failed: cannot project: symbol ?__cond_?pd not found`
 
 ## Resolution Criteria
 

--- a/docs/bugs/resolved/BUG_ENTITY_JOIN_LOSES_FIRST_TUPLE.md
+++ b/docs/bugs/resolved/BUG_ENTITY_JOIN_LOSES_FIRST_TUPLE.md
@@ -39,8 +39,8 @@ StreamingRelation has a materialization bug when its iterator is partially consu
 
 Debug output from `relation.go:853-865`:
 ```
-[StreamingRelation.materializeOnce] Starting materialization, columns=[?bar], counter=&{0x1400027d5e0 1 false}
-[StreamingRelation.materializeOnce] Materialized 4 tuples, columns=[?bar]
+[StreamingRelation.materializeOnce] Starting materialization, symbols=[?bar], counter=&{0x1400027d5e0 1 false}
+[StreamingRelation.materializeOnce] Materialized 4 tuples, symbols=[?bar]
 ```
 
 The counter exists with `count=1` (one tuple already read), then materialization only captures 4 remaining tuples.
@@ -136,7 +136,7 @@ query := `[:find ?bar :where [?bar :price/high ?h] [?bar :price/low ?l]]`
 ### Verification
 
 - ✅ `TestEntityJoinBug` - Returns 5/5 results (was 4/5)
-- ✅ `TestMultipleAggregateSubqueriesNilBug` - Returns correct aggregates (was 0 rows)
+- ✅ `TestMultipleAggregateSubqueriesNilBug` - Returns correct aggregates (was 0 tuples)
 
 ## Impact (When Bug Was Active)
 

--- a/docs/bugs/resolved/BUG_EXPRESSION_ONLY_PHASES.md
+++ b/docs/bugs/resolved/BUG_EXPRESSION_ONLY_PHASES.md
@@ -166,7 +166,7 @@ These should ALWAYS be true:
    - Previous phase's `Keep` symbols (projected result)
 
 2. **Output Invariant**: Every phase produces:
-   - A Relation with columns matching `phase.Provides` (or subset in `Keep`)
+   - A Relation with symbols matching `phase.Provides` (or subset in `Keep`)
    - Never returns `nil` for successful execution
 
 3. **Data Flow Invariant**:

--- a/docs/bugs/resolved/BUG_EXPRESSION_PHASE_ASSIGNMENT_AFTER_REORDERING.md
+++ b/docs/bugs/resolved/BUG_EXPRESSION_PHASE_ASSIGNMENT_AFTER_REORDERING.md
@@ -16,7 +16,7 @@ The planner was assigning expressions to phases BEFORE phase reordering happened
 ### TestComprehensiveExecutorValidation/all_features_combined
 
 Both tests failed with errors about missing symbols:
-- `projection failed: cannot project: column ?total not found`
+- `projection failed: cannot project: symbol ?total not found`
 - `predicate requires symbols not available: [?total]`
 
 ## Root Cause

--- a/docs/bugs/resolved/BUG_LEGACY_EXECUTOR_EXPRESSION_SYMBOL_AVAILABILITY.md
+++ b/docs/bugs/resolved/BUG_LEGACY_EXECUTOR_EXPRESSION_SYMBOL_AVAILABILITY.md
@@ -28,7 +28,7 @@ This breaks executor validation because both executors must behave identically f
 **Error:**
 ```
 Legacy error: phase 1 failed: projection failed: cannot project:
-             column ?total not found in relation (has columns: [?person ?name ?score])
+             symbol ?total not found in relation (has symbols: [?person ?name ?score])
 New error: <nil>
 ```
 

--- a/docs/bugs/resolved/BUG_STRING_PREDICATES_CANT_USE_PARAMETERS.md
+++ b/docs/bugs/resolved/BUG_STRING_PREDICATES_CANT_USE_PARAMETERS.md
@@ -122,7 +122,7 @@ Hypothesis: The planner may be treating input parameters in expression contexts 
 
 **Root Cause**: The predicate assignment logic in `planner_expressions.go` only added input parameters to the `available` map for phase 0. For phases > 0, it only looked at previous phases' `Provides`, missing input parameters that should be available throughout query execution.
 
-**Key Insight**: Input parameters are "environment" symbols that should be available in ALL phases for filtering/correlation (see INPUT_PARAMETER_KEEP_BUG.md). While they're not columns in output relations (Provides), they must be accessible for predicate evaluation (Available).
+**Key Insight**: Input parameters are "environment" symbols that should be available in ALL phases for filtering/correlation (see INPUT_PARAMETER_KEEP_BUG.md). While they're not symbols in output relations (Provides), they must be accessible for predicate evaluation (Available).
 
 **The Fix**: Modified `assignExpressionsToPhases()` to use `phases[i].Available` for each phase, which correctly includes:
 - Input parameters (from `:in` clause)

--- a/docs/bugs/resolved/CONDITIONAL_AGGREGATE_REWRITING_BUG.md
+++ b/docs/bugs/resolved/CONDITIONAL_AGGREGATE_REWRITING_BUG.md
@@ -15,7 +15,7 @@ The conditional aggregate rewriting optimization produces incorrect results beca
 
 **With rewriting enabled:** ❌ FAIL
 - Returns wrong results: `[(Alice, 15, Alice), (Alice, 16, Alice)]`
-- The third column should be the max value (150, 200) but returns the person name instead
+- The third symbol should be the max value (150, 200) but returns the person name instead
 
 ## Root Cause Analysis
 
@@ -94,8 +94,8 @@ Phase.Keep: [?day ?p]
 The aggregate metadata says to aggregate over `?v`, but:
 1. `?v` is in `Provides` (it gets computed)
 2. `?v` is NOT in `Keep` (it doesn't get projected forward!)
-3. The aggregation logic receives tuples with columns `[?name ?day ...]` but no `?v`
-4. It falls back to aggregating over the wrong column (probably column 0 = ?name)
+3. The aggregation logic receives tuples with symbols `[?name ?day ...]` but no `?v`
+4. It falls back to aggregating over the wrong symbol (probably symbol 0 = ?name)
 5. Result: "Alice" instead of 150
 
 ## The Architectural Problem
@@ -272,7 +272,7 @@ After implementing the fix:
 
 4. **Check projection logic:**
    - Executor properly projects aggregate variables before aggregation
-   - Final result has correct columns in correct order
+   - Final result has correct symbols in correct order
 
 ## Related Bugs Fixed
 
@@ -293,7 +293,7 @@ This encoder bug caused Identity values to be all zeros, which masked the condit
 The bug manifested in multi-phase queries where:
 1. Phase 0 executed the conditional aggregate rewriting and stored metadata
 2. Phase 1+ added additional patterns (like looking up `?name`)
-3. Phase 1+ didn't know about the aggregate requirements and projected away critical columns
+3. Phase 1+ didn't know about the aggregate requirements and projected away critical symbols
 
 **Concrete example from failing test:**
 ```
@@ -307,7 +307,7 @@ Phase 1: [?p :person/name ?name]
          → Keep: [?name ?day] ✗ WRONG! Dropped ?v and ?__cond_?pd
 
 Result: Aggregation receives [?name ?day] instead of [?name ?day ?v ?__cond_?pd]
-        → max() operates on wrong column → returns "Alice" instead of 150
+        → max() operates on wrong symbol → returns "Alice" instead of 150
 ```
 
 ### The Fix: Phase Symbol Metadata Propagation
@@ -316,7 +316,7 @@ Result: Aggregation receives [?name ?day] instead of [?name ?day ?v ?__cond_?pd]
 **Function:** `updatePhaseSymbols`
 **Lines:** 342-358
 
-The `updatePhaseSymbols` function recalculates `Keep` columns after phase reordering. It was only checking the current phase for aggregate metadata:
+The `updatePhaseSymbols` function recalculates `Keep` symbols after phase reordering. It was only checking the current phase for aggregate metadata:
 
 ```go
 // BEFORE (BROKEN):
@@ -334,7 +334,7 @@ if phases[i].Metadata != nil {
 }
 ```
 
-This failed because only Phase 0 had the metadata. Phase 1+ would drop the aggregate columns.
+This failed because only Phase 0 had the metadata. Phase 1+ would drop the aggregate symbols.
 
 **Fix:** Check ALL previous phases (0 through current) for aggregate metadata:
 
@@ -342,7 +342,7 @@ This failed because only Phase 0 had the metadata. Phase 1+ would drop the aggre
 // AFTER (FIXED):
 // 2b. Keep symbols needed for conditional aggregates in ANY phase
 // These are stored in phase metadata by the conditional aggregate rewriter
-// IMPORTANT: Aggregate required columns must be carried through ALL later phases,
+// IMPORTANT: Aggregate required symbols must be carried through ALL later phases,
 // not just the phase that has the metadata!
 for j := 0; j <= i; j++ {
     if phases[j].Metadata != nil {
@@ -359,7 +359,7 @@ for j := 0; j <= i; j++ {
 }
 ```
 
-**Why this works:** Aggregate metadata from Phase 0 now propagates to ALL subsequent phases. Each phase preserves the aggregate input columns (`?v`, `?__cond_?pd`) in its Keep list, ensuring they're available when the final aggregation executes.
+**Why this works:** Aggregate metadata from Phase 0 now propagates to ALL subsequent phases. Each phase preserves the aggregate input symbols (`?v`, `?__cond_?pd`) in its Keep list, ensuring they're available when the final aggregation executes.
 
 ### Verification: Before vs After
 
@@ -367,7 +367,7 @@ for j := 0; j <= i; j++ {
 ```
 Phase 0 Keep: [?day ?p ?v ?__cond_?pd] ✓
 Phase 1 Keep: [?name ?day] ✗
-currentResult columns: [?name ?day]
+currentResult symbols: [?name ?day]
 Result: [Alice, 15, Alice] ✗ WRONG!
 ```
 
@@ -375,7 +375,7 @@ Result: [Alice, 15, Alice] ✗ WRONG!
 ```
 Phase 0 Keep: [?day ?p ?v ?__cond_?pd] ✓
 Phase 1 Keep: [?name ?day ?v ?__cond_?pd] ✓
-currentResult columns: [?name ?day ?v ?__cond_?pd]
+currentResult symbols: [?name ?day ?v ?__cond_?pd]
 Result: [Alice, 15, 150] ✓ CORRECT!
 ```
 

--- a/docs/bugs/resolved/IDENTITY_ZERO_BUG_WITH_REORDERING.md
+++ b/docs/bugs/resolved/IDENTITY_ZERO_BUG_WITH_REORDERING.md
@@ -17,7 +17,7 @@ The wrong results (15, 16) are day numbers being used where max event values sho
 Debug output shows tuples with empty Identity values:
 
 ```
-Relation columns: [?e ?p ?time ?day] (size=3)
+Relation symbols: [?e ?p ?time ?day] (size=3)
 
 Tuple 0 (len=4): [  2025-01-15 05:00:00 -0500 EST 15]
   tuple[0] =  (type *datalog.Identity)   <-- EMPTY
@@ -95,8 +95,8 @@ Hash joins or other join types might not properly handle Identity values when bu
 ### 3. Materialization Bug
 When relations are materialized between phases, Identity values might be losing their internal data.
 
-### 4. Column Reordering Bug
-If phase reordering changes column order, and the code doesn't properly map Identity values to new positions.
+### 4. Symbol Reordering Bug
+If phase reordering changes symbol order, and the code doesn't properly map Identity values to new positions.
 
 ## What We Know Works
 

--- a/docs/bugs/resolved/INPUT_PARAMETER_KEEP_BUG.md
+++ b/docs/bugs/resolved/INPUT_PARAMETER_KEEP_BUG.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-The phase symbol update logic was incorrectly adding input parameters to the `Keep` list even when those parameters weren't present in the relation produced by the phase patterns. This caused projection errors like "cannot project: column ?symbol not found in relation".
+The phase symbol update logic was incorrectly adding input parameters to the `Keep` list even when those parameters weren't present in the relation produced by the phase patterns. This caused projection errors like "cannot project: symbol ?symbol not found in relation".
 
 ## Symptom
 
@@ -13,7 +13,7 @@ The phase symbol update logic was incorrectly adding input parameters to the `Ke
 **Error:**
 ```
 Query failed: query execution failed: phase 2 failed: projection failed:
-cannot project: column ?symbol not found in relation (has columns: [?s ?p ?time ?close])
+cannot project: symbol ?symbol not found in relation (has symbols: [?s ?p ?time ?close])
 ```
 
 **Query:**
@@ -32,7 +32,7 @@ cannot project: column ?symbol not found in relation (has columns: [?s ?p ?time 
   - Available: `[?symbol ?s]` (inputs from phase 0)
   - Provides: `[?close ?p ?s ?time]` (outputs from patterns)
   - Keep: `[?time ?close ?symbol]` ✗ WRONG! `?symbol` isn't in the relation!
-- Projection tries to keep `?symbol` but it's not in the relation columns, causing the error
+- Projection tries to keep `?symbol` but it's not in the relation symbols, causing the error
 
 ## Root Cause Analysis
 
@@ -94,7 +94,7 @@ But `Keep` should ONLY contain symbols that are actually IN THE RELATION produce
 
 ### The Key Insight
 
-**Input parameters are in `Available` but NOT in the relation.** They're used to filter or correlate data during pattern matching, but they don't appear as columns in the output relation.
+**Input parameters are in `Available` but NOT in the relation.** They're used to filter or correlate data during pattern matching, but they don't appear as symbols in the output relation.
 
 **Example:**
 ```datalog
@@ -103,7 +103,7 @@ But `Keep` should ONLY contain symbols that are actually IN THE RELATION produce
        [?p :price/symbol ?s]        ← Produces ?p, ?s
 ```
 
-The relation produced has columns `[?s ?p ...]`, NOT `[?symbol ?s ?p ...]`.
+The relation produced has symbols `[?s ?p ...]`, NOT `[?symbol ?s ?p ...]`.
 
 ## The Actual Fix
 
@@ -142,7 +142,7 @@ if i > 0 && len(phases[i].Available) > 0 {
 }
 ```
 
-**Why this works:** We now check that the join symbol actually exists in the relation (`Provides`) before adding it to `Keep`. This ensures we never try to project a column that doesn't exist.
+**Why this works:** We now check that the join symbol actually exists in the relation (`Provides`) before adding it to `Keep`. This ensures we never try to project a symbol that doesn't exist.
 
 ### Verification: Before vs After
 
@@ -153,7 +153,7 @@ Phase 1:
   Provides: [?close ?p ?s ?time]
   Keep: [?time ?close ?symbol]  ✗ ?symbol not in Provides!
 
-Error: cannot project: column ?symbol not found
+Error: cannot project: symbol ?symbol not found
 ```
 
 **After fix:**
@@ -206,7 +206,7 @@ In Datalog query execution:
 **Correct mental model:**
 ```
 Available = Environment symbols (inputs + previous phase outputs)
-Provides = Relation columns (what THIS phase's patterns produce)
+Provides = Relation symbols (what THIS phase's patterns produce)
 Keep ⊆ Provides (you can only keep what's actually in the relation!)
 ```
 
@@ -215,7 +215,7 @@ Keep ⊆ Provides (you can only keep what's actually in the relation!)
 Keep ⊆ Provides ∩ Available
 ```
 
-This is analogous to SQL's `SELECT` clause - you can only select columns that exist in the result set, even if you used parameters in the `WHERE` clause.
+This is analogous to SQL's `SELECT` clause - you can only select symbols that exist in the result set, even if you used parameters in the `WHERE` clause.
 
 ## Related Issues
 

--- a/docs/bugs/resolved/INVESTIGATION_JOIN_RETURNS_ZERO.md
+++ b/docs/bugs/resolved/INVESTIGATION_JOIN_RETURNS_ZERO.md
@@ -63,7 +63,7 @@ Each pattern successfully retrieves data from storage.
 Join result size: 0
 ```
 
-The join of two 1-tuple relations with a shared column `?e` produces **0 results** instead of 1.
+The join of two 1-tuple relations with a shared symbol `?e` produces **0 results** instead of 1.
 
 ## Root Cause Hypothesis
 
@@ -82,7 +82,7 @@ The bug is in the **join/collapse logic**, likely related to the lazy materializ
 
 3. **Collapse/Join Logic**
    - `executor_sequential.go:123-131` - Pattern results are added to `independentGroups` and collapsed
-   - `relations.go:135-187` - `Collapse()` method joins relations with shared columns
+   - `relations.go:135-187` - `Collapse()` method joins relations with shared symbols
    - `join.go:136-536` - `HashJoin` builds a hash table and probes
 
 4. **materializeRelationsForPattern()**
@@ -112,7 +112,7 @@ The bug is in the **join/collapse logic**, likely related to the lazy materializ
 ### Join Execution Path
 1. `executor_sequential.go:12` - `executePhaseSequential()`
 2. `executor_sequential.go:123-131` - Add pattern results to independentGroups, collapse
-3. `relations.go:135` - `Collapse()` joins relations with shared columns
+3. `relations.go:135` - `Collapse()` joins relations with shared symbols
 4. `relations.go:166` - `ctx.JoinRelations()` wrapper for annotation
 5. `relation.go:570` - `MaterializedRelation.Join()` delegates to `HashJoin()`
 6. `join.go:136` - `HashJoinWithOptions()` builds hash table and probes
@@ -181,7 +181,7 @@ All of these may share the same underlying join/iterator issue.
 
 **Added debug logging to HashJoin**:
 ```
-[HashJoin] Called with left/right types, sizes, columns
+[HashJoin] Called with left/right types, sizes, symbols
 [HashJoin] Build phase: X tuples, first key/tuple
 [HashJoin] Probe phase: probed X tuples, found X matches, produced X results
 ```
@@ -289,7 +289,7 @@ func (it *ProjectIterator) Next() bool {
 
 **2. Updated `StreamingRelation.Project()` to pass relation** (`relation.go:1087-1093`):
 ```go
-projIter := NewProjectIterator(r, r.columns, columns)  // Pass r, not r.iterator
+projIter := NewProjectIterator(r, r.symbols, symbols)  // Pass r, not r.iterator
 ```
 
 **3. Fixed `CachingIterator.signalComplete()` race condition** (`relation.go:218-236`):
@@ -397,7 +397,7 @@ for it.Next() {
     tuples = append(tuples, it.Tuple())
 }
 it.Close()
-currentResult = NewMaterializedRelationWithOptions(phaseResult.Columns(), tuples, opts)
+currentResult = NewMaterializedRelationWithOptions(phaseResult.Symbols(), tuples, opts)
 ```
 
 **This materialization is unnecessary** given the ProjectIterator fix and lazy materialization architecture.

--- a/docs/bugs/resolved/PHASE_REORDERING_CONDITIONAL_AGGREGATE_BUG.md
+++ b/docs/bugs/resolved/PHASE_REORDERING_CONDITIONAL_AGGREGATE_BUG.md
@@ -11,10 +11,10 @@
 **Actual Bug**: Phase reordering **alone** breaks subquery execution
 
 Test results from `TestOptimizationComposition`:
-- ✅ **Baseline (no optimizations)**: Returns 2 rows correctly
-- ❌ **Phase Reordering only**: Returns 0 rows (BROKEN!)
-- ✅ **Conditional Aggregates only**: Returns 2 rows correctly
-- ✅ **Both optimizations**: Returns 2 rows correctly (!!)
+- ✅ **Baseline (no optimizations)**: Returns 2 tuples correctly
+- ❌ **Phase Reordering only**: Returns 0 tuples (BROKEN!)
+- ✅ **Conditional Aggregates only**: Returns 2 tuples correctly
+- ✅ **Both optimizations**: Returns 2 tuples correctly (!!)
 
 **The Real Problem**: `EnableDynamicReordering: true` breaks queries with subqueries, regardless of conditional aggregate rewriting.
 
@@ -24,12 +24,12 @@ Test results from `TestOptimizationComposition`:
 
 **Configuration 1**: Rewriting ON, Phase Reordering ON (default)
 ```
-Result: FAIL - projection failed: cannot project: column ?__cond_?pd not found
+Result: FAIL - projection failed: cannot project: symbol ?__cond_?pd not found
 ```
 
 **Configuration 2**: Rewriting OFF, Phase Reordering ON (default)
 ```
-Result: Returns 0 rows (should return 30 rows)
+Result: Returns 0 tuples (should return 30 tuples)
 ```
 
 **Configuration 3**: Rewriting ON, Phase Reordering OFF
@@ -41,7 +41,7 @@ Result: UNKNOWN - Not yet tested
 
 **Configuration 1**: Rewriting OFF
 ```
-Result: FAIL - Returns 0 rows (should return 2 rows)
+Result: FAIL - Returns 0 tuples (should return 2 tuples)
 Expected: [(Alice, 15, 150), (Alice, 16, 200)]
 Actual: []
 ```
@@ -79,21 +79,21 @@ Returns: [(Alice, 15, 150), (Alice, 16, 200)]
 The bug manifests during **query execution**, not planning:
 
 1. **Planning**: Phases reordered, subqueries preserved, Keep lists correct
-2. **Execution**: Query returns 0 rows instead of expected results
+2. **Execution**: Query returns 0 tuples instead of expected results
 3. **Hypothesis**: Executor makes assumptions about phase order that break after reordering
 
 ### The Projection Error (From Benchmark)
 
 ```
-cannot project: column ?__cond_?pd not found in relation
-  (has columns: [?p ?name ?ev ?t ?v ?pd])
+cannot project: symbol ?__cond_?pd not found in relation
+  (has symbols: [?p ?name ?ev ?t ?v ?pd])
 ```
 
 This error only appears with BOTH reordering + conditional aggregates enabled.
-**But** reordering alone also breaks queries (returns 0 rows without error).
+**But** reordering alone also breaks queries (returns 0 tuples without error).
 
 **Two separate bugs**:
-1. Phase reordering breaks subquery execution (silent failure, 0 rows)
+1. Phase reordering breaks subquery execution (silent failure, 0 tuples)
 2. Phase reordering + conditional aggregates breaks projection (explicit error)
 
 ### The Missing Metadata Propagation
@@ -141,7 +141,7 @@ Phase 0 (after renaming):
   Metadata["aggregate_required_columns"] = [?v, ?__cond_?pd]  ← NOT UPDATED!
 ```
 
-**Step 4**: updatePhaseSymbols tries to keep metadata columns
+**Step 4**: updatePhaseSymbols tries to keep metadata symbols
 ```
 Check available[?v] ✓ - exists as ?v
 Check available[?__cond_?pd] ✗ - doesn't exist! (it's now ?__cond_?p or was renamed)
@@ -181,7 +181,7 @@ This is a classic **representation invariant violation**:
 If phase reordering doesn't update metadata, other features that store symbol names in metadata could break:
 
 1. **Predicate pushdown**: Stores predicate variable names in metadata
-2. **Join condition optimization**: Stores join column names
+2. **Join condition optimization**: Stores join symbol names
 3. **Any future feature**: That uses metadata to track symbols
 
 **General principle**: Variable renaming is a **global transformation** that must update **all** references to those variables, not just patterns.

--- a/docs/bugs/resolved/PULLINTO_CRDT_RESOLUTION.md
+++ b/docs/bugs/resolved/PULLINTO_CRDT_RESOLUTION.md
@@ -79,11 +79,11 @@ When the cache path is taken (`matchFromCache` in matcher_relations.go:527), CRD
 case schema.CardinalityOne:
     val := entry.OneValue()
     if val == nil {
-        return executor.NewMaterializedRelationWithOptions(columns, nil, m.options), true
+        return executor.NewMaterializedRelationWithOptions(symbols, nil, m.options), true
     }
     // Returns single-tuple relation with resolved value
     tuple := buildTuple(val, entry.Version())
-    return executor.NewMaterializedRelationWithOptions(columns, []executor.Tuple{tuple}, m.options), true
+    return executor.NewMaterializedRelationWithOptions(symbols, []executor.Tuple{tuple}, m.options), true
 ```
 
 - CardinalityOne → returns `entry.OneValue()` (single value)

--- a/docs/bugs/resolved/README.md
+++ b/docs/bugs/resolved/README.md
@@ -49,7 +49,7 @@ Each bug report follows a consistent format:
 ### [PHASE_REORDERING_CONDITIONAL_AGGREGATE_BUG.md](./PHASE_REORDERING_CONDITIONAL_AGGREGATE_BUG.md)
 **Fixed:** October 14-17, 2025 (during fix-buffered-iterator-architecture branch)
 
-**Problem:** Phase reordering alone was breaking all subquery execution, returning 0 rows when it should return multiple rows. Initially thought to be interaction with conditional aggregates, but turned out to be core phase reordering issue.
+**Problem:** Phase reordering alone was breaking all subquery execution, returning 0 tuples when it should return multiple tuples. Initially thought to be interaction with conditional aggregates, but turned out to be core phase reordering issue.
 
 **Key Lesson:** Test optimization interactions - bugs can be masked by other optimizations that happen to work around them.
 

--- a/docs/bugs/resolved/SUBQUERY_BINDING_NOT_IN_FIND_BUG.md
+++ b/docs/bugs/resolved/SUBQUERY_BINDING_NOT_IN_FIND_BUG.md
@@ -66,7 +66,7 @@ Include the subquery binding variable in the `:find` clause, even if you don't n
  ...]
 ```
 
-Then ignore the extra column in the result.
+Then ignore the extra symbol in the result.
 
 ## Impact
 

--- a/docs/bugs/resolved/slow-single-pattern-input-query.md
+++ b/docs/bugs/resolved/slow-single-pattern-input-query.md
@@ -65,7 +65,7 @@ Phase 1:
 
 Execution:
   Total time: 14.962209ms
-  Result rows: 63
+  Result tuples: 63
 
 Event Summary:
   Joins: hash=1, nested=0, merge=0

--- a/docs/decisions/UNCORRELATED_SUBQUERY_CARTESIAN_PRODUCTS.md
+++ b/docs/decisions/UNCORRELATED_SUBQUERY_CARTESIAN_PRODUCTS.md
@@ -16,9 +16,9 @@ During the implementation of QueryExecutor (Stage B), we encountered an architec
 ```
 
 This query creates a **disjoint relation scenario**:
-- Pattern `[?e :person/name ?name]` produces relation with columns `[?e, ?name]`
-- Subquery produces relation with columns `[?max-age]` (after filtering out `$`)
-- These relations **share no columns** → cannot be joined
+- Pattern `[?e :person/name ?name]` produces relation with symbols `[?e, ?name]`
+- Subquery produces relation with symbols `[?max-age]` (after filtering out `$`)
+- These relations **share no symbols** → cannot be joined
 - Projecting `[:find ?name ?max-age]` requires both relations
 
 ## The Dilemma
@@ -82,8 +82,8 @@ if len(groups) > 1 {
    - Prevents accidental explosions from malformed queries
 
 3. **Performance characteristics**:
-   - Uncorrelated subqueries usually return 1 row (aggregations like `max`, `min`)
-   - Product with 1-row relation is essentially a broadcast
+   - Uncorrelated subqueries usually return 1 tuple (aggregations like `max`, `min`)
+   - Product with 1-tuple relation is essentially a broadcast
    - Not a performance concern in typical usage
 
 ### Edge Cases to Watch

--- a/docs/dev-notes/READ_PATH.md
+++ b/docs/dev-notes/READ_PATH.md
@@ -94,7 +94,7 @@
            if m.cache != nil && m.txID == 0 {
                if a := m.extractValue(pattern.GetA()); a != nil {
                    if aKw, ok := a.(datalog.Keyword); ok {
-                       cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, columns, aKw)
+                       cacheResult, handled := m.matchWithBindingsFromCache(pattern, bindingRel, symbols, aKw)
                        if handled {
                            return cacheResult, nil  // CACHE HIT: Return immediately
                        }

--- a/docs/dev-notes/executor/SUBQUERY_API_NOTES.md
+++ b/docs/dev-notes/executor/SUBQUERY_API_NOTES.md
@@ -37,8 +37,8 @@ type SubqueryPattern struct {
 ```
 
 ### Binding Forms
-- `TupleBinding`: `[[?var ...]]` - Expects single result row
-- `RelationBinding`: `[[?a ?b] ...]` - Multiple result rows
+- `TupleBinding`: `[[?var ...]]` - Expects single result tuple
+- `RelationBinding`: `[[?a ?b] ...]` - Multiple result tuples
 - `CollectionBinding`: `?coll` - Collect all values (not implemented)
 
 ## Data Flow
@@ -68,15 +68,15 @@ inputRelations := e.createInputRelations(subqPlan.Subquery.Query, inputValues, s
 - Maps outer variables to inner `:in` clause variables **by position**
 - Creates Relations for each `:in` specification:
   - `ScalarInput`: Single value relation
-  - `TupleInput`: Multi-column single row
-  - `RelationInput`: Multi-column multi-row (treated as single row currently)
+  - `TupleInput`: Multi-symbol single tuple
+  - `RelationInput`: Multi-symbol multi-tuple (treated as single tuple currently)
 
 **Critical Mapping**: The subquery pattern `(q [...] ?s)` passes `?s` which maps to the second `:in` element (after `$`).
 
 Example:
 - Outer: `?s = "symbol:aapl"`
 - Inner `:in $ ?sym` 
-- Creates: Relation with column `?sym` and value `"symbol:aapl"`
+- Creates: Relation with symbol `?sym` and value `"symbol:aapl"`
 
 ##### 2b. Execute Nested Query
 ```go
@@ -90,13 +90,13 @@ result, err := e.executePhasesWithInputs(ctx, subqPlan.NestedPlan, inputRelation
 boundResult, err := e.applyBindingForm(result, binding, inputValues, subqPlan.Inputs)
 ```
 - Transforms subquery results according to binding form
-- Adds input values as columns (for correlation)
-- TupleBinding: Expects exactly 1 result row
-- RelationBinding: Accepts multiple rows
+- Adds input values as symbols (for correlation)
+- TupleBinding: Expects exactly 1 result tuple
+- RelationBinding: Accepts multiple tuples
 
 #### Step 3: Combine Results
 - Union all results from different input combinations
-- Returns final relation with columns: `[input-vars... binding-vars...]`
+- Returns final relation with symbols: `[input-vars... binding-vars...]`
 
 ## Example Walkthrough
 

--- a/docs/ideas/REMOVE_HASHJOIN_MATERIALIZATION.md
+++ b/docs/ideas/REMOVE_HASHJOIN_MATERIALIZATION.md
@@ -85,8 +85,8 @@ iter := &hashJoinIterator{
     seen:         NewTupleKeyMapWithCapacity(expectedResults),
     buildIsLeft:  buildIsLeft,
     joinCols:     joinCols,
-    leftCols:     left.Columns(),
-    rightCols:    right.Columns(),
+    leftCols:     left.Symbols(),
+    rightCols:    right.Symbols(),
     probeIndices: probeIndices,
     options:      opts,
     matchIdx:     0,
@@ -94,7 +94,7 @@ iter := &hashJoinIterator{
 
 // Return streaming result
 return &StreamingRelation{
-    columns:  outputCols,
+    symbols:  outputCols,
     iterator: iter,
     size:     -1, // unknown size until consumed
     options:  opts,
@@ -317,7 +317,7 @@ return NewMaterializedRelationWithOptions(outputCols, results, opts)
 // StreamingRelation enforces single-use semantics via panic if Iterator() called twice
 // Caller can explicitly call Materialize() if multiple iterations needed
 return &StreamingRelation{
-    columns:  outputCols,
+    symbols:  outputCols,
     iterator: iter,
     size:     -1, // unknown size until consumed
     options:  opts,

--- a/docs/ideas/TEST_COVERAGE_PLAN.md
+++ b/docs/ideas/TEST_COVERAGE_PLAN.md
@@ -91,7 +91,7 @@ Write tests for critical uncovered functionality:
 func TestSortingQueries(t *testing.T) {
     // MISSING: sortRelation has 0% coverage
     // Test ORDER BY with different types
-    // Test multi-column sorting
+    // Test multi-symbol sorting
 }
 
 func TestExpressionQueries(t *testing.T) {

--- a/docs/papers/PAPER_PROPOSAL_1_GREEDY_JOINS.md
+++ b/docs/papers/PAPER_PROPOSAL_1_GREEDY_JOINS.md
@@ -61,7 +61,7 @@ SELECT * FROM customers WHERE country = 'Micronesia';
 ```datalog
 [?s :symbol/ticker "NVDA"]  ; Obviously very selective (1 symbol)
 [?p :price/symbol ?s]        ; Natural join path via ?s
-[?p :price/time ?t]          ; Same entity, more columns
+[?p :price/time ?t]          ; Same entity, more symbols
 [(year ?t) ?y]               ; Derived attribute
 [(= ?y 2025)]                ; Filter
 ```
@@ -100,9 +100,9 @@ SELECT * FROM customers WHERE country = 'Micronesia';
 For query: R1 ⋈ R2 ⋈ R3
 
 1. Gather statistics:
-   - |R1| = 1,000,000 rows
-   - |R2| = 100,000 rows
-   - |R3| = 10,000 rows
+   - |R1| = 1,000,000 tuples
+   - |R2| = 100,000 tuples
+   - |R3| = 10,000 tuples
    - Selectivity factors for join predicates
 
 2. Estimate costs for all orderings:
@@ -200,9 +200,9 @@ func CollapseRelations(relations []Relation) []Relation {
 
 **Key features:**
 1. **No statistics** required
-2. **Natural join detection** via shared columns
+2. **Natural join detection** via shared symbols
 3. **Early termination** on empty intermediate results
-4. **Disjoint handling** returns multiple groups if no shared columns
+4. **Disjoint handling** returns multiple groups if no shared symbols
 
 ### 3.2 Integration with Query Planner
 
@@ -211,7 +211,7 @@ The greedy algorithm operates on relations produced by the planner:
 ```
 Planner Output: Ordered list of patterns by selectivity heuristics
                 ↓
-Greedy Collapser: Progressive joining based on shared columns
+Greedy Collapser: Progressive joining based on shared symbols
                 ↓
 Result: Single relation (or error on Cartesian product)
 ```
@@ -225,7 +225,7 @@ Result: Single relation (or error on Cartesian product)
 
 **Theorem 3.1** (Correctness): The greedy algorithm produces a valid join order for all queries without Cartesian products.
 
-**Proof sketch:** By construction, only relations with shared columns are joined. Relations without shared columns remain in separate groups. Cartesian products are explicitly rejected.
+**Proof sketch:** By construction, only relations with shared symbols are joined. Relations without shared symbols remain in separate groups. Cartesian products are explicitly rejected.
 
 **Theorem 3.2** (Early Termination): If any intermediate join produces zero tuples, the algorithm terminates immediately with empty result.
 

--- a/docs/papers/PAPER_PROPOSAL_2_DATALOG_AS_RELATIONAL_ALGEBRA.md
+++ b/docs/papers/PAPER_PROPOSAL_2_DATALOG_AS_RELATIONAL_ALGEBRA.md
@@ -108,8 +108,8 @@ This work demonstrates that the theory-practice gap can be closed: classical dat
 
 | Symbol | Operation | Definition |
 |--------|-----------|------------|
-| π | Projection | Select columns |
-| σ | Selection | Filter rows |
+| π | Projection | Select symbols |
+| σ | Selection | Filter tuples |
 | ⋈ | Natural Join | Combine on shared attributes |
 | × | Cartesian Product | All combinations |
 | ∪ | Union | Set union |
@@ -220,7 +220,7 @@ Result = R1 ⋈_{p} R2
 **Where:**
 - EAVT is the storage relation (Entity-Attribute-Value-Transaction)
 - σ filters to specific attribute
-- π projects relevant columns
+- π projects relevant symbols
 - ⋈ joins on shared entity
 
 **Key insight:** Shared variables become natural join keys
@@ -312,7 +312,7 @@ Result = R1 ⋈_{p} R2
 ```go
 type Relation interface {
     // Core RA operations
-    Project(columns []Symbol) (Relation, error)    // π
+    Project(symbols []Symbol) (Relation, error)    // π
     Filter(predicate Predicate) Relation            // σ
     Join(other Relation) Relation                   // ⋈
     HashJoin(other Relation, cols []Symbol) Relation
@@ -322,7 +322,7 @@ type Relation interface {
     Sort(orderBy []OrderBy) Relation                // τ
 
     // Metadata
-    Columns() []Symbol
+    Symbols() []Symbol
     Iterator() Iterator
 
     // Properties: IMMUTABLE, DEDUPLICATED
@@ -377,7 +377,7 @@ func (it *FilterIterator) Next() bool {
 ```go
 type ProjectIterator struct {
     source  Iterator
-    indices []int  // Column indices to keep
+    indices []int  // Symbol indices to keep
 }
 
 func (it *ProjectIterator) Next() bool {
@@ -420,7 +420,7 @@ func HashJoin(left, right Relation, joinCols []Symbol) Relation {
 ```go
 result := storageRelation.
     Filter(predicate1).      // σ
-    Project(columns).         // π
+    Project(symbols).         // π
     Join(otherRelation).      // ⋈
     Filter(predicate2).       // σ
     Aggregate(aggs)           // γ
@@ -542,7 +542,7 @@ func (m *BadgerMatcher) Match(pattern *DataPattern) Relation {
 
     // Return as StreamingRelation
     return &StreamingRelation{
-        columns:  pattern.Symbols(),
+        symbols:  pattern.Symbols(),
         iterator: iterator,
     }
 }
@@ -643,7 +643,7 @@ ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).
 ### 7.2 Relational Algebra Implementation
 
 **Volcano (Graefe, 1993):** Iterator-based operators
-**MonetDB (Boncz et al., 1999):** Column-oriented execution
+**MonetDB (Boncz et al., 1999):** Symbol-oriented execution
 
 **Similarity:** We also use iterators
 **Difference:** We target Datalog directly, prove RA suffices

--- a/docs/papers/PAPER_PROPOSAL_3_FUNCTIONAL_STREAMING.md
+++ b/docs/papers/PAPER_PROPOSAL_3_FUNCTIONAL_STREAMING.md
@@ -93,7 +93,7 @@ result = take 100 $ filter predicate $ map transform $ largeList
 
 **Typical OLAP query execution:**
 ```
-Scan: 1M rows → Filter: 100K rows → Join: 500K rows → Aggregate: 10K rows
+Scan: 1M tuples → Filter: 100K tuples → Join: 500K tuples → Aggregate: 10K tuples
 ```
 
 **Traditional approach:**
@@ -278,11 +278,11 @@ class Relation {
 type Relation interface {
     // ALL operations return NEW relations
     Filter(predicate Predicate) Relation      // Returns new
-    Project(columns []Symbol) Relation        // Returns new
+    Project(symbols []Symbol) Relation        // Returns new
     Join(other Relation) Relation             // Returns new
 
     // Properties
-    Columns() []Symbol                        // Immutable schema
+    Symbols() []Symbol                        // Immutable schema
     Iterator() Iterator                       // Fresh iterator each call
 
     // Metadata
@@ -299,7 +299,7 @@ type Relation interface {
 **MaterializedRelation:**
 ```go
 type MaterializedRelation struct {
-    columns []Symbol
+    symbols []Symbol
     tuples  []Tuple  // Immutable slice
     options ExecutorOptions
 }
@@ -308,12 +308,12 @@ func (r *MaterializedRelation) Filter(pred Predicate) Relation {
     // Create NEW relation with filtered tuples
     filtered := make([]Tuple, 0, len(r.tuples))
     for _, tuple := range r.tuples {
-        if pred.Eval(tuple, r.columns) {
+        if pred.Eval(tuple, r.symbols) {
             filtered = append(filtered, tuple)
         }
     }
     return &MaterializedRelation{
-        columns: r.columns,
+        symbols: r.symbols,
         tuples:  filtered,  // New slice
         options: r.options,
     }
@@ -325,7 +325,7 @@ func (r *MaterializedRelation) Filter(pred Predicate) Relation {
 **StreamingRelation:**
 ```go
 type StreamingRelation struct {
-    columns  []Symbol
+    symbols  []Symbol
     iterator Iterator  // Lazy source
     options  ExecutorOptions
 }
@@ -333,11 +333,11 @@ type StreamingRelation struct {
 func (r *StreamingRelation) Filter(pred Predicate) Relation {
     // Return NEW StreamingRelation wrapping filtered iterator
     return &StreamingRelation{
-        columns: r.columns,
+        symbols: r.symbols,
         iterator: &FilterIterator{
             source:    r.iterator,
             predicate: pred,
-            columns:   r.columns,
+            symbols:   r.symbols,
         },
         options: r.options,
     }
@@ -396,7 +396,7 @@ type Iterator interface {
 type FilterIterator struct {
     source    Iterator
     predicate Predicate
-    columns   []Symbol
+    symbols   []Symbol
     current   Tuple
 }
 
@@ -404,7 +404,7 @@ func (it *FilterIterator) Next() bool {
     // Lazy filtering - only advances when requested
     for it.source.Next() {
         it.current = it.source.Tuple()
-        if it.predicate.Eval(it.current, it.columns) {
+        if it.predicate.Eval(it.current, it.symbols) {
             return true  // Found match
         }
     }
@@ -426,7 +426,7 @@ func (it *FilterIterator) Tuple() Tuple {
 ```go
 type ProjectIterator struct {
     source     Iterator
-    indices    []int  // Column indices to keep
+    indices    []int  // Symbol indices to keep
     newColumns []Symbol
     current    Tuple
 }
@@ -439,7 +439,7 @@ func (it *ProjectIterator) Next() bool {
     sourceTuple := it.source.Tuple()
     it.current = make(Tuple, len(it.indices))
     for i, idx := range it.indices {
-        it.current[i] = sourceTuple[idx]  // Extract columns
+        it.current[i] = sourceTuple[idx]  // Extract symbols
     }
     return true
 }
@@ -468,7 +468,7 @@ func (it *TransformIterator) Next() bool {
 }
 ```
 
-**Use case:** Add computed columns
+**Use case:** Add computed symbols
 ```go
 // Add (price * quantity) as total
 transform := func(t Tuple) Tuple {
@@ -744,7 +744,7 @@ func shouldMaterialize(relation Relation) bool {
 - **Janus-Streaming**: This work (functional streaming)
 - **Janus-Materialized**: Same system, forced materialization
 - **PostgreSQL**: Traditional Volcano model
-- **MonetDB**: Column-oriented (materialize columns)
+- **MonetDB**: Symbol-oriented (materialize symbols)
 
 **Workloads:**
 1. Financial time-series (OHLC queries)

--- a/docs/proposals/CRDT_VECTOR_STORAGE_IMPLEMENTATION_PLAN.md
+++ b/docs/proposals/CRDT_VECTOR_STORAGE_IMPLEMENTATION_PLAN.md
@@ -4088,7 +4088,7 @@ func init() {
 
 // enumerate decomposes vector into (index, value) pairs
 // Usage: [(enumerate ?vec) ?idx ?val]
-// Returns: Relation with columns [?idx, ?val]
+// Returns: Relation with symbols [?idx, ?val]
 func builtinEnumerate(args []any) (Relation, error) {
     vec, ok := args[0].([]any)
     if !ok {

--- a/docs/proposals/ITERATOR_LIFECYCLE_MANAGEMENT.md
+++ b/docs/proposals/ITERATOR_LIFECYCLE_MANAGEMENT.md
@@ -223,7 +223,7 @@ Streaming should be the primitive. Materialization should be the convenience wra
 type Tuples struct {
     rel     executor.Relation
     iter    executor.Iterator
-    columns []string
+    symbols []string
 }
 
 // Query executes a Datalog query and returns a streaming handle.
@@ -258,8 +258,8 @@ func (t *Tuples) Scan(dest ...any) error
 //   tuples.ScanInto(&p)
 func (t *Tuples) ScanInto(dest any) error
 
-// Columns returns the column names (find variable names without ?).
-func (t *Tuples) Columns() []string
+// Symbols returns the symbol names (find variable names without ?).
+func (t *Tuples) Symbols() []string
 
 // Collect materializes all remaining tuples into a slice. This is the
 // convenience method for when you want everything in memory.
@@ -337,14 +337,14 @@ func (d *DB) Query(queryInput any, inputs ...any) (*Tuples, error) {
     if err != nil {
         return nil, err
     }
-    columns := make([]string, len(rel.Columns()))
-    for i, sym := range rel.Columns() {
-        columns[i] = string(sym)
+    symbols := make([]string, len(rel.Symbols()))
+    for i, sym := range rel.Symbols() {
+        symbols[i] = string(sym)
     }
     return &Tuples{
         rel:     rel,
         iter:    rel.Iterator(),
-        columns: columns,
+        symbols: symbols,
     }, nil
 }
 

--- a/docs/proposals/PREPARED_QUERIES.md
+++ b/docs/proposals/PREPARED_QUERIES.md
@@ -57,7 +57,7 @@ type PreparedQuery struct {
     queryStr string              // Original query string (for debugging)
     query    *query.Query        // Parsed query
     plan     *planner.QueryPlan  // Pre-computed plan
-    findCols []string            // Column names for result mapping
+    findCols []string            // Symbol names for result mapping
     mu       sync.RWMutex        // Protects plan updates (for Replan)
 }
 

--- a/docs/proposals/SUBQUERY_SINGLE_PASS_JOIN.md
+++ b/docs/proposals/SUBQUERY_SINGLE_PASS_JOIN.md
@@ -87,7 +87,7 @@ func (e *Executor) executeSubqueryWithHashTable(
         inputKey := NewTupleKey(inputValues, ...)
         inputCombinations.Put(inputKey, inputValues)
 
-        // Build hash table for join (keyed by join columns)
+        // Build hash table for join (keyed by join symbols)
         joinKey := NewTupleKey(tuple, joinIndices)
         hashTable.Put(joinKey, tuple)  // Store full tuple
     }

--- a/docs/proposals/TUPLEKEYMAP_OPTIMIZATION.md
+++ b/docs/proposals/TUPLEKEYMAP_OPTIMIZATION.md
@@ -77,7 +77,7 @@ func (s *TupleSet) Contains(tuple Tuple) bool {
 
 ### Option 2: Interned Value Fast Path
 
-For single-column projections on interned types (`*Identity`, `*Keyword`), use pointer comparison:
+For single-symbol projections on interned types (`*Identity`, `*Keyword`), use pointer comparison:
 
 ```go
 type SingleColumnSet struct {
@@ -93,7 +93,7 @@ func (s *SingleColumnSet) Add(val interface{}) bool {
 }
 ```
 
-**When applicable**: Projection to single column of interned type.
+**When applicable**: Projection to single symbol of interned type.
 **Expected speedup**: Significant - avoids hashing entirely, uses Go's native map.
 
 ### Option 3: Adaptive Strategy
@@ -101,8 +101,8 @@ func (s *SingleColumnSet) Add(val interface{}) bool {
 Choose strategy based on projection characteristics:
 
 ```go
-func NewDedupIterator(source Iterator, columns []Symbol) Iterator {
-    if len(columns) == 1 && isInternedType(columns[0]) {
+func NewDedupIterator(source Iterator, symbols []Symbol) Iterator {
+    if len(symbols) == 1 && isInternedType(symbols[0]) {
         return &SingleColumnDedupIterator{...}
     }
     if expectedCardinality < 100 {
@@ -122,8 +122,8 @@ Use Bloom filter for approximate membership. **Rejected** because false positive
    - Simple change, no behavior difference
    - Measure improvement
 
-2. **Phase 2**: Add single-column fast path (Option 2)
-   - Requires detecting projection column types
+2. **Phase 2**: Add single-symbol fast path (Option 2)
+   - Requires detecting projection symbol types
    - Only if Phase 1 shows insufficient improvement
 
 3. **Phase 3**: Adaptive strategy (Option 3)

--- a/docs/proposals/dataflow-symbol-analysis.md
+++ b/docs/proposals/dataflow-symbol-analysis.md
@@ -11,7 +11,7 @@ This model breaks down for OR clauses with fallback semantics because:
 2. The planner can't distinguish between internal join variables and correlation variables
 3. OR clauses are analyzed in isolation, without context of the surrounding query
 
-**Result**: The planner incorrectly reorders OR clauses before patterns that should bind their correlation variables, breaking per-row fallback semantics.
+**Result**: The planner incorrectly reorders OR clauses before patterns that should bind their correlation variables, breaking per-tuple fallback semantics.
 
 ## Current Workaround
 

--- a/docs/reference/ARCHITECTURAL_PHILOSOPHY.md
+++ b/docs/reference/ARCHITECTURAL_PHILOSOPHY.md
@@ -56,7 +56,7 @@ Phase 2:
   Collapse() → joins on ?p
 
   Expression [(str ?name " works in " ?d) ?summary]
-  → adds column, might bridge disjoint groups
+  → adds symbol, might bridge disjoint groups
 ```
 
 ### The Key Differences
@@ -64,13 +64,13 @@ Phase 2:
 | Volcano | Janus |
 |---------|-------|
 | Plan tree fixed at compile time | Join order determined at runtime by `Collapse()` |
-| Operators statically linked | Relations are values, combined based on columns |
+| Operators statically linked | Relations are values, combined based on symbols |
 | Single pipeline | Multiple disjoint groups that might merge later |
-| Plan knows the shape | Shape emerges from what columns exist |
+| Plan knows the shape | Shape emerges from what symbols exist |
 
 ### Dynamic Bridging
 
-Expressions can create join columns that bridge previously disjoint groups:
+Expressions can create join symbols that bridge previously disjoint groups:
 
 ```
 Group 1: {?x, ?y}     Group 2: {?a, ?b}
@@ -84,7 +84,7 @@ Group 1: {?x, ?y, ?z}  Group 2: {?a, ?b, ?z}
               Collapse() joins them
 ```
 
-This isn't Volcano. Volcano doesn't rewire the plan based on what columns emerge from expressions.
+This isn't Volcano. Volcano doesn't rewire the plan based on what symbols emerge from expressions.
 
 **The characterization:** Schema-driven dataflow with Volcano-style iterators.
 
@@ -119,7 +119,7 @@ This isn't Volcano. Volcano doesn't rewire the plan based on what columns emerge
 | Pattern with 1 constant | 200 | Some filtering |
 | Pattern with 2 bound vars | 120 | Join only, no filtering |
 | OR clause | 80 | Data source but less predictable |
-| Expression producing symbol | 10 | Computed column |
+| Expression producing symbol | 10 | Computed symbol |
 | Filter predicate | 5 | Just filters |
 | NOT clause | 2 | Filters last |
 
@@ -131,7 +131,7 @@ This isn't Volcano. Volcano doesn't rewire the plan based on what columns emerge
 |----------------|---------|-------------------|
 | **When** | Before execution | During execution |
 | **Decides** | Which clauses can execute together | How to combine results |
-| **Based on** | Symbol dependencies (static) | Actual column overlap (dynamic) |
+| **Based on** | Symbol dependencies (static) | Actual symbol overlap (dynamic) |
 | **Join order** | No | Yes |
 | **Selectivity** | Orders clauses within phase | N/A |
 
@@ -139,7 +139,7 @@ This isn't Volcano. Volcano doesn't rewire the plan based on what columns emerge
 
 Traditional query planners do more work at plan time. Janus deliberately defers join ordering to runtime, which means:
 - Less optimization opportunity (no cost-based planning)
-- More flexibility (handles dynamic schemas, expressions that create join columns)
+- More flexibility (handles dynamic schemas, expressions that create join symbols)
 - Simpler planner (just dependency analysis + selectivity ordering)
 
 **The trade-off:** Simplicity over optimization. The planner ensures you start with small result sets. `Collapse()` handles the mechanical joining.
@@ -355,7 +355,7 @@ This is **premature documentation** instead of premature optimization - write do
 | Index attributes (`:skill/0`, `:skill/1`) | Renumber on insert |
 | Separate entity per element | N+1 queries, entity explosion |
 | Different database for vectors | Two databases, no joins |
-| Blob column | Complete surrender |
+| Blob symbol | Complete surrender |
 
 ### The Rabbit Hole
 

--- a/docs/reference/KEY_ENCODING_AND_CRDT.md
+++ b/docs/reference/KEY_ENCODING_AND_CRDT.md
@@ -28,7 +28,7 @@ Janus treats it as an **indexing problem**: "How do we structure keys so CRDT re
 
 **The key insight: The key IS the value.**
 
-In traditional databases, keys point to data stored elsewhere. In Janus, the key contains the complete datom: `[E][A][V][Tx][Op]`. There's no pointer chasing, no separate row fetch. Every index is a covering index by default. This is why CRDT resolution can be O(1) - the answer is in the key itself, not behind a pointer.
+In traditional databases, keys point to data stored elsewhere. In Janus, the key contains the complete datom: `[E][A][V][Tx][Op]`. There's no pointer chasing, no separate tuple fetch. Every index is a covering index by default. This is why CRDT resolution can be O(1) - the answer is in the key itself, not behind a pointer.
 
 The result:
 - **O(1) LWW resolution** even without caching (965ns to resolve current value when 1000 historical versions exist)
@@ -150,7 +150,7 @@ This is perhaps the most fundamental design insight in Janus, and it's easy to m
 ### Traditional Database Model
 
 ```
-Index Key → Pointer → Row/Document → Extract Field
+Index Key → Pointer → Tuple/Document → Extract Field
 ```
 
 In a traditional database:
@@ -173,10 +173,10 @@ In Janus:
 
 | Aspect | Traditional | Janus |
 |--------|-------------|-------|
-| Read one datom | Key lookup + row fetch | Key lookup only |
+| Read one datom | Key lookup + tuple fetch | Key lookup only |
 | Index overhead | Keys + pointers + separate data | Just keys (which ARE data) |
 | Covering index | Special optimization | Default for ALL indices |
-| Range scan | Fetch keys, then fetch each row | Scan keys, done |
+| Range scan | Fetch keys, then fetch each tuple | Scan keys, done |
 
 ### The CRDT Connection
 
@@ -198,7 +198,7 @@ There's no step 2-3. The key's sort order IS the resolution, and the key contain
 
 The seven indices aren't "7× overhead pointing to data stored elsewhere."
 
-Each index IS a complete copy of the data in a different sort order. There's no separate "row store" being indexed. The storage cost is:
+Each index IS a complete copy of the data in a different sort order. There's no separate "tuple store" being indexed. The storage cost is:
 
 ```
 7 indices × datom size = total storage
@@ -207,7 +207,7 @@ Each index IS a complete copy of the data in a different sort order. There's no 
 Not:
 
 ```
-1 row store + 6 indices pointing to it = total storage
+1 tuple store + 6 indices pointing to it = total storage
 ```
 
 This is more like 7 different sort orders of the same data than 7 indices plus a base table. The mental model from relational databases ("indices are overhead on top of tables") doesn't apply.
@@ -919,7 +919,7 @@ Most databases ask "how do we index our data?" Janus asks "what if the index IS 
 
 Most CRDT systems require loading and reconstructing documents to access data. Janus's key encoding makes CRDT resolution a property of the index structure itself:
 
-- **The key contains the complete datom** - no pointer chasing, no separate row fetch
+- **The key contains the complete datom** - no pointer chasing, no separate tuple fetch
 - **LWW**: Seek + read first key = current value is IN the key (O(1) in practice)
 - **Sets**: Scan keys grouped by value + add-wins comparison
 - **Vectors**: Load keys + RGA graph traversal

--- a/docs/reference/OR_FALLBACK_SEMANTICS.md
+++ b/docs/reference/OR_FALLBACK_SEMANTICS.md
@@ -21,7 +21,7 @@ Consider a scenario where you want to count tasks but return 0 when none exist:
    $ ?scenario) [[?count]]]
 ```
 
-When no matching tasks exist, this subquery returns empty (no rows), causing the outer query row to be excluded entirely.
+When no matching tasks exist, this subquery returns empty (no tuples), causing the outer query tuple to be excluded entirely.
 
 With OR fallback semantics, you can provide a default:
 
@@ -44,7 +44,7 @@ When all branches contain only patterns, standard Datalog union semantics apply:
     [?e :user/premium true])
 ```
 
-Both branches execute, and results are merged (deduplicated on common columns).
+Both branches execute, and results are merged (deduplicated on common symbols).
 
 ### OR with Expressions (Fallback Semantics)
 

--- a/docs/reference/QUERY_BUILDER.md
+++ b/docs/reference/QUERY_BUILDER.md
@@ -278,7 +278,7 @@ Equivalent EDN: `[(get-else $ ?e :person/nickname "Anonymous") ?nickname]`
 
 ### Missing - Check Attribute Absence
 
-**As a predicate** (filter rows where attribute is missing):
+**As a predicate** (filter tuples where attribute is missing):
 
 ```go
 q := qb.Query().
@@ -347,10 +347,10 @@ qb.Scalar(nameVar)
 // Collection input - iterate over values
 qb.Collection(nameVar)
 
-// Tuple input - single row of values
+// Tuple input - single tuple of values
 qb.Tuple(nameVar, ageVar)
 
-// Relation input - multiple rows
+// Relation input - multiple tuples
 qb.Relation(nameVar, ageVar)
 
 // Named source - additional database or PatternMatcher
@@ -541,9 +541,9 @@ q := qb.Query().
 ```
 
 Binding forms:
-- `BindTuple(vars...)` - single row result `[[?a ?b]]`
-- `BindRelation(vars...)` - multiple rows `[[?a ?b] ...]`
-- `BindCollection(v)` - single column `[?a ...]`
+- `BindTuple(vars...)` - single tuple result `[[?a ?b]]`
+- `BindRelation(vars...)` - multiple tuples `[[?a ?b] ...]`
+- `BindCollection(v)` - single symbol `[?a ...]`
 
 ### Variable Scoping in Subqueries
 
@@ -834,8 +834,8 @@ func main() {
         panic(err)
     }
 
-    for _, row := range results {
-        fmt.Printf("%s (%d) - %s\n", row[0], row[1], row[2])
+    for _, tuple := range results {
+        fmt.Printf("%s (%d) - %s\n", tuple[0], tuple[1], tuple[2])
     }
 }
 ```

--- a/docs/reference/QUERY_INTO.md
+++ b/docs/reference/QUERY_INTO.md
@@ -10,14 +10,14 @@ The QueryInto API eliminates manual tuple iteration by populating typed Go value
 - **`QueryOneInto()`** - Query into a single struct or scalar (expects at most one result)
 
 Both APIs support:
-- **Structs** for multi-column queries (map columns to fields via tags)
-- **Scalars** for single-column queries (`string`, `int64`, `float64`, `bool`, `time.Time`, `Identity`, `Keyword`, `[]byte`)
+- **Structs** for multi-symbol queries (map symbols to fields via tags)
+- **Scalars** for single-symbol queries (`string`, `int64`, `float64`, `bool`, `time.Time`, `Identity`, `Keyword`, `[]byte`)
 
 ## Basic Usage
 
 ### Define Result Struct
 
-Use the `datalog` tag to map struct fields to query columns:
+Use the `datalog` tag to map struct fields to query symbols:
 
 ```go
 type PersonResult struct {
@@ -59,9 +59,9 @@ if !found {
 }
 ```
 
-### Scalar Queries (Single Column)
+### Scalar Queries (Single Symbol)
 
-For single-column queries, use scalar slices or values directly without structs:
+For single-symbol queries, use scalar slices or values directly without structs:
 
 ```go
 // Get all names as []string
@@ -89,7 +89,7 @@ found, err := d.QueryOneInto(&age, `
 
 Supported scalar types: `string`, `int64`, `int`, `float64`, `bool`, `time.Time`, `datalog.Identity`, `datalog.Keyword`, `[]byte`
 
-**Note:** Scalar queries require exactly one column in the `:find` clause. Multi-column queries require a struct.
+**Note:** Scalar queries require exactly one symbol in the `:find` clause. Multi-symbol queries require a struct.
 
 ## Tag Mapping
 
@@ -131,12 +131,12 @@ If no fields have `datalog` tags, positional mapping is used:
 
 ```go
 type PositionalResult struct {
-    Name string  // maps to column 0
-    Age  int64   // maps to column 1
+    Name string  // maps to symbol 0
+    Age  int64   // maps to symbol 1
 }
 
 // Query: [:find ?name ?age :where ...]
-// Column 0 (?name) -> Name, Column 1 (?age) -> Age
+// Symbol 0 (?name) -> Name, Symbol 1 (?age) -> Age
 ```
 
 **Note:** Mixing tagged and untagged fields in the same struct is an error.
@@ -206,7 +206,7 @@ if errors.Is(err, dlreflect.ErrSymbolNotFound) {
 
 ## Aggregates on Empty Result Sets
 
-**Important:** Following Datomic semantics, aggregate functions over empty result sets return an empty result, not a row with default values.
+**Important:** Following Datomic semantics, aggregate functions over empty result sets return an empty result, not a tuple with default values.
 
 ```go
 // If no entities match the where clause, found=false (not an error)
@@ -390,7 +390,7 @@ err := d.QueryInto(&people, `[:find ?name ?age :where ...]`)
 | API | Purpose | Use Case |
 |-----|---------|----------|
 | `QueryInto` | Query results → struct slice | Typed query results |
-| `QueryOneInto` | Query results → single struct | Single-row queries |
+| `QueryOneInto` | Query results → single struct | Single-tuple queries |
 | `PullInto` | Entity → struct | Load entity by ID |
 | `Query` | Query → `[][]interface{}` | Dynamic/untyped results |
 

--- a/docs/reviews/PLANNER_AS_CAS_2025_01.md
+++ b/docs/reviews/PLANNER_AS_CAS_2025_01.md
@@ -513,7 +513,7 @@ Cost-based optimizers (PostgreSQL, Oracle) use statistics:
 ```sql
 -- PostgreSQL estimates cardinality from histograms
 SELECT * FROM users WHERE age > 25;
--- Estimates: 50,000 rows (from pg_stats)
+-- Estimates: 50,000 tuples (from pg_stats)
 ```
 
 This requires:
@@ -682,7 +682,7 @@ Because plans are deterministic (no statistics dependencies), caching is highly 
 The planner cannot predict intermediate result sizes:
 
 ```datalog
-:where [?e :person/name ?name]  # Could return 1 or 1,000,000 rows
+:where [?e :person/name ?name]  # Could return 1 or 1,000,000 tuples
        [?e :person/age ?age]
 ```
 
@@ -699,7 +699,7 @@ Entity grouping assumes patterns sharing entity variables join efficiently. This
 
 ### 3. No Adaptive Optimization
 
-Plans don't adapt based on execution feedback. If a pattern unexpectedly returns millions of rows, the plan doesn't adjust.
+Plans don't adapt based on execution feedback. If a pattern unexpectedly returns millions of tuples, the plan doesn't adjust.
 
 ### 4. Limited to Pattern Structure
 

--- a/docs/reviews/RELATIONAL_ALGEBRA_REVIEW_2025_01.md
+++ b/docs/reviews/RELATIONAL_ALGEBRA_REVIEW_2025_01.md
@@ -102,7 +102,7 @@ func (rs Relations) Collapse(ctx Context) Relations {
         currentGroup := remaining[0]  // Start with first relation
         remaining = remaining[1:]
 
-        // Keep joining relations that share columns
+        // Keep joining relations that share symbols
         changed := true
         for changed {
             changed = false
@@ -123,7 +123,7 @@ func (rs Relations) Collapse(ctx Context) Relations {
 
 ### Complexity Analysis
 
-**Best case (all relations share columns):** O(n) - each relation joins exactly once
+**Best case (all relations share symbols):** O(n) - each relation joins exactly once
 
 **Worst case (all disjoint):** O(n²) - checks every pair
 
@@ -169,7 +169,7 @@ func (rs Relations) Collapse(ctx Context) Relations {
 **1. hasSharedColumns is O(cols1 × cols2)**
 
 Could use a map for O(cols1 + cols2), but:
-- Typical column count: 2-5
+- Typical symbol count: 2-5
 - 10-25 comparisons (pointer equality, ~5ns each)
 - Map allocation overhead > savings at this scale
 
@@ -185,7 +185,7 @@ Could swap-with-last for O(1), but:
 
 **3. Repeated checking of disjoint relations**
 
-After joining, loop restarts and re-checks all relations, including ones that don't share columns.
+After joining, loop restarts and re-checks all relations, including ones that don't share symbols.
 
 **Example pathology:**
 ```
@@ -193,7 +193,7 @@ currentGroup = R1(?x, ?y)
 remaining = [R2(?a, ?b), R3(?y, ?z)]
 
 First pass:
-- Check R2: no shared columns
+- Check R2: no shared symbols
 - Check R3: shares ?y, JOIN
 
 After join:
@@ -201,7 +201,7 @@ After join:
 - remaining = [R2(?a, ?b)]
 
 Second pass:
-- Check R2 again: still no shared columns (wasted work!)
+- Check R2 again: still no shared symbols (wasted work!)
 ```
 
 **When does this matter?**
@@ -226,7 +226,7 @@ For n completely disjoint relations:
 
 **Executor:**
 - Matches patterns → Relations
-- Collapses greedily based on shared columns
+- Collapses greedily based on shared symbols
 - Handles actual data
 
 **Interface:**
@@ -449,7 +449,7 @@ The buffer reuse and performance optimization are **implementation details** sup
 
 ### Low Priority (Nice to Have)
 
-6. **hasSharedColumns optimization** - Use map if column count typically >10 (need data)
+6. **hasSharedColumns optimization** - Use map if symbol count typically >10 (need data)
 7. **Adaptive collapse** - Track if repeated disjoint checks are actually happening
 8. **Benchmark collapse overhead** - Measure actual impact on real queries
 

--- a/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
+++ b/docs/wip/AETV_INDEX_AND_VALUE_ELIMINATION.md
@@ -280,7 +280,7 @@ func TestAETVSortOrder(t *testing.T) {
 
 ```go
 func TestIndexSelectionMatrix(t *testing.T) {
-    // Test all rows of the selection matrix
+    // Test all tuples of the selection matrix
     // Verify correct index is chosen for each scenario
 }
 

--- a/docs/wip/CONDITIONAL_AGGREGATE_REWRITING.md
+++ b/docs/wip/CONDITIONAL_AGGREGATE_REWRITING.md
@@ -122,7 +122,7 @@ Automatic query rewriting to transform correlated aggregate subqueries into cond
 
 **Symptoms**:
 - Query with `EnableConditionalAggregateRewriting: false` → Returns correct results
-- Same query with `EnableConditionalAggregateRewriting: true` → Returns 0 rows (empty result)
+- Same query with `EnableConditionalAggregateRewriting: true` → Returns 0 tuples (empty result)
 - No error thrown - query executes but produces empty results
 
 **Evidence**:

--- a/docs/wip/DECORRELATION_NEW_EXECUTOR_PLAN.md
+++ b/docs/wip/DECORRELATION_NEW_EXECUTOR_PLAN.md
@@ -188,13 +188,13 @@ func distributeBatchResults(
     inputCombinations []map[query.Symbol]interface{},
 ) map[int]Relation {
 
-    // The batch result contains columns:
+    // The batch result contains symbols:
     // [correlation_vars..., agg_result_1, agg_result_2, ..., agg_result_N]
 
     // For each subquery:
     results := make(map[int]Relation)
     for i, subqIdx := range subqueryIndices {
-        // Extract just the columns for this subquery
+        // Extract just the symbols for this subquery
         // Join back with correlation variables for binding
         results[subqIdx] = extractSubqueryResults(batchResult, i)
     }
@@ -240,11 +240,11 @@ Execute pattern clauses → groups = [tuples with ?s, ?year, ?hour]
   │
   ├─ Execute ONCE with all 870 combinations as RelationInput
   │    │
-  │    └─ Batch query returns: [?s ?year ?hour ?high ?low] with 870 rows
+  │    └─ Batch query returns: [?s ?year ?hour ?high ?low] with 870 tuples
   │
   └─ Distribute results:
-       ├─ SubQ1 gets ?high column
-       └─ SubQ2 gets ?low column
+       ├─ SubQ1 gets ?high symbol
+       └─ SubQ2 gets ?low symbol
 
 Total subquery executions: 1 (batch with 2 aggregations)
 ```

--- a/docs/wip/GO_FUNCTIONS_AND_RULES.md
+++ b/docs/wip/GO_FUNCTIONS_AND_RULES.md
@@ -347,10 +347,10 @@ func (r *CompiledRule) Fire(db *Database) *Transaction {
     // Create transaction
     tx := db.NewTransaction()
 
-    // For each result row, apply effects with bound values
-    for _, row := range results {
+    // For each result tuple, apply effects with bound values
+    for _, tuple := range results {
         for _, effect := range r.effects {
-            effect.apply(tx, row)
+            effect.apply(tx, tuple)
         }
     }
 

--- a/docs/wip/OR_CLAUSE_EXECUTION_ANALYSIS.md
+++ b/docs/wip/OR_CLAUSE_EXECUTION_ANALYSIS.md
@@ -71,7 +71,7 @@ In `applyExpressionsAndPredicates`, OR clauses execute first:
 
 ```go
 // lines 32-40
-groups := relations  // Pattern results: 3 tuples with columns [?t, ?type]
+groups := relations  // Pattern results: 3 tuples with symbols [?t, ?type]
 
 for _, orClause := range phase.OrClauses {
     orResult, err := e.executeOrClause(ctx, orClause, groups)
@@ -92,16 +92,16 @@ func (e *Executor) executeOrClause(ctx Context, clause *query.OrClause, availabl
         // CRITICAL: Branches execute with nil binding (not constrained by available)
         branchResult, err := e.executeInnerClauses(ctx, branch, nil)
 
-        // Track common columns across branches
+        // Track common symbols across branches
         if i == 0 {
-            commonCols = branchResult.Columns()
+            commonCols = branchResult.Symbols()
         } else {
-            commonCols = intersect(commonCols, branchResult.Columns())
+            commonCols = intersect(commonCols, branchResult.Symbols())
         }
         branchResults = append(branchResults, branchResult)
     }
 
-    // Union all branch results, projecting to common columns
+    // Union all branch results, projecting to common symbols
     return unionRelations(branchResults, commonCols, e.options), nil
 }
 ```
@@ -136,14 +136,14 @@ When `bindings` is nil or empty:
 ```go
 // Match (lines 55-58)
 if bindings == nil || len(bindings) == 0 {
-    return m.matchUnboundAsRelation(pattern, columns, constraints)
+    return m.matchUnboundAsRelation(pattern, symbols, constraints)
 }
 ```
 
 This scans the database directly:
 - Chooses index based on bound pattern elements (AVET for A+V bound)
 - Returns all matching datoms as a streaming relation
-- Columns come from `pattern.ExtractColumns()` (only variables)
+- Symbols come from `pattern.ExtractColumns()` (only variables)
 
 ### 8. Relation Collapse/Join (`datalog/executor/relations.go`)
 
@@ -169,7 +169,7 @@ func (rs Relations) Collapse(ctx Context) Relations {
 
 The join is implemented as a hash join:
 
-1. **Determine common columns** (line 1181-1195 in relation.go)
+1. **Determine common symbols** (line 1181-1195 in relation.go)
 2. **Choose build vs probe relation** (lines 205-258):
    - If left is streaming and right is materialized, right becomes build
    - OR result (MaterializedRelation) becomes build side
@@ -183,10 +183,10 @@ The join is implemented as a hash join:
 
 ### Expected for Query with OR:
 
-1. Patterns produce: `[(task1, :type/a), (task2, :type/b), (task3, :type/c)]` with columns `[?t, ?type]`
-2. OR branch 1 `[?t :task/type :type/a]` produces: `[(task1)]` with columns `[?t]`
-3. OR branch 2 `[?t :task/type :type/b]` produces: `[(task2)]` with columns `[?t]`
-4. OR union: `[(task1), (task2)]` with columns `[?t]`
+1. Patterns produce: `[(task1, :type/a), (task2, :type/b), (task3, :type/c)]` with symbols `[?t, ?type]`
+2. OR branch 1 `[?t :task/type :type/a]` produces: `[(task1)]` with symbols `[?t]`
+3. OR branch 2 `[?t :task/type :type/b]` produces: `[(task2)]` with symbols `[?t]`
+4. OR union: `[(task1), (task2)]` with symbols `[?t]`
 5. Join on `?t`: `[(task1, :type/a), (task2, :type/b)]` - **2 tuples**
 
 ### Actual Result:

--- a/docs/wip/PHASE_AS_QUERY_ARCHITECTURE.md
+++ b/docs/wip/PHASE_AS_QUERY_ARCHITECTURE.md
@@ -103,7 +103,7 @@ func executePhase(phase *Phase) Relation {
         rel = executeSubquery(subq, rel)
     }
 
-    // 6. Project to Keep columns
+    // 6. Project to Keep symbols
     return rel.Project(phase.Keep)
 }
 ```
@@ -128,11 +128,11 @@ func executePhase(phase *Phase) Relation {
 
 4. **Fixed execution order limits optimization**:
    ```datalog
-   [?e :event/value ?value]      ; 1M rows
-   [(* ?value 2) ?doubled]       ; Expression computes on 1M rows
-   [(> ?value 100)]              ; Predicate filters to 1K rows
+   [?e :event/value ?value]      ; 1M tuples
+   [(* ?value 2) ?doubled]       ; Expression computes on 1M tuples
+   [(> ?value 100)]              ; Predicate filters to 1K tuples
    ```
-   We compute on 1M rows, then filter. Optimal: filter first, compute on 1K.
+   We compute on 1M tuples, then filter. Optimal: filter first, compute on 1K.
 
 ## Clojure Reference Architecture
 
@@ -418,7 +418,7 @@ func (e *Executor) executePhase(ctx Context, phase *Phase, input Relation) (Rela
         return nil, err
     }
 
-    // Project to Keep columns
+    // Project to Keep symbols
     if len(phase.Keep) > 0 {
         return result.Project(phase.Keep)
     }
@@ -562,7 +562,7 @@ func (e *Executor) executePhase(ctx Context, phase *Phase, input Relation) (Rela
         return nil, err
     }
 
-    // Project to Keep columns (if specified)
+    // Project to Keep symbols (if specified)
     if len(phase.Keep) > 0 {
         return result.Project(phase.Keep)
     }
@@ -632,7 +632,7 @@ func (p *Planner) generateQueryForGroup(group PatternGroup) *query.Query {
     // Generate :in clause if needed (for non-first phases)
     var in []query.Input
     if len(group.Available) > 0 {
-        // Input is a relation with Available columns
+        // Input is a relation with Available symbols
         in = append(in, query.DatabaseInput{})
         in = append(in, query.RelationInput{Symbols: group.Available})
     }
@@ -731,14 +731,14 @@ Same pattern, different scores based on context!
 
 **Current**: Fixed order (patterns → expressions → predicates → subqueries)
 ```datalog
-[?e :event/value ?value]      ; 1M rows
+[?e :event/value ?value]      ; 1M tuples
 [(* ?value 2) ?doubled]       ; Compute on 1M
 [(> ?value 100)]              ; Filter to 1K
 ```
 
 **Proposed**: Optimizer can reorder based on selectivity
 ```datalog
-[?e :event/value ?value]      ; 1M rows
+[?e :event/value ?value]      ; 1M tuples
 [(> ?value 100)]              ; Filter to 1K first!
 [(* ?value 2) ?doubled]       ; Compute on 1K
 ```
@@ -950,7 +950,7 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan) (Rel
             return nil, fmt.Errorf("phase %d failed: %w", phaseIndex+1, err)
         }
 
-        // Project each group to Keep columns (what passes to next phase)
+        // Project each group to Keep symbols (what passes to next phase)
         if len(phase.Keep) > 0 {
             for i, group := range groups {
                 projected, err := group.Project(phase.Keep)
@@ -986,7 +986,7 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan) (Rel
 
 1. **Multi-Relation Semantics**: QueryExecutor returns `[]Relation` to handle disjoint relation groups
 2. **Progressive Collapse**: After each clause, append new relation and collapse (joins sharing symbols, preserves disjoint)
-3. **Phase Boundaries**: Multiple groups can flow between phases, projected to Keep columns
+3. **Phase Boundaries**: Multiple groups can flow between phases, projected to Keep symbols
 4. **Final Phase Validation**: Error if final phase has multiple disjoint groups (prevents Cartesian products)
 5. **Clause Execution**: Stubbed for future implementation (pattern, expression, predicate, subquery handlers)
 

--- a/docs/wip/QUERY_EXECUTOR_FEATURE_GAPS.md
+++ b/docs/wip/QUERY_EXECUTOR_FEATURE_GAPS.md
@@ -55,8 +55,8 @@ The QueryExecutor (clause-based execution) now has feature parity for all critic
 - `executor.go:executeRealizedNonIterating()` - Core QueryExecutor path per tuple
 
 **Parity Tests**: `TestRelationInputDualExecutorParity` in `dual_executor_test.go`
-- Simple RelationInput with two columns
-- Single column RelationInput
+- Simple RelationInput with two symbols
+- Single symbol RelationInput
 - RelationInput with no aggregation
 - RelationInput with predicate filter
 - Empty RelationInput
@@ -133,7 +133,7 @@ The QueryExecutor (clause-based execution) now has feature parity for all critic
 
 **QueryExecutor Gap**:
 - Projects directly to find symbols without checking input parameters
-- Missing columns cause projection errors
+- Missing symbols cause projection errors
 
 **Impact**: Rare edge case - queries where input parameters only appear in `:find` (not in patterns) may fail.
 
@@ -149,11 +149,11 @@ The QueryExecutor (clause-based execution) now has feature parity for all critic
 
 **QueryExecutor**: May not handle expression-only phases correctly. Needs verification with conditional aggregate rewriting tests.
 
-### Aggregate Required Columns Tracking
+### Aggregate Required Symbols Tracking
 
-**Legacy**: Reads `"aggregate_required_columns"` from metadata to prevent dropping columns needed for aggregation.
+**Legacy**: Reads `"aggregate_required_columns"` from metadata to prevent dropping symbols needed for aggregation.
 
-**QueryExecutor**: May eliminate columns prematurely. Lower risk since aggregation tests pass.
+**QueryExecutor**: May eliminate symbols prematurely. Lower risk since aggregation tests pass.
 
 ### Disjoint Relation Group Handling
 

--- a/docs/wip/REQUIRES_COPY_ANALYSIS.md
+++ b/docs/wip/REQUIRES_COPY_ANALYSIS.md
@@ -66,16 +66,16 @@ Add `requiresCopy bool` field to `StreamingRelation`:
 
 ```go
 type StreamingRelation struct {
-    columns      []query.Symbol
+    symbols      []query.Symbol
     iterator     Iterator
     options      ExecutorOptions
     requiresCopy bool  // NEW: set at construction
     // ...
 }
 
-func NewStreamingRelationWithOptions(columns []query.Symbol, iterator Iterator, opts ExecutorOptions, requiresCopy bool) *StreamingRelation {
+func NewStreamingRelationWithOptions(symbols []query.Symbol, iterator Iterator, opts ExecutorOptions, requiresCopy bool) *StreamingRelation {
     return &StreamingRelation{
-        columns:      columns,
+        symbols:      symbols,
         iterator:     iterator,
         options:      opts,
         requiresCopy: requiresCopy,

--- a/docs/wip/SUBQUERY_COMPONENTIZATION_PLAN.md
+++ b/docs/wip/SUBQUERY_COMPONENTIZATION_PLAN.md
@@ -144,18 +144,18 @@ func (b *SubqueryBatcher) BuildBatchedInput(
 	}
 
 	// Filter to only the symbols we're passing (exclude $)
-	var columns []query.Symbol
+	var symbols []query.Symbol
 	for _, sym := range inputSymbols {
 		if sym != "$" {
-			columns = append(columns, sym)
+			symbols = append(symbols, sym)
 		}
 	}
 
 	// Build tuples from all combinations
 	var tuples []Tuple
 	for _, values := range combinations {
-		tuple := make(Tuple, len(columns))
-		for i, col := range columns {
+		tuple := make(Tuple, len(symbols))
+		for i, col := range symbols {
 			if val, ok := values[col]; ok {
 				tuple[i] = val
 			}
@@ -163,7 +163,7 @@ func (b *SubqueryBatcher) BuildBatchedInput(
 		tuples = append(tuples, tuple)
 	}
 
-	return NewMaterializedRelation(columns, tuples)
+	return NewMaterializedRelation(symbols, tuples)
 }
 
 // ExtractInputSymbols extracts variable symbols from subquery inputs (excludes $ and constants)
@@ -331,7 +331,7 @@ func (s *StreamingUnionBuilder) Union(relations []Relation) Relation {
 
 // unionStreaming creates a streaming union via channel
 func (s *StreamingUnionBuilder) unionStreaming(relations []Relation) Relation {
-	columns := relations[0].Columns()
+	symbols := relations[0].Symbols()
 
 	// Create channel for streaming
 	unionChan := make(chan relationItem, 1)
@@ -343,12 +343,12 @@ func (s *StreamingUnionBuilder) unionStreaming(relations []Relation) Relation {
 		}
 	}()
 
-	return NewUnionRelation(unionChan, columns, s.opts)
+	return NewUnionRelation(unionChan, symbols, s.opts)
 }
 
 // unionMaterialized combines all relations by materializing
 func (s *StreamingUnionBuilder) unionMaterialized(relations []Relation) Relation {
-	columns := relations[0].Columns()
+	symbols := relations[0].Symbols()
 	var allTuples []Tuple
 
 	for _, rel := range relations {
@@ -359,7 +359,7 @@ func (s *StreamingUnionBuilder) unionMaterialized(relations []Relation) Relation
 		}
 	}
 
-	return NewMaterializedRelation(columns, allTuples)
+	return NewMaterializedRelation(symbols, allTuples)
 }
 ```
 

--- a/docs/wip/SUBQUERY_MATERIALIZATION_FIX.md
+++ b/docs/wip/SUBQUERY_MATERIALIZATION_FIX.md
@@ -47,7 +47,7 @@ func combineSubqueryResults(allResults []Relation, ...) {
         it.Close()
     }
 
-    return NewMaterializedRelation(columns, allTuples)  // ← Giant materialized relation
+    return NewMaterializedRelation(symbols, allTuples)  // ← Giant materialized relation
 }
 ```
 
@@ -171,7 +171,7 @@ type SubqueryUnion struct {
     executor          *Executor
     subqPlan          planner.SubqueryPlan
     inputCombinations []map[query.Symbol]interface{}
-    columns           []query.Symbol
+    symbols           []query.Symbol
 }
 
 func NewSubqueryUnion(
@@ -179,19 +179,19 @@ func NewSubqueryUnion(
     subqPlan planner.SubqueryPlan,
     inputCombinations []map[query.Symbol]interface{},
 ) *SubqueryUnion {
-    // Get columns from binding
-    columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+    // Get symbols from binding
+    symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
 
     return &SubqueryUnion{
         executor:          executor,
         subqPlan:          subqPlan,
         inputCombinations: inputCombinations,
-        columns:           columns,
+        symbols:           symbols,
     }
 }
 
-func (s *SubqueryUnion) Columns() []query.Symbol {
-    return s.columns
+func (s *SubqueryUnion) Symbols() []query.Symbol {
+    return s.symbols
 }
 
 func (s *SubqueryUnion) Iterator() Iterator {
@@ -326,8 +326,8 @@ func executeSubquerySequential(...) (Relation, error) {
 
     if accumulator == nil {
         // Return empty relation
-        columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
-        return NewMaterializedRelation(columns, []Tuple{}), nil
+        symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+        return NewMaterializedRelation(symbols, []Tuple{}), nil
     }
 
     return accumulator, nil
@@ -374,8 +374,8 @@ func executeSubquerySequential(...) (Relation, error) {
     }
 
     if len(batches) == 0 {
-        columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
-        return NewMaterializedRelation(columns, []Tuple{}), nil
+        symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+        return NewMaterializedRelation(symbols, []Tuple{}), nil
     }
 
     if len(batches) == 1 {
@@ -394,12 +394,12 @@ Create a dedicated streaming combiner that never holds all relations:
 ```go
 // StreamingUnionRelation builds union progressively without holding all input relations
 type StreamingUnionRelation struct {
-    columns []query.Symbol
+    symbols []query.Symbol
     tuples  []Tuple  // Accumulated so far
 }
 
 func executeSubquerySequential(...) (Relation, error) {
-    var columns []query.Symbol
+    var symbols []query.Symbol
     var tuples []Tuple
 
     for _, inputValues := range inputCombinations {
@@ -413,9 +413,9 @@ func executeSubquerySequential(...) (Relation, error) {
             return nil, err
         }
 
-        // Extract columns from first non-empty result
-        if columns == nil && !boundResult.IsEmpty() {
-            columns = boundResult.Columns()
+        // Extract symbols from first non-empty result
+        if symbols == nil && !boundResult.IsEmpty() {
+            symbols = boundResult.Symbols()
         }
 
         // Stream tuples out and accumulate
@@ -428,11 +428,11 @@ func executeSubquerySequential(...) (Relation, error) {
         // ← boundResult can now be GC'd, we don't hold it
     }
 
-    if columns == nil {
-        columns = getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+    if symbols == nil {
+        symbols = getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
     }
 
-    return NewMaterializedRelation(columns, tuples), nil
+    return NewMaterializedRelation(symbols, tuples), nil
 }
 ```
 
@@ -451,8 +451,8 @@ func combineSubqueryResults(allResults []Relation, subqPlan planner.SubqueryPlan
     }
 
     if len(validResults) == 0 {
-        columns := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
-        return NewMaterializedRelation(columns, []Tuple{}), nil
+        symbols := getBindingColumns(subqPlan.Subquery.Binding, subqPlan.Inputs)
+        return NewMaterializedRelation(symbols, []Tuple{}), nil
     }
 
     if len(validResults) == 1 {

--- a/examples/README.md
+++ b/examples/README.md
@@ -158,7 +158,7 @@ Compute aggregate statistics across groups of data.
 
 ### Level 4: Advanced Features
 
-Tackle complex queries with subqueries, time-based queries, and multi-row relations.
+Tackle complex queries with subqueries, time-based queries, and multi-tuple relations.
 
 #### `subquery_simple_demo.go`
 **What it demonstrates:** Basic subqueries
@@ -190,16 +190,16 @@ Sophisticated subquery usage with multiple subqueries and bindings.
 
 Calculate stock market OHLC prices using subqueries - a complete real-world example.
 
-#### `multi_row_relation_demo.go`
-**What it demonstrates:** Multi-row relation binding
+#### `multi_tuple_relation_demo.go`
+**What it demonstrates:** Multi-tuple relation binding
 **Concepts:** Relations as inputs, filtering with relation sets, batch operations
 **Time:** 15 minutes
 
 Pass multiple tuples into patterns for efficient batch filtering.
 
-#### `proof_multi_row_relations.go`
+#### `proof_multi_tuple_relations.go`
 **What it demonstrates:** Relation-based filtering mechanics
-**Concepts:** How Relations constrain pattern matches, multi-column binding
+**Concepts:** How Relations constrain pattern matches, multi-symbol binding
 **Time:** 10 minutes
 
 Proof-of-concept showing how the Relations API filters pattern matches.
@@ -341,8 +341,8 @@ Complete integration showing real-world financial market data queries.
 - `financial_asof_demo.go` - Point-in-time queries
 
 ### Relations
-- `multi_row_relation_demo.go` - Multi-row binding
-- `proof_multi_row_relations.go` - Relation mechanics
+- `multi_tuple_relation_demo.go` - Multi-tuple binding
+- `proof_multi_tuple_relations.go` - Relation mechanics
 
 ### Performance
 - `planner_demo.go` - Query planning

--- a/examples/annotations_demo.go
+++ b/examples/annotations_demo.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	fmt.Println("=== Multi-Row Relations with Annotations Demo ===\n")
+	fmt.Println("=== Multi-Tuple Relations with Annotations Demo ===\n")
 
 	// Create a database
 	db, err := storage.NewDatabase("/tmp/annotations_demo")
@@ -70,10 +70,10 @@ func main() {
 	baseMatcher := storage.NewBadgerMatcher(db.Store())
 	matcher := executor.WrapMatcher(baseMatcher, handler).(executor.PatternMatcher)
 
-	// Demo 1: Single-row binding (baseline)
-	fmt.Println("1. Single-row binding (traditional approach):")
+	// Demo 1: Single-tuple binding (baseline)
+	fmt.Println("1. Single-tuple binding (traditional approach):")
 	{
-		// Create a single-row relation
+		// Create a single-tuple relation
 		singleRel := executor.NewMaterializedRelation(
 			[]query.Symbol{"?stock"},
 			[]executor.Tuple{{stocks[0].id}}, // Just AAPL
@@ -95,10 +95,10 @@ func main() {
 		fmt.Printf("   Found %d result\n", results.Size())
 	}
 
-	// Demo 2: Multi-row single-column binding
-	fmt.Println("\n2. Multi-row single-column binding:")
+	// Demo 2: Multi-tuple single-symbol binding
+	fmt.Println("\n2. Multi-tuple single-symbol binding:")
 	{
-		// Create a multi-row relation with 5 stocks
+		// Create a multi-tuple relation with 5 stocks
 		var tuples []executor.Tuple
 		for i := 0; i < 5; i++ {
 			tuples = append(tuples, executor.Tuple{stocks[i].id})
@@ -121,11 +121,11 @@ func main() {
 		fmt.Printf("   Found %d results with one call\n", results.Size())
 	}
 
-	// Demo 3: Multi-row multi-column binding
-	fmt.Println("\n3. Multi-row multi-column binding:")
+	// Demo 3: Multi-tuple multi-symbol binding
+	fmt.Println("\n3. Multi-tuple multi-symbol binding:")
 	{
 		// Create a relation with stock-attribute pairs
-		multiColRel := executor.NewMaterializedRelation(
+		multiSymRel := executor.NewMaterializedRelation(
 			[]query.Symbol{"?s", "?attr"},
 			[]executor.Tuple{
 				{stocks[0].id, priceAttr},  // AAPL price
@@ -143,7 +143,7 @@ func main() {
 			},
 		}
 
-		results, err := matcher.Match(pattern, executor.Relations{multiColRel})
+		results, err := matcher.Match(pattern, executor.Relations{multiSymRel})
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -151,8 +151,8 @@ func main() {
 		fmt.Printf("   Found %d results for specific stock-attribute pairs\n", results.Size())
 	}
 
-	// Demo 4: Large multi-row binding
-	fmt.Println("\n4. Large multi-row binding (all stocks):")
+	// Demo 4: Large multi-tuple binding
+	fmt.Println("\n4. Large multi-tuple binding (all stocks):")
 	{
 		// Create a relation with all stocks
 		var allTuples []executor.Tuple
@@ -217,7 +217,7 @@ func main() {
 
 	fmt.Printf("Total operations: %d\n", totalEvents)
 	fmt.Printf("Multi-match operations: %d\n", multiMatchCount)
-	fmt.Printf("Efficiency gain: Using multi-row relations reduced API calls significantly\n")
+	fmt.Printf("Efficiency gain: Using multi-tuple relations reduced API calls significantly\n")
 
 	// Show the efficiency of multi-match
 	for _, event := range eventTypes["pattern/multi-match"] {
@@ -229,7 +229,7 @@ func main() {
 		fmt.Printf("  - %d bindings processed in ONE call\n", bindingCount)
 		fmt.Printf("  - %d total matches found\n", totalMatched)
 		fmt.Printf("  - %d unique results after deduplication\n", uniqueResults)
-		fmt.Printf("  - Without multi-row relations: %d separate API calls needed\n", bindingCount)
+		fmt.Printf("  - Without multi-tuple relations: %d separate API calls needed\n", bindingCount)
 	}
 
 	// Track events before empty relation test

--- a/examples/binding_demo.go
+++ b/examples/binding_demo.go
@@ -75,7 +75,7 @@ func main() {
 
 	// Test 2: Match with sym1 binding
 	fmt.Println("\nTest 2: Match with ?s bound to symbol-1")
-	// Create a single-row relation with the binding
+	// Create a single-tuple relation with the binding
 	rel := executor.NewMaterializedRelation([]query.Symbol{"?s"}, []executor.Tuple{{sym1}})
 	results, err = matcher.Match(pattern, []executor.Relation{rel})
 	if err != nil {
@@ -90,7 +90,7 @@ func main() {
 
 	// Test 3: Match with sym2 binding
 	fmt.Println("\nTest 3: Match with ?s bound to symbol-2")
-	// Create a single-row relation with the binding
+	// Create a single-tuple relation with the binding
 	rel = executor.NewMaterializedRelation([]query.Symbol{"?s"}, []executor.Tuple{{sym2}})
 	results, err = matcher.Match(pattern, []executor.Relation{rel})
 	if err != nil {

--- a/examples/expression_demo.go
+++ b/examples/expression_demo.go
@@ -27,21 +27,21 @@ func (m *MockMatcher) Match(pattern *query.DataPattern, bindings executor.Relati
 		}
 	}
 
-	// Extract pattern variables to determine columns
-	var columns []query.Symbol
+	// Extract pattern variables to determine symbols
+	var symbols []query.Symbol
 	if e := pattern.GetE(); e != nil && e.IsVariable() {
 		if v, ok := e.(*query.Variable); ok {
-			columns = append(columns, v.Name)
+			symbols = append(symbols, v.Name)
 		}
 	}
 	if a := pattern.GetA(); a != nil && a.IsVariable() {
 		if v, ok := a.(*query.Variable); ok {
-			columns = append(columns, v.Name)
+			symbols = append(symbols, v.Name)
 		}
 	}
 	if v := pattern.GetV(); v != nil && v.IsVariable() {
 		if vr, ok := v.(*query.Variable); ok {
-			columns = append(columns, vr.Name)
+			symbols = append(symbols, vr.Name)
 		}
 	}
 
@@ -61,7 +61,7 @@ func (m *MockMatcher) Match(pattern *query.DataPattern, bindings executor.Relati
 		tuples = append(tuples, tuple)
 	}
 
-	return executor.NewMaterializedRelation(columns, tuples), nil
+	return executor.NewMaterializedRelation(symbols, tuples), nil
 }
 
 func matchesDatom(d datalog.Datom, pattern *query.DataPattern) bool {
@@ -128,18 +128,18 @@ func runQuery(name string, queryStr string, datoms []datalog.Datom) {
 	}
 
 	// Display results
-	columns := result.Columns()
+	symbols := result.Symbols()
 	fmt.Printf("Results (%d):\n", result.Size())
 
 	iter := result.Iterator()
 	for iter.Next() {
 		tuple := iter.Tuple()
 		fmt.Printf("  ")
-		for j, col := range columns {
+		for j, sym := range symbols {
 			if j > 0 {
 				fmt.Printf(", ")
 			}
-			fmt.Printf("%s = %v", col, tuple[j])
+			fmt.Printf("%s = %v", sym, tuple[j])
 		}
 		fmt.Printf("\n")
 	}

--- a/examples/join_demo.go
+++ b/examples/join_demo.go
@@ -124,7 +124,7 @@ func runQuery(exec *executor.Executor, queryStr string) {
 		log.Fatalf("Failed to execute query: %v", err)
 	}
 
-	fmt.Printf("Results (%d rows):\n", result.Size())
+	fmt.Printf("Results (%d tuples):\n", result.Size())
 	for i := 0; i < result.Size(); i++ {
 		fmt.Printf("  %v\n", result.Get(i))
 	}

--- a/examples/multi_tuple_relation_demo.go
+++ b/examples/multi_tuple_relation_demo.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	fmt.Println("=== Multi-Row Relation Demo ===\n")
+	fmt.Println("=== Multi-Tuple Relation Demo ===\n")
 
 	// Create test data
 	alice := datalog.NewIdentity("emp:alice")
@@ -52,7 +52,7 @@ func main() {
 
 	matcher := executor.NewMemoryPatternMatcher(datoms)
 
-	// Demo 1: Simple multi-row binding - find salaries for specific employees
+	// Demo 1: Simple multi-tuple binding - find salaries for specific employees
 	fmt.Println("1. Find salaries for Alice and Bob only:")
 	{
 		// Create a relation with multiple employee IDs
@@ -89,7 +89,7 @@ func main() {
 		}
 	}
 
-	// Demo 2: Multi-column binding - find specific attribute values
+	// Demo 2: Multi-symbol binding - find specific attribute values
 	fmt.Println("\n2. Find specific attributes for specific employees:")
 	{
 		// Create a relation with employee-attribute pairs
@@ -128,7 +128,7 @@ func main() {
 		}
 	}
 
-	// Demo 3: Department filtering using multi-row relations
+	// Demo 3: Department filtering using multi-tuple relations
 	fmt.Println("\n3. Find all employees in Engineering department:")
 	{
 		// First, find all engineering employees
@@ -215,7 +215,7 @@ func main() {
 			},
 		}
 
-		// Project just the ?emp column from highEarnerRel
+		// Project just the ?emp symbol from highEarnerRel
 		empOnlyTuples := []executor.Tuple{}
 		it = highEarnerRel.Iterator()
 		for it.Next() {

--- a/examples/proof_multi_tuple_relations.go
+++ b/examples/proof_multi_tuple_relations.go
@@ -86,7 +86,7 @@ func main() {
 				{bob},
 			},
 		)
-		fmt.Printf("Binding relation has %d rows: Alice and Bob\n", bindingRel.Size())
+		fmt.Printf("Binding relation has %d tuples: Alice and Bob\n", bindingRel.Size())
 
 		// Pattern: [?person :person/age ?age]
 		pattern := &query.DataPattern{
@@ -128,11 +128,11 @@ func main() {
 		}
 	}
 
-	// PROOF 2: Multi-column relation binds multiple variables
-	fmt.Println("\n\nPROOF 2: Multi-column relation binds multiple variables")
+	// PROOF 2: Multi-symbol relation binds multiple variables
+	fmt.Println("\n\nPROOF 2: Multi-symbol relation binds multiple variables")
 	fmt.Println("-------------------------------------------------------")
 	{
-		// Create a multi-column relation with person-attribute pairs
+		// Create a multi-symbol relation with person-attribute pairs
 		bindingRel := executor.NewMaterializedRelation(
 			[]query.Symbol{"?p", "?attr"},
 			[]executor.Tuple{
@@ -141,10 +141,10 @@ func main() {
 				{charlie, cityAttr}, // Get Charlie's city
 			},
 		)
-		fmt.Printf("Binding relation has %d rows with 2 columns each\n", bindingRel.Size())
-		fmt.Println("  Row 1: (alice, :person/name)")
-		fmt.Println("  Row 2: (bob, :person/age)")
-		fmt.Println("  Row 3: (charlie, :person/city)")
+		fmt.Printf("Binding relation has %d tuples with 2 symbols each\n", bindingRel.Size())
+		fmt.Println("  Tuple 1: (alice, :person/name)")
+		fmt.Println("  Tuple 2: (bob, :person/age)")
+		fmt.Println("  Tuple 3: (charlie, :person/city)")
 
 		// Pattern: [?p ?attr ?value]
 		pattern := &query.DataPattern{
@@ -155,7 +155,7 @@ func main() {
 			},
 		}
 
-		// Match with multi-column binding
+		// Match with multi-symbol binding
 		results, err := matcher.Match(pattern, executor.Relations{bindingRel})
 		if err != nil {
 			log.Fatal(err)
@@ -170,7 +170,7 @@ func main() {
 		it.Close()
 
 		if results.Size() == 3 {
-			fmt.Println("✅ SUCCESS: Multi-column relation correctly bound multiple variables")
+			fmt.Println("✅ SUCCESS: Multi-symbol relation correctly bound multiple variables")
 		} else {
 			fmt.Println("❌ FAILED: Expected exactly 3 results")
 		}
@@ -185,7 +185,7 @@ func main() {
 			[]query.Symbol{"?person"},
 			[]executor.Tuple{}, // No tuples!
 		)
-		fmt.Printf("Empty relation has %d rows\n", emptyRel.Size())
+		fmt.Printf("Empty relation has %d tuples\n", emptyRel.Size())
 
 		// Pattern that would normally match all names
 		pattern := &query.DataPattern{

--- a/examples/query_execution.go
+++ b/examples/query_execution.go
@@ -84,8 +84,8 @@ func runQuery(exec *executor.Executor, queryStr string) {
 	}
 
 	// Print results
-	fmt.Printf("Columns: %v\n", result.Columns)
-	fmt.Printf("Results (%d rows):\n", result.Size())
+	fmt.Printf("Symbols: %v\n", result.Symbols)
+	fmt.Printf("Results (%d tuples):\n", result.Size())
 	for i := 0; i < result.Size(); i++ {
 		fmt.Printf("  %v\n", result.Get(i))
 	}

--- a/examples/subquery_proper_demo.go
+++ b/examples/subquery_proper_demo.go
@@ -378,15 +378,15 @@ func main() {
 		log.Fatal("Failed to execute query 6:", err)
 	}
 
-	fmt.Printf("\nResults (3 rows, one per day with correct OHLC data, sorted by date):\n")
+	fmt.Printf("\nResults (3 tuples, one per day with correct OHLC data, sorted by date):\n")
 	executor.PrintResult(result6)
 
 	fmt.Println("\nWithout subqueries, this query would produce 3 days × multiple bars per day")
-	fmt.Println("= many incorrect rows due to Cartesian product!")
+	fmt.Println("= many incorrect tuples due to Cartesian product!")
 
 	fmt.Println("\nNote: Without subqueries, combining aggregated values (max/min) with")
 	fmt.Println("non-aggregated values (specific open/close) in a single query would")
-	fmt.Println("produce a Cartesian product with many incorrect rows, as described in")
+	fmt.Println("produce a Cartesian product with many incorrect tuples, as described in")
 	fmt.Println("the bug report. Subqueries properly scope each aggregation and lookup!")
 	fmt.Println("\nThis solves the issue reported in ../gopher-street/datalog_aggregation_bug_report.md")
 }

--- a/tests/cardinality_one_test.go
+++ b/tests/cardinality_one_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	dlreflect "github.com/wbrown/janus-datalog/datalog/reflect"
 	"github.com/wbrown/janus-datalog/datalog/storage"
 )
@@ -58,10 +59,10 @@ func TestCardinalityOneBehavior(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify: empty string was saved
-		loreValues1, err := db.ExecuteQueryWithInputs(
+		loreValues1, err := executor.CollectTuples(db.Query(
 			`[:find ?lore :in $ ?e :where [?e :entity/lore ?lore]]`,
 			id,
-		)
+		))
 		require.NoError(t, err)
 		require.Len(t, loreValues1, 1, "Empty string should be saved")
 		assert.Equal(t, "", loreValues1[0][0], "Value should be empty string")
@@ -75,10 +76,10 @@ func TestCardinalityOneBehavior(t *testing.T) {
 		require.NoError(t, err)
 
 		// Step 3: Query for lore values - with LWW, only latest value is returned
-		loreValues2, err := db.ExecuteQueryWithInputs(
+		loreValues2, err := executor.CollectTuples(db.Query(
 			`[:find ?lore :in $ ?e :where [?e :entity/lore ?lore]]`,
 			id,
-		)
+		))
 		require.NoError(t, err)
 
 		// With CRDT LWW semantics, tx.Add updates the value (highest ElementID wins)
@@ -120,10 +121,10 @@ func TestCardinalityOneBehavior(t *testing.T) {
 		require.NoError(t, err)
 
 		// Step 3: Query - should have exactly ONE value
-		loreValues, err := db.ExecuteQueryWithInputs(
+		loreValues, err := executor.CollectTuples(db.Query(
 			`[:find ?lore :in $ ?e :where [?e :entity/lore ?lore]]`,
 			entity.ID,
-		)
+		))
 		require.NoError(t, err)
 
 		t.Logf("After SaveStruct update: %d lore value(s): %v", len(loreValues), loreValues)
@@ -172,10 +173,10 @@ func TestCardinalityOneBehavior(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify: only one value, and it's the updated one
-		loreValues, err := db.ExecuteQueryWithInputs(
+		loreValues, err := executor.CollectTuples(db.Query(
 			`[:find ?lore :in $ ?e :where [?e :entity/lore ?lore]]`,
 			id,
-		)
+		))
 		require.NoError(t, err)
 		require.Len(t, loreValues, 1)
 		assert.Equal(t, "Updated lore", loreValues[0][0])
@@ -209,10 +210,10 @@ func TestEmptyStringsAreSaved(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query for lore - empty string IS saved
-	loreValues, err := db.ExecuteQueryWithInputs(
+	loreValues, err := executor.CollectTuples(db.Query(
 		`[:find ?lore :in $ ?e :where [?e :entity/lore ?lore]]`,
 		id,
-	)
+	))
 	require.NoError(t, err)
 
 	// Document: empty strings are persisted

--- a/tests/entity_join_bug_test.go
+++ b/tests/entity_join_bug_test.go
@@ -70,7 +70,7 @@ func TestEntityJoinBug(t *testing.T) {
 	// Now test the Relation directly from the matcher (before executor)
 	highPattern := hq.Where[0].(*query.DataPattern)
 	highRel, _ := matcher.Match(highPattern, nil)
-	t.Logf("High pattern Match() returned type=%T, columns=%v", highRel, highRel.Columns())
+	t.Logf("High pattern Match() returned type=%T, columns=%v", highRel, highRel.Symbols())
 
 	// Iterate directly to see all tuples
 	hPatIt := highRel.Iterator()
@@ -108,7 +108,7 @@ func TestEntityJoinBug(t *testing.T) {
 	// Now test the low pattern directly
 	lowPattern := lq.Where[0].(*query.DataPattern)
 	lowRel, _ := matcher.Match(lowPattern, nil)
-	t.Logf("Low pattern Match() returned type=%T, columns=%v", lowRel, lowRel.Columns())
+	t.Logf("Low pattern Match() returned type=%T, columns=%v", lowRel, lowRel.Symbols())
 
 	// Iterate directly to see all tuples
 	lPatIt := lowRel.Iterator()

--- a/tests/identity_comparison_test.go
+++ b/tests/identity_comparison_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/storage"
 )
 
@@ -50,10 +51,10 @@ func TestIdentityComparisonBestPractices(t *testing.T) {
 	}
 
 	// Query to find the child
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?c :in $ ?parent :where [?c :test/ref ?parent]]`,
 		parent,
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}

--- a/tests/identity_input_matching_bug_test.go
+++ b/tests/identity_input_matching_bug_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/codec"
+	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/storage"
 )
 
@@ -73,10 +74,10 @@ func TestIdentityInputMatchingBug(t *testing.T) {
 	t.Logf("child2: %v (refs parent2)", child2)
 
 	// Query: find children of parent1
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?c ?code :in $ ?parent :where [?c :test/ref ?parent] [?c :test/code ?code]]`,
 		parent1,
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -111,10 +112,10 @@ func TestIdentityInputMatchingBug(t *testing.T) {
 			child1.Hash(), foundID.Hash(), child1.L85(), foundID.L85())
 
 		// Debug: what is the actual ref of the found entity?
-		refs, _ := db.ExecuteQueryWithInputs(
+		refs, _ := executor.CollectTuples(db.Query(
 			`[:find ?ref :in $ ?e :where [?e :test/ref ?ref]]`,
 			foundID,
-		)
+		))
 		if len(refs) > 0 {
 			t.Logf("Found entity's actual ref (L85): %v", refs[0][0])
 			t.Logf("Our parent1 (L85):               %v", parent1.L85())
@@ -176,10 +177,10 @@ func TestIdentityInputMatchingWithMultipleConstraints(t *testing.T) {
 	t.Logf("Created dungeon: %v with map=%v", dungeonID, mapID)
 
 	// Query: find dungeon by map, code, and type
-	tuples, err := db.ExecuteQueryWithInputs(
+	tuples, err := executor.CollectTuples(db.Query(
 		`[:find ?e :in $ ?map ?code :where [?e :entity/map ?map] [?e :entity/code ?code] [?e :entity/type :entity.type/dungeon]]`,
 		mapID, "POI A",
-	)
+	))
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -203,10 +204,10 @@ func TestIdentityInputMatchingWithMultipleConstraints(t *testing.T) {
 		t.Errorf("Wrong entity returned:\n  expected hash: %x\n  got hash:      %x", dungeonID.Hash(), foundID.Hash())
 
 		// Debug: what are the actual attributes of the found entity?
-		attrs, _ := db.ExecuteQueryWithInputs(
+		attrs, _ := executor.CollectTuples(db.Query(
 			`[:find ?a ?v :in $ ?e :where [?e ?a ?v]]`,
 			foundID,
-		)
+		))
 		t.Logf("Found entity attributes:")
 		for _, attr := range attrs {
 			t.Logf("  %v = %v", attr[0], attr[1])


### PR DESCRIPTION
## Why

The public API was lying about what the engine does.

**The engine streams.** Hash joins, predicate pushdown, phase execution — the entire query pipeline operates on iterator chains. Then `Query()` called `relationToSlice()` and materialized everything into `[][]any` at the last moment, throwing away the streaming property before the caller ever saw a result. `QueryInto` was worse — double materialization.

Meanwhile, the codebase called its core abstractions "columns" and "rows." This is a Datalog engine built on relational algebra, not SQL. Columns and rows are SQL concepts that carry the wrong mental model — flat tables with positional access. The correct terms are symbols (logical variables that bind during unification) and tuples (satisfying assignments to those variables). Terminology shapes thinking: when the code says "columns" a reader reaches for SQL intuitions. When it says "symbols" the reader reaches for the right ones — variable binding, unification, pattern matching. Wrong vocabulary leads to wrong design instincts, wrong optimizations, and wrong bug fixes.

## What changed

Three commits, each building on the last:

### 1. `Query()` returns streaming `executor.Relation`

- `Query()` returns `executor.Relation` instead of `[][]any`
- Callers iterate via `rel.Iterator()` and call `iter.Close()` when done
- `QueryInto` streams internally — single-pass `MapTuple` per tuple
- `QueryOneInto` reads one tuple and stops, no materialization

### 2. Rename columns/rows → symbols/tuples (273 files)

- `Relation` interface: removed `Columns()`, `Symbols()` is sole accessor
- All struct fields, function names, parameters, locals renamed
- All comments, error messages, annotation keys, format strings
- File renames: `*_column_*` → `*_symbol_*`, `*_row_*` → `*_tuple_*`
- All `.md` documentation updated

### 3. Delete `ExecuteQuery`, `ExecuteQueryWithInputs`, `ExecuteQueryRelation`

These were three ways to do the same thing `Query()` now does. Deleted all three plus `relationToSlice`. `Query()` is the sole query API.

- Added `executor.CollectTuples(rel, err)` — accepts `Query()`'s return pair directly, returns `([][]any, error)` for callers that need materialized results
- ~290 test call sites updated to `executor.CollectTuples(db.Query(...))`
- Tests that intentionally exercise streaming behavior iterate directly

### Iterator safety: `BadgerIterator` leak protection

Streaming `Query()` means callers now hold open BadgerDB iterators. A leaked iterator holds a BadgerDB read transaction open indefinitely, which prevents value log GC and will eventually exhaust memory.

- `BadgerIterator.Close()` is now idempotent — nil-checks `txn` so double-close is safe
- `runtime.SetFinalizer` set on every `BadgerIterator` at creation (`Scan()` and `NewKeyOnlyIterator()`) as a safety net for unclosed iterators
- Finalizer cleared on explicit `Close()` so well-behaved callers pay no GC cost

### Bug fix: `extractFindSymbols` missing `FindPull` case

During the rename from `extractFindColumns` → `extractFindSymbols`, discovered the function was missing the `FindPull` case. Pull expressions in `:find` clauses would produce "cannot project empty symbol list" errors. Added the missing case.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 ./...` — all 16 packages pass
- [x] `gofmt -w .` clean
- [x] Streaming tests verified not accidentally materialized with `CollectTuples`
- [x] Variable shadowing from `row` → `tuple` rename found and fixed (3 cases)

298 files changed, ~3700 lines.
