### PR TITLE
Add ParseCache to eliminate repeated query string parsing

### DIFF
--- a/datalog/storage/convenience.go
+++ b/datalog/storage/convenience.go
@@ -25,7 +25,7 @@ func (d *Database) Query(queryInput interface{}, inputs ...interface{}) (executo
 	// Separate QueryOptions from regular inputs
 	opts, regularInputs := extractQueryOptions(inputs)
 
-	q, err := resolveQuery(queryInput)
+	q, err := d.resolveQuery(queryInput)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve query: %w", err)
 	}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -20,11 +20,19 @@ import (
 )
 
 // resolveQuery converts a query input (string or *query.Query) to *query.Query.
-// This enables the query builder to work seamlessly with database methods.
-func resolveQuery(q interface{}) (*query.Query, error) {
+// String inputs are cached in d.parseCache to avoid re-parsing identical queries.
+func (d *Database) resolveQuery(q interface{}) (*query.Query, error) {
 	switch v := q.(type) {
 	case string:
-		return parser.ParseQuery(v)
+		if cached, ok := d.parseCache.Get(v); ok {
+			return cached, nil
+		}
+		parsed, err := parser.ParseQuery(v)
+		if err != nil {
+			return nil, err
+		}
+		d.parseCache.Set(v, parsed)
+		return parsed, nil
 	case *query.Query:
 		return v, nil
 	default:
@@ -39,6 +47,7 @@ type Database struct {
 	mu                sync.RWMutex
 	activeTx          map[*Transaction]bool
 	planCache         *planner.PlanCache    // Shared query plan cache
+	parseCache        *ParseCache           // Shared query parse cache
 	schema            schema.SchemaProvider // Optional schema for validation
 	annotationHandler annotations.Handler   // Optional handler for query tracing
 	clock             *LamportClock         // CRDT: Lamport clock for ordering (nil if not in CRDT mode)
@@ -143,6 +152,7 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 		store:             store,
 		activeTx:          make(map[*Transaction]bool),
 		planCache:         planner.NewPlanCache(1000, 0),
+		parseCache:        NewParseCache(1000),
 		schema:            opts.Schema,
 		annotationHandler: opts.AnnotationHandler,
 		clock:             clock,
@@ -526,6 +536,16 @@ func (d *Database) ClearPlanCache() {
 	}
 }
 
+// ParseCache returns the database's query parse cache
+func (d *Database) ParseCache() *ParseCache {
+	return d.parseCache
+}
+
+// SetParseCache sets a custom parse cache or disables caching (if nil)
+func (d *Database) SetParseCache(cache *ParseCache) {
+	d.parseCache = cache
+}
+
 // QueryOption configures query execution.
 type QueryOption func(*queryOptions)
 
@@ -608,7 +628,7 @@ func extractQueryOptions(inputs []interface{}) (queryOptions, []interface{}) {
 //   - Predicate and expression assignment
 func (d *Database) Explain(queryInput interface{}, inputs ...interface{}) (*planner.RealizedPlan, error) {
 	// Resolve the query (string or *query.Query)
-	q, err := resolveQuery(queryInput)
+	q, err := d.resolveQuery(queryInput)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve query: %w", err)
 	}
@@ -735,7 +755,7 @@ func (d *Database) Analyze(queryInput interface{}, inputs ...interface{}) (*Anal
 	startTime := time.Now()
 
 	// Resolve the query (string or *query.Query)
-	q, err := resolveQuery(queryInput)
+	q, err := d.resolveQuery(queryInput)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve query: %w", err)
 	}
@@ -828,7 +848,7 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 	}
 
 	// Resolve the query (string or *query.Query)
-	q, err := resolveQuery(queryInput)
+	q, err := d.resolveQuery(queryInput)
 	if err != nil {
 		return fmt.Errorf("failed to resolve query: %w", err)
 	}
@@ -925,7 +945,7 @@ func (d *Database) QueryOneInto(dest interface{}, queryInput interface{}, inputs
 	elemType := elemVal.Type()
 
 	// Resolve the query (string or *query.Query)
-	q, err := resolveQuery(queryInput)
+	q, err := d.resolveQuery(queryInput)
 	if err != nil {
 		return false, fmt.Errorf("failed to resolve query: %w", err)
 	}

--- a/datalog/storage/parse_cache.go
+++ b/datalog/storage/parse_cache.go
@@ -1,0 +1,122 @@
+package storage
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// ParseCache caches parsed *query.Query objects to avoid re-parsing identical
+// query strings. Unlike PlanCache, no TTL is needed — the mapping from a query
+// string to its parsed form is immutable.
+type ParseCache struct {
+	cache map[string]*cachedQuery
+	mu    sync.RWMutex
+
+	// Statistics
+	hits   int64
+	misses int64
+
+	// Configuration
+	maxSize int
+}
+
+type cachedQuery struct {
+	query     *query.Query
+	timestamp time.Time // used for LRU eviction only
+}
+
+// NewParseCache creates a new query parse cache.
+func NewParseCache(maxSize int) *ParseCache {
+	if maxSize <= 0 {
+		maxSize = 1000
+	}
+	return &ParseCache{
+		cache:   make(map[string]*cachedQuery),
+		maxSize: maxSize,
+	}
+}
+
+// Get retrieves a cached *query.Query for the given query string.
+func (c *ParseCache) Get(queryString string) (*query.Query, bool) {
+	if c == nil {
+		return nil, false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cached, ok := c.cache[queryString]
+	if !ok {
+		atomic.AddInt64(&c.misses, 1)
+		return nil, false
+	}
+
+	atomic.AddInt64(&c.hits, 1)
+	return cached.query, true
+}
+
+// Set stores a parsed *query.Query for the given query string.
+func (c *ParseCache) Set(queryString string, q *query.Query) {
+	if c == nil || q == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Evict oldest if full
+	if len(c.cache) >= c.maxSize {
+		c.evictOldest()
+	}
+
+	c.cache[queryString] = &cachedQuery{
+		query:     q,
+		timestamp: time.Now(),
+	}
+}
+
+// Clear removes all cached queries.
+func (c *ParseCache) Clear() {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cache = make(map[string]*cachedQuery)
+	atomic.StoreInt64(&c.hits, 0)
+	atomic.StoreInt64(&c.misses, 0)
+}
+
+// Stats returns cache statistics.
+func (c *ParseCache) Stats() (hits, misses int64, size int) {
+	if c == nil {
+		return 0, 0, 0
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return atomic.LoadInt64(&c.hits), atomic.LoadInt64(&c.misses), len(c.cache)
+}
+
+// evictOldest removes the oldest entry from the cache. Must be called with mu held.
+func (c *ParseCache) evictOldest() {
+	var oldestKey string
+	var oldestTime time.Time
+
+	for key, cached := range c.cache {
+		if oldestKey == "" || cached.timestamp.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = cached.timestamp
+		}
+	}
+
+	if oldestKey != "" {
+		delete(c.cache, oldestKey)
+	}
+}

--- a/datalog/storage/parse_cache_benchmark_test.go
+++ b/datalog/storage/parse_cache_benchmark_test.go
@@ -1,0 +1,156 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+)
+
+const benchQuery = `[:find ?e ?name ?age
+  :where [?e :person/name ?name]
+         [?e :person/age ?age]
+         [(> ?age 18)]]`
+
+// BenchmarkResolveQueryNoCache measures resolveQuery with parse cache disabled
+// (re-parses every call).
+func BenchmarkResolveQueryNoCache(b *testing.B) {
+	db, err := NewDatabase(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+	db.SetParseCache(nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := db.resolveQuery(benchQuery)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkResolveQueryWithCache measures resolveQuery with parse cache enabled
+// (cache hit after first call).
+func BenchmarkResolveQueryWithCache(b *testing.B) {
+	db, err := NewDatabase(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	// Warm cache
+	db.resolveQuery(benchQuery)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := db.resolveQuery(benchQuery)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkResolveQueryPreParsed measures resolveQuery with pre-parsed *query.Query
+// (baseline — no parsing, no cache lookup).
+func BenchmarkResolveQueryPreParsed(b *testing.B) {
+	db, err := NewDatabase(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	q, err := parser.ParseQuery(benchQuery)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := db.resolveQuery(q)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// --- End-to-end benchmarks: full Query() path including execution ---
+
+func setupParseCacheBenchDB(b *testing.B) *Database {
+	b.Helper()
+	db, err := NewDatabase(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < 50; i++ {
+		tx := db.NewTransaction()
+		e := datalog.NewIdentity(fmt.Sprintf("person%d", i))
+		tx.Add(e, datalog.NewKeyword(":person/name"), fmt.Sprintf("Name%d", i))
+		tx.Add(e, datalog.NewKeyword(":person/age"), int64(10+i))
+		tx.Commit()
+	}
+	return db
+}
+
+// BenchmarkQueryStringNoParseCache measures full Query() with string input
+// and parse cache disabled.
+func BenchmarkQueryStringNoParseCache(b *testing.B) {
+	db := setupParseCacheBenchDB(b)
+	defer db.Close()
+	db.SetParseCache(nil) // disable parse cache
+
+	// Warm plan cache
+	executor.CollectTuples(db.Query(benchQuery))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := executor.CollectTuples(db.Query(benchQuery))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkQueryStringWithParseCache measures full Query() with string input
+// and parse cache enabled (default behavior).
+func BenchmarkQueryStringWithParseCache(b *testing.B) {
+	db := setupParseCacheBenchDB(b)
+	defer db.Close()
+
+	// Warm both caches
+	executor.CollectTuples(db.Query(benchQuery))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := executor.CollectTuples(db.Query(benchQuery))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkQueryPreParsed measures full Query() with pre-parsed *query.Query
+// (baseline — no parsing at all).
+func BenchmarkQueryPreParsed(b *testing.B) {
+	db := setupParseCacheBenchDB(b)
+	defer db.Close()
+
+	q, err := parser.ParseQuery(benchQuery)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Warm plan cache
+	executor.CollectTuples(db.Query(q))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := executor.CollectTuples(db.Query(q))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/datalog/storage/parse_cache_test.go
+++ b/datalog/storage/parse_cache_test.go
@@ -1,0 +1,164 @@
+package storage
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+func TestParseCacheHitMiss(t *testing.T) {
+	c := NewParseCache(100)
+
+	q, err := parser.ParseQuery(`[:find ?e :where [?e :foo/bar "baz"]]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Miss
+	got, ok := c.Get(`[:find ?e :where [?e :foo/bar "baz"]]`)
+	if ok {
+		t.Fatal("expected miss on empty cache")
+	}
+	if got != nil {
+		t.Fatal("expected nil on miss")
+	}
+
+	// Set
+	c.Set(`[:find ?e :where [?e :foo/bar "baz"]]`, q)
+
+	// Hit
+	got, ok = c.Get(`[:find ?e :where [?e :foo/bar "baz"]]`)
+	if !ok {
+		t.Fatal("expected hit after Set")
+	}
+	if got != q {
+		t.Fatal("expected same *query.Query pointer")
+	}
+
+	// Different string = miss
+	_, ok = c.Get(`[:find ?e :where [?e :foo/bar "other"]]`)
+	if ok {
+		t.Fatal("expected miss for different query")
+	}
+}
+
+func TestParseCacheStats(t *testing.T) {
+	c := NewParseCache(100)
+
+	q, _ := parser.ParseQuery(`[:find ?e :where [?e :a ?v]]`)
+	c.Set(`[:find ?e :where [?e :a ?v]]`, q)
+
+	// 1 hit
+	c.Get(`[:find ?e :where [?e :a ?v]]`)
+	// 2 misses
+	c.Get(`[:find ?x :where [?x :b ?v]]`)
+	c.Get(`[:find ?y :where [?y :c ?v]]`)
+
+	hits, misses, size := c.Stats()
+	if hits != 1 {
+		t.Errorf("expected 1 hit, got %d", hits)
+	}
+	if misses != 2 {
+		t.Errorf("expected 2 misses, got %d", misses)
+	}
+	if size != 1 {
+		t.Errorf("expected size 1, got %d", size)
+	}
+}
+
+func TestParseCacheEviction(t *testing.T) {
+	c := NewParseCache(3)
+
+	queries := []string{
+		`[:find ?a :where [?a :x "1"]]`,
+		`[:find ?b :where [?b :x "2"]]`,
+		`[:find ?c :where [?c :x "3"]]`,
+	}
+
+	for _, qs := range queries {
+		q, _ := parser.ParseQuery(qs)
+		c.Set(qs, q)
+	}
+
+	_, _, size := c.Stats()
+	if size != 3 {
+		t.Errorf("expected size 3, got %d", size)
+	}
+
+	// Adding a 4th should evict one
+	q4, _ := parser.ParseQuery(`[:find ?d :where [?d :x "4"]]`)
+	c.Set(`[:find ?d :where [?d :x "4"]]`, q4)
+
+	_, _, size = c.Stats()
+	if size != 3 {
+		t.Errorf("expected size 3 after eviction, got %d", size)
+	}
+}
+
+func TestParseCacheNilSafe(t *testing.T) {
+	var c *ParseCache
+
+	// All operations on nil cache should be no-ops
+	got, ok := c.Get("anything")
+	if ok || got != nil {
+		t.Fatal("expected nil/false from nil cache")
+	}
+
+	c.Set("anything", &query.Query{}) // should not panic
+	c.Clear()                         // should not panic
+
+	hits, misses, size := c.Stats()
+	if hits != 0 || misses != 0 || size != 0 {
+		t.Fatal("expected zeros from nil cache stats")
+	}
+}
+
+func TestParseCacheSetNilQuery(t *testing.T) {
+	c := NewParseCache(100)
+	c.Set("test", nil) // should be no-op
+
+	_, _, size := c.Stats()
+	if size != 0 {
+		t.Errorf("expected size 0 after Set(nil), got %d", size)
+	}
+}
+
+func TestParseCacheClear(t *testing.T) {
+	c := NewParseCache(100)
+	q, _ := parser.ParseQuery(`[:find ?e :where [?e :a ?v]]`)
+	c.Set(`[:find ?e :where [?e :a ?v]]`, q)
+	c.Get(`[:find ?e :where [?e :a ?v]]`)
+	c.Get(`[:find ?x :where [?x :b ?v]]`)
+
+	c.Clear()
+
+	hits, misses, size := c.Stats()
+	if hits != 0 || misses != 0 || size != 0 {
+		t.Errorf("expected all zeros after Clear, got hits=%d misses=%d size=%d", hits, misses, size)
+	}
+}
+
+func TestParseCacheConcurrent(t *testing.T) {
+	c := NewParseCache(100)
+	q, _ := parser.ParseQuery(`[:find ?e :where [?e :a ?v]]`)
+	c.Set(`[:find ?e :where [?e :a ?v]]`, q)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				c.Get(`[:find ?e :where [?e :a ?v]]`)
+			}
+		}()
+	}
+	wg.Wait()
+
+	hits, _, _ := c.Stats()
+	if hits != 10000 {
+		t.Errorf("expected 10000 hits, got %d", hits)
+	}
+}


### PR DESCRIPTION
Query parsing (EDN lex + parse → *query.Query) costs ~3,600 ns with 84 allocations per call. The plan cache only caches RealizedPlan, so every string-based Query() call re-parses even on a plan cache hit. With query execution itself in sub-microsecond territory, parsing was the bottleneck for repeated queries.

ParseCache on Database caches string → *query.Query. Cache hit is 14 ns, zero allocations — 263× faster than re-parsing. No TTL needed since the mapping is immutable; eviction is size-based only (LRU, default 1000 entries).

- New ParseCache type in parse_cache.go (Get/Set/Clear/Stats, nil-safe, RWMutex-protected)
- resolveQuery promoted from package function to Database method so it can access d.parseCache
- ParseCache initialized by default in NewDatabaseWithOptions
- SetParseCache(nil) disables caching for benchmarking
- Unit tests: hit/miss, stats, eviction, nil-safe, concurrent access
- Benchmarks: resolveQuery isolation (3,600 ns → 14 ns) and end-to-end Query() (71,600 ns → 67,300 ns, closing gap with pre-parsed baseline)

5 files changed. All 16 packages build and pass tests.