### PR TITLE
Fix vector literal matching in data patterns

### DIFF
--- a/datalog/compare.go
+++ b/datalog/compare.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -252,6 +253,26 @@ func ValuesEqual(a, b interface{}) bool {
 		return false
 	}
 
+	// Slice comparison — must come before a == b which panics on slices.
+	// Handles typed slices ([]string, []int64) and []interface{} with
+	// element-wise recursive comparison via ValuesEqual.
+	ra := reflect.ValueOf(a)
+	rb := reflect.ValueOf(b)
+	if ra.Kind() == reflect.Slice || rb.Kind() == reflect.Slice {
+		if ra.Kind() != reflect.Slice || rb.Kind() != reflect.Slice {
+			return false // one is a slice, the other isn't
+		}
+		if ra.Len() != rb.Len() {
+			return false
+		}
+		for i := 0; i < ra.Len(); i++ {
+			if !ValuesEqual(ra.Index(i).Interface(), rb.Index(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+
 	// Quick pointer equality check for interned values
 	// This handles Identity (always interned pointers) directly
 	if a == b {
@@ -315,8 +336,8 @@ func ValuesEqual(a, b interface{}) bool {
 		}
 	}
 
-	// Fall back to string comparison for unknown types
-	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+	// Unknown types: not equal. All comparable types are handled above.
+	return false
 }
 
 // stringValue converts any value to a string for comparison

--- a/datalog/compare_test.go
+++ b/datalog/compare_test.go
@@ -377,6 +377,151 @@ func TestElementIDPointerValueCrossComparison(t *testing.T) {
 	}
 }
 
+// TestValuesEqualSlices tests ValuesEqual with slice types.
+// These are critical for vector literal matching in data patterns:
+// stored vectors are typed ([]string, []int64) while pattern values
+// from the parser are []interface{}.
+func TestValuesEqualSlices(t *testing.T) {
+	t.Run("empty []interface{} equal", func(t *testing.T) {
+		a := []interface{}{}
+		b := []interface{}{}
+		if !ValuesEqual(a, b) {
+			t.Error("two empty []interface{} should be equal")
+		}
+	})
+
+	t.Run("populated []interface{} equal", func(t *testing.T) {
+		a := []interface{}{"x", "y"}
+		b := []interface{}{"x", "y"}
+		if !ValuesEqual(a, b) {
+			t.Error("identical []interface{} should be equal")
+		}
+	})
+
+	t.Run("populated []interface{} not equal", func(t *testing.T) {
+		a := []interface{}{"x", "y"}
+		b := []interface{}{"x", "z"}
+		if ValuesEqual(a, b) {
+			t.Error("different []interface{} should not be equal")
+		}
+	})
+
+	t.Run("different length []interface{}", func(t *testing.T) {
+		a := []interface{}{"x"}
+		b := []interface{}{"x", "y"}
+		if ValuesEqual(a, b) {
+			t.Error("different length slices should not be equal")
+		}
+	})
+
+	t.Run("[]string equal", func(t *testing.T) {
+		a := []string{"a", "b"}
+		b := []string{"a", "b"}
+		if !ValuesEqual(a, b) {
+			t.Error("identical []string should be equal")
+		}
+	})
+
+	t.Run("[]string not equal", func(t *testing.T) {
+		a := []string{"a", "b"}
+		b := []string{"a", "c"}
+		if ValuesEqual(a, b) {
+			t.Error("different []string should not be equal")
+		}
+	})
+
+	t.Run("[]int64 equal", func(t *testing.T) {
+		a := []int64{1, 2, 3}
+		b := []int64{1, 2, 3}
+		if !ValuesEqual(a, b) {
+			t.Error("identical []int64 should be equal")
+		}
+	})
+
+	t.Run("[]int64 not equal", func(t *testing.T) {
+		a := []int64{1, 2}
+		b := []int64{1, 3}
+		if ValuesEqual(a, b) {
+			t.Error("different []int64 should not be equal")
+		}
+	})
+
+	t.Run("empty []string equal", func(t *testing.T) {
+		a := []string{}
+		b := []string{}
+		if !ValuesEqual(a, b) {
+			t.Error("two empty []string should be equal")
+		}
+	})
+
+	// Cross-type: typed slice vs []interface{} — this is the critical case
+	// for vector literal matching. The parser produces []interface{} from
+	// the query, but storage returns []string, []int64, etc.
+	t.Run("[]string vs []interface{} with same values", func(t *testing.T) {
+		a := []string{"a", "b"}
+		b := []interface{}{"a", "b"}
+		if !ValuesEqual(a, b) {
+			t.Error("[]string and []interface{} with same string elements should be equal")
+		}
+	})
+
+	t.Run("[]interface{} vs []string with same values", func(t *testing.T) {
+		a := []interface{}{"a", "b"}
+		b := []string{"a", "b"}
+		if !ValuesEqual(a, b) {
+			t.Error("[]interface{} and []string with same string elements should be equal")
+		}
+	})
+
+	t.Run("[]int64 vs []interface{} with same values", func(t *testing.T) {
+		a := []int64{1, 2, 3}
+		b := []interface{}{int64(1), int64(2), int64(3)}
+		if !ValuesEqual(a, b) {
+			t.Error("[]int64 and []interface{} with same int64 elements should be equal")
+		}
+	})
+
+	t.Run("empty []string vs empty []interface{}", func(t *testing.T) {
+		a := []string{}
+		b := []interface{}{}
+		if !ValuesEqual(a, b) {
+			t.Error("empty []string and empty []interface{} should be equal")
+		}
+	})
+
+	t.Run("[]any with Keywords equal", func(t *testing.T) {
+		a := []interface{}{NewKeyword(":flag/active"), NewKeyword(":flag/visible")}
+		b := []interface{}{NewKeyword(":flag/active"), NewKeyword(":flag/visible")}
+		if !ValuesEqual(a, b) {
+			t.Error("[]any with same Keywords should be equal")
+		}
+	})
+
+	t.Run("[]any with Keywords not equal", func(t *testing.T) {
+		a := []interface{}{NewKeyword(":flag/active")}
+		b := []interface{}{NewKeyword(":flag/other")}
+		if ValuesEqual(a, b) {
+			t.Error("[]any with different Keywords should not be equal")
+		}
+	})
+
+	t.Run("slice vs non-slice", func(t *testing.T) {
+		a := []interface{}{"x"}
+		b := "x"
+		if ValuesEqual(a, b) {
+			t.Error("slice vs non-slice should not be equal")
+		}
+	})
+
+	t.Run("non-slice vs slice", func(t *testing.T) {
+		a := "x"
+		b := []interface{}{"x"}
+		if ValuesEqual(a, b) {
+			t.Error("non-slice vs slice should not be equal")
+		}
+	})
+}
+
 // TestElementIDZeroValues tests comparison with zero/HEAD ElementID
 func TestElementIDZeroValues(t *testing.T) {
 	zero := ElementIDZero

--- a/datalog/executor/testing.go
+++ b/datalog/executor/testing.go
@@ -251,29 +251,9 @@ func compareTuplesEqual(a, b Tuple) bool {
 		return false
 	}
 	for i := range a {
-		if !compareValuesEqual(a[i], b[i]) {
+		if !datalog.ValuesEqual(a[i], b[i]) {
 			return false
 		}
 	}
 	return true
-}
-
-func compareValuesEqual(a, b interface{}) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-
-	// Handle Identity
-	if aId, ok := a.(datalog.Identity); ok {
-		if bId, ok := b.(datalog.Identity); ok {
-			return aId.L85() == bId.L85()
-		}
-		return false
-	}
-
-	// Simple comparison
-	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
 }

--- a/datalog/query/clause.go
+++ b/datalog/query/clause.go
@@ -130,6 +130,14 @@ func BranchHasExpressions(branch []Clause) bool {
 			return true
 		case *GroundPredicate:
 			return true
+		case Predicate:
+			// Predicates that require input symbols (e.g., DatabaseFunctionPredicate
+			// for missing?, Comparison for [(< ?x 5)]) need outer bindings to
+			// evaluate — union mode passes nil. Predicates with no required symbols
+			// (e.g., HistoryPredicate) can work in union mode.
+			if pred, ok := c.(Predicate); ok && len(pred.RequiredSymbols()) > 0 {
+				return true
+			}
 		}
 	}
 	return false

--- a/datalog/storage/crdt_vector_test.go
+++ b/datalog/storage/crdt_vector_test.go
@@ -2191,3 +2191,334 @@ func TestVectorClearedVsNeverSet(t *testing.T) {
 	assert.False(t, bobFound, "never-set vector should not be found")
 	assert.Nil(t, bobResult, "never-set vector should return nil")
 }
+
+// =============================================================================
+// Vector Literal Matching in Data Patterns
+// =============================================================================
+//
+// Bug: [?e :attr []] treated as wildcard instead of "match empty vector".
+// See docs/bugs/BUG_EMPTY_VECTOR_LITERAL_MATCHES_NONEMPTY.md
+
+// TestVectorLiteralMatch verifies that vector literals in data patterns match
+// by exact equality, not as wildcards.
+func TestVectorLiteralMatch(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "vector-literal-match-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	s, err := schema.NewBuilder().
+		Attribute(":entity/name").Type(schema.TypeString).Add().
+		Attribute(":entity/lore").Type(schema.TypeString).Vector().Add().
+		Attribute(":entity/scores").Type(schema.TypeLong).Vector().Add().
+		Attribute(":entity/flags").Type(schema.TypeKeyword).Vector().Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	name := datalog.NewKeyword(":entity/name")
+	lore := datalog.NewKeyword(":entity/lore")
+	scores := datalog.NewKeyword(":entity/scores")
+	flags := datalog.NewKeyword(":entity/flags")
+
+	hasLore := datalog.NewIdentity("has-lore")
+	emptyLore := datalog.NewIdentity("empty-lore")
+	noLore := datalog.NewIdentity("no-lore")
+	twoLore := datalog.NewIdentity("two-lore")
+	hasScores := datalog.NewIdentity("has-scores")
+	twoScores := datalog.NewIdentity("two-scores")
+	emptyScores := datalog.NewIdentity("empty-scores")
+	hasFlags := datalog.NewIdentity("has-flags")
+	twoFlags := datalog.NewIdentity("two-flags")
+	emptyFlags := datalog.NewIdentity("empty-flags")
+
+	// Populate data
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(hasLore, name, "HasLore"))
+	require.NoError(t, tx.Add(hasLore, lore, "Deep in the mountains..."))
+
+	require.NoError(t, tx.Add(emptyLore, name, "EmptyLore"))
+	// emptyLore gets lore added then cleared below
+
+	require.NoError(t, tx.Add(noLore, name, "NoLore"))
+	// noLore: no lore attribute at all
+
+	require.NoError(t, tx.Add(twoLore, name, "TwoLore"))
+	require.NoError(t, tx.Add(twoLore, lore, "alpha"))
+	require.NoError(t, tx.Add(twoLore, lore, "beta"))
+
+	require.NoError(t, tx.Add(hasScores, name, "HasScores"))
+	require.NoError(t, tx.Add(hasScores, scores, int64(100)))
+	require.NoError(t, tx.Add(hasScores, scores, int64(250)))
+	require.NoError(t, tx.Add(hasScores, scores, int64(175)))
+
+	require.NoError(t, tx.Add(twoScores, name, "TwoScores"))
+	require.NoError(t, tx.Add(twoScores, scores, int64(50)))
+	require.NoError(t, tx.Add(twoScores, scores, int64(75)))
+
+	require.NoError(t, tx.Add(emptyScores, name, "EmptyScores"))
+	// emptyScores gets scores added then cleared below
+
+	require.NoError(t, tx.Add(hasFlags, name, "HasFlags"))
+	require.NoError(t, tx.Add(hasFlags, flags, datalog.NewKeyword(":flag/active")))
+	require.NoError(t, tx.Add(hasFlags, flags, datalog.NewKeyword(":flag/visible")))
+
+	require.NoError(t, tx.Add(twoFlags, name, "TwoFlags"))
+	require.NoError(t, tx.Add(twoFlags, flags, datalog.NewKeyword(":flag/hidden")))
+	require.NoError(t, tx.Add(twoFlags, flags, datalog.NewKeyword(":flag/locked")))
+
+	require.NoError(t, tx.Add(emptyFlags, name, "EmptyFlags"))
+	// emptyFlags gets flags added then cleared below
+
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Create then clear vectors to get "empty but set" state (tombstones)
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Add(emptyLore, lore, "placeholder"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+	tx3 := db.NewTransaction()
+	require.NoError(t, tx3.Set(emptyLore, lore, []interface{}{}))
+	_, err = tx3.Commit()
+	require.NoError(t, err)
+
+	tx4 := db.NewTransaction()
+	require.NoError(t, tx4.Add(emptyScores, scores, int64(999)))
+	_, err = tx4.Commit()
+	require.NoError(t, err)
+	tx5 := db.NewTransaction()
+	require.NoError(t, tx5.Set(emptyScores, scores, []interface{}{}))
+	_, err = tx5.Commit()
+	require.NoError(t, err)
+
+	tx6 := db.NewTransaction()
+	require.NoError(t, tx6.Add(emptyFlags, flags, datalog.NewKeyword(":flag/placeholder")))
+	_, err = tx6.Commit()
+	require.NoError(t, err)
+	tx7 := db.NewTransaction()
+	require.NoError(t, tx7.Set(emptyFlags, flags, []interface{}{}))
+	_, err = tx7.Commit()
+	require.NoError(t, err)
+
+	// Helper to collect names from query results
+	collectNames := func(t *testing.T, q string) []string {
+		t.Helper()
+		results, err := executor.CollectTuples(db.Query(q))
+		require.NoError(t, err)
+		names := make([]string, len(results))
+		for i, tuple := range results {
+			names[i] = tuple[0].(string)
+		}
+		return names
+	}
+
+	// --- String vector tests ---
+
+	t.Run("string/empty literal matches only empty vector", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/lore []]]`)
+		assert.Equal(t, []string{"EmptyLore"}, names)
+	})
+
+	t.Run("string/empty literal excludes non-empty", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/lore []]]`)
+		assert.NotContains(t, names, "HasLore")
+		assert.NotContains(t, names, "TwoLore")
+	})
+
+	t.Run("string/empty literal excludes missing", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/lore []]]`)
+		assert.NotContains(t, names, "NoLore")
+	})
+
+	t.Run("string/populated literal matches exact", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/lore ["Deep in the mountains..."]]]`)
+		assert.Equal(t, []string{"HasLore"}, names)
+	})
+
+	t.Run("string/populated literal no partial match", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/lore ["alpha"]]]`)
+		assert.Empty(t, names, "subset should not match")
+	})
+
+	t.Run("string/multi-element literal matches exact", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/lore ["alpha" "beta"]]]`)
+		assert.Equal(t, []string{"TwoLore"}, names)
+	})
+
+	t.Run("string/unbound V returns all vectors", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/lore ?lore]]`)
+		// Empty vectors produce zero tuples (treated as "not found"),
+		// so unbound V only returns entities with non-empty vectors.
+		assert.Len(t, names, 2, "should find HasLore, TwoLore (empty vectors produce no tuples)")
+		assert.Contains(t, names, "HasLore")
+		assert.Contains(t, names, "TwoLore")
+	})
+
+	// --- Int64 vector tests ---
+
+	t.Run("int64/empty literal", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/scores []]]`)
+		assert.Equal(t, []string{"EmptyScores"}, names)
+	})
+
+	t.Run("int64/populated literal matches exact", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/scores [100 250 175]]]`)
+		assert.Equal(t, []string{"HasScores"}, names)
+	})
+
+	t.Run("int64/populated literal excludes other non-empty", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/scores [100 250 175]]]`)
+		assert.NotContains(t, names, "TwoScores")
+	})
+
+	t.Run("int64/multi-element literal matches exact", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/scores [50 75]]]`)
+		assert.Equal(t, []string{"TwoScores"}, names)
+	})
+
+	t.Run("int64/wrong values no match", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/scores [100 250]]]`)
+		assert.Empty(t, names)
+	})
+
+	t.Run("int64/unbound V returns all non-empty", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/scores ?s]]`)
+		assert.Len(t, names, 2, "should find HasScores, TwoScores")
+		assert.Contains(t, names, "HasScores")
+		assert.Contains(t, names, "TwoScores")
+	})
+
+	// --- Keyword vector tests ---
+
+	t.Run("keyword/empty literal", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/flags []]]`)
+		assert.Equal(t, []string{"EmptyFlags"}, names)
+	})
+
+	t.Run("keyword/populated literal matches exact", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/flags [:flag/active :flag/visible]]]`)
+		assert.Equal(t, []string{"HasFlags"}, names)
+	})
+
+	t.Run("keyword/populated literal excludes other non-empty", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/flags [:flag/active :flag/visible]]]`)
+		assert.NotContains(t, names, "TwoFlags")
+	})
+
+	t.Run("keyword/multi-element literal matches exact", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/flags [:flag/hidden :flag/locked]]]`)
+		assert.Equal(t, []string{"TwoFlags"}, names)
+	})
+
+	t.Run("keyword/wrong values no match", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/flags [:flag/active]]]`)
+		assert.Empty(t, names)
+	})
+
+	t.Run("keyword/unbound V returns all non-empty", func(t *testing.T) {
+		names := collectNames(t,
+			`[:find ?name :where [?e :entity/name ?name] [?e :entity/flags ?f]]`)
+		assert.Len(t, names, 2, "should find HasFlags, TwoFlags")
+		assert.Contains(t, names, "HasFlags")
+		assert.Contains(t, names, "TwoFlags")
+	})
+}
+
+// TestVectorLiteralWithOr verifies the (or ...) scenario from the bug report:
+// (or [(missing? $ ?e :attr)] [?e :attr []]) should return entities where the
+// attribute is missing OR empty, but NOT entities with non-empty vectors.
+func TestVectorLiteralWithOr(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "vector-literal-or-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	s, err := schema.NewBuilder().
+		Attribute(":entity/name").Type(schema.TypeString).Add().
+		Attribute(":entity/lore").Type(schema.TypeString).Vector().Add().
+		Build()
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	name := datalog.NewKeyword(":entity/name")
+	lore := datalog.NewKeyword(":entity/lore")
+
+	hasLore := datalog.NewIdentity("has-lore")
+	emptyLore := datalog.NewIdentity("empty-lore")
+	noLore := datalog.NewIdentity("no-lore")
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(hasLore, name, "HasLore"))
+	require.NoError(t, tx.Add(hasLore, lore, "Deep in the mountains..."))
+	require.NoError(t, tx.Add(emptyLore, name, "EmptyLore"))
+	require.NoError(t, tx.Add(noLore, name, "NoLore"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Create then clear emptyLore's vector
+	tx2 := db.NewTransaction()
+	require.NoError(t, tx2.Add(emptyLore, lore, "placeholder"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+	tx3 := db.NewTransaction()
+	require.NoError(t, tx3.Set(emptyLore, lore, []interface{}{}))
+	_, err = tx3.Commit()
+	require.NoError(t, err)
+
+	// Sanity check: missing? alone should find NoLore
+	missingResults, err := executor.CollectTuples(db.Query(
+		`[:find ?name :where
+		  [?e :entity/name ?name]
+		  [(missing? $ ?e :entity/lore)]]`))
+	require.NoError(t, err)
+	t.Logf("missing? alone: %v", missingResults)
+
+	// Sanity check: [] alone should find EmptyLore
+	emptyResults, err := executor.CollectTuples(db.Query(
+		`[:find ?name :where
+		  [?e :entity/name ?name]
+		  [?e :entity/lore []]]`))
+	require.NoError(t, err)
+	t.Logf("[] alone: %v", emptyResults)
+
+	results, err := executor.CollectTuples(db.Query(
+		`[:find ?name :where
+		  [?e :entity/name ?name]
+		  (or [(missing? $ ?e :entity/lore)]
+		      [?e :entity/lore []])]`))
+	require.NoError(t, err)
+	t.Logf("or combined: %v", results)
+
+	names := make([]string, len(results))
+	for i, tuple := range results {
+		names[i] = tuple[0].(string)
+	}
+
+	assert.Contains(t, names, "NoLore", "missing attribute should match")
+	assert.Contains(t, names, "EmptyLore", "empty vector should match")
+	assert.NotContains(t, names, "HasLore", "non-empty vector should NOT match")
+	assert.Len(t, names, 2)
+}

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -508,6 +508,10 @@ func (m *BadgerMatcher) extractValue(elem query.PatternElement) interface{} {
 	case query.Constant:
 		// Constants must match exactly
 		return e.Value
+	case query.VectorConstant:
+		// Vector literals: return the Values slice for comparison
+		// after RGA resolution. Empty slice means "match empty vector".
+		return e.Values
 	default:
 		return nil
 	}

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -95,7 +95,8 @@ func (m *BadgerMatcher) MatchWithConstraints(
 			if kw, ok := aResolved.(datalog.Keyword); ok {
 				if attr := m.schema.GetAttribute(kw); attr != nil {
 					if attr.Cardinality == schema.CardinalityVector {
-						return m.matchVectorWithBindings(pattern, bindingRel, symbols, kw, attr.ValueType)
+						vBound := m.extractValue(pattern.GetV())
+						return m.matchVectorWithBindings(pattern, bindingRel, symbols, kw, vBound, attr.ValueType)
 					}
 				}
 			}
@@ -297,9 +298,13 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, symbo
 				useAddWinsResolution = true
 			}
 		} else {
-			// V is bound - for cardinality-many, this is a membership check
-			if card == schema.CardinalityMany {
+			// V is bound
+			switch card {
+			case schema.CardinalityMany:
 				useMembershipCheck = true
+			case schema.CardinalityVector:
+				// Vector literal: resolve RGA then compare against bound V
+				useVectorResolution = true
 			}
 		}
 	} else if e == nil && a != nil && v != nil && card == schema.CardinalityOne {
@@ -321,6 +326,11 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, symbo
 			BoundV:          v,
 		}
 		return m.matchWithVValidation(pattern, bindingRel, symbols, strategy, nil)
+	} else if e == nil && a != nil && card == schema.CardinalityVector {
+		// E unbound, A bound, cardinality-vector
+		// Scan all entities with this attribute, resolve each vector, compare against V.
+		// Pass v (nil for unbound, []interface{} for bound literal).
+		return m.matchVectorScanAllEntities(pattern, symbols, a, v, valueType)
 	} else if e == nil && a != nil && card == schema.CardinalityMany {
 		// E is unbound, A is bound, cardinality-many
 		// Need to scan all entities with this attribute and apply add-wins resolution
@@ -345,7 +355,7 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, symbo
 
 	// For cardinality-vector with E+A bound: use vector resolution
 	if useVectorResolution {
-		return m.matchCardinalityVectorAsRelation(pattern, symbols, e, a, valueType)
+		return m.matchCardinalityVectorAsRelation(pattern, symbols, e, a, v, valueType)
 	}
 
 	// For cardinality-many with E+A bound, V unbound: use add-wins resolution
@@ -1076,7 +1086,7 @@ func (m *BadgerMatcher) matchFromCache(
 		}
 		if v != nil {
 			// V is bound - check if it matches
-			if !valuesEqual(val, v) {
+			if !datalog.ValuesEqual(val, v) {
 				return executor.NewMaterializedRelationWithOptions(symbols, nil, m.options), true
 			}
 		}
@@ -1107,16 +1117,19 @@ func (m *BadgerMatcher) matchFromCache(
 
 	case schema.CardinalityVector:
 		list := entry.VectorList()
-		if len(list) == 0 {
+		resolved := typedVector(list, valueType)
+		if v != nil {
+			// V is bound - compare resolved vector against bound value
+			if !datalog.ValuesEqual(resolved, v) {
+				return executor.NewMaterializedRelationWithOptions(symbols, nil, m.options), true
+			}
+			// Matched — fall through to build tuple
+		}
+		if len(list) == 0 && v == nil {
+			// Empty vector with unbound V — no tuples
 			return executor.NewMaterializedRelationWithOptions(symbols, nil, m.options), true
 		}
-		if v != nil {
-			// V is bound - check if vector equals (for vector, V is the whole list)
-			// This is an edge case - usually V is unbound for vectors
-			return nil, false // Fallback to storage for this case
-		}
-		// V is unbound - return the vector as a single typed value
-		tuple := buildTuple(typedVector(list, valueType), entry.Version())
+		tuple := buildTuple(resolved, entry.Version())
 		return executor.NewMaterializedRelationWithOptions(symbols, []executor.Tuple{tuple}, m.options), true
 	}
 
@@ -1297,7 +1310,7 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 			if val == nil {
 				continue // No value for this E
 			}
-			if v != nil && !valuesEqual(val, v) {
+			if v != nil && !datalog.ValuesEqual(val, v) {
 				continue // Value doesn't match bound V
 			}
 			resultTuples = append(resultTuples, buildTuple(eIdent, val, entry.Version()))
@@ -1333,39 +1346,6 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 	}
 
 	return executor.NewMaterializedRelationWithOptions(symbols, resultTuples, m.options), true
-}
-
-// valuesEqual compares two values for equality
-func valuesEqual(a, b interface{}) bool {
-	// Handle common types directly for performance
-	switch av := a.(type) {
-	case string:
-		if bv, ok := b.(string); ok {
-			return av == bv
-		}
-	case int64:
-		if bv, ok := b.(int64); ok {
-			return av == bv
-		}
-	case float64:
-		if bv, ok := b.(float64); ok {
-			return av == bv
-		}
-	case bool:
-		if bv, ok := b.(bool); ok {
-			return av == bv
-		}
-	case datalog.Identity:
-		if bv, ok := b.(datalog.Identity); ok {
-			return av.Hash() == bv.Hash()
-		}
-	case datalog.Keyword:
-		if bv, ok := b.(datalog.Keyword); ok {
-			return av == bv
-		}
-	}
-	// Fallback to reflect-based comparison
-	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
 }
 
 // matchCardinalityManyAsRelation handles cardinality-many patterns using add-wins resolution
@@ -1427,7 +1407,7 @@ func (m *BadgerMatcher) matchCardinalityManyAsRelation(
 func (m *BadgerMatcher) matchCardinalityVectorAsRelation(
 	pattern *query.DataPattern,
 	symbols []query.Symbol,
-	e, a interface{},
+	e, a, v interface{},
 	valueType schema.ValueType,
 ) (executor.Relation, error) {
 	// Get entity and attribute bytes
@@ -1447,8 +1427,25 @@ func (m *BadgerMatcher) matchCardinalityVectorAsRelation(
 		return nil, fmt.Errorf("vector resolution failed: %w", err)
 	}
 
-	// If empty vector, return empty relation
-	if len(result.Elements) == 0 {
+	// No datoms at all → attribute was never set
+	if result.Stats.TotalElements == 0 {
+		return executor.NewMaterializedRelation(symbols, nil), nil
+	}
+
+	// Convert resolved elements to a typed vector
+	resolved := typedVector(result.Elements, valueType)
+
+	// If V is bound, compare the resolved vector against the bound value
+	if v != nil {
+		if !datalog.ValuesEqual(resolved, v) {
+			return executor.NewMaterializedRelation(symbols, nil), nil
+		}
+		// Matched — fall through to build the tuple
+	}
+
+	// If empty vector (and V was nil/matched), return empty relation
+	// Empty vectors produce no tuples for unbound V queries.
+	if len(result.Elements) == 0 && v == nil {
 		return executor.NewMaterializedRelation(symbols, nil), nil
 	}
 
@@ -1464,8 +1461,7 @@ func (m *BadgerMatcher) matchCardinalityVectorAsRelation(
 			tuple[i] = a
 		case pattern.GetV() != nil && pattern.GetV().IsVariable() &&
 			pattern.GetV().(query.Variable).Name == sym:
-			// Return the entire vector as a typed slice
-			tuple[i] = typedVector(result.Elements, valueType)
+			tuple[i] = resolved
 		case pattern.GetT() != nil && pattern.GetT().IsVariable() &&
 			pattern.GetT().(query.Variable).Name == sym:
 			// Use the max ElementID as the "current" transaction
@@ -1485,6 +1481,7 @@ func (m *BadgerMatcher) matchVectorWithBindings(
 	bindingRel executor.Relation,
 	symbols []query.Symbol,
 	attr datalog.Keyword,
+	v interface{},
 	valueType schema.ValueType,
 ) (executor.Relation, error) {
 	// Find which symbol in bindings provides the entity
@@ -1535,8 +1532,22 @@ func (m *BadgerMatcher) matchVectorWithBindings(
 			return nil, fmt.Errorf("vector resolution failed for entity: %w", err)
 		}
 
-		// Skip entities with empty vectors
-		if len(result.Elements) == 0 {
+		resolved := typedVector(result.Elements, valueType)
+
+		neverSet := result.Stats.TotalElements == 0
+
+		// Entity has no datoms at all for this attribute — skip always
+		if neverSet {
+			continue
+		}
+
+		// If V is bound, compare the resolved vector against bound value
+		if v != nil {
+			if !datalog.ValuesEqual(resolved, v) {
+				continue
+			}
+		} else if len(result.Elements) == 0 {
+			// Unbound V: skip entities with empty vectors
 			continue
 		}
 
@@ -1552,8 +1563,7 @@ func (m *BadgerMatcher) matchVectorWithBindings(
 				tuple[i] = attr
 			case pattern.GetV() != nil && pattern.GetV().IsVariable() &&
 				pattern.GetV().(query.Variable).Name == sym:
-				// Return the entire vector as a typed slice
-				tuple[i] = typedVector(result.Elements, valueType)
+				tuple[i] = resolved
 			case pattern.GetT() != nil && pattern.GetT().IsVariable() &&
 				pattern.GetT().(query.Variable).Name == sym:
 				tuple[i] = result.MaxElementID
@@ -1724,6 +1734,132 @@ func (it *cardinalityManyScanAllEntitiesIterator) Tuple() executor.Tuple {
 }
 
 func (it *cardinalityManyScanAllEntitiesIterator) Close() error {
+	if it.storageIter != nil {
+		return it.storageIter.Close()
+	}
+	return nil
+}
+
+// matchVectorScanAllEntities handles [?e :attr <vector-literal>] where E is unbound.
+// Scans all entities with the attribute and resolves each vector using RGA.
+// If v is non-nil, only entities whose resolved vector equals v are returned.
+// If v is nil, all entities with non-empty vectors are returned.
+func (m *BadgerMatcher) matchVectorScanAllEntities(
+	pattern *query.DataPattern,
+	symbols []query.Symbol,
+	a, v interface{},
+	valueType schema.ValueType,
+) (executor.Relation, error) {
+	var aBytes [32]byte
+	if kw, ok := a.(datalog.Keyword); ok {
+		copy(aBytes[:], kw.String())
+	}
+
+	// Scan AEVT to find all entities with this attribute
+	prefix := make([]byte, 1+32)
+	prefix[0] = byte(AEVT)
+	copy(prefix[1:33], aBytes[:])
+
+	storageIter, err := m.store.Scan(AEVT, prefix, prefixEnd(prefix))
+	if err != nil {
+		return nil, fmt.Errorf("AEVT scan failed: %w", err)
+	}
+
+	iter := &vectorScanAllEntitiesIterator{
+		matcher:      m,
+		pattern:      pattern,
+		symbols:      symbols,
+		a:            a,
+		v:            v,
+		aBytes:       aBytes,
+		valueType:    valueType,
+		storageIter:  storageIter,
+		seenEntities: make(map[[20]byte]bool),
+	}
+
+	return executor.NewStreamingRelationWithOptions(symbols, iter, m.options), nil
+}
+
+// vectorScanAllEntitiesIterator streams results for vector patterns with E unbound.
+// For each unique entity, resolves the RGA vector and yields a tuple if it matches.
+type vectorScanAllEntitiesIterator struct {
+	matcher      *BadgerMatcher
+	pattern      *query.DataPattern
+	symbols      []query.Symbol
+	a, v         interface{}
+	aBytes       [32]byte
+	valueType    schema.ValueType
+	storageIter  Iterator
+	seenEntities map[[20]byte]bool
+
+	currentTuple executor.Tuple
+}
+
+func (it *vectorScanAllEntitiesIterator) Next() bool {
+	for it.storageIter.Next() {
+		datom, err := it.storageIter.Datom()
+		if err != nil {
+			continue
+		}
+
+		eBytes := datom.E.Hash()
+		if it.seenEntities[eBytes] {
+			continue
+		}
+		it.seenEntities[eBytes] = true
+
+		// Resolve vector for this entity
+		result, err := it.matcher.resolveVector(eBytes[:], it.aBytes[:])
+		if err != nil {
+			continue
+		}
+
+		// Never set — skip
+		if result.Stats.TotalElements == 0 {
+			continue
+		}
+
+		resolved := typedVector(result.Elements, it.valueType)
+
+		if it.v != nil {
+			// V is bound — compare
+			if !datalog.ValuesEqual(resolved, it.v) {
+				continue
+			}
+		} else if len(result.Elements) == 0 {
+			// Unbound V: skip empty vectors
+			continue
+		}
+
+		// Build tuple
+		tuple := make(executor.Tuple, len(it.symbols))
+		for i, sym := range it.symbols {
+			switch {
+			case it.pattern.GetE() != nil && it.pattern.GetE().IsVariable() &&
+				it.pattern.GetE().(query.Variable).Name == sym:
+				tuple[i] = datom.E
+			case it.pattern.GetA() != nil && it.pattern.GetA().IsVariable() &&
+				it.pattern.GetA().(query.Variable).Name == sym:
+				tuple[i] = it.a
+			case it.pattern.GetV() != nil && it.pattern.GetV().IsVariable() &&
+				it.pattern.GetV().(query.Variable).Name == sym:
+				tuple[i] = resolved
+			case it.pattern.GetT() != nil && it.pattern.GetT().IsVariable() &&
+				it.pattern.GetT().(query.Variable).Name == sym:
+				tuple[i] = result.MaxElementID
+			}
+		}
+		it.currentTuple = tuple
+		return true
+	}
+	return false
+}
+
+func (it *vectorScanAllEntitiesIterator) Tuple() executor.Tuple {
+	return it.currentTuple
+}
+
+func (it *vectorScanAllEntitiesIterator) Close() error {
 	if it.storageIter != nil {
 		return it.storageIter.Close()
 	}

--- a/docs/bugs/BUG_EMPTY_VECTOR_LITERAL_MATCHES_NONEMPTY.md
+++ b/docs/bugs/BUG_EMPTY_VECTOR_LITERAL_MATCHES_NONEMPTY.md
@@ -1,0 +1,106 @@
+# Empty Vector Literal in Data Pattern Matches Non-Empty Vectors
+
+**Date**: 2026-02-24
+**Severity**: Correctness (High)
+**Status**: Fixed (2026-02-25)
+**Affected**: Any query using `[?e :attr []]` to match entities with empty vector attributes
+
+## Summary
+
+When a data pattern uses an empty vector literal `[]` in the value position (e.g., `[?e :entity/lore []]`), it matches entities that have **non-empty** vectors — the opposite of what it should do. An entity with `:entity/lore ["Deep in the mountains..."]` matches `[?e :entity/lore []]`.
+
+Additionally, the combination with `(or ...)` is broken: `(or [(missing? $ ?e :attr)] [?e :attr []])` returns only the `[]` branch results (the wrong entities), not a union of both branches.
+
+## Discovery
+
+Found during PR review of a `string` → `cardinality/vector` migration in a downstream application. A query was changed from:
+
+```clojure
+(or [(missing? $ ?e :entity/lore)]
+    [?e :entity/lore ""])
+```
+
+to:
+
+```clojure
+(or [(missing? $ ?e :entity/lore)]
+    [?e :entity/lore []])
+```
+
+The expectation was that `[?e :entity/lore []]` would match entities with an empty vector, complementing `missing?` which matches entities without the attribute at all. Instead, the query returned entities that **had** lore and missed entities that **didn't**.
+
+## Reproduction
+
+Three entities created:
+- POI A: no `:entity/lore` attribute
+- POI B: `:entity/lore` = `["Deep in the mountains..."]`
+- POI C: no `:entity/lore` attribute
+
+### Query 1: `missing?` alone (correct)
+
+```clojure
+[:find ?code :in $ ?map ?type :where
+  [?e :entity/map ?map]
+  [?e :entity/type ?type]
+  [?e :entity/code ?code]
+  [(missing? $ ?e :entity/lore)]]
+```
+
+**Result**: `[POI A, POI C]` — correct.
+
+### Query 2: `[?e :entity/lore []]` alone (wrong)
+
+```clojure
+[:find ?code :in $ ?map ?type :where
+  [?e :entity/map ?map]
+  [?e :entity/type ?type]
+  [?e :entity/code ?code]
+  [?e :entity/lore []]]
+```
+
+**Result**: `[POI B]` — **wrong**. POI B has non-empty lore. POI A and POI C (which have no lore at all) are not returned.
+
+### Query 3: `(or ...)` combining both (wrong)
+
+```clojure
+[:find ?code :in $ ?map ?type :where
+  [?e :entity/map ?map]
+  [?e :entity/type ?type]
+  [?e :entity/code ?code]
+  (or [(missing? $ ?e :entity/lore)]
+      [?e :entity/lore []])]
+```
+
+**Result**: `[POI B]` — **wrong**. Returns only the `[]` branch results, not the union of both branches.
+
+## Root Causes (Confirmed)
+
+Five issues, not two:
+
+1. **`extractValue()` didn't handle `VectorConstant`.** It returned `nil` for vector literals, making `[]` and `["a" "b"]` both act as wildcards. Fixed in `matcher.go` — now returns `e.Values`.
+
+2. **Vector matching paths never compared against bound V.** Even with `extractValue` fixed, three code paths (`matchCardinalityVectorAsRelation`, `matchVectorWithBindings`, `matchFromCache`) resolved the RGA vector but never compared it against the bound value. All three now call `datalog.ValuesEqual(resolved, v)` when V is non-nil.
+
+3. **E-unbound vector patterns panicked.** Patterns like `[?e :attr []]` without E bindings reached `chooseIndex` which called `datalog.Type()` on `[]interface{}` and panicked. New `matchVectorScanAllEntities` with streaming iterator handles this path, following the `cardinalityManyScanAllEntitiesIterator` pattern.
+
+4. **"Never set" confused with "cleared to empty".** `resolveVector` returns an empty typed slice for both "attribute never written" (`TotalElements=0`) and "attribute cleared to empty" (`TotalElements>0, LiveElements=0`). The empty literal `[]` must match only "cleared". All vector paths now check `Stats.TotalElements==0` to distinguish.
+
+5. **`BranchHasExpressions` missed predicates.** `[(missing? $ ?e :attr)]` parses as `*DatabaseFunctionPredicate` (a `Predicate`, not `*Expression`). `BranchHasExpressions` didn't detect it, routing the OR clause to union mode which passes `nil` binding — predicate-only branches can't produce results without input bindings. Added `Predicate` detection gated on `RequiredSymbols()>0` in `query/clause.go`.
+
+Also consolidated `ValuesEqual`: added reflect-based slice comparison for typed (`[]string`) vs untyped (`[]interface{}`) vectors, removed unsafe `fmt.Sprintf` fallback, eliminated duplicate wrapper functions.
+
+## Files Changed
+
+- `datalog/storage/matcher.go` — `extractValue` handles `VectorConstant`
+- `datalog/storage/matcher_relations.go` — bound-V comparison in all vector paths, `matchVectorScanAllEntities` streaming iterator, cache path comparison, "never set" detection
+- `datalog/query/clause.go` — `BranchHasExpressions` detects binding-dependent predicates
+- `datalog/compare.go` — `ValuesEqual` slice comparison, removed `fmt.Sprintf` fallback
+- `datalog/compare_test.go` — 17 `TestValuesEqualSlices` subtests
+- `datalog/executor/testing.go` — eliminated duplicate `valuesEqual` wrapper
+- `datalog/storage/crdt_vector_test.go` — 19 `TestVectorLiteralMatch` subtests (string, int64, keyword) + `TestVectorLiteralWithOr`
+
+## Regression Tests
+
+- `datalog/storage/crdt_vector_test.go:TestVectorLiteralMatch` — 19 subtests covering empty/populated literals across string, int64, keyword vector types; exact match, partial match rejection, unbound V behavior
+- `datalog/storage/crdt_vector_test.go:TestVectorLiteralWithOr` — the original `(or [(missing? ...)] [?e :attr []])` pattern
+- Downstream application has a corresponding regression test


### PR DESCRIPTION
Vector literals like `[?e :attr []]` and `[?e :attr ["a" "b"]]` were treated as wildcards because `extractValue()` didn't handle `VectorConstant`, returning nil. Even after fixing that, the vector matching code paths never compared the resolved RGA vector against the bound value.

Five root causes fixed:

1. `extractValue()` for `VectorConstant` — now returns `e.Values` so vector literals produce a bound `V` value instead of nil (wildcard).

2. Vector matching with bound `V` — three code paths updated to compare the resolved typed vector against the bound value via `ValuesEqual`: `matchCardinalityVectorAsRelation` (E+A bound, no bindings), `matchVectorWithBindings` (E+A from binding relation), and the EA cache path in matchFromCache.

3. `E`-unbound vector scan — new `matchVectorScanAllEntities` with streaming iterator (follows `cardinalityManyScanAllEntitiesIterator` pattern) for patterns like `[?e :attr []]` where E is unbound. Previously this reached `chooseIndex` which panicked on `[]interface{}`.

4. "Never set" vs "cleared to empty" — `resolveVector` returns an empty typed slice for both "attribute never written" (`TotalElements=0`) and "attribute cleared to empty" (`TotalElements>0`, `LiveElements=0`). The empty literal `[]` must match only "cleared", not "never set". All three vector paths now check `Stats.TotalElements==0` to distinguish.

5. BranchHasExpressions missed predicates — `[(missing? $ ?e :attr)]` parses as `DatabaseFunctionPredicate` (a `Predicate`, not an `Expression`). `BranchHasExpressions` didn't detect it, routing the OR clause to union mode which passes `nil` binding — predicate-only branches can't produce results without input bindings. Added `Predicate` detection gated on `RequiredSymbols()>0` so only binding-dependent predicates trigger fallback semantics; predicates like `HistoryPredicate` that don't filter remain in union mode.

Also consolidates `ValuesEqual`: adds reflect-based slice comparison for typed (`[]string`) vs untyped (`[]interface{}`) vectors, removes unsafe `fmt.Sprintf` fallback, eliminates duplicate wrapper functions.