### PR TITLE
Fix CRDT tombstone re-add in SaveStruct; add op-inferred resolution fallback

### DIFF
--- a/datalog/reflect/integration_test.go
+++ b/datalog/reflect/integration_test.go
@@ -2,6 +2,7 @@ package reflect_test
 
 import (
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/wbrown/janus-datalog/datalog"
@@ -1490,5 +1491,209 @@ func TestPullInto_CardinalityManyStrings_MultipleValues(t *testing.T) {
 		t.Errorf("PullInto: expected 3 hooks, got %d (BUG: only first value returned)", len(loaded.Hooks))
 		t.Errorf("Expected: %v", dungeon.Hooks)
 		t.Errorf("Got: %v", loaded.Hooks)
+	}
+}
+
+// TestCRDTTombstoneReAdd demonstrates a bug where SaveStruct cannot re-add a
+// value to a cardinality-many field after that value was previously removed.
+//
+// ROOT CAUSE: Transaction.SaveStruct creates a BadgerMatcher via
+// NewBadgerMatcher(t.db.Store()) which does NOT set the cache field. This
+// causes LookupAllAttributes to use a fallback code path (raw AEVT scan) that
+// returns ALL datoms — both Add and Remove ops — without performing add-wins
+// CRDT resolution. The diff logic in updateSliceField then sees tombstoned
+// values as still present and skips the re-add.
+//
+// See docs/bugs/BUG-CRDT-READD-SAVESTRUCT.md for full analysis.
+func TestCRDTTombstoneReAdd(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crdt-tombstone-readd")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(PersonWithTags{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Step 1: Create entity with initial tags
+	alice := PersonWithTags{
+		Name: "Alice",
+		Tags: []string{"fantasy", "adventure", "epic"},
+	}
+	tx := db.NewTransaction()
+	aliceID, err := tx.SaveStruct(&alice)
+	if err != nil {
+		t.Fatalf("SaveStruct (initial): %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Commit (initial): %v", err)
+	}
+
+	// Verify initial state
+	var loaded PersonWithTags
+	if err := db.PullInto(aliceID, &loaded); err != nil {
+		t.Fatalf("PullInto (initial): %v", err)
+	}
+	sort.Strings(loaded.Tags)
+	if len(loaded.Tags) != 3 {
+		t.Fatalf("initial: expected 3 tags, got %d: %v", len(loaded.Tags), loaded.Tags)
+	}
+	t.Logf("Step 1 - Initial tags: %v", loaded.Tags)
+
+	// Step 2: Remove "adventure" by saving with a subset (creates CRDT tombstone)
+	alice.ID = aliceID
+	alice.Tags = []string{"fantasy", "epic"}
+	tx = db.NewTransaction()
+	if _, err := tx.SaveStruct(&alice); err != nil {
+		t.Fatalf("SaveStruct (remove): %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Commit (remove): %v", err)
+	}
+
+	if err := db.PullInto(aliceID, &loaded); err != nil {
+		t.Fatalf("PullInto (after remove): %v", err)
+	}
+	sort.Strings(loaded.Tags)
+	t.Logf("Step 2 - After removal: %v", loaded.Tags)
+	if len(loaded.Tags) != 2 {
+		t.Fatalf("after removal: expected 2 tags %v, got %d: %v",
+			[]string{"epic", "fantasy"}, len(loaded.Tags), loaded.Tags)
+	}
+
+	// Step 3: Re-add "adventure" via SaveStruct — THIS IS THE BUG
+	alice.Tags = []string{"fantasy", "epic", "adventure"}
+	tx = db.NewTransaction()
+	if _, err := tx.SaveStruct(&alice); err != nil {
+		t.Fatalf("SaveStruct (re-add): %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Commit (re-add): %v", err)
+	}
+
+	if err := db.PullInto(aliceID, &loaded); err != nil {
+		t.Fatalf("PullInto (after re-add): %v", err)
+	}
+	sort.Strings(loaded.Tags)
+	t.Logf("Step 3 - After re-add via SaveStruct: %v", loaded.Tags)
+
+	// Diagnose: show what LookupAllAttributes returns with and without cache
+	matcherNoCache := storage.NewBadgerMatcher(db.Store())
+	uncachedVals := matcherNoCache.LookupAllAttributes(aliceID, datalog.NewKeyword(":person-with-tags/tags"))
+	t.Logf("DIAGNOSTIC: LookupAllAttributes WITHOUT cache: %v (%d values)", uncachedVals, len(uncachedVals))
+
+	matcherWithCache := db.Matcher().(*storage.BadgerMatcher)
+	cachedVals := matcherWithCache.LookupAllAttributes(aliceID, datalog.NewKeyword(":person-with-tags/tags"))
+	t.Logf("DIAGNOSTIC: LookupAllAttributes WITH cache:    %v (%d values)", cachedVals, len(cachedVals))
+
+	if len(uncachedVals) != len(cachedVals) {
+		t.Logf("BUG CONFIRMED: uncached path returns %d values, cached path returns %d",
+			len(uncachedVals), len(cachedVals))
+	}
+
+	// Assert correct behavior: "adventure" must be re-added
+	expected := []string{"adventure", "epic", "fantasy"}
+	if len(loaded.Tags) != len(expected) {
+		t.Errorf("after re-add: expected %d tags %v, got %d tags %v",
+			len(expected), expected, len(loaded.Tags), loaded.Tags)
+	} else {
+		for i := range expected {
+			if loaded.Tags[i] != expected[i] {
+				t.Errorf("after re-add: tag[%d] expected %q, got %q", i, expected[i], loaded.Tags[i])
+			}
+		}
+	}
+}
+
+// TestCRDTTombstoneReAdd_TxSetWorkaround verifies that tx.Set() correctly
+// handles tombstone re-adds, serving as the workaround for the SaveStruct bug.
+func TestCRDTTombstoneReAdd_TxSetWorkaround(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "crdt-tombstone-txset")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	schema, err := dlreflect.SchemaFromStruct(PersonWithTags{})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	db, err := storage.NewDatabaseWithSchema(tmpDir, schema)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	// Step 1: Create entity with initial tags
+	alice := PersonWithTags{
+		Name: "Alice",
+		Tags: []string{"fantasy", "adventure", "epic"},
+	}
+	tx := db.NewTransaction()
+	aliceID, err := tx.SaveStruct(&alice)
+	if err != nil {
+		t.Fatalf("SaveStruct (initial): %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Commit (initial): %v", err)
+	}
+
+	// Step 2: Remove "adventure" via SaveStruct (creates tombstone)
+	alice.ID = aliceID
+	alice.Tags = []string{"fantasy", "epic"}
+	tx = db.NewTransaction()
+	if _, err := tx.SaveStruct(&alice); err != nil {
+		t.Fatalf("SaveStruct (remove): %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Commit (remove): %v", err)
+	}
+
+	var loaded PersonWithTags
+	if err := db.PullInto(aliceID, &loaded); err != nil {
+		t.Fatalf("PullInto (after remove): %v", err)
+	}
+	sort.Strings(loaded.Tags)
+	if len(loaded.Tags) != 2 {
+		t.Fatalf("after removal: expected 2 tags, got %d: %v", len(loaded.Tags), loaded.Tags)
+	}
+
+	// Step 3: Re-add "adventure" via tx.Set() — workaround that performs
+	// proper add-wins CRDT resolution
+	tagKw := datalog.NewKeyword(":person-with-tags/tags")
+	tagVals := []interface{}{"fantasy", "epic", "adventure"}
+	tx = db.NewTransaction()
+	if err := tx.Set(aliceID, tagKw, tagVals); err != nil {
+		t.Fatalf("tx.Set (re-add): %v", err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Commit (re-add): %v", err)
+	}
+
+	if err := db.PullInto(aliceID, &loaded); err != nil {
+		t.Fatalf("PullInto (after re-add): %v", err)
+	}
+	sort.Strings(loaded.Tags)
+	t.Logf("After re-add via tx.Set(): %v", loaded.Tags)
+
+	expected := []string{"adventure", "epic", "fantasy"}
+	if len(loaded.Tags) != len(expected) {
+		t.Errorf("after re-add via tx.Set: expected %d tags %v, got %d tags %v",
+			len(expected), expected, len(loaded.Tags), loaded.Tags)
+	} else {
+		for i := range expected {
+			if loaded.Tags[i] != expected[i] {
+				t.Errorf("after re-add via tx.Set: tag[%d] expected %q, got %q", i, expected[i], loaded.Tags[i])
+			}
+		}
 	}
 }

--- a/datalog/reflect/integration_test.go
+++ b/datalog/reflect/integration_test.go
@@ -1587,11 +1587,17 @@ func TestCRDTTombstoneReAdd(t *testing.T) {
 
 	// Diagnose: show what LookupAllAttributes returns with and without cache
 	matcherNoCache := storage.NewBadgerMatcher(db.Store())
-	uncachedVals := matcherNoCache.LookupAllAttributes(aliceID, datalog.NewKeyword(":person-with-tags/tags"))
+	uncachedVals, err := matcherNoCache.LookupAllAttributes(aliceID, datalog.NewKeyword(":person-with-tags/tags"))
+	if err != nil {
+		t.Fatalf("LookupAllAttributes (no cache): %v", err)
+	}
 	t.Logf("DIAGNOSTIC: LookupAllAttributes WITHOUT cache: %v (%d values)", uncachedVals, len(uncachedVals))
 
 	matcherWithCache := db.Matcher().(*storage.BadgerMatcher)
-	cachedVals := matcherWithCache.LookupAllAttributes(aliceID, datalog.NewKeyword(":person-with-tags/tags"))
+	cachedVals, err := matcherWithCache.LookupAllAttributes(aliceID, datalog.NewKeyword(":person-with-tags/tags"))
+	if err != nil {
+		t.Fatalf("LookupAllAttributes (with cache): %v", err)
+	}
 	t.Logf("DIAGNOSTIC: LookupAllAttributes WITH cache:    %v (%d values)", cachedVals, len(cachedVals))
 
 	if len(uncachedVals) != len(cachedVals) {

--- a/datalog/reflect/ordered_set_test.go
+++ b/datalog/reflect/ordered_set_test.go
@@ -161,8 +161,8 @@ func (m *mockTransaction) LookupAttribute(entity datalog.Identity, attr datalog.
 	return nil, false
 }
 
-func (m *mockTransaction) LookupAllAttributes(entity datalog.Identity, attr datalog.Keyword) []interface{} {
-	return nil
+func (m *mockTransaction) LookupAllAttributes(entity datalog.Identity, attr datalog.Keyword) ([]interface{}, error) {
+	return nil, nil
 }
 
 // CharacterWithPreferences tests OrderedSet[string] fields

--- a/datalog/reflect/writer.go
+++ b/datalog/reflect/writer.go
@@ -56,7 +56,7 @@ type EntityLookup interface {
 
 	// LookupAllAttributes returns all values for a cardinality-many attribute
 	// Returns empty slice if attribute not found
-	LookupAllAttributes(entity datalog.Identity, attr datalog.Keyword) []interface{}
+	LookupAllAttributes(entity datalog.Identity, attr datalog.Keyword) ([]interface{}, error)
 }
 
 // UpdateMode controls how cardinality-many fields are updated
@@ -363,7 +363,10 @@ func (sw *StructWriter) updateSliceField(tx TransactionUpdater, lookup EntityLoo
 	// For cardinality-many: use element-by-element diff
 	if mode == UpdateModeReplace {
 		// Diff-based set assignment: slice IS the new complete state
-		existingVals := lookup.LookupAllAttributes(entity, kw)
+		existingVals, err := lookup.LookupAllAttributes(entity, kw)
+		if err != nil {
+			return fmt.Errorf("lookup existing values for %s: %w", kw, err)
+		}
 
 		// Remove values in existing but not in new (CRDT tombstone)
 		for _, existing := range existingVals {
@@ -385,7 +388,10 @@ func (sw *StructWriter) updateSliceField(tx TransactionUpdater, lookup EntityLoo
 	} else {
 		// UpdateModeAdd - union semantics: add new values to existing set
 		// Only add values that don't already exist
-		existingVals := lookup.LookupAllAttributes(entity, kw)
+		existingVals, err := lookup.LookupAllAttributes(entity, kw)
+		if err != nil {
+			return fmt.Errorf("lookup existing values for %s: %w", kw, err)
+		}
 		for _, newVal := range newVals {
 			if !containsValue(existingVals, newVal) {
 				if err := tx.Add(entity, kw, newVal); err != nil {

--- a/datalog/storage/cache_integration_test.go
+++ b/datalog/storage/cache_integration_test.go
@@ -106,7 +106,8 @@ func TestPullAPIUsesCache(t *testing.T) {
 	assert.Equal(t, "Alice", name)
 
 	// Lookup all tags (cardinality-many via LookupAllAttributes)
-	tags := bm.LookupAllAttributes(e, datalog.NewKeyword(":person/tags"))
+	tags, err := bm.LookupAllAttributes(e, datalog.NewKeyword(":person/tags"))
+	require.NoError(t, err)
 	assert.Len(t, tags, 2)
 	// Convert to set for order-independent comparison
 	tagSet := make(map[interface{}]bool)

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -1882,7 +1882,7 @@ func (t *Transaction) AddMap(attrs map[string]interface{}) (datalog.Identity, er
 //	person.Name = "Alice Smith"
 //	id, err = tx.SaveStruct(&person)  // Updates name, age unchanged
 func (t *Transaction) SaveStruct(v interface{}) (datalog.Identity, error) {
-	matcher := NewBadgerMatcher(t.db.Store())
+	matcher := t.db.Matcher().(*BadgerMatcher)
 	return dlreflect.SaveStruct(t, matcher, v, t.db.Schema())
 }
 

--- a/datalog/storage/lookup_all_crdt_test.go
+++ b/datalog/storage/lookup_all_crdt_test.go
@@ -31,7 +31,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_LWW_LatestValue(t *testing.T) {
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	// LWW: should return only the latest value
 	if len(vals) != 1 {
@@ -56,7 +59,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_LWW_SingleValue(t *testing.T) {
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	if len(vals) != 1 {
 		t.Errorf("expected 1 value, got %d: %v", len(vals), vals)
@@ -84,7 +90,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_AddWins_Basic(t *testing.T) {
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	got := toStringSlice(t, vals)
 	sort.Strings(got)
@@ -111,7 +120,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_AddWins_AfterRemoval(t *testing.T) 
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	got := toStringSlice(t, vals)
 	sort.Strings(got)
@@ -141,7 +153,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_AddWins_ReAdd(t *testing.T) {
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	got := toStringSlice(t, vals)
 	sort.Strings(got)
@@ -166,7 +181,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_AddWins_ConcurrentAddWins(t *testin
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	got := toStringSlice(t, vals)
 	expected := []string{"adventure"}
@@ -188,7 +206,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_AddWins_OnlyRemoves(t *testing.T) {
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	if len(vals) != 0 {
 		t.Errorf("expected 0 values for remove-only, got %d: %v", len(vals), vals)
@@ -219,7 +240,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_RGA_Basic(t *testing.T) {
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	// RGA should preserve insertion order
 	expected := []interface{}{"line one", "line two", "line three"}
@@ -250,7 +274,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_RGA_WithTombstone(t *testing.T) {
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	// elem2 is tombstoned, but elem3 (its child) should still appear
 	expected := []interface{}{"line one", "line three"}
@@ -277,7 +304,10 @@ func TestLookupAllAttributes_NoCacheNoSchema_RGA_ConcurrentInserts(t *testing.T)
 	}
 
 	matcher := NewBadgerMatcher(db.Store())
-	vals := matcher.LookupAllAttributes(entity, attr)
+	vals, err := matcher.LookupAllAttributes(entity, attr)
+	if err != nil {
+		t.Fatalf("LookupAllAttributes: %v", err)
+	}
 
 	// Both preserved, ordered by ElementID (lower ReplicaID first)
 	expected := []interface{}{"from replica 1", "from replica 2"}

--- a/datalog/storage/lookup_all_crdt_test.go
+++ b/datalog/storage/lookup_all_crdt_test.go
@@ -1,0 +1,343 @@
+package storage
+
+import (
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// Tests for LookupAllAttributes CRDT resolution without cache or schema.
+// These verify that the fallback path infers cardinality from ops and
+// resolves correctly, rather than returning raw datoms including tombstones.
+
+// --- Cardinality-One (LWW): OpNone datoms ---
+
+func TestLookupAllAttributes_NoCacheNoSchema_LWW_LatestValue(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("lww-entity")
+	attr := datalog.NewKeyword(":person/name")
+
+	// Two LWW writes: older value then newer value
+	datoms := []datalog.Datom{
+		{E: entity, A: attr, V: "Alice", Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1}, Op: datalog.OpNone},
+		{E: entity, A: attr, V: "Bob", Tx: datalog.ElementID{Lamport: 200, ReplicaID: 1}, Op: datalog.OpNone},
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	// LWW: should return only the latest value
+	if len(vals) != 1 {
+		t.Errorf("expected 1 value (latest LWW), got %d: %v", len(vals), vals)
+	} else if vals[0] != "Bob" {
+		t.Errorf("expected latest value 'Bob', got %v", vals[0])
+	}
+}
+
+func TestLookupAllAttributes_NoCacheNoSchema_LWW_SingleValue(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("lww-single")
+	attr := datalog.NewKeyword(":person/name")
+
+	datoms := []datalog.Datom{
+		{E: entity, A: attr, V: "Alice", Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1}, Op: datalog.OpNone},
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	if len(vals) != 1 {
+		t.Errorf("expected 1 value, got %d: %v", len(vals), vals)
+	} else if vals[0] != "Alice" {
+		t.Errorf("expected 'Alice', got %v", vals[0])
+	}
+}
+
+// --- Cardinality-Many (Add-Wins Set): OpCRDTAdd / OpCRDTRemove datoms ---
+
+func TestLookupAllAttributes_NoCacheNoSchema_AddWins_Basic(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("set-entity")
+	attr := datalog.NewKeyword(":person/tags")
+
+	datoms := []datalog.Datom{
+		{E: entity, A: attr, V: "fantasy", Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+		{E: entity, A: attr, V: "epic", Tx: datalog.ElementID{Lamport: 101, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+		{E: entity, A: attr, V: "adventure", Tx: datalog.ElementID{Lamport: 102, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	got := toStringSlice(t, vals)
+	sort.Strings(got)
+	expected := []string{"adventure", "epic", "fantasy"}
+	assertStringSlicesEqual(t, "basic add-wins", got, expected)
+}
+
+func TestLookupAllAttributes_NoCacheNoSchema_AddWins_AfterRemoval(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("set-removal")
+	attr := datalog.NewKeyword(":person/tags")
+
+	datoms := []datalog.Datom{
+		{E: entity, A: attr, V: "fantasy", Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+		{E: entity, A: attr, V: "adventure", Tx: datalog.ElementID{Lamport: 101, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+		{E: entity, A: attr, V: "epic", Tx: datalog.ElementID{Lamport: 102, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+		// Remove "adventure" at higher Lamport
+		{E: entity, A: attr, V: "adventure", Tx: datalog.ElementID{Lamport: 200, ReplicaID: 1}, Op: datalog.OpCRDTRemove},
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	got := toStringSlice(t, vals)
+	sort.Strings(got)
+	expected := []string{"epic", "fantasy"}
+	assertStringSlicesEqual(t, "after removal", got, expected)
+}
+
+func TestLookupAllAttributes_NoCacheNoSchema_AddWins_ReAdd(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("set-readd")
+	attr := datalog.NewKeyword(":person/tags")
+
+	datoms := []datalog.Datom{
+		// Initial add
+		{E: entity, A: attr, V: "fantasy", Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+		{E: entity, A: attr, V: "adventure", Tx: datalog.ElementID{Lamport: 101, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+		{E: entity, A: attr, V: "epic", Tx: datalog.ElementID{Lamport: 102, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+		// Remove "adventure"
+		{E: entity, A: attr, V: "adventure", Tx: datalog.ElementID{Lamport: 200, ReplicaID: 1}, Op: datalog.OpCRDTRemove},
+		// Re-add "adventure" at even higher Lamport
+		{E: entity, A: attr, V: "adventure", Tx: datalog.ElementID{Lamport: 300, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	got := toStringSlice(t, vals)
+	sort.Strings(got)
+	expected := []string{"adventure", "epic", "fantasy"}
+	assertStringSlicesEqual(t, "after re-add", got, expected)
+}
+
+func TestLookupAllAttributes_NoCacheNoSchema_AddWins_ConcurrentAddWins(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("set-concurrent")
+	attr := datalog.NewKeyword(":person/tags")
+
+	// Same Lamport for add and remove — add should win
+	datoms := []datalog.Datom{
+		{E: entity, A: attr, V: "adventure", Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1}, Op: datalog.OpCRDTAdd},
+		{E: entity, A: attr, V: "adventure", Tx: datalog.ElementID{Lamport: 100, ReplicaID: 2}, Op: datalog.OpCRDTRemove},
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	got := toStringSlice(t, vals)
+	expected := []string{"adventure"}
+	assertStringSlicesEqual(t, "concurrent add wins", got, expected)
+}
+
+func TestLookupAllAttributes_NoCacheNoSchema_AddWins_OnlyRemoves(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("set-only-removes")
+	attr := datalog.NewKeyword(":person/tags")
+
+	datoms := []datalog.Datom{
+		{E: entity, A: attr, V: "ghost", Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1}, Op: datalog.OpCRDTRemove},
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	if len(vals) != 0 {
+		t.Errorf("expected 0 values for remove-only, got %d: %v", len(vals), vals)
+	}
+}
+
+// --- Cardinality-Vector (RGA): OpRGAInsert / OpRGATombstone datoms ---
+
+func TestLookupAllAttributes_NoCacheNoSchema_RGA_Basic(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("vec-entity")
+	attr := datalog.NewKeyword(":doc/content")
+
+	// Three inserts forming a chain: HEAD -> elem1 -> elem2 -> elem3
+	elem1 := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+	elem2 := datalog.ElementID{Lamport: 101, ReplicaID: 1}
+	elem3 := datalog.ElementID{Lamport: 102, ReplicaID: 1}
+
+	datoms := []datalog.Datom{
+		{E: entity, A: attr, V: "line one", Tx: elem1, Op: datalog.OpRGAInsert, AfterRef: datalog.ElementID{}}, // after HEAD
+		{E: entity, A: attr, V: "line two", Tx: elem2, Op: datalog.OpRGAInsert, AfterRef: elem1},               // after elem1
+		{E: entity, A: attr, V: "line three", Tx: elem3, Op: datalog.OpRGAInsert, AfterRef: elem2},             // after elem2
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	// RGA should preserve insertion order
+	expected := []interface{}{"line one", "line two", "line three"}
+	assertInterfaceSlicesEqual(t, "basic RGA", vals, expected)
+}
+
+func TestLookupAllAttributes_NoCacheNoSchema_RGA_WithTombstone(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("vec-tombstone")
+	attr := datalog.NewKeyword(":doc/content")
+
+	elem1 := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+	elem2 := datalog.ElementID{Lamport: 101, ReplicaID: 1}
+	elem3 := datalog.ElementID{Lamport: 102, ReplicaID: 1}
+	tombstone := datalog.ElementID{Lamport: 200, ReplicaID: 1}
+
+	datoms := []datalog.Datom{
+		{E: entity, A: attr, V: "line one", Tx: elem1, Op: datalog.OpRGAInsert, AfterRef: datalog.ElementID{}},
+		{E: entity, A: attr, V: "line two", Tx: elem2, Op: datalog.OpRGAInsert, AfterRef: elem1},
+		{E: entity, A: attr, V: "line three", Tx: elem3, Op: datalog.OpRGAInsert, AfterRef: elem2},
+		// Tombstone elem2 ("line two")
+		{E: entity, A: attr, V: "line two", Tx: tombstone, Op: datalog.OpRGATombstone, AfterRef: elem2},
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	// elem2 is tombstoned, but elem3 (its child) should still appear
+	expected := []interface{}{"line one", "line three"}
+	assertInterfaceSlicesEqual(t, "RGA with tombstone", vals, expected)
+}
+
+func TestLookupAllAttributes_NoCacheNoSchema_RGA_ConcurrentInserts(t *testing.T) {
+	db, cleanup := createLookupTestDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("vec-concurrent")
+	attr := datalog.NewKeyword(":doc/content")
+
+	// Two concurrent inserts after HEAD — lower ReplicaID first
+	elemA := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+	elemB := datalog.ElementID{Lamport: 100, ReplicaID: 2}
+
+	datoms := []datalog.Datom{
+		{E: entity, A: attr, V: "from replica 1", Tx: elemA, Op: datalog.OpRGAInsert, AfterRef: datalog.ElementID{}},
+		{E: entity, A: attr, V: "from replica 2", Tx: elemB, Op: datalog.OpRGAInsert, AfterRef: datalog.ElementID{}},
+	}
+	if err := db.Store().Assert(datoms); err != nil {
+		t.Fatalf("Assert failed: %v", err)
+	}
+
+	matcher := NewBadgerMatcher(db.Store())
+	vals := matcher.LookupAllAttributes(entity, attr)
+
+	// Both preserved, ordered by ElementID (lower ReplicaID first)
+	expected := []interface{}{"from replica 1", "from replica 2"}
+	assertInterfaceSlicesEqual(t, "concurrent RGA inserts", vals, expected)
+}
+
+// --- Helpers ---
+
+func createLookupTestDB(t *testing.T) (*Database, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "lookup-all-crdt-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := NewDatabase(dir)
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	return db, func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+}
+
+func toStringSlice(t *testing.T, vals []interface{}) []string {
+	t.Helper()
+	result := make([]string, len(vals))
+	for i, v := range vals {
+		s, ok := v.(string)
+		if !ok {
+			t.Fatalf("expected string at index %d, got %T: %v", i, v, v)
+		}
+		result[i] = s
+	}
+	return result
+}
+
+func assertStringSlicesEqual(t *testing.T, context string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s: expected %d values %v, got %d values %v", context, len(want), want, len(got), got)
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("%s: value[%d] expected %q, got %q", context, i, want[i], got[i])
+		}
+	}
+}
+
+func assertInterfaceSlicesEqual(t *testing.T, context string, got, want []interface{}) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s: expected %d values %v, got %d values %v", context, len(want), want, len(got), got)
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("%s: value[%d] expected %v, got %v", context, i, want[i], got[i])
+		}
+	}
+}

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -1091,32 +1091,95 @@ func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalo
 		}
 	}
 
-	// Fallback to storage scan (for as-of queries or when cache is not set)
+	// Fallback to storage scan (for as-of queries or when cache is not set).
+	// Infer cardinality from the CRDT ops present in the datoms and resolve
+	// accordingly, rather than returning raw datoms including tombstones.
+	return m.lookupAllAttributesFallback(eBytes[:], aStorage[:])
+}
+
+// lookupAllAttributesFallback resolves values for (E, A) without cache by
+// inferring cardinality from the CRDT ops present in storage:
+//   - OpNone → LWW (cardinality-one): return latest value by ElementID
+//   - OpCRDTAdd/OpCRDTRemove → add-wins set (cardinality-many): resolve membership
+//   - OpRGAInsert/OpRGATombstone → RGA vector (cardinality-vector): reconstruct ordered list
+func (m *BadgerMatcher) lookupAllAttributesFallback(eBytes, aBytes []byte) []interface{} {
 	encoder := m.store.encoder
 
-	// Use AEVT index which orders by A, then E
-	start, end := encoder.EncodePrefixRange(AEVT, aStorage[:], eBytes[:])
-
+	// Peek at first datom to determine op type
+	start, end := encoder.EncodePrefixRange(AEVT, aBytes, eBytes)
 	iter, err := m.store.ScanKeysOnly(AEVT, start, end)
 	if err != nil {
 		return nil
 	}
-	defer iter.Close()
 
-	var values []interface{}
-	for iter.Next() {
-		datom, err := iter.Datom()
-		if err != nil {
-			continue
-		}
-
-		// Check transaction filter for as-of queries
-		if m.shouldFilterTx(datom.Tx) {
-			continue
-		}
-
-		values = append(values, datom.V)
+	if !iter.Next() {
+		iter.Close()
+		return nil
 	}
+	firstDatom, err := iter.Datom()
+	if err != nil {
+		iter.Close()
+		return nil
+	}
+	firstOp := firstDatom.Op
+	iter.Close()
 
-	return values
+	switch {
+	case firstOp == datalog.OpCRDTAdd || firstOp == datalog.OpCRDTRemove:
+		// Add-wins set resolution
+		result, err := m.resolveAddWinsSet(eBytes, aBytes)
+		if err != nil {
+			return nil
+		}
+		values := make([]interface{}, 0, len(result.Members))
+		for v := range result.Members {
+			values = append(values, v)
+		}
+		return values
+
+	case firstOp == datalog.OpRGAInsert || firstOp == datalog.OpRGATombstone:
+		// RGA vector resolution
+		result, err := m.resolveVector(eBytes, aBytes)
+		if err != nil {
+			return nil
+		}
+		values := make([]interface{}, len(result.Elements))
+		for i, v := range result.Elements {
+			values[i] = v
+		}
+		return values
+
+	default:
+		// LWW: return the value with the highest ElementID
+		// Re-scan since we closed the iterator
+		iter2, err := m.store.ScanKeysOnly(AEVT, start, end)
+		if err != nil {
+			return nil
+		}
+		defer iter2.Close()
+
+		var latestVal interface{}
+		var latestTx datalog.ElementID
+		found := false
+
+		for iter2.Next() {
+			datom, err := iter2.Datom()
+			if err != nil {
+				continue
+			}
+			if m.shouldFilterTx(datom.Tx) {
+				continue
+			}
+			if !found || datom.Tx.Compare(latestTx) > 0 {
+				latestVal = datom.V
+				latestTx = datom.Tx
+				found = true
+			}
+		}
+
+		if !found {
+			return nil
+		}
+		return []interface{}{latestVal}
+	}
 }

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -1045,9 +1045,9 @@ func (m *BadgerMatcher) TypeDefault(attr datalog.Keyword, defaultVal interface{}
 
 // LookupAllAttributes retrieves all values of a cardinality-many attribute for an entity.
 // Returns all matching values, or empty slice if none found.
-func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalog.Keyword) []interface{} {
+func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalog.Keyword) ([]interface{}, error) {
 	if entity == nil {
-		return nil
+		return nil, nil
 	}
 
 	// Convert to storage format
@@ -1078,15 +1078,15 @@ func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalo
 				for v := range set {
 					result = append(result, v)
 				}
-				return result
+				return result, nil
 			case schema.CardinalityVector:
-				return entry.VectorList()
+				return entry.VectorList(), nil
 			case schema.CardinalityOne:
 				// For cardinality-one, return single value as slice
 				if entry.OneValue() != nil {
-					return []interface{}{entry.OneValue()}
+					return []interface{}{entry.OneValue()}, nil
 				}
-				return nil
+				return nil, nil
 			}
 		}
 	}
@@ -1102,24 +1102,24 @@ func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalo
 //   - OpNone → LWW (cardinality-one): return latest value by ElementID
 //   - OpCRDTAdd/OpCRDTRemove → add-wins set (cardinality-many): resolve membership
 //   - OpRGAInsert/OpRGATombstone → RGA vector (cardinality-vector): reconstruct ordered list
-func (m *BadgerMatcher) lookupAllAttributesFallback(eBytes, aBytes []byte) []interface{} {
+func (m *BadgerMatcher) lookupAllAttributesFallback(eBytes, aBytes []byte) ([]interface{}, error) {
 	encoder := m.store.encoder
 
 	// Peek at first datom to determine op type
 	start, end := encoder.EncodePrefixRange(AEVT, aBytes, eBytes)
 	iter, err := m.store.ScanKeysOnly(AEVT, start, end)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("scanning AEVT for LookupAllAttributes: %w", err)
 	}
 
 	if !iter.Next() {
 		iter.Close()
-		return nil
+		return nil, nil
 	}
 	firstDatom, err := iter.Datom()
 	if err != nil {
 		iter.Close()
-		return nil
+		return nil, fmt.Errorf("decoding first datom for LookupAllAttributes: %w", err)
 	}
 	firstOp := firstDatom.Op
 	iter.Close()
@@ -1129,32 +1129,32 @@ func (m *BadgerMatcher) lookupAllAttributesFallback(eBytes, aBytes []byte) []int
 		// Add-wins set resolution
 		result, err := m.resolveAddWinsSet(eBytes, aBytes)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("resolving add-wins set: %w", err)
 		}
 		values := make([]interface{}, 0, len(result.Members))
 		for v := range result.Members {
 			values = append(values, v)
 		}
-		return values
+		return values, nil
 
 	case firstOp == datalog.OpRGAInsert || firstOp == datalog.OpRGATombstone:
 		// RGA vector resolution
 		result, err := m.resolveVector(eBytes, aBytes)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("resolving RGA vector: %w", err)
 		}
 		values := make([]interface{}, len(result.Elements))
 		for i, v := range result.Elements {
 			values[i] = v
 		}
-		return values
+		return values, nil
 
 	default:
 		// LWW: return the value with the highest ElementID
 		// Re-scan since we closed the iterator
 		iter2, err := m.store.ScanKeysOnly(AEVT, start, end)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("re-scanning AEVT for LWW resolution: %w", err)
 		}
 		defer iter2.Close()
 
@@ -1178,8 +1178,8 @@ func (m *BadgerMatcher) lookupAllAttributesFallback(eBytes, aBytes []byte) []int
 		}
 
 		if !found {
-			return nil
+			return nil, nil
 		}
-		return []interface{}{latestVal}
+		return []interface{}{latestVal}, nil
 	}
 }


### PR DESCRIPTION
## Summary

`SaveStruct` silently fails to re-add a value to a cardinality-many field after that value was previously removed. The removed value's CRDT tombstone causes the diff logic to think the value is still present, so the re-add is skipped. No error is returned.

### Reproduction

```
1. SaveStruct with tags ["fantasy", "adventure", "epic"]
2. SaveStruct with tags ["fantasy", "epic"]           — "adventure" removed (tombstone created)
3. SaveStruct with tags ["fantasy", "epic", "adventure"] — re-add "adventure"
4. PullInto → tags = ["fantasy", "epic"]              — "adventure" is GONE
```

### Root cause

`Transaction.SaveStruct` created a bare `NewBadgerMatcher(t.db.Store())` without setting cache or schema. This caused `LookupAllAttributes` to hit its fallback code path — a raw AEVT storage scan that returned **all** datoms including tombstones, without performing CRDT resolution. The diff logic in `updateSliceField` then saw tombstoned values in the "existing" set and skipped the re-add.

## Changes

### Fix 1: SaveStruct matcher (database.go)

`SaveStruct` now uses `t.db.Matcher()` instead of bare `NewBadgerMatcher(t.db.Store())`. `Database.Matcher()` correctly sets both cache and schema on the matcher, so `LookupAllAttributes` takes the cache path with proper add-wins CRDT resolution.

This is a one-line fix that addresses the immediate bug.

### Fix 2: LookupAllAttributes fallback with op-inferred CRDT resolution (matcher.go)

The deeper problem: `LookupAllAttributes` had a fallback path that returned raw unresolved datoms whenever cache was nil. Any caller constructing a `BadgerMatcher` without cache would silently get wrong results for cardinality-many and cardinality-vector attributes — including the `datalog` CLI which operates without a schema.

The fallback now **infers cardinality from the CRDT ops** present in the datoms and delegates to the appropriate resolver:

- **`OpNone`** → LWW (cardinality-one): returns the value with the highest ElementID
- **`OpCRDTAdd` / `OpCRDTRemove`** → add-wins set (cardinality-many): delegates to `resolveAddWinsSet`
- **`OpRGAInsert` / `OpRGATombstone`** → RGA vector (cardinality-vector): delegates to `resolveVector`

This is a behavioral change to `LookupAllAttributes` that makes it correct regardless of whether cache or schema is set. All three resolvers (`resolveAddWinsSet`, `resolveVector`, inline LWW) already existed — the fallback just wasn't using them.

## Tests

- **`TestCRDTTombstoneReAdd`** — reproduces the SaveStruct bug: add → remove → re-add → verify value is present. Includes diagnostic that compares cached vs uncached `LookupAllAttributes` output.
- **`TestCRDTTombstoneReAdd_TxSetWorkaround`** — confirms `tx.Set()` was never affected (it calls `resolveAddWinsSet` directly).
- **`TestLookupAllAttributes_NoCacheNoSchema_*`** (10 tests) — exercises the fallback path directly on a bare `NewBadgerMatcher` without cache or schema:
  - **LWW**: single value, latest-wins with multiple writes
  - **Add-wins**: basic membership, after removal, after re-add, concurrent ops (same Lamport → add wins), remove-only (empty result)
  - **RGA**: ordered reconstruction, tombstone filtering (child of tombstoned element preserved), concurrent inserts (ordered by ElementID)

See `docs/bugs/BUG-CRDT-READD-SAVESTRUCT.md` for the full analysis.

## Test plan

- [x] `TestCRDTTombstoneReAdd` passes (was failing before fix)
- [x] `TestCRDTTombstoneReAdd_TxSetWorkaround` passes
- [x] All 10 `TestLookupAllAttributes_NoCacheNoSchema_*` tests pass
- [x] Full `go test ./datalog/...` suite passes
