### PR TITLE
Fix nested or-join execution, add Iterator Error() propagation

### DIFF
--- a/datalog/executor/buffered_iterator.go
+++ b/datalog/executor/buffered_iterator.go
@@ -85,6 +85,13 @@ func (it *BufferedIterator) Close() error {
 	return nil
 }
 
+func (it *BufferedIterator) Error() error {
+	if it.source != nil {
+		return it.source.Error()
+	}
+	return nil
+}
+
 // Size returns the number of tuples (requires full consumption)
 func (it *BufferedIterator) Size() int {
 	it.mu.Lock()
@@ -186,3 +193,5 @@ func (it *bufferedSliceIterator) Tuple() Tuple {
 func (it *bufferedSliceIterator) Close() error {
 	return nil
 }
+
+func (it *bufferedSliceIterator) Error() error { return nil }

--- a/datalog/executor/buffered_iterator_test.go
+++ b/datalog/executor/buffered_iterator_test.go
@@ -241,6 +241,7 @@ type countingMockIterator struct {
 	tuples        []Tuple
 	pos           int
 	nextCallCount *int
+	err           error
 }
 
 func (it *countingMockIterator) Next() bool {
@@ -259,6 +260,8 @@ func (it *countingMockIterator) Tuple() Tuple {
 func (it *countingMockIterator) Close() error {
 	return nil
 }
+
+func (it *countingMockIterator) Error() error { return it.err }
 
 func TestStreamingRelationWithBuffering(t *testing.T) {
 	// Test that StreamingRelation uses auto-materialization for multiple iterations

--- a/datalog/executor/datom_relation.go
+++ b/datalog/executor/datom_relation.go
@@ -73,6 +73,8 @@ func (it *DatomIterator) Close() error {
 	return nil
 }
 
+func (it *DatomIterator) Error() error { return nil }
+
 // NewDatomRelation creates a relation from datoms
 func NewDatomRelation(datoms []datalog.Datom, binding PatternBinding) Relation {
 	// Build symbols from binding

--- a/datalog/executor/indexed_memory_matcher.go
+++ b/datalog/executor/indexed_memory_matcher.go
@@ -77,6 +77,8 @@ func (it *boundDatomIterator) Close() error {
 	return nil
 }
 
+func (it *boundDatomIterator) Error() error { return nil }
+
 // NewIndexedMemoryMatcher creates a new indexed pattern matcher for in-memory datoms
 func NewIndexedMemoryMatcher(datoms []datalog.Datom) *IndexedMemoryMatcher {
 	return &IndexedMemoryMatcher{

--- a/datalog/executor/iterator_composition.go
+++ b/datalog/executor/iterator_composition.go
@@ -71,6 +71,8 @@ func (it *FilterIterator) Close() error {
 	return it.source.Close()
 }
 
+func (it *FilterIterator) Error() error { return it.source.Error() }
+
 // ProjectIterator projects specific symbols from the source relation
 type ProjectIterator struct {
 	relation   Relation // Source relation (may be cached/materialized)
@@ -135,6 +137,13 @@ func (it *ProjectIterator) Close() error {
 	return nil
 }
 
+func (it *ProjectIterator) Error() error {
+	if it.source != nil {
+		return it.source.Error()
+	}
+	return nil
+}
+
 // TransformIterator applies a transformation function to each tuple
 type TransformIterator struct {
 	source    Iterator
@@ -168,6 +177,8 @@ func (it *TransformIterator) Tuple() Tuple {
 func (it *TransformIterator) Close() error {
 	return it.source.Close()
 }
+
+func (it *TransformIterator) Error() error { return it.source.Error() }
 
 // ConcatIterator concatenates multiple iterators sequentially
 type ConcatIterator struct {
@@ -213,6 +224,13 @@ func (it *ConcatIterator) Close() error {
 		}
 	}
 	return lastErr
+}
+
+func (it *ConcatIterator) Error() error {
+	if it.current < len(it.iterators) {
+		return it.iterators[it.current].Error()
+	}
+	return nil
 }
 
 // PredicateFilterIterator wraps another iterator and filters based on a query.Predicate
@@ -263,6 +281,8 @@ func (it *PredicateFilterIterator) Tuple() Tuple {
 func (it *PredicateFilterIterator) Close() error {
 	return it.source.Close()
 }
+
+func (it *PredicateFilterIterator) Error() error { return it.source.Error() }
 
 // FunctionEvaluatorIterator adds a new symbol by evaluating a function
 type FunctionEvaluatorIterator struct {
@@ -327,6 +347,8 @@ func (it *FunctionEvaluatorIterator) Close() error {
 	return it.source.Close()
 }
 
+func (it *FunctionEvaluatorIterator) Error() error { return it.source.Error() }
+
 // DedupIterator removes duplicate tuples based on full tuple equality
 type DedupIterator struct {
 	source  Iterator
@@ -364,3 +386,5 @@ func (it *DedupIterator) Tuple() Tuple {
 func (it *DedupIterator) Close() error {
 	return it.source.Close()
 }
+
+func (it *DedupIterator) Error() error { return it.source.Error() }

--- a/datalog/executor/iterator_composition_test.go
+++ b/datalog/executor/iterator_composition_test.go
@@ -13,6 +13,7 @@ import (
 type mockIterator struct {
 	tuples []Tuple
 	pos    int
+	err    error
 }
 
 func newMockIterator(tuples []Tuple) *mockIterator {
@@ -37,6 +38,8 @@ func (it *mockIterator) Tuple() Tuple {
 func (it *mockIterator) Close() error {
 	return nil
 }
+
+func (it *mockIterator) Error() error { return it.err }
 
 func TestFilterIterator(t *testing.T) {
 	// Create test data

--- a/datalog/executor/join.go
+++ b/datalog/executor/join.go
@@ -124,6 +124,13 @@ func (it *hashJoinIterator) Close() error {
 	return nil
 }
 
+func (it *hashJoinIterator) Error() error {
+	if it.probeIt != nil {
+		return it.probeIt.Error()
+	}
+	return nil
+}
+
 // HashJoin performs a hash join on specified symbols
 // It attempts to get options from the input relations
 func HashJoin(left, right Relation, joinCols []query.Symbol) Relation {

--- a/datalog/executor/lazy_seq_relation.go
+++ b/datalog/executor/lazy_seq_relation.go
@@ -24,6 +24,19 @@ func NewLazySeqRelation(seq *LazySeq, symbols []query.Symbol) *LazySeqRelation {
 	return &LazySeqRelation{seq: seq, symbols: symbols}
 }
 
+// WrapStreamingAsLazy wraps a StreamingRelation's iterator in a LazySeqRelation
+// so it can be safely re-iterated. Non-streaming relations are returned as-is.
+// Use this when a streaming result will participate in a join or collapse that
+// may call Iterator() multiple times.
+func WrapStreamingAsLazy(rel Relation) Relation {
+	sr, ok := rel.(*StreamingRelation)
+	if !ok {
+		return rel
+	}
+	seq := NewTupleSeq(sr.Iterator(), sr.RequiresCopy())
+	return NewLazySeqRelation(seq, sr.Symbols())
+}
+
 func (r *LazySeqRelation) Symbols() []query.Symbol { return r.symbols }
 func (r *LazySeqRelation) Size() int               { return -1 } // streaming
 func (r *LazySeqRelation) Get(i int) Tuple          { return nil }

--- a/datalog/executor/lazy_seq_relation.go
+++ b/datalog/executor/lazy_seq_relation.go
@@ -111,6 +111,7 @@ type lazySeqIterator struct {
 	cur     *LazySeq
 	current Tuple
 	done    bool
+	err     error
 }
 
 func (it *lazySeqIterator) Next() bool {
@@ -122,7 +123,12 @@ func (it *lazySeqIterator) Next() bool {
 		return false
 	}
 	v, err := it.cur.First()
-	if err != nil || v == nil {
+	if err != nil {
+		it.err = err
+		it.done = true
+		return false
+	}
+	if v == nil {
 		it.done = true
 		return false
 	}
@@ -150,3 +156,5 @@ func (it *lazySeqIterator) Close() error {
 	it.done = true
 	return nil
 }
+
+func (it *lazySeqIterator) Error() error { return it.err }

--- a/datalog/executor/lazy_seq_relation_test.go
+++ b/datalog/executor/lazy_seq_relation_test.go
@@ -136,6 +136,7 @@ func makeTupleSeq(tuples []Tuple) *LazySeq {
 type sliceTupleIterator struct {
 	tuples []Tuple
 	pos    int
+	err    error
 }
 
 func (it *sliceTupleIterator) Next() bool {
@@ -153,3 +154,5 @@ func (it *sliceTupleIterator) Tuple() Tuple {
 func (it *sliceTupleIterator) Close() error {
 	return nil
 }
+
+func (it *sliceTupleIterator) Error() error { return it.err }

--- a/datalog/executor/lazy_seq_relation_test.go
+++ b/datalog/executor/lazy_seq_relation_test.go
@@ -156,3 +156,105 @@ func (it *sliceTupleIterator) Close() error {
 }
 
 func (it *sliceTupleIterator) Error() error { return it.err }
+
+// TestLazySeqRelation_MultipleIteratorsSafe verifies that calling Iterator()
+// multiple times on a LazySeqRelation produces independent cursors that all
+// see the same data, and the underlying iterator advances only once.
+func TestLazySeqRelation_MultipleIteratorsSafe(t *testing.T) {
+	callCount := 0
+	tuples := make([]Tuple, 10)
+	for i := range tuples {
+		tuples[i] = Tuple{i, "val"}
+	}
+
+	// Wrap in a counting iterator to track how many Next() calls reach storage
+	countingIt := &countingSliceIterator{tuples: tuples, nextCalls: &callCount}
+	seq := NewTupleSeq(countingIt, false)
+	syms := []query.Symbol{datalog.NewSymbol("?i"), datalog.NewSymbol("?v")}
+	rel := NewLazySeqRelation(seq, syms)
+
+	// Create three independent cursors
+	var results [3][]Tuple
+	for c := 0; c < 3; c++ {
+		it := rel.Iterator()
+		for it.Next() {
+			results[c] = append(results[c], it.Tuple())
+		}
+		it.Close()
+	}
+
+	// All three cursors see the same 10 tuples
+	for c := 0; c < 3; c++ {
+		require.Len(t, results[c], 10, "cursor %d should see 10 tuples", c)
+		for i, tuple := range results[c] {
+			assert.Equal(t, i, tuple[0], "cursor %d tuple %d", c, i)
+		}
+	}
+
+	// The underlying iterator advanced exactly 10 steps (not 30)
+	assert.Equal(t, 10, callCount, "underlying iterator should advance only 10 times total")
+}
+
+// TestLazySeqRelation_FromStreamingRelation verifies the specific wrapping
+// pattern: StreamingRelation → NewTupleSeq → LazySeqRelation. Two Iterator()
+// calls on the result both produce identical data with no panic.
+func TestLazySeqRelation_FromStreamingRelation(t *testing.T) {
+	tuples := []Tuple{{1, "a"}, {2, "b"}, {3, "c"}}
+	syms := []query.Symbol{datalog.NewSymbol("?x"), datalog.NewSymbol("?y")}
+
+	// Create a StreamingRelation (single-use)
+	baseIt := &sliceTupleIterator{tuples: tuples}
+	sr := NewStreamingRelation(syms, baseIt)
+
+	// Wrap: consume the streaming iterator once via NewTupleSeq, then
+	// create a LazySeqRelation that supports multiple cursors.
+	seq := NewTupleSeq(sr.Iterator(), sr.RequiresCopy())
+	lazyRel := NewLazySeqRelation(seq, sr.Symbols())
+
+	// First cursor
+	var results1 []Tuple
+	it1 := lazyRel.Iterator()
+	for it1.Next() {
+		results1 = append(results1, it1.Tuple())
+	}
+	it1.Close()
+
+	// Second cursor — must not panic
+	var results2 []Tuple
+	it2 := lazyRel.Iterator()
+	for it2.Next() {
+		results2 = append(results2, it2.Tuple())
+	}
+	it2.Close()
+
+	require.Len(t, results1, 3)
+	require.Len(t, results2, 3)
+	for i := range results1 {
+		assert.Equal(t, results1[i][0], results2[i][0])
+		assert.Equal(t, results1[i][1], results2[i][1])
+	}
+}
+
+// countingSliceIterator tracks how many times Next() is called.
+type countingSliceIterator struct {
+	tuples    []Tuple
+	pos       int
+	nextCalls *int
+	err       error
+}
+
+func (it *countingSliceIterator) Next() bool {
+	if it.pos >= len(it.tuples) {
+		return false
+	}
+	*it.nextCalls++
+	it.pos++
+	return true
+}
+
+func (it *countingSliceIterator) Tuple() Tuple {
+	return it.tuples[it.pos-1]
+}
+
+func (it *countingSliceIterator) Close() error { return nil }
+func (it *countingSliceIterator) Error() error { return it.err }

--- a/datalog/executor/lazy_seq_test.go
+++ b/datalog/executor/lazy_seq_test.go
@@ -132,6 +132,7 @@ type lazySeqTestIterator struct {
 	pos     int
 	closed  bool
 	closeMu sync.Mutex
+	err     error
 }
 
 func newLazySeqTestIterator(tuples []Tuple) *lazySeqTestIterator {
@@ -156,6 +157,8 @@ func (m *lazySeqTestIterator) Close() error {
 	m.closed = true
 	return nil
 }
+
+func (m *lazySeqTestIterator) Error() error { return m.err }
 
 func (m *lazySeqTestIterator) IsClosed() bool {
 	m.closeMu.Lock()

--- a/datalog/executor/or_fallback_relation.go
+++ b/datalog/executor/or_fallback_relation.go
@@ -168,6 +168,23 @@ func collectBranchOutputSymbols(branch []query.Clause) []query.Symbol {
 					outputs = append(outputs, b.Variable)
 				}
 			}
+		case *query.OrJoinClause:
+			// or-join declares its output symbols as join vars
+			for _, v := range clause.JoinVars {
+				if !seen[v] {
+					seen[v] = true
+					outputs = append(outputs, v)
+				}
+			}
+		case *query.OrClause:
+			// plain or: output symbols are the intersection across branches
+			orOutputs := computeOrBranchOutputSymbols(clause)
+			for _, v := range orOutputs {
+				if !seen[v] {
+					seen[v] = true
+					outputs = append(outputs, v)
+				}
+			}
 		}
 	}
 	return outputs

--- a/datalog/executor/or_fallback_relation.go
+++ b/datalog/executor/or_fallback_relation.go
@@ -881,3 +881,5 @@ func filterBranchToOuterTuple(branchResult Relation, outerTuple Tuple, outerSyms
 func (it *projectedIterator) Close() error {
 	return it.inner.Close()
 }
+
+func (it *projectedIterator) Error() error { return it.inner.Error() }

--- a/datalog/executor/pattern_match.go
+++ b/datalog/executor/pattern_match.go
@@ -310,6 +310,8 @@ func (it *datomIterator) Close() error {
 	return nil
 }
 
+func (it *datomIterator) Error() error { return nil }
+
 // datomsToRelation converts datoms to a streaming relation (zero-copy lazy evaluation)
 func datomsToRelation(datoms []datalog.Datom, pattern *query.DataPattern, symbols []query.Symbol) Relation {
 	return datomsToRelationWithOptions(datoms, pattern, symbols, ExecutorOptions{})

--- a/datalog/executor/prepended_relation.go
+++ b/datalog/executor/prepended_relation.go
@@ -201,3 +201,10 @@ func (it *PrependedIterator) Close() error {
 	it.done = true
 	return nil
 }
+
+func (it *PrependedIterator) Error() error {
+	if it.restIter != nil {
+		return it.restIter.Error()
+	}
+	return nil
+}

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -498,21 +498,69 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 				}
 			}
 
-			// Add the new symbols to each relation in groups
+			// For each binding symbol: if already in the relation, filter
+			// (unify) instead of extending. If not present, extend.
 			var resultRels []Relation
 			for _, rel := range groups {
-				newCols := append(rel.Symbols(), bindingCols...)
-				var newTuples []Tuple
+				relSyms := rel.Symbols()
+
+				// Partition binding symbols into existing (filter) and new (extend)
+				var filterIdx []int   // indices into bindingCols that already exist in rel
+				var filterRelIdx []int // corresponding positions in relSyms
+				var extendIdx []int   // indices into bindingCols that are new
+
+				for i, bs := range bindingCols {
+					found := false
+					for j, rs := range relSyms {
+						if bs == rs {
+							filterIdx = append(filterIdx, i)
+							filterRelIdx = append(filterRelIdx, j)
+							found = true
+							break
+						}
+					}
+					if !found {
+						extendIdx = append(extendIdx, i)
+					}
+				}
+
+				// Build output symbols: existing + only the new binding symbols
+				outputSyms := make([]query.Symbol, len(relSyms))
+				copy(outputSyms, relSyms)
+				for _, ei := range extendIdx {
+					outputSyms = append(outputSyms, bindingCols[ei])
+				}
+
+				var outputTuples []Tuple
 				iter := rel.Iterator()
 				for iter.Next() {
 					oldTuple := iter.Tuple()
-					newTuple := make(Tuple, len(oldTuple)+len(bindingValues))
+
+					// Check filter conditions: existing symbols must match ground values
+					match := true
+					for k, fi := range filterIdx {
+						_ = k
+						if filterRelIdx[k] < len(oldTuple) {
+							if !valuesEqual(oldTuple[filterRelIdx[k]], bindingValues[fi]) {
+								match = false
+								break
+							}
+						}
+					}
+					if !match {
+						continue
+					}
+
+					// Build output tuple: old values + new extension values
+					newTuple := make(Tuple, len(outputSyms))
 					copy(newTuple, oldTuple)
-					copy(newTuple[len(oldTuple):], bindingValues)
-					newTuples = append(newTuples, newTuple)
+					for i, ei := range extendIdx {
+						newTuple[len(relSyms)+i] = bindingValues[ei]
+					}
+					outputTuples = append(outputTuples, newTuple)
 				}
 				iter.Close()
-				resultRels = append(resultRels, NewMaterializedRelationWithOptions(newCols, newTuples, e.options))
+				resultRels = append(resultRels, NewMaterializedRelationWithOptions(outputSyms, outputTuples, e.options))
 			}
 			return resultRels, nil
 		}
@@ -1952,6 +2000,26 @@ func (e *DefaultQueryExecutor) executeInnerClauses(ctx Context, clauses []query.
 			if err != nil {
 				return nil, err
 			}
+
+		case *query.OrClause:
+			newRel, err := e.executeOrClause(ctx, c, groups)
+			if err != nil {
+				return nil, err
+			}
+			if newRel != nil {
+				groups = append(groups, newRel)
+			}
+			groups = groups.Collapse(ctx)
+
+		case *query.OrJoinClause:
+			newRel, err := e.executeOrJoinClause(ctx, c, groups)
+			if err != nil {
+				return nil, err
+			}
+			if newRel != nil {
+				groups = append(groups, newRel)
+			}
+			groups = groups.Collapse(ctx)
 
 		default:
 			return nil, fmt.Errorf("unsupported inner clause type: %T", clause)

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -158,6 +158,11 @@ type Iterator interface {
 
 	// Close releases any resources
 	Close() error
+
+	// Error returns any error encountered during iteration.
+	// Callers must check Error() after Next() returns false to
+	// distinguish normal exhaustion from execution failure.
+	Error() error
 }
 
 // CountingIterator wraps an iterator and tracks tuple count without buffering
@@ -193,6 +198,8 @@ func (i *CountingIterator) Tuple() Tuple {
 func (i *CountingIterator) Close() error {
 	return i.inner.Close()
 }
+
+func (i *CountingIterator) Error() error { return i.inner.Error() }
 
 // Count returns the number of tuples seen so far
 func (i *CountingIterator) Count() int {
@@ -274,6 +281,8 @@ func (ci *CachingIterator) Close() error {
 	ci.signalComplete()
 	return ci.inner.Close()
 }
+
+func (ci *CachingIterator) Error() error { return ci.inner.Error() }
 
 func (ci *CachingIterator) signalComplete() {
 	ci.mu.Lock()
@@ -747,6 +756,8 @@ func (it *sliceIterator) Tuple() Tuple {
 func (it *sliceIterator) Close() error {
 	return nil
 }
+
+func (it *sliceIterator) Error() error { return nil }
 
 // StreamingRelation wraps an iterator as a relation
 type StreamingRelation struct {
@@ -1560,6 +1571,17 @@ func (pi *ProductIterator) Close() error {
 	for _, it := range pi.iterators {
 		if it != nil {
 			it.Close()
+		}
+	}
+	return nil
+}
+
+func (pi *ProductIterator) Error() error {
+	for _, it := range pi.iterators {
+		if it != nil {
+			if err := it.Error(); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/datalog/executor/symmetric_hash_join.go
+++ b/datalog/executor/symmetric_hash_join.go
@@ -285,6 +285,18 @@ func (it *symmetricHashJoinIterator) Close() error {
 	return err2
 }
 
+func (it *symmetricHashJoinIterator) Error() error {
+	if it.leftIt != nil {
+		if err := it.leftIt.Error(); err != nil {
+			return err
+		}
+	}
+	if it.rightIt != nil {
+		return it.rightIt.Error()
+	}
+	return nil
+}
+
 // ChooseJoinStrategy selects the appropriate join strategy based on relation types
 func ChooseJoinStrategy(left, right Relation, joinCols []query.Symbol, opts ExecutorOptions) string {
 	leftStreaming := isStreaming(left)

--- a/datalog/executor/union_relation.go
+++ b/datalog/executor/union_relation.go
@@ -296,3 +296,13 @@ func (it *UnionIterator) Close() error {
 	}
 	return it.firstError
 }
+
+func (it *UnionIterator) Error() error {
+	if it.firstError != nil {
+		return it.firstError
+	}
+	if it.currentIter != nil {
+		return it.currentIter.Error()
+	}
+	return nil
+}

--- a/datalog/executor/wrapper_relation_copy_test.go
+++ b/datalog/executor/wrapper_relation_copy_test.go
@@ -66,6 +66,7 @@ type mockUnsafeIterator struct {
 	data      [][]interface{}
 	workspace Tuple // Reused on each Next()
 	pos       int
+	err       error
 }
 
 func (it *mockUnsafeIterator) Next() bool {
@@ -85,6 +86,8 @@ func (it *mockUnsafeIterator) Tuple() Tuple {
 func (it *mockUnsafeIterator) Close() error {
 	return nil
 }
+
+func (it *mockUnsafeIterator) Error() error { return it.err }
 
 // =============================================================================
 // Test 1: UnionIterator with RequiresCopy source

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -748,13 +748,15 @@ type hashJoinIterator struct {
 	workspace     executor.Tuple // Reusable workspace for tuple building
 	datomsScanned int            // Track number of datoms scanned for event reporting
 	matchesFound  int            // Track number of matches for event reporting
+	err           error          // First error from storage operations
 }
 
 func (it *hashJoinIterator) Next() bool {
 	for it.iter.Next() {
 		datom, err := it.iter.Datom()
 		if err != nil {
-			continue
+			it.err = err
+			return false
 		}
 
 		// Count every datom scanned for performance monitoring
@@ -824,6 +826,8 @@ func (it *hashJoinIterator) Close() error {
 	return nil
 }
 
+func (it *hashJoinIterator) Error() error { return it.err }
+
 // mergeJoinIterator performs lazy merge join iteration
 type mergeJoinIterator struct {
 	matcher      *BadgerMatcher
@@ -839,13 +843,15 @@ type mergeJoinIterator struct {
 	tupleBuilder *query.InternedTupleBuilder
 	current      executor.Tuple
 	workspace    executor.Tuple // Reusable workspace for tuple building
+	err          error          // First error from storage operations
 }
 
 func (it *mergeJoinIterator) Next() bool {
 	for it.iter.Next() {
 		datom, err := it.iter.Datom()
 		if err != nil {
-			continue
+			it.err = err
+			return false
 		}
 
 		// Check transaction validity
@@ -913,3 +919,5 @@ func (it *mergeJoinIterator) Close() error {
 	}
 	return nil
 }
+
+func (it *mergeJoinIterator) Error() error { return it.err }

--- a/datalog/storage/matcher_iterator_nonreusing.go
+++ b/datalog/storage/matcher_iterator_nonreusing.go
@@ -22,6 +22,7 @@ type nonReusingIterator struct {
 	workspace    executor.Tuple // Reusable workspace for tuple building
 	totalScanned int
 	totalMatched int
+	err          error // First error from storage operations
 
 	// Pattern extraction utility
 	patternExtractor *query.PatternExtractor
@@ -36,7 +37,8 @@ func (it *nonReusingIterator) Next() bool {
 		for it.currentScan.Next() {
 			datom, err := it.currentScan.Datom()
 			if err != nil {
-				continue
+				it.err = err
+				return false
 			}
 
 			it.totalScanned++
@@ -73,6 +75,7 @@ func (it *nonReusingIterator) Next() bool {
 
 	rawIter, err := it.matcher.store.ScanKeysOnly(index, start, end)
 	if err != nil {
+		it.err = err
 		return false
 	}
 
@@ -97,6 +100,8 @@ func (it *nonReusingIterator) Close() error {
 	}
 	return nil
 }
+
+func (it *nonReusingIterator) Error() error { return it.err }
 
 func (it *nonReusingIterator) extractBoundValues(bindingTuple executor.Tuple) (e, a, v, tx interface{}) {
 	// Use the pattern extractor to get all bound values at once

--- a/datalog/storage/matcher_iterator_reusing.go
+++ b/datalog/storage/matcher_iterator_reusing.go
@@ -35,6 +35,8 @@ type reusingIterator struct {
 	// Performance tracking
 	datomsScanned int // Total datoms scanned
 	datomsMatched int // Total datoms matched
+
+	err error // First error from storage operations
 }
 
 func (it *reusingIterator) Next() bool {
@@ -66,6 +68,7 @@ func (it *reusingIterator) Next() bool {
 		var err error
 		rawIter, err := it.matcher.store.ScanKeysOnly(it.index, startKey, endKey)
 		if err != nil {
+			it.err = err
 			return false
 		}
 
@@ -91,8 +94,8 @@ func (it *reusingIterator) Next() bool {
 			for hasNext {
 				datom, err := it.storageIter.Datom()
 				if err != nil {
-					hasNext = it.storageIter.Next()
-					continue
+					it.err = err
+					return false
 				}
 
 				// Track datom scan
@@ -249,6 +252,8 @@ func (it *reusingIterator) Close() error {
 	}
 	return nil
 }
+
+func (it *reusingIterator) Error() error { return it.err }
 
 // getSymbolIndex returns the index of a symbol in the binding relation symbols
 func (it *reusingIterator) getSymbolIndex(variable query.Variable) int {

--- a/datalog/storage/matcher_iterator_unbound.go
+++ b/datalog/storage/matcher_iterator_unbound.go
@@ -29,6 +29,8 @@ type unboundIterator struct {
 	// CRDT cardinality-one support: stop after first result
 	returnOnlyFirst bool
 	foundFirst      bool
+
+	err error // First error from storage operations
 }
 
 func (it *unboundIterator) Next() bool {
@@ -40,7 +42,8 @@ func (it *unboundIterator) Next() bool {
 	for it.storageIter.Next() {
 		datom, err := it.storageIter.Datom()
 		if err != nil {
-			continue
+			it.err = err
+			return false
 		}
 
 		it.datomsScanned++
@@ -64,6 +67,8 @@ func (it *unboundIterator) Next() bool {
 func (it *unboundIterator) Tuple() executor.Tuple {
 	return it.currentTuple
 }
+
+func (it *unboundIterator) Error() error { return it.err }
 
 func (it *unboundIterator) Close() error {
 	// Emit scan statistics if handler is available
@@ -109,6 +114,8 @@ type unboundMaskIterator struct {
 	// CRDT cardinality-one support: stop after first result
 	returnOnlyFirst bool
 	foundFirst      bool
+
+	err error // First error from storage operations
 }
 
 func (it *unboundMaskIterator) Next() bool {
@@ -121,7 +128,8 @@ func (it *unboundMaskIterator) Next() bool {
 	for it.storageIter.Next() {
 		datom, err := it.storageIter.Datom()
 		if err != nil {
-			continue
+			it.err = err
+			return false
 		}
 
 		it.datomsScanned++
@@ -176,3 +184,5 @@ func (it *unboundMaskIterator) Close() error {
 	}
 	return nil
 }
+
+func (it *unboundMaskIterator) Error() error { return it.err }

--- a/datalog/storage/matcher_multi_position_test.go
+++ b/datalog/storage/matcher_multi_position_test.go
@@ -656,6 +656,7 @@ func TestMultiPositionWithStreamingBinding(t *testing.T) {
 type sliceTupleIterator struct {
 	tuples []executor.Tuple
 	idx    int
+	err    error
 }
 
 func (it *sliceTupleIterator) Next() bool {
@@ -673,3 +674,5 @@ func (it *sliceTupleIterator) Tuple() executor.Tuple {
 func (it *sliceTupleIterator) Close() error {
 	return nil
 }
+
+func (it *sliceTupleIterator) Error() error { return it.err }

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -434,6 +434,7 @@ func (m *BadgerMatcher) matchUnboundAsRelation(pattern *query.DataPattern, symbo
 		Next() bool
 		Tuple() executor.Tuple
 		Close() error
+		Error() error
 	}
 
 	if keyMask != nil {
@@ -671,6 +672,8 @@ type validatingVBoundIterator struct {
 
 	// Current V value being searched
 	currentBoundV any
+
+	err error // First error from storage operations
 }
 
 func (it *validatingVBoundIterator) Next() bool {
@@ -680,7 +683,8 @@ func (it *validatingVBoundIterator) Next() bool {
 			for it.crdtIter.Next() {
 				datom, err := it.crdtIter.Datom()
 				if err != nil {
-					continue
+					it.err = err
+					return false
 				}
 
 				// Emit annotation for CRDT-resolved candidate
@@ -740,7 +744,8 @@ func (it *validatingVBoundIterator) Next() bool {
 		var err error
 		it.crdtIter, it.rawIter, err = it.openCRDTScan()
 		if err != nil {
-			continue
+			it.err = err
+			return false
 		}
 	}
 }
@@ -995,6 +1000,8 @@ func (it *validatingVBoundIterator) Close() error {
 	}
 	return nil
 }
+
+func (it *validatingVBoundIterator) Error() error { return it.err }
 
 // matchWithSimpleBatchScanning uses simplified batch scanning to process large binding sets efficiently
 func (m *BadgerMatcher) matchWithSimpleBatchScanning(
@@ -1674,6 +1681,7 @@ type cardinalityManyScanAllEntitiesIterator struct {
 	currentMaxElementID datalog.ElementID
 	currentMemberIdx    int
 	currentTuple        executor.Tuple
+	err                 error // First error from storage operations
 }
 
 func (it *cardinalityManyScanAllEntitiesIterator) Next() bool {
@@ -1709,7 +1717,8 @@ func (it *cardinalityManyScanAllEntitiesIterator) Next() bool {
 		for it.storageIter.Next() {
 			datom, err := it.storageIter.Datom()
 			if err != nil {
-				continue
+				it.err = err
+				return false
 			}
 
 			// Get entity bytes
@@ -1724,7 +1733,8 @@ func (it *cardinalityManyScanAllEntitiesIterator) Next() bool {
 			// Resolve the set for this entity using add-wins semantics
 			result, err := it.matcher.resolveAddWinsSet(eBytes[:], it.aBytes[:])
 			if err != nil {
-				continue
+				it.err = err
+				return false
 			}
 
 			// If set has members, set up iteration
@@ -1760,6 +1770,8 @@ func (it *cardinalityManyScanAllEntitiesIterator) Close() error {
 	}
 	return nil
 }
+
+func (it *cardinalityManyScanAllEntitiesIterator) Error() error { return it.err }
 
 // matchVectorScanAllEntities handles [?e :attr <vector-literal>] where E is unbound.
 // Scans all entities with the attribute and resolves each vector using RGA.
@@ -1814,13 +1826,15 @@ type vectorScanAllEntitiesIterator struct {
 	seenEntities map[[20]byte]bool
 
 	currentTuple executor.Tuple
+	err          error // First error from storage operations
 }
 
 func (it *vectorScanAllEntitiesIterator) Next() bool {
 	for it.storageIter.Next() {
 		datom, err := it.storageIter.Datom()
 		if err != nil {
-			continue
+			it.err = err
+			return false
 		}
 
 		eBytes := datom.E.Hash()
@@ -1832,7 +1846,8 @@ func (it *vectorScanAllEntitiesIterator) Next() bool {
 		// Resolve vector for this entity
 		result, err := it.matcher.resolveVector(eBytes[:], it.aBytes[:])
 		if err != nil {
-			continue
+			it.err = err
+			return false
 		}
 
 		// Never set — skip
@@ -1886,6 +1901,8 @@ func (it *vectorScanAllEntitiesIterator) Close() error {
 	}
 	return nil
 }
+
+func (it *vectorScanAllEntitiesIterator) Error() error { return it.err }
 
 // matchCardinalityManyScanAllEntities handles [?e :attr ?v] where E is unbound
 // Scans all entities with the attribute and resolves each set using add-wins
@@ -1955,6 +1972,7 @@ type cardinalityManyAVETValueIterator struct {
 	// Result
 	currentTuple executor.Tuple
 	done         bool
+	err          error // First error from storage operations
 }
 
 func (it *cardinalityManyAVETValueIterator) Next() bool {
@@ -1975,7 +1993,8 @@ func (it *cardinalityManyAVETValueIterator) Next() bool {
 
 		datom, err := it.storageIter.Datom()
 		if err != nil {
-			continue
+			it.err = err
+			return false
 		}
 
 		eBytes := datom.E.Hash()
@@ -2073,6 +2092,8 @@ func (it *cardinalityManyAVETValueIterator) Close() error {
 	}
 	return nil
 }
+
+func (it *cardinalityManyAVETValueIterator) Error() error { return it.err }
 
 // cardinalityManyFindEntitiesWithValueIterator streams results for [?e :attr "value"] patterns
 // where E is unbound and cardinality is many. It iterates through entities and checks

--- a/datalog/storage/or_union_expressions_test.go
+++ b/datalog/storage/or_union_expressions_test.go
@@ -8,64 +8,64 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
-	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/executor"
 )
 
-// TestOrUnionWithExpressionBranches verifies that OR-union semantics work
-// correctly when branches contain expressions (ground, subqueries, NOT).
-//
-// Currently, BranchHasExpressions forces fallback semantics whenever any
-// branch contains an expression. This prevents using OR-union for the
-// left-outer-join pattern:
-//
-//	(or-join [?key ?value]
-//	  [?key :attr ?value]                            ;; branch 1: has value
-//	  (and (not [?key :attr _]) [(ground 0) ?value]) ;; branch 2: default
-//	)
-//
-// Both branches should run independently and merge (union). Fallback mode
-// tries branch 1 per-tuple and short-circuits, never reaching branch 2.
-func TestOrUnionWithExpressionBranches(t *testing.T) {
+// setupBaseEntities creates a fresh database with 3 named entities.
+// Alice has score 100, Bob has score 200, Carol has no score.
+func setupBaseEntities(t *testing.T) (*Database, datalog.Identity, datalog.Identity, datalog.Identity) {
+	t.Helper()
 	dir, err := os.MkdirTemp("", "or-union-expr-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	t.Cleanup(func() { os.RemoveAll(dir) })
 
-	db, err := NewDatabaseWithOptions(DatabaseOptions{
-		Path: dir,
-		AnnotationHandler: func(e annotations.Event) {
-			if e.Name == "or/union" || e.Name == "or/branch.complete" || e.Name == "or/complete" {
-				t.Logf("[%s] %v", e.Name, e.Data)
-			}
-			if e.Name == "algebra/compiled" || e.Name == "algebra/optimized" || e.Name == "algebra/bridge-complete" {
-				t.Logf("[%s] %v", e.Name, e.Data)
-			}
-		},
-	})
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() { db.Close() })
 
-	// Setup: 3 entities, only 2 have :score attribute
-	tx := db.NewTransaction()
 	e1 := datalog.NewIdentity("entity:1")
 	e2 := datalog.NewIdentity("entity:2")
 	e3 := datalog.NewIdentity("entity:3")
 
+	tx := db.NewTransaction()
 	tx.Add(e1, datalog.NewKeyword(":entity/name"), "Alice")
 	tx.Add(e2, datalog.NewKeyword(":entity/name"), "Bob")
 	tx.Add(e3, datalog.NewKeyword(":entity/name"), "Carol")
 	tx.Add(e1, datalog.NewKeyword(":entity/score"), int64(100))
 	tx.Add(e2, datalog.NewKeyword(":entity/score"), int64(200))
-	// e3 has no :entity/score
-
 	_, err = tx.Commit()
 	require.NoError(t, err)
 
-	// Test: or-join with expression branch should use union semantics
-	// Branch 1: entities WITH score → get the score
-	// Branch 2: entities WITHOUT score → default 0
-	// Union = all entities with scores
+	return db, e1, e2, e3
+}
+
+// addChildrenTypesAndFriends adds children, types, and friend relationships.
+func addChildrenTypesAndFriends(t *testing.T, db *Database, e1, e2, e3 datalog.Identity) {
+	t.Helper()
+	tx := db.NewTransaction()
+	for i := 0; i < 3; i++ {
+		c := datalog.NewIdentity(fmt.Sprintf("child:1:%d", i))
+		tx.Add(c, datalog.NewKeyword(":child/parent"), e1)
+	}
+	c := datalog.NewIdentity("child:2:0")
+	tx.Add(c, datalog.NewKeyword(":child/parent"), e2)
+
+	tx.Add(e1, datalog.NewKeyword(":entity/type"), datalog.NewKeyword(":type/parent"))
+	tx.Add(e2, datalog.NewKeyword(":entity/type"), datalog.NewKeyword(":type/parent"))
+	tx.Add(e3, datalog.NewKeyword(":entity/type"), datalog.NewKeyword(":type/child"))
+
+	tx.Add(e1, datalog.NewKeyword(":entity/friend"), e2)
+	tx.Add(e2, datalog.NewKeyword(":entity/friend"), e1)
+	tx.Add(e3, datalog.NewKeyword(":entity/friend"), e1)
+
+	_, err := tx.Commit()
+	require.NoError(t, err)
+}
+
+func TestOrUnionWithExpressionBranches(t *testing.T) {
 	t.Run("or_join_union_with_ground_default", func(t *testing.T) {
+		db, _, _, _ := setupBaseEntities(t)
+
 		results, err := executor.CollectTuples(db.Query(`
 			[:find ?name ?score
 			 :where [?e :entity/name ?name]
@@ -73,9 +73,9 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 			          [?e :entity/score ?score]
 			          (and (not [?e :entity/score _])
 			               [(ground 0) ?score]))]`))
-		require.NoError(t, err, "OR-join with expression branches should work with union semantics")
+		require.NoError(t, err)
 		t.Logf("Results: %v", results)
-		require.Len(t, results, 3, "should return all 3 entities")
+		require.Len(t, results, 3)
 
 		byName := make(map[string]int64)
 		for _, row := range results {
@@ -86,17 +86,18 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 		assert.Equal(t, int64(0), byName["Carol"])
 	})
 
-	// Same test with plain or (not or-join)
 	t.Run("or_union_with_ground_default", func(t *testing.T) {
+		db, _, _, _ := setupBaseEntities(t)
+
 		results, err := executor.CollectTuples(db.Query(`
 			[:find ?name ?score
 			 :where [?e :entity/name ?name]
 			        (or [?e :entity/score ?score]
 			            (and (not [?e :entity/score _])
 			                 [(ground 0) ?score]))]`))
-		require.NoError(t, err, "OR with expression branches should work with union semantics")
+		require.NoError(t, err)
 		t.Logf("Results: %v", results)
-		require.Len(t, results, 3, "should return all 3 entities")
+		require.Len(t, results, 3)
 
 		byName := make(map[string]int64)
 		for _, row := range results {
@@ -107,22 +108,10 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 		assert.Equal(t, int64(0), byName["Carol"])
 	})
 
-	// Setup children data before these tests
-	{
-		tx := db.NewTransaction()
-		for i := 0; i < 3; i++ {
-			c := datalog.NewIdentity(fmt.Sprintf("child:1:%d", i))
-			tx.Add(c, datalog.NewKeyword(":child/parent"), e1)
-		}
-		c := datalog.NewIdentity("child:2:0")
-		tx.Add(c, datalog.NewKeyword(":child/parent"), e2)
-		// e3 has no children
-		_, err := tx.Commit()
-		require.NoError(t, err)
-	}
-
-	// Verify NOT branch independently: entities without children
 	t.Run("not_branch_standalone", func(t *testing.T) {
+		db, e1, e2, e3 := setupBaseEntities(t)
+		addChildrenTypesAndFriends(t, db, e1, e2, e3)
+
 		results, err := executor.CollectTuples(db.Query(`
 			[:find ?name
 			 :where [?e :entity/name ?name]
@@ -133,8 +122,167 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 		assert.Equal(t, "Carol", results[0][0])
 	})
 
-	// Test: decorrelated subquery in or-join union branch
+	t.Run("nested_or_join_in_and_branches", func(t *testing.T) {
+		db, e1, e2, e3 := setupBaseEntities(t)
+		addChildrenTypesAndFriends(t, db, e1, e2, e3)
+
+		results, err := executor.CollectTuples(db.Query(`
+			[:find ?self-name ?related-name
+			 :where [?self :entity/name ?self-name]
+			        [?self :entity/type ?stype]
+			        (or-join [?related ?self ?stype]
+			          (and [(ground :type/parent) ?stype]
+			               (or-join [?related ?self]
+			                 [?related :child/parent ?self]
+			                 [?self :entity/friend ?related]))
+			          (and [(ground :type/child) ?stype]
+			               [?self :entity/friend ?related]))
+			        [?related :entity/name ?related-name]]`))
+		require.NoError(t, err)
+		t.Logf("Results: %v", results)
+		require.Greater(t, len(results), 0)
+
+		byPair := make(map[string]bool)
+		for _, row := range results {
+			byPair[row[0].(string)+"→"+row[1].(string)] = true
+		}
+		assert.True(t, byPair["Alice→Bob"], "Alice should find friend Bob")
+		assert.True(t, byPair["Bob→Alice"], "Bob should find friend Alice")
+		assert.True(t, byPair["Carol→Alice"], "Carol should find friend Alice")
+	})
+
+	// Generic version of the 4-branch nested or-join pattern.
+	// Same structure as the downstream query but with abstract names.
+	// 4 entity types, each with type-dependent relationship rules:
+	//   alpha: related by containment OR shared region
+	//   beta: related by co-location (or location itself) OR provider
+	//   gamma: related by co-location (or location itself)
+	//   delta: related by link OR parent link chain
+	t.Run("deeply_nested_or_join_4_branches_generic", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "deep-nested-generic-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+		require.NoError(t, err)
+		t.Cleanup(func() { db.Close() })
+
+		// Entities:
+		//   A1 (alpha) — located at A2, in region R1
+		//   A2 (alpha) — in region R1
+		//   R1 (region, no type)
+		//   B1 (beta) — at A2 location, provider for A1
+		//   G1 (gamma) — at A2 location
+		//   D1 (delta) — linked to D2 (parent)
+		//   D2 (delta) — parent
+
+		a1 := datalog.NewIdentity("a1")
+		a2 := datalog.NewIdentity("a2")
+		r1 := datalog.NewIdentity("r1")
+		b1 := datalog.NewIdentity("b1")
+		g1 := datalog.NewIdentity("g1")
+		d1 := datalog.NewIdentity("d1")
+		d2 := datalog.NewIdentity("d2")
+
+		tx := db.NewTransaction()
+
+		tx.Add(a1, datalog.NewKeyword(":entity/name"), "A1")
+		tx.Add(a2, datalog.NewKeyword(":entity/name"), "A2")
+		tx.Add(r1, datalog.NewKeyword(":entity/name"), "R1")
+		tx.Add(b1, datalog.NewKeyword(":entity/name"), "B1")
+		tx.Add(g1, datalog.NewKeyword(":entity/name"), "G1")
+		tx.Add(d1, datalog.NewKeyword(":entity/name"), "D1")
+		tx.Add(d2, datalog.NewKeyword(":entity/name"), "D2")
+
+		tx.Add(a1, datalog.NewKeyword(":entity/type"), datalog.NewKeyword(":type/alpha"))
+		tx.Add(a2, datalog.NewKeyword(":entity/type"), datalog.NewKeyword(":type/alpha"))
+		tx.Add(b1, datalog.NewKeyword(":entity/type"), datalog.NewKeyword(":type/beta"))
+		tx.Add(g1, datalog.NewKeyword(":entity/type"), datalog.NewKeyword(":type/gamma"))
+		tx.Add(d1, datalog.NewKeyword(":entity/type"), datalog.NewKeyword(":type/delta"))
+		tx.Add(d2, datalog.NewKeyword(":entity/type"), datalog.NewKeyword(":type/delta"))
+
+		tx.Add(a1, datalog.NewKeyword(":rel/location"), a2)
+		tx.Add(a1, datalog.NewKeyword(":rel/region"), r1)
+		tx.Add(a2, datalog.NewKeyword(":rel/region"), r1)
+
+		tx.Add(b1, datalog.NewKeyword(":rel/location"), a2)
+		tx.Add(b1, datalog.NewKeyword(":rel/provider"), a1)
+
+		tx.Add(g1, datalog.NewKeyword(":rel/location"), a2)
+
+		tx.Add(d1, datalog.NewKeyword(":rel/link"), d2)
+
+		_, err = tx.Commit()
+		require.NoError(t, err)
+
+		// Same 4-branch structure with generic attributes
+		results, err := executor.CollectTuples(db.Query(`
+			[:find ?rname ?rtype
+			 :where
+			 [?self :entity/name "A1"]
+			 [?self :entity/type ?stype]
+			 (or-join [?related ?self ?stype]
+			   (and [(ground :type/alpha) ?stype]
+			        (or-join [?related ?self]
+			          [?related :rel/location ?self]
+			          (and [?self :rel/region ?rgn]
+			               [?related :rel/region ?rgn])))
+			   (and [(ground :type/beta) ?stype]
+			        (or-join [?related ?self]
+			          (and [?self :rel/location ?loc]
+			               (or [?related :rel/location ?loc]
+			                   [(identity ?loc) ?related]))
+			          [?related :rel/provider ?self]))
+			   (and [(ground :type/gamma) ?stype]
+			        [?self :rel/location ?loc2]
+			        (or [?related :rel/location ?loc2]
+			            [(identity ?loc2) ?related]))
+			   (and [(ground :type/delta) ?stype]
+			        (or-join [?related ?self]
+			          [?related :rel/link ?self]
+			          (and [?self :rel/link ?parent]
+			               (or [(identity ?parent) ?related]
+			                   [?related :rel/link ?parent])))))
+			 [?related :entity/name ?rname]
+			 [?related :entity/type ?rtype]]`))
+		require.NoError(t, err)
+		t.Logf("Results (%d):", len(results))
+		for _, row := range results {
+			t.Logf("  %s (%s)", row[0], row[1])
+		}
+
+		// A1 is type alpha. Branch 1 applies:
+		//   [?related :rel/location ?self] → nothing located AT A1
+		//   [?self :rel/region ?rgn] [?related :rel/region ?rgn]
+		//     → A1 in R1, A2 also in R1 → A2 is related via shared region
+		byName := make(map[string]bool)
+		for _, row := range results {
+			byName[row[0].(string)] = true
+		}
+		require.Greater(t, len(results), 0, "A1 should find related entities")
+		assert.True(t, byName["A2"], "should find A2 via shared region")
+	})
+
+	t.Run("ground_rebinding_existing_symbol", func(t *testing.T) {
+		db, e1, e2, e3 := setupBaseEntities(t)
+		addChildrenTypesAndFriends(t, db, e1, e2, e3)
+
+		results, err := executor.CollectTuples(db.Query(`
+			[:find ?name ?stype
+			 :where [?e :entity/name ?name]
+			        [?e :entity/type ?stype]
+			        (or-join [?e ?stype]
+			          (and [(ground :type/parent) ?stype]
+			               [?e :entity/friend _])
+			          (and [(ground :type/child) ?stype]
+			               [?e :entity/friend _]))]`))
+		require.NoError(t, err)
+		t.Logf("Results: %v", results)
+		require.Greater(t, len(results), 0, "ground rebinding existing symbol should produce results")
+	})
+
 	t.Run("or_join_decorrelated_subquery_with_default", func(t *testing.T) {
+		db, e1, e2, e3 := setupBaseEntities(t)
+		addChildrenTypesAndFriends(t, db, e1, e2, e3)
 
 		results, err := executor.CollectTuples(db.Query(`
 			[:find ?name ?count
@@ -146,9 +294,9 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 			              $) [[?e ?count] ...]]
 			          (and (not [_ :child/parent ?e])
 			               [(ground 0) ?count]))]`))
-		require.NoError(t, err, "decorrelated subquery in or-join union should work")
+		require.NoError(t, err)
 		t.Logf("Results: %v", results)
-		require.Len(t, results, 3, "should return all 3 entities")
+		require.Len(t, results, 3)
 
 		byName := make(map[string]int64)
 		for _, row := range results {

--- a/datalog/storage/simple_batch_scanner.go
+++ b/datalog/storage/simple_batch_scanner.go
@@ -26,6 +26,8 @@ type simpleBatchScanner struct {
 
 	// Optimized tuple builder
 	tupleBuilder *query.InternedTupleBuilder
+
+	err error // First error from storage operations during scan
 }
 
 // newSimpleBatchScanner creates a new simple batch scanner
@@ -280,7 +282,8 @@ func (s *simpleBatchScanner) scanAndFilter(iter Iterator, bindingSet map[string]
 	for iter.Next() {
 		datom, err := iter.Datom()
 		if err != nil {
-			continue
+			s.err = err
+			break
 		}
 		datomCount++
 
@@ -369,3 +372,5 @@ func (s *simpleBatchScanner) Close() error {
 	// Results are already materialized, nothing to close
 	return nil
 }
+
+func (s *simpleBatchScanner) Error() error { return s.err }

--- a/docs/bugs/BUG-NESTED-ORJOIN-INNER-CLAUSES.md
+++ b/docs/bugs/BUG-NESTED-ORJOIN-INNER-CLAUSES.md
@@ -1,0 +1,68 @@
+# Nested or-join inside AND branches: unsupported inner clause type
+
+## Trigger
+
+A query uses nested `or-join` inside `and` branches of an outer `or-join` to implement type-dependent relationship traversal:
+
+```clojure
+(or-join [?related ?self ?stype]
+  (and [(ground :type/alpha) ?stype]
+       (or-join [?related ?self]
+         [?related :rel/location ?self]
+         (and [?self :rel/region ?rgn]
+              [?related :rel/region ?rgn])))
+  (and [(ground :type/beta) ?stype]
+       (or-join [?related ?self]
+         (and [?self :rel/location ?loc]
+              (or [?related :rel/location ?loc]
+                  [(identity ?loc) ?related]))
+         [?related :rel/provider ?self]))
+  ...)
+```
+
+## Error
+
+```
+unsupported inner clause type: *query.OrJoinClause
+```
+
+The executor's `executeInnerClauses` function — which evaluates the clauses within `and` branches of OR fallback — handles DataPattern, Expression, Predicate, SubqueryPattern, NotClause, and NotJoinClause, but not OrClause or OrJoinClause.
+
+## Root cause
+
+`executeInnerClauses` was built incrementally. It started handling DataPatterns and Expressions, then NOT/NOT-JOIN were added when the algebra compiler needed them. But OR/OR-JOIN inside and branches were never encountered in the test suite until this query pattern.
+
+The OR fallback evaluator (`OrFallbackIterator`) calls `executeInnerClauses` for each branch per outer tuple. When a branch contains `(and [(ground :type/alpha) ?stype] (or-join ...))`, the and-branch has two clauses: an Expression and an OrJoinClause. The Expression is handled; the OrJoinClause hits the default case and errors.
+
+## Error swallowing (secondary bug)
+
+The error from `executeInnerClauses` was being swallowed by `OrFallbackIterator.Next()`:
+
+```go
+branchResult, err = it.executor.executeInnerClauses(it.ctx, branch, execInput)
+if err != nil {
+    it.err = err
+    it.done = true
+    return false
+}
+```
+
+The `Iterator` interface had no `Error()` method, so `it.err` was unreachable. Callers saw 0 results with no error — the query silently returned empty instead of failing.
+
+## Fix (two parts)
+
+### Part 1: Add Error() to Iterator interface
+
+Added `Error() error` to the `Iterator` interface so iteration errors can propagate:
+
+- **Storage-level iterators** (leaf): store errors from `Datom()`, `ScanKeysOnly()`, etc. in an `err` field. `Error()` returns the stored error.
+- **Wrapper iterators** (executor): delegate `Error()` to their inner iterator. No `err` field needed — errors propagate up the chain.
+- **Test mocks**: have an `err` field so tests can inject errors and verify propagation.
+
+### Part 2: Extend executeInnerClauses
+
+Add `*query.OrClause` and `*query.OrJoinClause` cases to `executeInnerClauses`, delegating to the existing `executeOrClause` and `executeOrJoinClause` methods.
+
+## Reproduction test
+
+`TestOrUnionWithExpressionBranches/nested_or_join_in_and_branches` in `datalog/storage/or_union_expressions_test.go`.

--- a/docs/bugs/PROOF-ORJOIN-ITERATION-SEMANTICS.md
+++ b/docs/bugs/PROOF-ORJOIN-ITERATION-SEMANTICS.md
@@ -1,0 +1,113 @@
+# Proof: OR-join does not require multiple iterations of the same sequence
+
+## Question
+
+Does the OR-join evaluation algorithm inherently require iterating the same
+data sequence multiple times? If not, the `StreamingRelation.Iterator() called
+multiple times` panic is a bug in the implementation, not a fundamental
+limitation requiring LazySeq wrapping or materialization.
+
+## OR-join has two semantic modes
+
+### Mode 1: Union semantics (no expressions in branches)
+
+Each branch runs independently, once. Results are merged.
+
+```
+(or-join [?x ?y]
+  [?x :attr1 ?y]     ;; branch 1: one scan
+  [?x :attr2 ?y])    ;; branch 2: one scan
+```
+
+- Branch 1 executes → produces Relation R1
+- Branch 2 executes → produces Relation R2
+- Result = R1 ∪ R2
+- Each branch iterator is consumed exactly once
+- The union result is iterated exactly once by the consumer
+
+**No re-iteration required.**
+
+### Mode 2: Fallback semantics (branches contain expressions)
+
+Per outer tuple, try branches in order until one matches.
+
+```
+(or-join [?x ?count]
+  [(q [...] $) [[?x ?count] ...]]    ;; branch 1: subquery
+  [(ground 0) ?count])                ;; branch 2: default
+```
+
+For each outer tuple:
+1. Execute branch 1 with this tuple's context → Relation or nil
+2. If branch 1 matched, use it. Otherwise try branch 2.
+3. Short-circuit: stop on first match.
+
+Each branch execution is independent — fresh evaluation per outer tuple.
+No branch result is shared across outer tuples. The branch result is
+consumed once (to check for matches and extract tuples), then discarded.
+
+**No re-iteration required.**
+
+## Nested OR-join
+
+Consider the failing query pattern:
+
+```
+(or-join [?related ?self ?stype]            ;; OUTER: fallback (has ground)
+  (and [(ground :type/parent) ?stype]
+       (or-join [?related ?self]            ;; INNER: union (pure DataPatterns)
+         [?related :child/parent ?self]
+         [?self :entity/friend ?related]))
+  (and [(ground :type/child) ?stype]
+       [?self :entity/friend ?related]))
+```
+
+The **outer** or-join uses fallback semantics (branches contain `ground`).
+The **inner** or-join uses union semantics (branches are pure DataPatterns).
+
+For each outer tuple (e.g., Alice with ?stype=:type/parent):
+1. Evaluate outer branch 1: `(and [(ground :type/parent) ?stype] (or-join ...))`
+2. The `ground` expression binds ?stype — checked against outer tuple
+3. The inner or-join executes:
+   - Branch A: scan `[?related :child/parent Alice]` → one iterator, consumed once
+   - Branch B: scan `[Alice :entity/friend ?related]` → one iterator, consumed once
+   - Union: merge A and B → consumed once by the and-branch collapse
+4. The and-branch result is consumed once by the outer fallback to check for matches
+
+At no point is any iterator consumed more than once.
+
+## Why the panic occurs
+
+The `ProductIterator` panic means the executor has **disjoint relation groups**
+after clause execution — groups that don't share symbols and can't be joined.
+`ProductIterator` computes their cross product, which requires re-iterating
+the shorter relation for each tuple of the longer one.
+
+But this query should NOT have disjoint groups. The symbols flow:
+- Clause 1: `[?self :entity/name ?self-name]` → provides `{?self, ?self-name}`
+- Clause 2: `[?self :entity/type ?stype]` → provides `{?self, ?stype}`, joins on `?self`
+- Clause 3: `(or-join [?related ?self ?stype] ...)` → provides `{?related, ?self, ?stype}`, joins on `?self, ?stype`
+- Clause 4: `[?related :entity/name ?related-name]` → provides `{?related, ?related-name}`, joins on `?related`
+
+Every clause shares at least one symbol with the accumulated context. No
+disjoint groups should exist. The `ProductIterator` should never be created.
+
+## Conclusion
+
+1. **OR-join does not require multiple iterations.** Both union and fallback
+   modes consume each branch iterator exactly once.
+
+2. **The ProductIterator panic is a symptom of a symbol-tracking bug.** The
+   executor is failing to recognize that the or-join result shares symbols
+   with other groups, creating a false disjoint condition.
+
+3. **LazySeq wrapping is treating the symptom, not the cause.** The real fix
+   is to ensure the or-join result has correct symbols so the collapse joins
+   it with the other groups instead of creating a cross product.
+
+## Investigation needed
+
+Check what symbols `executeOrJoinClauseFallback` reports on its result.
+The `OrFallbackRelation.Symbols()` must include the join variables
+(`?related`, `?self`, `?stype`). If the symbols are wrong or empty,
+the collapse will treat it as disjoint and create a `ProductIterator`.


### PR DESCRIPTION
## Summary

Fixes nested `or-join` inside `and` branches — the pattern used by complex type-dependent relationship queries. Adds `Error()` to the `Iterator` interface so iteration errors propagate instead of being silently lost.

## What was broken

A downstream query using nested `or-join` inside `and` branches of an outer `or-join` failed silently, returning 0 results with no error:

```clojure
(or-join [?related ?self ?stype]
  (and [(ground :type/alpha) ?stype]
       (or-join [?related ?self]
         [?related :rel/location ?self]
         (and [?self :rel/region ?rgn]
              [?related :rel/region ?rgn])))
  (and [(ground :type/beta) ?stype]
       ...)
  ...)
```

Three bugs contributed:

**1. `executeInnerClauses` missing OR clause types.** The executor's inner clause handler (used by OR fallback branch evaluation) didn't handle `OrClause` or `OrJoinClause`. Nested or-join inside and branches hit the default case and returned `unsupported inner clause type: *query.OrJoinClause`.

**2. Silent error swallowing.** The error from (1) was stored in `OrFallbackIterator.err` but the `Iterator` interface had no `Error()` method. Callers saw `Next()` return false and assumed normal exhaustion. The query returned 0 results with no error indication.

**3. `collectBranchOutputSymbols` missing OR clause types.** The function that computes output symbols for OR fallback branches didn't handle nested OR clauses. When a branch contained an inner or-join producing `?related`, that symbol wasn't reported. The outer OR result was missing symbols, creating false disjoint groups in the collapse, which created a `ProductIterator` that panicked trying to re-iterate a `StreamingRelation`.

**4. Ground expression duplicating bound symbols.** `[(ground :type/alpha) ?stype]` where `?stype` is already bound from the outer relation appended a duplicate `?stype` column instead of filtering (unifying). Hash joins on duplicated symbols produced 0 results because the key structure was wrong.

## Fixes

### Iterator Error() propagation

Added `Error() error` to the `Iterator` interface. Every iterator type implements it:

- **Storage-level iterators** (leaves): store errors from `Datom()`, `ScanKeysOnly()`, and other I/O operations that were previously swallowed with `continue`. These are the only types with `err` fields.
- **Wrapper iterators** (executor): delegate `Error()` to their inner iterator. No `err` field — errors propagate up the chain automatically.
- **Test mocks**: have an `err` field so tests can inject errors and verify propagation.

### executeInnerClauses

Added `*query.OrClause` and `*query.OrJoinClause` cases, delegating to the existing `executeOrClause` and `executeOrJoinClause` methods.

### collectBranchOutputSymbols

Added `*query.OrJoinClause` (uses declared join vars as output symbols) and `*query.OrClause` (recursively computes output symbols from branches).

### Ground expression unification

When a ground expression binds a symbol already present in the relation, the executor now partitions binding symbols into filter (already present — check equality) and extend (new — append value). Previously it unconditionally appended, duplicating the symbol.

### WrapStreamingAsLazy helper

Added `WrapStreamingAsLazy()` to `lazy_seq_relation.go` — wraps a `StreamingRelation` in a `LazySeqRelation` for safe re-iteration without materialization. Built and tested during investigation; not needed for the final fix (the root cause was symbol tracking, not re-iteration) but available for future use.

## Proof: OR-join does not require multiple iterations

During investigation, we proved that OR-join evaluation (both union and fallback modes) consumes each branch iterator exactly once. The `StreamingRelation` re-iteration panic was a symptom of wrong symbol metadata causing false disjoint groups, not a fundamental limitation of OR-join semantics. See `docs/bugs/PROOF-ORJOIN-ITERATION-SEMANTICS.md`.

## Test plan

- [x] 4-branch deeply nested or-join with 3 levels of nesting (generic names, production structure)
- [x] 2-branch nested or-join in and branches
- [x] Ground expression rebinding existing symbol (unification, not extension)
- [x] LazySeqRelation multiple independent cursors over shared cells
- [x] LazySeqRelation wrapping a StreamingRelation
- [x] Each subtest uses its own isolated database (no shared mutable state)
- [x] All 13 datalog packages pass
