### PR TITLE
Split OR semantics: (or) = Datomic union, (or-default) = fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ The storage layer connects the query engine to BadgerDB:
 22. **Pull API** - Declarative entity attribute retrieval with nested refs, cycle detection, wildcards (9× faster than queries)
 23. **Schema support** - Type validation, cardinality (one/many), uniqueness constraints; optional and additive
 24. **CRDT storage** - LWW for cardinality-one, add-wins for cardinality-many, RGA for cardinality-vector; all writes preserved with ElementIDs; `db.History()` for raw datom access, `db.AsOf(elementID)` for point-in-time queries; three-mode `*ElementID` matcher (`nil`=latest, `&ElementID{}`=history, `&ElementID{L,R}`=as-of)
-25. **NOT/OR clauses** - Full support for `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with Datomic-compatible semantics; OR supports fallback expressions for default values
+25. **NOT/OR clauses** - Full support for `(not ...)`, `(not-join ...)`, `(or ...)`, `(or-join ...)` with Datomic-compatible union semantics; `(or-default ...)`, `(or-default-join ...)` for fallback/default-value patterns (janus extension)
 26. **QueryInto API** - Typed query results via `QueryInto()` and `QueryOneInto()` with struct tag mapping for variables and aggregates
 27. **Multi-source queries** - Named sources (`$name`), `SourceRouter`, cross-source joins, `MemoryPatternMatcher`, `SliceSource[T]`, query builder `Source()`/`PatFrom()`
 28. **Database export/import** - EDN format export/import for backup and migration; CLI flags `-export` and `-import`; preserves all value types and transaction IDs

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -244,23 +244,33 @@ Logical negation and disjunction for complex query patterns:
                  [?e :admin/status "enabled"])]
 ```
 
-**OR with fallback expressions:**
+**OR semantics (Datomic-compatible):**
 
-When an OR clause contains expression branches (e.g., `ground`, arithmetic), janus-datalog uses **fallback semantics**: branches are tried in order, returning the first non-empty result. This enables default values:
+`(or ...)` and `(or-join ...)` use **union semantics**, matching Datomic: all branches are evaluated and results are merged. This includes branches with expressions like `identity`:
+
+```clojure
+;; Union: returns rooms sharing the area AND the area entity itself
+(or [?related :entity/area ?target]
+    [(identity ?target) ?related])
+```
+
+**OR-DEFAULT (janus extension for fallback/defaults):**
+
+`(or-default ...)` and `(or-default-join ...)` use **fallback semantics**: branches are tried in order, returning the first non-empty result. This enables default values — a pattern not available in Datomic's query language:
 
 ```clojure
 ;; Return "Unknown" if no name exists
 [:find ?name
- :where (or [?e :person/name ?name]
-            [(ground "Unknown") ?name])]
+ :where (or-default [?e :person/name ?name]
+                    [(ground "Unknown") ?name])]
 
 ;; Count with zero default
 [:find ?count
- :where (or [(q [:find (count ?t) :where [?t :task/done true]] $) [[?count]]]
-            [(ground 0) ?count])]
+ :where (or-default [(q [:find (count ?t) :where [?t :task/done true]] $) [[?count]]]
+                    [(ground 0) ?count])]
 ```
 
-This differs from Datomic, where OR always uses union semantics. See [OR_FALLBACK_SEMANTICS.md](docs/reference/OR_FALLBACK_SEMANTICS.md) for details.
+See [OR_FALLBACK_SEMANTICS.md](docs/reference/OR_FALLBACK_SEMANTICS.md) for details.
 
 **Note:** NOT clauses support data patterns. Predicates and expressions inside NOT are not yet supported.
 

--- a/datalog/algebra/compile.go
+++ b/datalog/algebra/compile.go
@@ -67,6 +67,12 @@ func compileClause(clause query.Clause, current *Node) (*Node, error) {
 	case *query.OrJoinClause:
 		return compileOrJoin(c, current)
 
+	case *query.OrDefaultClause:
+		return compileOrDefault(c, current)
+
+	case *query.OrDefaultJoinClause:
+		return compileOrDefaultJoin(c, current)
+
 	case *query.Comparison:
 		return compilePredicate(c, current), nil
 
@@ -237,26 +243,50 @@ func compileNotJoin(nj *query.NotJoinClause, current *Node) (*Node, error) {
 	}, nil
 }
 
-// compileOr handles OR clauses. Union semantics produce a Union node.
-// Fallback semantics (OR with subquery + ground default) produce a
-// LateralJoin with default values.
+// compileOr handles OR clauses — union semantics.
+// When branches contain correlated predicates (NOT, missing?) that require
+// outer context, routes to the fallback/lateral-join path since independent
+// union branches can't express anti-joins against the outer relation.
 func compileOr(oc *query.OrClause, current *Node) (*Node, error) {
-	if !query.OrHasExpressions(oc.Branches) {
-		// Union semantics
-		return compileOrUnion(oc.Branches, current)
+	if branchesRequireOuterContext(oc.Branches) {
+		return compileOrFallback(oc.Branches, current)
 	}
+	return compileOrUnion(oc.Branches, current)
+}
 
-	// Fallback semantics — check for the correlated subquery + ground pattern
+// compileOrJoin handles OR-JOIN clauses — union semantics with join vars.
+// Same correlated-predicate detection as compileOr.
+func compileOrJoin(oj *query.OrJoinClause, current *Node) (*Node, error) {
+	if branchesRequireOuterContext(oj.Branches) {
+		return compileOrFallbackWithJoinVars(oj.Branches, oj.JoinVars, current)
+	}
+	return compileOrUnionWithJoinVars(oj.Branches, oj.JoinVars, current)
+}
+
+// branchesRequireOuterContext returns true if any branch contains predicates
+// that are inherently correlated — they reference the outer relation and
+// cannot be compiled as independent union branches.
+func branchesRequireOuterContext(branches [][]query.Clause) bool {
+	for _, branch := range branches {
+		for _, c := range branch {
+			switch c.(type) {
+			case *query.NotClause, *query.NotJoinClause:
+				return true
+			case *query.MissingPredicate:
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// compileOrDefault handles OR-DEFAULT clauses — fallback semantics.
+func compileOrDefault(oc *query.OrDefaultClause, current *Node) (*Node, error) {
 	return compileOrFallback(oc.Branches, current)
 }
 
-// compileOrJoin is like compileOr but with explicit join variables.
-// The join variables are preserved on the Union node so the decompiler
-// can emit OrJoinClause (not OrClause) to maintain round-trip fidelity.
-func compileOrJoin(oj *query.OrJoinClause, current *Node) (*Node, error) {
-	if !query.OrHasExpressions(oj.Branches) {
-		return compileOrUnionWithJoinVars(oj.Branches, oj.JoinVars, current)
-	}
+// compileOrDefaultJoin handles OR-DEFAULT-JOIN clauses — fallback with join vars.
+func compileOrDefaultJoin(oj *query.OrDefaultJoinClause, current *Node) (*Node, error) {
 	return compileOrFallbackWithJoinVars(oj.Branches, oj.JoinVars, current)
 }
 
@@ -419,12 +449,12 @@ func compileOrFallbackExclusive(branches [][]query.Clause, joinVars []query.Symb
 
 	output := mergeSymbols(compiled[0].Symbols(), compiled[1].Symbols())
 
-	union := &Node{
-		Op:       RuleUnion,
-		Data:     &Union{Output: output, JoinVars: joinVars},
+	lateralUnion := &Node{
+		Op:       RuleLateralUnion,
+		Data:     &LateralUnion{Output: output, JoinVars: joinVars},
 		Children: compiled,
 	}
-	return union, nil
+	return lateralUnion, nil
 }
 
 // compilePredicate produces a Select node for any predicate type.

--- a/datalog/algebra/compile_test.go
+++ b/datalog/algebra/compile_test.go
@@ -73,7 +73,7 @@ func TestCompileOrFallback(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?count
 	  :where
 	  [?e :entity/type :entity.type/scenario]
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]]
@@ -399,7 +399,7 @@ func TestRoundTrip_LateralJoin(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?count
 	  :where
 	  [?e :entity/type :entity.type/scenario]
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]]
@@ -429,19 +429,19 @@ func TestRoundTrip_LateralJoin(t *testing.T) {
 		t.Logf("  [%d] %T: %s", i, c, c.String())
 	}
 
-	// Should have a DataPattern and an OrJoinClause (the OR-fallback with join vars)
+	// Should have a DataPattern and an OrDefaultJoinClause (the OR-fallback with join vars)
 	hasPattern := false
-	hasOrJoin := false
+	hasOrDefaultJoin := false
 	for _, c := range clauses {
 		switch c.(type) {
 		case *query.DataPattern:
 			hasPattern = true
-		case *query.OrJoinClause:
-			hasOrJoin = true
+		case *query.OrDefaultJoinClause:
+			hasOrDefaultJoin = true
 		}
 	}
 	assert.True(t, hasPattern, "decompiled has DataPattern")
-	assert.True(t, hasOrJoin, "decompiled has OrJoinClause (OR-fallback with defaults and join vars)")
+	assert.True(t, hasOrDefaultJoin, "decompiled has OrDefaultJoinClause (OR-fallback with defaults and join vars)")
 }
 
 func TestRoundTrip_LateralJoinNoDefaults(t *testing.T) {

--- a/datalog/algebra/decompile.go
+++ b/datalog/algebra/decompile.go
@@ -31,6 +31,8 @@ func decompileNode(n *Node) ([]query.Clause, error) {
 		return decompileAntiJoin(n)
 	case RuleUnion:
 		return decompileUnion(n)
+	case RuleLateralUnion:
+		return decompileLateralUnion(n)
 	case RuleLateralJoin:
 		return decompileLateralJoin(n)
 	case RuleAggregate:
@@ -200,16 +202,16 @@ func decompileLeftOuterJoin(n *Node) ([]query.Clause, error) {
 		}
 	}
 
-	// Use or-join with explicit join variables so the phaser knows this OR
+	// Use or-default-join with explicit join variables so the phaser knows this OR
 	// depends on the join symbols from the outer relation. Without explicit
 	// join vars, the phaser may reorder the OR before the DataPattern that
 	// provides the join symbols.
-	orJoinClause := &query.OrJoinClause{
+	orDefaultJoinClause := &query.OrDefaultJoinClause{
 		JoinVars: join.JoinSymbols,
 		Branches: [][]query.Clause{rightClauses, defaultBranch},
 	}
 
-	return append(leftClauses, orJoinClause), nil
+	return append(leftClauses, orDefaultJoinClause), nil
 }
 
 // decompileAntiJoin emits child clauses from left, then a NOT clause wrapping right.
@@ -245,6 +247,7 @@ func decompileAntiJoin(n *Node) ([]query.Clause, error) {
 }
 
 // decompileUnion emits an OR clause (or OR-join clause if join vars present).
+// Union nodes always decompile to OrClause/OrJoinClause (independent union).
 func decompileUnion(n *Node) ([]query.Clause, error) {
 	u := n.Data.(*Union)
 	var branches [][]query.Clause
@@ -262,6 +265,27 @@ func decompileUnion(n *Node) ([]query.Clause, error) {
 		}}, nil
 	}
 	return []query.Clause{&query.OrClause{Branches: branches}}, nil
+}
+
+// decompileLateralUnion emits an OR-DEFAULT clause (or OR-DEFAULT-JOIN if join vars present).
+// LateralUnion nodes represent correlated per-tuple branch evaluation.
+func decompileLateralUnion(n *Node) ([]query.Clause, error) {
+	lu := n.Data.(*LateralUnion)
+	var branches [][]query.Clause
+	for _, child := range n.Children {
+		branch, err := decompileNode(child)
+		if err != nil {
+			return nil, err
+		}
+		branches = append(branches, branch)
+	}
+	if len(lu.JoinVars) > 0 {
+		return []query.Clause{&query.OrDefaultJoinClause{
+			JoinVars: lu.JoinVars,
+			Branches: branches,
+		}}, nil
+	}
+	return []query.Clause{&query.OrDefaultClause{Branches: branches}}, nil
 }
 
 // decompileLateralJoin emits a SubqueryPattern clause.
@@ -362,16 +386,16 @@ func decompileLateralJoin(n *Node) ([]query.Clause, error) {
 	}
 
 	if len(joinVars) > 0 {
-		orJoinClause := &query.OrJoinClause{
+		orDefaultJoinClause := &query.OrDefaultJoinClause{
 			JoinVars: joinVars,
 			Branches: [][]query.Clause{subqueryBranch, defaultBranch},
 		}
-		clauses = append(clauses, orJoinClause)
+		clauses = append(clauses, orDefaultJoinClause)
 	} else {
-		orClause := &query.OrClause{
+		orDefaultClause := &query.OrDefaultClause{
 			Branches: [][]query.Clause{subqueryBranch, defaultBranch},
 		}
-		clauses = append(clauses, orClause)
+		clauses = append(clauses, orDefaultClause)
 	}
 	return clauses, nil
 }

--- a/datalog/algebra/rewrite_decorrelate_test.go
+++ b/datalog/algebra/rewrite_decorrelate_test.go
@@ -15,7 +15,7 @@ func TestDecorrelation_SimpleAggregate(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?count
 	  :where
 	  [?e :entity/type :entity.type/scenario]
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]]
@@ -122,13 +122,13 @@ func TestDecorrelation_MultipleSubqueries(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?count ?total
 	  :where
 	  [?e :entity/type :entity.type/scenario]
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]]
 	          $ ?e) [[?count]]]
 	      [(ground 0) ?count])
-	  (or [(q [:find (sum ?v)
+	  (or-default [(q [:find (sum ?v)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/value ?v]]
@@ -162,14 +162,14 @@ func TestDecorrelation_NestedWithIntermediateMap(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?count ?ready
 	  :where
 	  [?e :entity/type :entity.type/project]
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :item/project ?s]
 	                  [?t :item/status :status/done]]
 	          $ ?e) [[?count]]]
 	      [(ground 0) ?count])
 	  [[(> ?count 0)] ?ready]
-	  (or [(q [:find (sum ?c)
+	  (or-default [(q [:find (sum ?c)
 	           :in $ ?s
 	           :where [?t :item/project ?s]
 	                  [?t :item/cost ?c]]
@@ -205,14 +205,14 @@ func TestDecorrelation_NestedWithNotAndGetElse(t *testing.T) {
 	  [?e :entity/type :entity.type/project]
 	  (not [?e :entity/deleted true])
 	  [(get-else $ ?e :project/label "") ?label]
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :item/project ?s]
 	                  [?t :item/status :status/done]]
 	          $ ?e) [[?count]]]
 	      [(ground 0) ?count])
 	  [[(> ?count 0)] ?ready]
-	  (or [(q [:find (sum ?c)
+	  (or-default [(q [:find (sum ?c)
 	           :in $ ?s
 	           :where [?t :item/project ?s]
 	                  [?t :item/cost ?c]]
@@ -248,13 +248,13 @@ func TestDecorrelation_MixedAggregateAndNonAggregate(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?count ?lastKey
 	  :where
 	  [?e :entity/type :entity.type/project]
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :item/project ?s]
 	                  [?t :item/status :status/done]]
 	          $ ?e) [[?count]]]
 	      [(ground 0) ?count])
-	  (or [(q [:find ?key
+	  (or-default [(q [:find ?key
 	           :in $ ?s
 	           :where [?t :item/project ?s]
 	                  [?t :item/key ?key]]
@@ -303,7 +303,7 @@ func TestDecorrelation_ProductionStructure(t *testing.T) {
 	  [(get-else $ ?project :project/region "") ?region]
 	  [(get-else $ ?project :project/owner "") ?owner]
 	  [(get-else $ ?project :project/notes "") ?notes]
-	  (or [(q [:find (count ?i) (sum ?c) (sum ?w) (sum ?iu) (sum ?ou)
+	  (or-default [(q [:find (count ?i) (sum ?c) (sum ?w) (sum ?iu) (sum ?ou)
 	           :in $ ?p
 	           :where [?i :item/project ?p]
 	                  [?i :item/status :status/done]
@@ -314,7 +314,7 @@ func TestDecorrelation_ProductionStructure(t *testing.T) {
 	                  [(get-else $ ?i :item/output-units 0) ?ou]]
 	          $ ?project) [[?itemCount ?totalCost ?totalWeight ?inputUnits ?outputUnits]]]
 	      [(ground [0 0 0 0 0]) [[?itemCount ?totalCost ?totalWeight ?inputUnits ?outputUnits]]])
-	  (or [(q [:find (count ?i)
+	  (or-default [(q [:find (count ?i)
 	           :in $ ?p
 	           :where [?i :item/project ?p]
 	                  [?i :item/key :step/init]
@@ -323,7 +323,7 @@ func TestDecorrelation_ProductionStructure(t *testing.T) {
 	          $ ?project) [[?initCount]]]
 	      [(ground 0) ?initCount])
 	  [[(> ?initCount 0)] ?ready]
-	  (or [(q [:find ?key ?ca
+	  (or-default [(q [:find ?key ?ca
 	           :in $ ?p
 	           :where [?i :item/project ?p]
 	                  [?i :item/status :status/done]
@@ -383,13 +383,13 @@ func TestDecorrelation_NestedLateralJoins(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?count ?total
 	  :where
 	  [?e :entity/type :entity.type/project]
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :item/project ?s]
 	                  [?t :item/status :status/done]]
 	          $ ?e) [[?count]]]
 	      [(ground 0) ?count])
-	  (or [(q [:find (sum ?c)
+	  (or-default [(q [:find (sum ?c)
 	           :in $ ?s
 	           :where [?t :item/project ?s]
 	                  [?t :item/cost ?c]]
@@ -425,7 +425,7 @@ func TestDecorrelation_ArgmaxPattern(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?lastKey ?lastUpdatedAt
 	  :where
 	  [?e :entity/type :entity.type/project]
-	  (or [(q [:find ?key ?ca
+	  (or-default [(q [:find ?key ?ca
 	           :in $ ?s
 	           :where [?t :item/project ?s]
 	                  [?t :item/completed-at ?ca]
@@ -471,7 +471,7 @@ func TestDecorrelation_PureDataPatternSkipped(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?val
 	  :where
 	  [?e :entity/type :entity.type/project]
-	  (or [(q [:find ?v
+	  (or-default [(q [:find ?v
 	           :in $ ?s
 	           :where [?s :project/value ?v]]
 	          $ ?e) [[?val]]]

--- a/datalog/algebra/rewrite_getelse_test.go
+++ b/datalog/algebra/rewrite_getelse_test.go
@@ -186,8 +186,8 @@ func TestCompileMissingPredicateInOr(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?name
 	  :where
 	  [?e :entity/name ?name]
-	  (or [(missing? $ ?e :entity/lore)]
-	      [?e :entity/lore []])]`)
+	  (or-default [(missing? $ ?e :entity/lore)]
+	              [?e :entity/lore []])]`)
 	require.NoError(t, err)
 
 	root, err := Compile(q)

--- a/datalog/algebra/types.go
+++ b/datalog/algebra/types.go
@@ -24,8 +24,9 @@ const (
 	RuleMap         = "Map"
 	RuleJoin        = "Join"
 	RuleAntiJoin    = "AntiJoin"
-	RuleUnion       = "Union"
-	RuleLateralJoin = "LateralJoin"
+	RuleUnion        = "Union"
+	RuleLateralUnion = "LateralUnion"
+	RuleLateralJoin  = "LateralJoin"
 	RuleAggregate   = "Aggregate"
 	RuleConstant    = "Constant"
 )
@@ -177,11 +178,22 @@ func (a *AntiJoin) String() string {
 	return fmt.Sprintf("▷ on [%s]", strings.Join(syms, ", "))
 }
 
-// Union combines branches. R ∪ S
+// Union combines branches independently. R ∪ S
 // Compiled from query.OrClause or query.OrJoinClause with union semantics.
+// Branches are evaluated independently (no outer context).
 type Union struct {
 	Output   []query.Symbol // Shared output symbols across branches
 	JoinVars []query.Symbol // Explicit join variables from or-join (nil for plain or)
+}
+
+// LateralUnion combines branches with per-tuple evaluation against the outer relation.
+// R ⋈_L∪ (B₁ ∪ B₂ ∪ ... Bₙ)
+// Each branch sees the outer tuple as context. Used when branches contain
+// correlated predicates (NOT, missing?) or fallback defaults (or-default).
+// Decompiles to OrDefaultClause/OrDefaultJoinClause.
+type LateralUnion struct {
+	Output   []query.Symbol // Output symbols across branches
+	JoinVars []query.Symbol // Explicit join variables (nil for plain or-default)
 }
 
 func (u *Union) OutputSymbols() []query.Symbol { return u.Output }
@@ -194,6 +206,18 @@ func (u *Union) String() string {
 		return fmt.Sprintf("∪_join(%s)", strings.Join(syms, ", "))
 	}
 	return "∪"
+}
+
+func (lu *LateralUnion) OutputSymbols() []query.Symbol { return lu.Output }
+func (lu *LateralUnion) String() string {
+	if len(lu.JoinVars) > 0 {
+		syms := make([]string, len(lu.JoinVars))
+		for i, s := range lu.JoinVars {
+			syms[i] = s.String()
+		}
+		return fmt.Sprintf("⋈_L∪_join(%s)", strings.Join(syms, ", "))
+	}
+	return "⋈_L∪"
 }
 
 // LateralJoin is a correlated subquery. R ⋈_L S(r.x)

--- a/datalog/executor/helpers.go
+++ b/datalog/executor/helpers.go
@@ -372,6 +372,24 @@ func collectInnerVars(clauses []query.Clause) []query.Symbol {
 					}
 				}
 			}
+		case *query.OrDefaultClause:
+			for _, branch := range c.Branches {
+				for _, sym := range collectInnerVars(branch) {
+					if !seen[sym] {
+						seen[sym] = true
+						vars = append(vars, sym)
+					}
+				}
+			}
+		case *query.OrDefaultJoinClause:
+			for _, branch := range c.Branches {
+				for _, sym := range collectInnerVars(branch) {
+					if !seen[sym] {
+						seen[sym] = true
+						vars = append(vars, sym)
+					}
+				}
+			}
 		}
 	}
 

--- a/datalog/executor/not_or_test.go
+++ b/datalog/executor/not_or_test.go
@@ -551,14 +551,14 @@ func TestOrFallbackFirstBranchMatches(t *testing.T) {
 	matcher := NewMemoryPatternMatcher(datoms)
 	executor := NewExecutor(matcher, nil)
 
-	// Query: (or [?e :user/name ?x] [(ground "fallback") ?x])
+	// Query: (or-default [?e :user/name ?x] [(ground "fallback") ?x])
 	// First branch should match, so we should get "Alice", not "fallback"
 	q := &query.Query{
 		Find: []query.FindElement{
 			query.FindVariable{Symbol: datalog.NewSymbol("?x")},
 		},
 		Where: []query.Clause{
-			&query.OrClause{
+			&query.OrDefaultClause{
 				Branches: [][]query.Clause{
 					{
 						&query.DataPattern{
@@ -798,14 +798,14 @@ func TestOrFallbackPatternWithStreamingRelation(t *testing.T) {
 	matcher := NewMemoryPatternMatcher(datoms)
 	executor := NewExecutor(matcher, nil)
 
-	// Query: (or [?e :user/name ?x] [(ground "fallback") ?x])
+	// Query: (or-default [?e :user/name ?x] [(ground "fallback") ?x])
 	// Pattern should match, returning "Alice"
 	q := &query.Query{
 		Find: []query.FindElement{
 			query.FindVariable{Symbol: datalog.NewSymbol("?x")},
 		},
 		Where: []query.Clause{
-			&query.OrClause{
+			&query.OrDefaultClause{
 				Branches: [][]query.Clause{
 					{
 						&query.DataPattern{
@@ -858,9 +858,9 @@ func TestOrFallbackWithSubqueryPattern(t *testing.T) {
 	queryExecutor := NewExecutor(matcher, nil)
 
 	// Build the OR clause with SubqueryPattern and ground fallback
-	// (or [(q [:find (count ?t) :where [?t :task/status :status/complete]] $) [[?count]]]
-	//     [(ground 0) ?count])
-	orClause := &query.OrClause{
+	// (or-default [(q [:find (count ?t) :where [?t :task/status :status/complete]] $) [[?count]]]
+	//             [(ground 0) ?count])
+	orClause := &query.OrDefaultClause{
 		Branches: [][]query.Clause{
 			{
 				&query.SubqueryPattern{
@@ -966,7 +966,7 @@ func TestOrFallbackWithSubqueryPatternAndVariableInput(t *testing.T) {
 	//                         [?t :task/status :status/complete]]
 	//                $ ?scenario) [[?count]]]
 	//             [(ground 0) ?count])]
-	orClause := &query.OrClause{
+	orClause := &query.OrDefaultClause{
 		Branches: [][]query.Clause{
 			{
 				&query.SubqueryPattern{
@@ -1090,10 +1090,10 @@ func TestOrFallbackWithPatternAndTupleGround(t *testing.T) {
 	// Query:
 	// [:find ?scenario ?name ?taskCount
 	//  :where [?scenario :scenario/name ?name]
-	//         (or (and [?scenario :scenario/task ?task]
-	//                  [?task :task/count ?taskCount])
-	//             [(ground [0]) [?taskCount]])]
-	orClause := &query.OrClause{
+	//         (or-default (and [?scenario :scenario/task ?task]
+	//                         [?task :task/count ?taskCount])
+	//                    [(ground [0]) [?taskCount]])]
+	orClause := &query.OrDefaultClause{
 		Branches: [][]query.Clause{
 			// Branch 1: pattern-only (matches scenario1, not scenario2)
 			{
@@ -1209,7 +1209,7 @@ func TestOrFallbackWithPatternAndScalarGround(t *testing.T) {
 	executor := NewExecutor(matcher, nil)
 
 	// Same as TestOrFallbackWithPatternAndTupleGround but with SCALAR ground
-	orClause := &query.OrClause{
+	orClause := &query.OrDefaultClause{
 		Branches: [][]query.Clause{
 			{
 				&query.DataPattern{
@@ -1357,5 +1357,191 @@ func TestOrFallbackWithSubqueryPatternEmpty(t *testing.T) {
 		if val != int64(0) {
 			t.Errorf("Expected count=0 (fallback), got %v (type %T)", val, val)
 		}
+	}
+}
+
+// TestOrCorrelatedUnionWithIdentityBranch reproduces the bug where OR clauses
+// drop expression-only branches due to fallback short-circuiting.
+// See docs/bugs/BUG-OR-FALLBACK-DROPS-EXPRESSION-BRANCHES.md
+//
+// The OR has a data pattern branch (finds rooms in an area) and an identity
+// expression branch (binds the area entity itself). Both branches should
+// contribute results (union semantics). The bug: fallback short-circuits
+// after the data pattern branch succeeds, so the identity branch is never
+// evaluated.
+func TestOrCorrelatedUnionWithIdentityBranch(t *testing.T) {
+	area1 := datalog.NewIdentity("area:caves")
+	room1 := datalog.NewIdentity("room:guard")
+	room2 := datalog.NewIdentity("room:shrine")
+	room3 := datalog.NewIdentity("room:depths")
+
+	nameAttr := datalog.NewKeyword(":entity/name")
+	areaAttr := datalog.NewKeyword(":entity/area")
+
+	datoms := []datalog.Datom{
+		{E: area1, A: nameAttr, V: "Coastal Caves", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: room1, A: nameAttr, V: "Guard Chamber", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: room2, A: nameAttr, V: "Shrine Hall", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: room3, A: nameAttr, V: "The Depths", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: room1, A: areaAttr, V: area1, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: room2, A: areaAttr, V: area1, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: room3, A: areaAttr, V: area1, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	executor := NewExecutor(matcher, nil)
+
+	// Query:
+	// [:find ?rname
+	//  :where [?self :entity/name "Guard Chamber"]
+	//         [?self :entity/area ?target]
+	//         (or [?related :entity/area ?target]
+	//             [(identity ?target) ?related])
+	//         [?related :entity/name ?rname]]
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: datalog.NewSymbol("?rname")},
+		},
+		Where: []query.Clause{
+			&query.DataPattern{
+				Elements: []query.PatternElement{
+					query.Variable{Name: datalog.NewSymbol("?self")},
+					query.Constant{Value: nameAttr},
+					query.Constant{Value: "Guard Chamber"},
+				},
+			},
+			&query.DataPattern{
+				Elements: []query.PatternElement{
+					query.Variable{Name: datalog.NewSymbol("?self")},
+					query.Constant{Value: areaAttr},
+					query.Variable{Name: datalog.NewSymbol("?target")},
+				},
+			},
+			&query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: datalog.NewSymbol("?related")},
+								query.Constant{Value: areaAttr},
+								query.Variable{Name: datalog.NewSymbol("?target")},
+							},
+						},
+					},
+					{
+						&query.Expression{
+							Function: query.IdentityFunction{
+								Arg: query.VariableTerm{Symbol: datalog.NewSymbol("?target")},
+							},
+							Binding: datalog.NewSymbol("?related"),
+						},
+					},
+				},
+			},
+			&query.DataPattern{
+				Elements: []query.PatternElement{
+					query.Variable{Name: datalog.NewSymbol("?related")},
+					query.Constant{Value: nameAttr},
+					query.Variable{Name: datalog.NewSymbol("?rname")},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(q)
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	names := make(map[string]bool)
+	for i := 0; i < result.Size(); i++ {
+		name := result.Get(i)[0].(string)
+		names[name] = true
+		t.Logf("result[%d]: %s", i, name)
+	}
+
+	// All 3 rooms in the area (including Guard Chamber itself) + the area entity
+	if result.Size() != 4 {
+		t.Errorf("expected 4 results, got %d", result.Size())
+	}
+	if !names["Guard Chamber"] {
+		t.Error("missing 'Guard Chamber' (room in same area)")
+	}
+	if !names["Shrine Hall"] {
+		t.Error("missing 'Shrine Hall' (room in same area)")
+	}
+	if !names["The Depths"] {
+		t.Error("missing 'The Depths' (room in same area)")
+	}
+	if !names["Coastal Caves"] {
+		t.Error("missing 'Coastal Caves' (area entity via identity branch)")
+	}
+}
+
+// TestOrUnionIncludesAllBranches verifies that (or ...) with expression branches
+// uses union semantics (all branches contribute), not fallback (first-match-wins).
+func TestOrUnionIncludesAllBranches(t *testing.T) {
+	alice := datalog.NewIdentity("user:alice")
+	nameAttr := datalog.NewKeyword(":user/name")
+
+	datoms := []datalog.Datom{
+		{E: alice, A: nameAttr, V: "Alice", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+	}
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	executor := NewExecutor(matcher, nil)
+
+	// Query:
+	// [:find ?x
+	//  :where (or [?e :user/name ?x]
+	//             [(ground "nobody") ?x])]
+	q := &query.Query{
+		Find: []query.FindElement{
+			query.FindVariable{Symbol: datalog.NewSymbol("?x")},
+		},
+		Where: []query.Clause{
+			&query.OrClause{
+				Branches: [][]query.Clause{
+					{
+						&query.DataPattern{
+							Elements: []query.PatternElement{
+								query.Variable{Name: datalog.NewSymbol("?e")},
+								query.Constant{Value: nameAttr},
+								query.Variable{Name: datalog.NewSymbol("?x")},
+							},
+						},
+					},
+					{
+						&query.Expression{
+							Function: &query.GroundFunction{Value: "nobody"},
+							Binding:  datalog.NewSymbol("?x"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(q)
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	values := make(map[string]bool)
+	for i := 0; i < result.Size(); i++ {
+		val := result.Get(i)[0].(string)
+		values[val] = true
+		t.Logf("result[%d]: %s", i, val)
+	}
+
+	// Union: both branches should contribute
+	if result.Size() != 2 {
+		t.Errorf("expected 2 results (union of both branches), got %d", result.Size())
+	}
+	if !values["Alice"] {
+		t.Error("missing 'Alice' from data pattern branch")
+	}
+	if !values["nobody"] {
+		t.Error("missing 'nobody' from ground expression branch")
 	}
 }

--- a/datalog/executor/or_fallback_relation.go
+++ b/datalog/executor/or_fallback_relation.go
@@ -13,29 +13,32 @@ import (
 // Note: fmt is used for String() method
 
 // OrFallbackRelation is a streaming relation that evaluates OR branches
-// lazily per outer tuple. For each outer tuple, it tries branches in order
-// until one produces results, then yields those results.
+// lazily per outer tuple. When shortCircuit=true (or-default), it tries
+// branches in order until one produces results. When shortCircuit=false
+// (correlated union), it evaluates ALL branches and unions the results.
 type OrFallbackRelation struct {
 	executor      *DefaultQueryExecutor
 	ctx           Context
-	clause        *query.OrClause
+	branches      [][]query.Clause
 	outerRel      Relation
 	symbols       []query.Symbol // Determined lazily from first result
 	options       ExecutorOptions
 	iteratorCount int            // Track how many iterators have been created (for debugging)
 	joinSyms      []query.Symbol // From or-join: explicit join variables for cache keying
 	prefetched    bool           // True when PrefetchEntities has warmed the EA cache
+	shortCircuit  bool           // true = fallback (first match wins), false = correlated union (all branches)
 }
 
-// NewOrFallbackRelation creates a streaming OR fallback relation.
-// The symbols are computed upfront from the outer relation and OR clause
-// to avoid needing to peek at results.
+// NewOrFallbackRelation creates a streaming OR relation.
+// When shortCircuit=true, uses fallback semantics (first match wins).
+// When shortCircuit=false, uses correlated union (all branches contribute).
 func NewOrFallbackRelation(
 	executor *DefaultQueryExecutor,
 	ctx Context,
-	clause *query.OrClause,
+	branches [][]query.Clause,
 	outerRel Relation,
 	options ExecutorOptions,
+	shortCircuit bool,
 ) *OrFallbackRelation {
 	// Compute output symbols statically:
 	// Output = outer symbols + symbols produced by branches (that aren't in outer)
@@ -46,7 +49,7 @@ func NewOrFallbackRelation(
 	}
 
 	// Collect symbols that branches produce (common across all branches)
-	branchOutputs := computeOrBranchOutputSymbols(clause)
+	branchOutputs := computeOrBranchOutputSymbols(branches)
 
 	// Build output symbols: outer symbols first, then new symbols from branches
 	symbols := make([]query.Symbol, len(outerSyms))
@@ -58,25 +61,26 @@ func NewOrFallbackRelation(
 	}
 
 	return &OrFallbackRelation{
-		executor: executor,
-		ctx:      ctx,
-		clause:   clause,
-		outerRel: outerRel,
-		symbols:  symbols,
-		options:  options,
+		executor:     executor,
+		ctx:          ctx,
+		branches:     branches,
+		outerRel:     outerRel,
+		symbols:      symbols,
+		options:      options,
+		shortCircuit: shortCircuit,
 	}
 }
 
 // computeOrBranchOutputSymbols computes symbols that OR branches produce.
 // Returns symbols that are common to all branches (intersection).
-func computeOrBranchOutputSymbols(clause *query.OrClause) []query.Symbol {
-	if len(clause.Branches) == 0 {
+func computeOrBranchOutputSymbols(branches [][]query.Clause) []query.Symbol {
+	if len(branches) == 0 {
 		return nil
 	}
 
 	// Collect outputs from first branch
-	firstBranchOutputs := collectBranchOutputSymbols(clause.Branches[0])
-	if len(clause.Branches) == 1 {
+	firstBranchOutputs := collectBranchOutputSymbols(branches[0])
+	if len(branches) == 1 {
 		return firstBranchOutputs
 	}
 
@@ -87,8 +91,8 @@ func computeOrBranchOutputSymbols(clause *query.OrClause) []query.Symbol {
 	}
 
 	// Intersect with other branches
-	for i := 1; i < len(clause.Branches); i++ {
-		branchOutputs := collectBranchOutputSymbols(clause.Branches[i])
+	for i := 1; i < len(branches); i++ {
+		branchOutputs := collectBranchOutputSymbols(branches[i])
 		branchSet := make(map[query.Symbol]bool)
 		for _, sym := range branchOutputs {
 			branchSet[sym] = true
@@ -178,7 +182,15 @@ func collectBranchOutputSymbols(branch []query.Clause) []query.Symbol {
 			}
 		case *query.OrClause:
 			// plain or: output symbols are the intersection across branches
-			orOutputs := computeOrBranchOutputSymbols(clause)
+			orOutputs := computeOrBranchOutputSymbols(clause.Branches)
+			for _, v := range orOutputs {
+				if !seen[v] {
+					seen[v] = true
+					outputs = append(outputs, v)
+				}
+			}
+		case *query.OrDefaultClause:
+			orOutputs := computeOrBranchOutputSymbols(clause.Branches)
 			for _, v := range orOutputs {
 				if !seen[v] {
 					seen[v] = true
@@ -211,7 +223,8 @@ func (r *OrFallbackRelation) Iterator() Iterator {
 	return &OrFallbackIterator{
 		executor:   r.executor,
 		ctx:        r.ctx,
-		clause:     r.clause,
+		branches:     r.branches,
+		shortCircuit: r.shortCircuit,
 		outerIter:  outerIter,
 		outerRel:   r.outerRel, // Materialized relation for EA cache branch building
 		outerSyms:  r.outerRel.Symbols(),
@@ -332,11 +345,12 @@ func (r *OrFallbackRelation) RequiresCopy() bool {
 
 // OrFallbackIterator lazily evaluates OR branches per outer tuple.
 type OrFallbackIterator struct {
-	executor  *DefaultQueryExecutor
-	ctx       Context
-	clause    *query.OrClause
-	outerIter Iterator
-	outerRel  Relation       // Materialized outer relation (for EA cache branch building)
+	executor     *DefaultQueryExecutor
+	ctx          Context
+	branches     [][]query.Clause
+	shortCircuit bool // true = fallback, false = correlated union
+	outerIter    Iterator
+	outerRel     Relation       // Materialized outer relation (for EA cache branch building)
 	outerSyms []query.Symbol
 	options   ExecutorOptions
 	joinSyms  []query.Symbol // From or-join: used as cache key (not all shared symbols)
@@ -353,6 +367,11 @@ type OrFallbackIterator struct {
 	// See ALGEBRA.md "OR-Fallback Branch Caching" for specification.
 	branchCache map[int]*cachedBranch
 	prefetched  bool // True when PrefetchEntities has warmed the EA cache for outer entities
+
+	// Correlated union state: track which branch we're iterating within the current outer tuple
+	unionBranchIdx int    // next branch to try for current outer tuple
+	unionOuterTuple Tuple // current outer tuple being processed
+	unionInputRel   Relation // inputRel for current outer tuple
 }
 
 // cachedBranch holds a hash index over an uncorrelated branch result.
@@ -572,6 +591,98 @@ func (it *OrFallbackIterator) Next() bool {
 		return false
 	}
 
+	// Correlated union mode: yield from buffer if available
+	if !it.shortCircuit {
+		return it.nextCorrelatedUnion()
+	}
+
+	// Short-circuit (fallback/or-default) mode: original behavior
+	return it.nextShortCircuit()
+}
+
+// nextCorrelatedUnion streams through ALL branches per outer tuple.
+// Uses the same projectedIterator as the short-circuit path, but instead of
+// stopping after the first successful branch, advances to the next branch
+// when the current one is exhausted.
+func (it *OrFallbackIterator) nextCorrelatedUnion() bool {
+	for {
+		// If we have a current branch iterator, try to get next tuple from it
+		if it.currentBranchIter != nil {
+			if it.currentBranchIter.Next() {
+				it.currentTuple = it.currentBranchIter.Tuple()
+				return true
+			}
+			// Branch exhausted, close it
+			it.currentBranchIter.Close()
+			it.currentBranchIter = nil
+			it.currentBranchRelation = nil
+		}
+
+		// Try remaining branches for the current outer tuple
+		for it.unionBranchIdx < len(it.branches) {
+			branch := it.branches[it.unionBranchIdx]
+			it.unionBranchIdx++
+
+			branchResult, err := it.executor.executeInnerClauses(it.ctx, branch, it.unionInputRel)
+			if err != nil {
+				it.err = err
+				it.done = true
+				return false
+			}
+			if branchResult == nil {
+				continue
+			}
+
+			branchIter := branchResult.Iterator()
+			if branchIter.Next() {
+				branchSyms := branchResult.Symbols()
+				firstTuple := branchIter.Tuple()
+
+				if len(branchSyms) != len(it.outputSyms) || !symbolsMatch(branchSyms, it.outputSyms) {
+					it.currentTuple = projectTupleWithFallback(firstTuple, branchSyms, it.outputSyms, it.unionOuterTuple, it.outerSyms)
+				} else if branchResult.RequiresCopy() {
+					it.currentTuple = copyTuple(firstTuple)
+				} else {
+					it.currentTuple = firstTuple
+				}
+				it.currentBranchRelation = branchResult
+				it.currentBranchIter = &projectedIterator{
+					inner:          branchIter,
+					branchRelation: branchResult,
+					branchSyms:     branchSyms,
+					outputSyms:     it.outputSyms,
+					outerTuple:     it.unionOuterTuple,
+					outerSyms:      it.outerSyms,
+				}
+				return true
+			}
+			branchIter.Close()
+		}
+
+		// All branches exhausted for current outer tuple — advance to next
+		if !it.outerIter.Next() {
+			it.done = true
+			return false
+		}
+
+		it.unionOuterTuple = it.outerIter.Tuple()
+		it.unionBranchIdx = 0
+
+		// Build single-tuple relation for this input
+		if len(it.outerSyms) > 0 {
+			it.unionInputRel = NewMaterializedRelationWithOptions(
+				it.outerSyms,
+				[]Tuple{it.unionOuterTuple},
+				it.options,
+			)
+		} else {
+			it.unionInputRel = nil
+		}
+	}
+}
+
+// nextShortCircuit tries branches in order until one returns results (fallback semantics).
+func (it *OrFallbackIterator) nextShortCircuit() bool {
 	for {
 		// If we have a current branch iterator, try to get next tuple from it
 		if it.currentBranchIter != nil {
@@ -626,7 +737,7 @@ func (it *OrFallbackIterator) Next() bool {
 		}
 
 		// Try each branch until one returns results
-		for branchIdx, branch := range it.clause.Branches {
+		for branchIdx, branch := range it.branches {
 			var branchResult Relation
 
 			// Check cache for uncorrelated branches (O(1) probe)

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -171,6 +171,30 @@ func (e *DefaultQueryExecutor) Execute(ctx Context, q *query.Query, inputs []Rel
 				return []Relation(groups.Collapse(ctx))
 			}))
 
+		case *query.OrDefaultClause:
+			newRel, err := e.executeOrDefaultClause(ctx, c, groups)
+			if err != nil {
+				return nil, fmt.Errorf("clause %d (or-default) failed: %w", i, err)
+			}
+			if newRel != nil {
+				groups = append(groups, newRel)
+			}
+			groups = Relations(ctx.CollapseRelations([]Relation(groups), func() []Relation {
+				return []Relation(groups.Collapse(ctx))
+			}))
+
+		case *query.OrDefaultJoinClause:
+			newRel, err := e.executeOrDefaultJoinClause(ctx, c, groups)
+			if err != nil {
+				return nil, fmt.Errorf("clause %d (or-default-join) failed: %w", i, err)
+			}
+			if newRel != nil {
+				groups = append(groups, newRel)
+			}
+			groups = Relations(ctx.CollapseRelations([]Relation(groups), func() []Relation {
+				return []Relation(groups.Collapse(ctx))
+			}))
+
 		case *query.NotClause:
 			// NOT clauses filter existing relations (anti-join)
 			var err error
@@ -1200,7 +1224,9 @@ func (e *DefaultQueryExecutor) executePulls(rel Relation, find []query.FindEleme
 	}, nil
 }
 
-// executeOrClause performs union of OR branches, or fallback semantics for expression branches
+// executeOrClause performs union of OR branches.
+// Routes to correlated union (per-tuple, all branches) when branches reference
+// outer symbols, or uncorrelated union (independent execution) otherwise.
 func (e *DefaultQueryExecutor) executeOrClause(ctx Context, clause *query.OrClause, groups Relations) (Relation, error) {
 	start := time.Now()
 	collector := ctx.Collector()
@@ -1215,8 +1241,7 @@ func (e *DefaultQueryExecutor) executeOrClause(ctx Context, clause *query.OrClau
 			Name:  annotations.OrClauseBegin,
 			Start: start,
 			Data: map[string]interface{}{
-				"branch_count":    len(clause.Branches),
-				"has_expressions": query.OrHasExpressions(clause.Branches),
+				"branch_count": len(clause.Branches),
 			},
 		})
 	}
@@ -1225,12 +1250,13 @@ func (e *DefaultQueryExecutor) executeOrClause(ctx Context, clause *query.OrClau
 	var err error
 	var semantics string
 
-	// Check if any branch has expressions - use fallback semantics if so
-	if query.OrHasExpressions(clause.Branches) {
-		semantics = "fallback"
-		result, err = e.executeOrClauseFallback(ctx, clause, groups)
+	// Route to correlated union only when branches have expression clauses
+	// that require outer bindings. Pattern-only branches work fine in
+	// uncorrelated union — the join with outer context happens during collapse.
+	if branchesNeedCorrelatedExecution(clause.Branches) {
+		semantics = "correlated-union"
+		result, err = e.executeOrClauseCorrelatedUnion(ctx, clause.Branches, groups)
 	} else {
-		// Standard union semantics for pattern-only OR
 		semantics = "union"
 		result, err = e.executeOrClauseUnion(ctx, clause, groups)
 	}
@@ -1259,63 +1285,86 @@ func (e *DefaultQueryExecutor) executeOrClause(ctx Context, clause *query.OrClau
 	return result, err
 }
 
-// executeOrClauseFallback implements Clojure-style fallback semantics:
-// For each input tuple, try branches in order until one returns a result.
-// This is truly streaming - we process one tuple at a time with short-circuit evaluation.
-func (e *DefaultQueryExecutor) executeOrClauseFallback(ctx Context, clause *query.OrClause, groups Relations) (Relation, error) {
-	collector := ctx.Collector()
+// executeOrClauseCorrelatedUnion evaluates all branches per outer tuple and unions results.
+func (e *DefaultQueryExecutor) executeOrClauseCorrelatedUnion(ctx Context, branches [][]query.Clause, groups Relations) (Relation, error) {
+	neededSymbols := collectOrBranchRequiredSymbols(branches)
+	outerRel := e.findOuterRelation(neededSymbols, groups)
+	return NewOrFallbackRelation(e, ctx, branches, outerRel, e.options, false), nil
+}
 
-	// Emit fallback mode annotation
-	if collector != nil {
-		collector.Add(annotations.Event{
-			Name:  annotations.OrClauseFallback,
-			Start: time.Now(),
-			Data: map[string]interface{}{
-				"branch_count": len(clause.Branches),
-				"groups_count": len(groups),
-			},
-		})
+// executeOrDefaultClause implements fallback semantics for or-default clauses:
+// For each input tuple, try branches in order until one returns a result.
+func (e *DefaultQueryExecutor) executeOrDefaultClause(ctx Context, clause *query.OrDefaultClause, groups Relations) (Relation, error) {
+	neededSymbols := collectOrBranchRequiredSymbols(clause.Branches)
+	outerRel := e.findOuterRelation(neededSymbols, groups)
+	return NewOrFallbackRelation(e, ctx, clause.Branches, outerRel, e.options, true), nil
+}
+
+// executeOrDefaultJoinClause implements fallback semantics for or-default-join clauses.
+func (e *DefaultQueryExecutor) executeOrDefaultJoinClause(ctx Context, clause *query.OrDefaultJoinClause, groups Relations) (Relation, error) {
+	joinVarSet := make(map[query.Symbol]bool, len(clause.JoinVars))
+	for _, v := range clause.JoinVars {
+		joinVarSet[v] = true
 	}
 
-	// Find which symbols the OR branches need from outer context
-	neededSymbols := collectOrBranchRequiredSymbols(clause)
+	outerRel := e.findOuterRelationBySymbols(joinVarSet, groups)
 
-	// Always have an outer context - use unit relation if none available.
-	// This eliminates the "global fallback" path and unifies execution:
-	// per-tuple fallback on unit relation (one empty tuple) = try branches until one works.
-	var outerRel Relation
-	if len(groups) == 0 {
-		// No input groups - use unit relation as base case
-		outerRel = NewUnitRelation(e.options)
-	} else if len(neededSymbols) == 0 {
-		// No symbols needed from outer context - use unit relation
-		outerRel = NewUnitRelation(e.options)
-	} else {
-		// Find the group that provides ANY of the needed symbols
-		// Note: We use containsAny because neededSymbols may include OUTPUT symbols from
-		// the OR branches (like ?count in [(ground 0) ?count]). We correlate on whatever
-		// symbols ARE available from outer context.
-		var outerBindingIdx int = -1
-		for i, rel := range groups {
-			if containsAny(rel.Symbols(), neededSymbols) {
-				outerBindingIdx = i
-				break
+	prefetched := false
+	rel := NewOrFallbackRelation(e, ctx, clause.Branches, outerRel, e.options, true)
+	rel.joinSyms = clause.JoinVars
+	rel.prefetched = prefetched
+	return rel, nil
+}
+
+// branchesNeedCorrelatedExecution returns true if any branch has expression
+// clauses that require outer bindings to evaluate. Pattern-only branches
+// don't need correlated execution — they can be evaluated independently
+// and joined with outer context during collapse.
+func branchesNeedCorrelatedExecution(branches [][]query.Clause) bool {
+	for _, branch := range branches {
+		for _, c := range branch {
+			switch c.(type) {
+			case *query.Expression, *query.SubqueryPattern:
+				return true
+			case query.Predicate:
+				if pred, ok := c.(query.Predicate); ok && len(pred.RequiredSymbols()) > 0 {
+					return true
+				}
 			}
 		}
-		if outerBindingIdx < 0 {
-			// No group has needed symbols - use unit relation
-			outerRel = NewUnitRelation(e.options)
-		} else {
-			// Materialize the outer binding so it can be iterated multiple times:
-			// 1. By the OrFallbackRelation internally (per-tuple evaluation)
-			// 2. In the collapse operation after this function returns
-			groups[outerBindingIdx] = groups[outerBindingIdx].Materialize()
-			outerRel = groups[outerBindingIdx]
+	}
+	return false
+}
+
+// findOuterRelation finds and materializes the outer relation from groups
+// that provides any of the needed symbols. Returns unit relation if none found.
+func (e *DefaultQueryExecutor) findOuterRelation(neededSymbols []query.Symbol, groups Relations) Relation {
+	if len(groups) == 0 || len(neededSymbols) == 0 {
+		return NewUnitRelation(e.options)
+	}
+
+	for i, rel := range groups {
+		if containsAny(rel.Symbols(), neededSymbols) {
+			groups[i] = groups[i].Materialize()
+			return groups[i]
 		}
 	}
 
-	// Always use OrFallbackRelation for per-tuple evaluation
-	return NewOrFallbackRelation(e, ctx, clause, outerRel, e.options), nil
+	return NewUnitRelation(e.options)
+}
+
+// findOuterRelationBySymbols finds and materializes the outer relation that
+// provides any of the specified symbols. Returns unit relation if none found.
+func (e *DefaultQueryExecutor) findOuterRelationBySymbols(symSet map[query.Symbol]bool, groups Relations) Relation {
+	for i, rel := range groups {
+		for _, sym := range rel.Symbols() {
+			if symSet[sym] {
+				groups[i] = groups[i].Materialize()
+				return groups[i]
+			}
+		}
+	}
+	return NewUnitRelation(e.options)
 }
 
 // findCommonColumns returns symbols that exist in all relations
@@ -1519,7 +1568,8 @@ func (e *DefaultQueryExecutor) executeOrClauseUnion(ctx Context, clause *query.O
 	return unionRelations(branchResults, commonSyms, e.options), nil
 }
 
-// executeOrJoinClause performs union with explicit join variables, or fallback for expressions
+// executeOrJoinClause performs union with explicit join variables.
+// Routes to correlated union when branches reference outer symbols.
 func (e *DefaultQueryExecutor) executeOrJoinClause(ctx Context, clause *query.OrJoinClause, groups Relations) (Relation, error) {
 	if len(clause.Branches) == 0 {
 		return NewMaterializedRelationWithOptions(nil, nil, e.options), nil
@@ -1530,9 +1580,8 @@ func (e *DefaultQueryExecutor) executeOrJoinClause(ctx Context, clause *query.Or
 		return nil, fmt.Errorf("OR-JOIN clause has no join variables")
 	}
 
-	// Check if any branch has expressions - use fallback semantics if so
-	if query.OrHasExpressions(clause.Branches) {
-		return e.executeOrJoinClauseFallback(ctx, clause, groups)
+	if branchesNeedCorrelatedExecution(clause.Branches) {
+		return e.executeOrJoinClauseCorrelatedUnion(ctx, clause, groups)
 	}
 
 	var branchResults []Relation
@@ -1556,47 +1605,18 @@ func (e *DefaultQueryExecutor) executeOrJoinClause(ctx Context, clause *query.Or
 	return unionRelations(branchResults, joinVars, e.options), nil
 }
 
-// executeOrJoinClauseFallback implements per-tuple fallback semantics for or-join
-// with expressions. Uses the join variables to identify the outer relation,
-// then evaluates branches per outer tuple with OrFallbackRelation.
-func (e *DefaultQueryExecutor) executeOrJoinClauseFallback(ctx Context, clause *query.OrJoinClause, groups Relations) (Relation, error) {
-	// Find the outer group that provides any of the join variables
+// executeOrJoinClauseCorrelatedUnion evaluates all branches per outer tuple
+// for or-join clauses where branches reference outer symbols.
+func (e *DefaultQueryExecutor) executeOrJoinClauseCorrelatedUnion(ctx Context, clause *query.OrJoinClause, groups Relations) (Relation, error) {
 	joinVarSet := make(map[query.Symbol]bool, len(clause.JoinVars))
 	for _, v := range clause.JoinVars {
 		joinVarSet[v] = true
 	}
 
-	var outerRel Relation
-	for i, rel := range groups {
-		for _, sym := range rel.Symbols() {
-			if joinVarSet[sym] {
-				groups[i] = groups[i].Materialize()
-				outerRel = groups[i]
-				break
-			}
-		}
-		if outerRel != nil {
-			break
-		}
-	}
+	outerRel := e.findOuterRelationBySymbols(joinVarSet, groups)
 
-	if outerRel == nil {
-		outerRel = NewUnitRelation(e.options)
-	}
-
-	// Entity prefetch DISABLED: benchmarked at 26s vs 13s without.
-	// PrefetchEntities scans EATV per entity (8K broad scans) which is far
-	// more I/O than the normal path's ~4 narrow attribute-specific AETV scans.
-	// The prefetch approach is fundamentally wrong — it does N broad scans
-	// when the query only needs M narrow scans (M << N).
-	prefetched := false
-
-	orClause := &query.OrClause{
-		Branches: clause.Branches,
-	}
-	rel := NewOrFallbackRelation(e, ctx, orClause, outerRel, e.options)
+	rel := NewOrFallbackRelation(e, ctx, clause.Branches, outerRel, e.options, false)
 	rel.joinSyms = clause.JoinVars
-	rel.prefetched = prefetched
 	return rel, nil
 }
 
@@ -1639,11 +1659,11 @@ func extractEntityIDs(rel Relation, syms []query.Symbol) []datalog.Identity {
 }
 
 // collectOrBranchRequiredSymbols collects symbols that OR branches need from outer context
-func collectOrBranchRequiredSymbols(clause *query.OrClause) []query.Symbol {
+func collectOrBranchRequiredSymbols(branches [][]query.Clause) []query.Symbol {
 	seen := make(map[query.Symbol]bool)
 	var result []query.Symbol
 
-	for _, branch := range clause.Branches {
+	for _, branch := range branches {
 		// Track which symbols this branch provides (to distinguish from required)
 		branchProvides := make(map[query.Symbol]bool)
 
@@ -2013,6 +2033,26 @@ func (e *DefaultQueryExecutor) executeInnerClauses(ctx Context, clauses []query.
 
 		case *query.OrJoinClause:
 			newRel, err := e.executeOrJoinClause(ctx, c, groups)
+			if err != nil {
+				return nil, err
+			}
+			if newRel != nil {
+				groups = append(groups, newRel)
+			}
+			groups = groups.Collapse(ctx)
+
+		case *query.OrDefaultClause:
+			newRel, err := e.executeOrDefaultClause(ctx, c, groups)
+			if err != nil {
+				return nil, err
+			}
+			if newRel != nil {
+				groups = append(groups, newRel)
+			}
+			groups = groups.Collapse(ctx)
+
+		case *query.OrDefaultJoinClause:
+			newRel, err := e.executeOrDefaultJoinClause(ctx, c, groups)
 			if err != nil {
 				return nil, err
 			}

--- a/datalog/executor/wrapper_relation_copy_test.go
+++ b/datalog/executor/wrapper_relation_copy_test.go
@@ -457,7 +457,7 @@ func TestOrFallbackIteratorCopiesFromUnsafeOuter(t *testing.T) {
 	}
 
 	// Create OrFallbackRelation directly
-	orFallbackRel := NewOrFallbackRelation(queryExec, ctx, orClause, outerRel, ExecutorOptions{})
+	orFallbackRel := NewOrFallbackRelation(queryExec, ctx, orClause.Branches, outerRel, ExecutorOptions{}, true)
 
 	t.Logf("OrFallbackRelation RequiresCopy: %v", orFallbackRel.RequiresCopy())
 	t.Logf("Outer relation RequiresCopy: %v", outerRel.RequiresCopy())
@@ -626,7 +626,7 @@ func TestOrFallbackIteratorMultipleBranchResultsIntegration(t *testing.T) {
 	}
 
 	// Create OrFallbackRelation directly
-	orFallbackRel := NewOrFallbackRelation(queryExec, ctx, orClause, outerRel, ExecutorOptions{})
+	orFallbackRel := NewOrFallbackRelation(queryExec, ctx, orClause.Branches, outerRel, ExecutorOptions{}, true)
 
 	// Iterate and store tuple references WITHOUT copying
 	var storedTuples []Tuple
@@ -722,7 +722,7 @@ func TestOrFallbackIteratorWithFallbackBranch(t *testing.T) {
 	}
 
 	// Create OrFallbackRelation directly
-	orFallbackRel := NewOrFallbackRelation(queryExec, ctx, orClause, outerRel, ExecutorOptions{})
+	orFallbackRel := NewOrFallbackRelation(queryExec, ctx, orClause.Branches, outerRel, ExecutorOptions{}, true)
 
 	// Iterate and store tuple references WITHOUT copying
 	var storedTuples []Tuple

--- a/datalog/parser/not_or_test.go
+++ b/datalog/parser/not_or_test.go
@@ -281,3 +281,129 @@ func TestNotOrParseErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestParseOrDefaultClause(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		verify func(t *testing.T, q *query.Query)
+	}{
+		{
+			name: "simple or-default with ground fallback",
+			input: `[:find ?x
+                     :where [?e :user/name ?x]
+                            (or-default [?e :user/score ?x]
+                                        [(ground 0) ?x])]`,
+			verify: func(t *testing.T, q *query.Query) {
+				if len(q.Where) != 2 {
+					t.Fatalf("expected 2 where clauses, got %d", len(q.Where))
+				}
+				od, ok := q.Where[1].(*query.OrDefaultClause)
+				if !ok {
+					t.Fatalf("expected OrDefaultClause, got %T", q.Where[1])
+				}
+				if len(od.Branches) != 2 {
+					t.Fatalf("expected 2 branches, got %d", len(od.Branches))
+				}
+				if len(od.Branches[0]) != 1 {
+					t.Fatalf("expected 1 clause in branch 0, got %d", len(od.Branches[0]))
+				}
+				if len(od.Branches[1]) != 1 {
+					t.Fatalf("expected 1 clause in branch 1, got %d", len(od.Branches[1]))
+				}
+				// Branch 0 should be a DataPattern
+				if _, ok := od.Branches[0][0].(*query.DataPattern); !ok {
+					t.Fatalf("expected DataPattern in branch 0, got %T", od.Branches[0][0])
+				}
+				// Branch 1 should be an Expression
+				if _, ok := od.Branches[1][0].(*query.Expression); !ok {
+					t.Fatalf("expected Expression in branch 1, got %T", od.Branches[1][0])
+				}
+			},
+		},
+		{
+			name: "or-default with and branch",
+			input: `[:find ?x
+                     :where (or-default (and [?e :a1 ?x] [?e :a2 ?y])
+                                        [(ground 0) ?x])]`,
+			verify: func(t *testing.T, q *query.Query) {
+				od, ok := q.Where[0].(*query.OrDefaultClause)
+				if !ok {
+					t.Fatalf("expected OrDefaultClause, got %T", q.Where[0])
+				}
+				if len(od.Branches[0]) != 2 {
+					t.Fatalf("expected 2 clauses in branch 0 (and), got %d", len(od.Branches[0]))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, err := ParseQuery(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tt.verify(t, q)
+		})
+	}
+}
+
+func TestParseOrDefaultJoinClause(t *testing.T) {
+	input := `[:find ?x
+               :where [?e :user/name ?name]
+                      (or-default-join [?x]
+                        [?e :user/score ?x]
+                        [(ground 0) ?x])]`
+	q, err := ParseQuery(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(q.Where) != 2 {
+		t.Fatalf("expected 2 where clauses, got %d", len(q.Where))
+	}
+	odj, ok := q.Where[1].(*query.OrDefaultJoinClause)
+	if !ok {
+		t.Fatalf("expected OrDefaultJoinClause, got %T", q.Where[1])
+	}
+	if len(odj.JoinVars) != 1 {
+		t.Fatalf("expected 1 join var, got %d", len(odj.JoinVars))
+	}
+	if odj.JoinVars[0] != datalog.NewSymbol("?x") {
+		t.Fatalf("expected join var ?x, got %s", odj.JoinVars[0])
+	}
+	if len(odj.Branches) != 2 {
+		t.Fatalf("expected 2 branches, got %d", len(odj.Branches))
+	}
+}
+
+func TestParseOrDefaultErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		error string
+	}{
+		{
+			name:  "or-default with single branch",
+			input: `[:find ?e :where (or-default [?e :foo ?v])]`,
+			error: "or-default clause must have at least two branches",
+		},
+		{
+			name:  "or-default-join without enough elements",
+			input: `[:find ?e :where (or-default-join [?e])]`,
+			error: "or-default-join clause must have join vars and at least two branches",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseQuery(tt.input)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.error)
+			}
+			if !contains(err.Error(), tt.error) {
+				t.Errorf("expected error containing %q, got %q", tt.error, err.Error())
+			}
+		})
+	}
+}

--- a/datalog/parser/parser.go
+++ b/datalog/parser/parser.go
@@ -868,6 +868,10 @@ func parseListClause(node *edn.Node) (query.Clause, error) {
 		return parseOrClause(node)
 	case "or-join":
 		return parseOrJoinClause(node)
+	case "or-default":
+		return parseOrDefaultClause(node)
+	case "or-default-join":
+		return parseOrDefaultJoinClause(node)
 	default:
 		return nil, fmt.Errorf("unknown list clause type: %s", keyword)
 	}
@@ -977,6 +981,55 @@ func parseOrJoinClause(node *edn.Node) (*query.OrJoinClause, error) {
 	}
 
 	return &query.OrJoinClause{JoinVars: joinVars, Branches: branches}, nil
+}
+
+// parseOrDefaultClause parses (or-default branch1 branch2 ...)
+func parseOrDefaultClause(node *edn.Node) (*query.OrDefaultClause, error) {
+	var branches [][]query.Clause
+	for i := 1; i < len(node.Nodes); i++ {
+		branch, err := parseBranch(&node.Nodes[i])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing or-default branch %d: %w", i, err)
+		}
+		branches = append(branches, branch)
+	}
+
+	if len(branches) < 2 {
+		return nil, fmt.Errorf("or-default clause must have at least two branches")
+	}
+
+	return &query.OrDefaultClause{Branches: branches}, nil
+}
+
+// parseOrDefaultJoinClause parses (or-default-join [?x] branch1 branch2 ...)
+func parseOrDefaultJoinClause(node *edn.Node) (*query.OrDefaultJoinClause, error) {
+	if len(node.Nodes) < 4 {
+		return nil, fmt.Errorf("or-default-join clause must have join vars and at least two branches")
+	}
+
+	if node.Nodes[1].Type != edn.NodeVector {
+		return nil, fmt.Errorf("or-default-join second element must be a vector of join variables, got %v", node.Nodes[1].Type)
+	}
+
+	joinVars, err := parseJoinVars(&node.Nodes[1])
+	if err != nil {
+		return nil, fmt.Errorf("error parsing or-default-join vars: %w", err)
+	}
+
+	var branches [][]query.Clause
+	for i := 2; i < len(node.Nodes); i++ {
+		branch, err := parseBranch(&node.Nodes[i])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing or-default-join branch %d: %w", i, err)
+		}
+		branches = append(branches, branch)
+	}
+
+	if len(branches) < 2 {
+		return nil, fmt.Errorf("or-default-join clause must have at least two branches")
+	}
+
+	return &query.OrDefaultJoinClause{JoinVars: joinVars, Branches: branches}, nil
 }
 
 // parseJoinVars parses a vector of join variables [?x ?y ...]

--- a/datalog/planner/clause_utils.go
+++ b/datalog/planner/clause_utils.go
@@ -39,6 +39,10 @@ func extractClauseSymbols(clause query.Clause) ClauseSymbols {
 		return extractOrClauseSymbols(c)
 	case *query.OrJoinClause:
 		return extractOrJoinClauseSymbols(c)
+	case *query.OrDefaultClause:
+		return extractOrDefaultClauseSymbols(c)
+	case *query.OrDefaultJoinClause:
+		return extractOrDefaultJoinClauseSymbols(c)
 	default:
 		// Unknown clause type - conservative: requires and provides nothing
 		return ClauseSymbols{}
@@ -220,19 +224,109 @@ func extractNotJoinClauseSymbols(n *query.NotJoinClause) ClauseSymbols {
 	}
 }
 
-// extractOrClauseSymbols extracts symbols from an OR clause
-// - For union semantics (pattern-only): provides intersection of all branches
-// - For fallback semantics (has expressions): provides union of all branches
-// - Requires: symbols needed by branches but not provided within those branches
+// extractOrClauseSymbols extracts symbols from an OR clause.
+// Always uses INTERSECTION for provides (all branches execute in union mode).
 func extractOrClauseSymbols(o *query.OrClause) ClauseSymbols {
-	if len(o.Branches) == 0 {
+	return extractOrBranchSymbolsIntersection(o.Branches)
+}
+
+// extractOrDefaultClauseSymbols extracts symbols from an OR-DEFAULT clause.
+// Uses UNION for provides (only one branch executes in fallback mode).
+// Requires correlation symbols from pattern branches.
+func extractOrDefaultClauseSymbols(o *query.OrDefaultClause) ClauseSymbols {
+	return extractOrBranchSymbolsFallback(o.Branches)
+}
+
+// extractOrBranchSymbolsIntersection computes symbols for union semantics.
+// Provides = intersection of all branch provides. Requires = any branch's unmet needs.
+func extractOrBranchSymbolsIntersection(branches [][]query.Clause) ClauseSymbols {
+	if len(branches) == 0 {
 		return ClauseSymbols{}
 	}
 
-	// Collect provides and requires from each branch
-	branchProvides := make([]map[query.Symbol]bool, len(o.Branches))
-	branchRequires := make([]map[query.Symbol]bool, len(o.Branches))
-	for i, branch := range o.Branches {
+	branchProvides, branchRequires := collectBranchSymbols(branches)
+
+	// INTERSECTION: only symbols ALL branches provide
+	var provides []query.Symbol
+	for sym := range branchProvides[0] {
+		inAll := true
+		for i := 1; i < len(branchProvides); i++ {
+			if !branchProvides[i][sym] {
+				inAll = false
+				break
+			}
+		}
+		if inAll {
+			provides = append(provides, sym)
+		}
+	}
+
+	requires := collectBranchRequires(branchProvides, branchRequires)
+
+	return ClauseSymbols{
+		Requires: requires,
+		Provides: provides,
+	}
+}
+
+// extractOrBranchSymbolsFallback computes symbols for fallback semantics.
+// Provides = union of all branch provides (any branch might execute).
+// Requires correlation symbols from pattern branches for per-tuple evaluation.
+func extractOrBranchSymbolsFallback(branches [][]query.Clause) ClauseSymbols {
+	if len(branches) == 0 {
+		return ClauseSymbols{}
+	}
+
+	branchProvides, branchRequires := collectBranchSymbols(branches)
+
+	// UNION: any symbol any branch provides
+	var provides []query.Symbol
+	allSymbols := make(map[query.Symbol]bool)
+	for _, syms := range branchProvides {
+		for sym := range syms {
+			allSymbols[sym] = true
+		}
+	}
+	for sym := range allSymbols {
+		provides = append(provides, sym)
+	}
+
+	requires := collectBranchRequires(branchProvides, branchRequires)
+
+	// Add correlation symbols from pattern branches (entity variable of first pattern)
+	for _, branch := range branches {
+		for _, clause := range branch {
+			if pattern, ok := clause.(*query.DataPattern); ok {
+				if len(pattern.Elements) > 0 {
+					if v, ok := pattern.Elements[0].(query.Variable); ok {
+						found := false
+						for _, r := range requires {
+							if r == v.Name {
+								found = true
+								break
+							}
+						}
+						if !found {
+							requires = append(requires, v.Name)
+						}
+					}
+				}
+				break
+			}
+		}
+	}
+
+	return ClauseSymbols{
+		Requires: requires,
+		Provides: provides,
+	}
+}
+
+// collectBranchSymbols extracts provides/requires from each branch.
+func collectBranchSymbols(branches [][]query.Clause) ([]map[query.Symbol]bool, []map[query.Symbol]bool) {
+	branchProvides := make([]map[query.Symbol]bool, len(branches))
+	branchRequires := make([]map[query.Symbol]bool, len(branches))
+	for i, branch := range branches {
 		branchProvides[i] = make(map[query.Symbol]bool)
 		branchRequires[i] = make(map[query.Symbol]bool)
 		for _, clause := range branch {
@@ -245,84 +339,24 @@ func extractOrClauseSymbols(o *query.OrClause) ClauseSymbols {
 			}
 		}
 	}
+	return branchProvides, branchRequires
+}
 
-	var provides []query.Symbol
-
-	// Check if fallback semantics apply (any branch has expressions)
-	if query.OrHasExpressions(o.Branches) {
-		// Fallback semantics: only one branch executes, so use UNION
-		// Any symbol that any branch provides will be provided
-		allSymbols := make(map[query.Symbol]bool)
-		for _, syms := range branchProvides {
-			for sym := range syms {
-				allSymbols[sym] = true
-			}
-		}
-		for sym := range allSymbols {
-			provides = append(provides, sym)
-		}
-	} else {
-		// Union semantics: all branches execute, so use INTERSECTION
-		// Only symbols that ALL branches provide are guaranteed
-		for sym := range branchProvides[0] {
-			inAll := true
-			for i := 1; i < len(branchProvides); i++ {
-				if !branchProvides[i][sym] {
-					inAll = false
-					break
-				}
-			}
-			if inAll {
-				provides = append(provides, sym)
-			}
-		}
-	}
-
-	// Collect required symbols: any symbol required by any branch
-	// that isn't provided within that branch needs to come from outside
+// collectBranchRequires collects symbols required by any branch but not self-provided.
+func collectBranchRequires(branchProvides, branchRequires []map[query.Symbol]bool) []query.Symbol {
 	allRequires := make(map[query.Symbol]bool)
 	for i, reqs := range branchRequires {
 		for sym := range reqs {
-			// Only require if this branch doesn't self-provide it
 			if !branchProvides[i][sym] {
 				allRequires[sym] = true
 			}
 		}
 	}
-
-	// For fallback semantics, require the "correlation" symbol from pattern branches.
-	// This is the entity variable (first element) of the first pattern in each
-	// pattern branch. It represents the connection to outer context that enables
-	// per-tuple fallback evaluation.
-	//
-	// Example: (or [?scenario :task ?t] [(ground 0) ?x])
-	// Here ?scenario is the correlation symbol that should be bound from outside.
-	if query.OrHasExpressions(o.Branches) {
-		for _, branch := range o.Branches {
-			// Find the first pattern in this branch
-			for _, clause := range branch {
-				if pattern, ok := clause.(*query.DataPattern); ok {
-					// The entity variable (first element) is the correlation symbol
-					if len(pattern.Elements) > 0 {
-						if v, ok := pattern.Elements[0].(query.Variable); ok {
-							allRequires[v.Name] = true
-						}
-					}
-					break // Only look at the first pattern
-				}
-			}
-		}
-	}
-
 	var requires []query.Symbol
 	for sym := range allRequires {
 		requires = append(requires, sym)
 	}
-
-	return ClauseSymbols{
-		Requires: requires,
-		Provides: provides,
-	}
+	return requires
 }
 
 // extractOrJoinClauseSymbols extracts symbols from an OR-JOIN clause
@@ -407,6 +441,55 @@ func extractOrJoinClauseSymbols(o *query.OrJoinClause) ClauseSymbols {
 	}
 }
 
+// extractOrDefaultJoinClauseSymbols extracts symbols from an OR-DEFAULT-JOIN clause.
+// Uses fallback semantics (UNION of provides) with explicit join variables.
+func extractOrDefaultJoinClauseSymbols(o *query.OrDefaultJoinClause) ClauseSymbols {
+	if len(o.Branches) == 0 {
+		return ClauseSymbols{}
+	}
+
+	branchProvides, branchRequires := collectBranchSymbols(o.Branches)
+	requires := collectBranchRequires(branchProvides, branchRequires)
+
+	// Filter source symbols from requires
+	var filteredRequires []query.Symbol
+	for _, sym := range requires {
+		if !sym.IsSource() {
+			filteredRequires = append(filteredRequires, sym)
+		}
+	}
+
+	// UNION provides (fallback: any branch might execute)
+	providesSet := make(map[query.Symbol]bool)
+	for _, syms := range branchProvides {
+		for sym := range syms {
+			providesSet[sym] = true
+		}
+	}
+
+	// Join vars not produced by any branch are required from outside
+	allRequiresSet := make(map[query.Symbol]bool)
+	for _, r := range filteredRequires {
+		allRequiresSet[r] = true
+	}
+	for _, jv := range o.JoinVars {
+		if !providesSet[jv] && !allRequiresSet[jv] {
+			allRequiresSet[jv] = true
+			filteredRequires = append(filteredRequires, jv)
+		}
+	}
+
+	var provides []query.Symbol
+	for sym := range providesSet {
+		provides = append(provides, sym)
+	}
+
+	return ClauseSymbols{
+		Requires: filteredRequires,
+		Provides: provides,
+	}
+}
+
 // patternDependsOnPendingExpression checks if a data pattern uses a variable
 // that a pending (unselected) expression provides but that isn't yet available.
 // This prevents the planner from reordering data patterns before the expressions
@@ -480,22 +563,29 @@ func canExecuteClauseWithContext(clause query.Clause, available map[query.Symbol
 	// They should wait for correlation symbols IF those symbols will become available
 	// (i.e., some other clause provides them). If no other clause provides them,
 	// the OR can execute with global fallback.
-	if orClause, ok := clause.(*query.OrClause); ok {
-		if query.OrHasExpressions(orClause.Branches) {
-			for _, req := range symbols.Requires {
-				if available[req] {
-					// Symbol is available - good
-					continue
-				}
-				// Symbol not available - check if it could become available
-				if potentiallyProvidable != nil && potentiallyProvidable[req] {
-					// Another clause could provide this symbol - wait for it
-					return false
-				}
-				// No clause will provide this symbol - global fallback is OK
+	// Or-default clauses with fallback semantics need special handling for correlation symbols.
+	// They should wait for correlation symbols IF those symbols will become available.
+	if _, ok := clause.(*query.OrDefaultClause); ok {
+		for _, req := range symbols.Requires {
+			if available[req] {
+				continue
 			}
-			return true
+			if potentiallyProvidable != nil && potentiallyProvidable[req] {
+				return false
+			}
 		}
+		return true
+	}
+	if _, ok := clause.(*query.OrDefaultJoinClause); ok {
+		for _, req := range symbols.Requires {
+			if available[req] {
+				continue
+			}
+			if potentiallyProvidable != nil && potentiallyProvidable[req] {
+				return false
+			}
+		}
+		return true
 	}
 
 	// Standard check: all required symbols must be available
@@ -541,10 +631,8 @@ func scoreClause(clause query.Clause, available map[query.Symbol]bool) int {
 	}
 
 	// OR clauses that provide symbols are data sources too
-	if _, ok := clause.(*query.OrClause); ok {
-		score += 80
-	}
-	if _, ok := clause.(*query.OrJoinClause); ok {
+	switch clause.(type) {
+	case *query.OrClause, *query.OrJoinClause, *query.OrDefaultClause, *query.OrDefaultJoinClause:
 		score += 80
 	}
 
@@ -635,6 +723,14 @@ func collectDataPatternSymbols(clauses []query.Clause, out map[query.Symbol]bool
 				collectDataPatternSymbols(branch, out)
 			}
 		case *query.OrJoinClause:
+			for _, branch := range c.Branches {
+				collectDataPatternSymbols(branch, out)
+			}
+		case *query.OrDefaultClause:
+			for _, branch := range c.Branches {
+				collectDataPatternSymbols(branch, out)
+			}
+		case *query.OrDefaultJoinClause:
 			for _, branch := range c.Branches {
 				collectDataPatternSymbols(branch, out)
 			}

--- a/datalog/planner/clause_utils_test.go
+++ b/datalog/planner/clause_utils_test.go
@@ -237,10 +237,10 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 		}
 	})
 
-	t.Run("OR with expression uses union", func(t *testing.T) {
+	t.Run("OR with expression uses intersection", func(t *testing.T) {
 		// Branch 1 (pattern) provides: ?e, ?x
 		// Branch 2 (expression) provides: ?x
-		// Union should be: ?e, ?x (fallback semantics - one branch executes)
+		// OrClause always uses intersection now (all branches execute in union mode)
 		orClause := &query.OrClause{
 			Branches: [][]query.Clause{
 				{
@@ -263,7 +263,44 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 
 		syms := extractOrClauseSymbols(orClause)
 
-		// Should have both ?e and ?x (union)
+		// Intersection: only ?x is common to both branches
+		providedSet := make(map[query.Symbol]bool)
+		for _, sym := range syms.Provides {
+			providedSet[sym] = true
+		}
+
+		if !providedSet[datalog.NewSymbol("?x")] {
+			t.Errorf("Expected ?x to be provided (intersection), got: %v", syms.Provides)
+		}
+		if providedSet[datalog.NewSymbol("?e")] {
+			t.Errorf("?e should NOT be provided (intersection: not in branch 2), got: %v", syms.Provides)
+		}
+	})
+
+	t.Run("OR-DEFAULT with expression uses union", func(t *testing.T) {
+		// Same branches but OrDefaultClause — uses union provides (fallback: one branch executes)
+		orDefaultClause := &query.OrDefaultClause{
+			Branches: [][]query.Clause{
+				{
+					&query.DataPattern{
+						Elements: []query.PatternElement{
+							query.Variable{Name: datalog.NewSymbol("?e")},
+							query.Constant{Value: datalog.NewKeyword(":test/attr")},
+							query.Variable{Name: datalog.NewSymbol("?x")},
+						},
+					},
+				},
+				{
+					&query.Expression{
+						Function: &query.GroundFunction{Value: int64(0)},
+						Binding:  datalog.NewSymbol("?x"),
+					},
+				},
+			},
+		}
+
+		syms := extractOrDefaultClauseSymbols(orDefaultClause)
+
 		providedSet := make(map[query.Symbol]bool)
 		for _, sym := range syms.Provides {
 			providedSet[sym] = true
@@ -277,12 +314,12 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 		}
 	})
 
-	t.Run("SubqueryPattern with ground fallback uses union", func(t *testing.T) {
+	t.Run("OrDefault SubqueryPattern with ground fallback uses union", func(t *testing.T) {
 		// Branch 1 (SubqueryPattern) provides: ?openingCount
 		// Branch 2 (Expression) provides: ?openingCount
 		// Union should be: ?openingCount
-		// This is the real-world use case that broke
-		orClause := &query.OrClause{
+		// This is the real-world use case — uses OrDefaultClause for fallback
+		orClause := &query.OrDefaultClause{
 			Branches: [][]query.Clause{
 				{
 					&query.SubqueryPattern{
@@ -307,7 +344,7 @@ func TestOrClauseSymbolsUnionVsIntersection(t *testing.T) {
 			},
 		}
 
-		syms := extractOrClauseSymbols(orClause)
+		syms := extractOrDefaultClauseSymbols(orClause)
 
 		foundOpeningCount := false
 		for _, sym := range syms.Provides {

--- a/datalog/planner/types.go
+++ b/datalog/planner/types.go
@@ -35,8 +35,10 @@ type Phase struct {
 	DecorrelatedSubqueries []DecorrelatedSubqueryPlan // Decorrelated subquery groups
 	NotClauses             []*query.NotClause         // NOT clauses to apply (anti-join filtering)
 	NotJoinClauses         []*query.NotJoinClause     // NOT-JOIN clauses to apply
-	OrClauses              []*query.OrClause          // OR clauses to execute (union)
-	OrJoinClauses          []*query.OrJoinClause      // OR-JOIN clauses to execute
+	OrClauses              []*query.OrClause              // OR clauses to execute (union)
+	OrJoinClauses          []*query.OrJoinClause          // OR-JOIN clauses to execute
+	OrDefaultClauses       []*query.OrDefaultClause       // OR-DEFAULT clauses (fallback)
+	OrDefaultJoinClauses   []*query.OrDefaultJoinClause   // OR-DEFAULT-JOIN clauses (fallback)
 	Available              []query.Symbol             // Symbols available from previous phases (including bindings)
 	Provides               []query.Symbol             // Symbols this phase provides
 	Keep                   []query.Symbol             // Symbols to keep for later phases
@@ -715,6 +717,16 @@ func realizePhase(phase Phase, isLastPhase bool, prevKeep []query.Symbol) Realiz
 	// 3. Add OR-JOIN clauses (data sources)
 	for _, ojc := range phase.OrJoinClauses {
 		where = append(where, ojc)
+	}
+
+	// 3a. Add OR-DEFAULT clauses (fallback)
+	for _, odc := range phase.OrDefaultClauses {
+		where = append(where, odc)
+	}
+
+	// 3b. Add OR-DEFAULT-JOIN clauses (fallback)
+	for _, odjc := range phase.OrDefaultJoinClauses {
+		where = append(where, odjc)
 	}
 
 	// 4. Add expressions (in order)

--- a/datalog/qb/clause.go
+++ b/datalog/qb/clause.go
@@ -164,3 +164,76 @@ func (o *OrJoinBuilder) toClause() query.Clause {
 		Branches: qbranches,
 	}
 }
+
+// OrDefaultBuilder accumulates branches for an OR-DEFAULT clause (fallback semantics).
+type OrDefaultBuilder struct {
+	branches [][]interface{}
+}
+
+// OrDefault starts building an OR-DEFAULT clause.
+// For each outer tuple, tries branches in order until one returns results.
+func OrDefault() *OrDefaultBuilder {
+	return &OrDefaultBuilder{}
+}
+
+// Branch adds a branch with one or more clauses.
+func (o *OrDefaultBuilder) Branch(clauses ...interface{}) *OrDefaultBuilder {
+	o.branches = append(o.branches, clauses)
+	return o
+}
+
+func (o *OrDefaultBuilder) toClause() query.Clause {
+	qbranches := make([][]query.Clause, len(o.branches))
+	for i, branch := range o.branches {
+		qbranches[i] = make([]query.Clause, len(branch))
+		for j, c := range branch {
+			clause, ok := c.(Clause)
+			if !ok {
+				panic(fmt.Sprintf("OrDefault: branch %d argument %d is not a Clause (got %T)", i, j, c))
+			}
+			qbranches[i][j] = clause.toClause()
+		}
+	}
+	return &query.OrDefaultClause{Branches: qbranches}
+}
+
+// OrDefaultJoinBuilder accumulates branches for an OR-DEFAULT-JOIN clause.
+type OrDefaultJoinBuilder struct {
+	joinVars []*Var
+	branches [][]interface{}
+}
+
+// OrDefaultJoin starts building an OR-DEFAULT-JOIN clause with explicit join variables.
+func OrDefaultJoin(joinVars ...*Var) *OrDefaultJoinBuilder {
+	return &OrDefaultJoinBuilder{joinVars: joinVars}
+}
+
+// Branch adds a branch with one or more clauses.
+func (o *OrDefaultJoinBuilder) Branch(clauses ...interface{}) *OrDefaultJoinBuilder {
+	o.branches = append(o.branches, clauses)
+	return o
+}
+
+func (o *OrDefaultJoinBuilder) toClause() query.Clause {
+	joinSyms := make([]query.Symbol, len(o.joinVars))
+	for i, v := range o.joinVars {
+		joinSyms[i] = v.Symbol()
+	}
+
+	qbranches := make([][]query.Clause, len(o.branches))
+	for i, branch := range o.branches {
+		qbranches[i] = make([]query.Clause, len(branch))
+		for j, c := range branch {
+			clause, ok := c.(Clause)
+			if !ok {
+				panic(fmt.Sprintf("OrDefaultJoin: branch %d argument %d is not a Clause (got %T)", i, j, c))
+			}
+			qbranches[i][j] = clause.toClause()
+		}
+	}
+
+	return &query.OrDefaultJoinClause{
+		JoinVars: joinSyms,
+		Branches: qbranches,
+	}
+}

--- a/datalog/qb/qb_test.go
+++ b/datalog/qb/qb_test.go
@@ -578,6 +578,55 @@ func TestOrJoinClause(t *testing.T) {
 	}
 }
 
+func TestOrDefaultClauseQB(t *testing.T) {
+	e := NewVar("e")
+	x := NewVar("x")
+	attr := Kw(":user/score")
+
+	od := OrDefault().
+		Branch(Pat(e, attr, x)).
+		Branch(Ground(int64(0)).As(x))
+
+	clause := od.toClause()
+	odc, ok := clause.(*query.OrDefaultClause)
+	if !ok {
+		t.Fatalf("Expected *query.OrDefaultClause, got %T", clause)
+	}
+	if len(odc.Branches) != 2 {
+		t.Errorf("Expected 2 branches, got %d", len(odc.Branches))
+	}
+	// Branch 0 should be a DataPattern
+	if _, ok := odc.Branches[0][0].(*query.DataPattern); !ok {
+		t.Errorf("Expected DataPattern in branch 0, got %T", odc.Branches[0][0])
+	}
+	// Branch 1 should be an Expression
+	if _, ok := odc.Branches[1][0].(*query.Expression); !ok {
+		t.Errorf("Expected Expression in branch 1, got %T", odc.Branches[1][0])
+	}
+}
+
+func TestOrDefaultJoinClauseQB(t *testing.T) {
+	e := NewVar("e")
+	x := NewVar("x")
+	attr := Kw(":user/score")
+
+	odj := OrDefaultJoin(x).
+		Branch(Pat(e, attr, x)).
+		Branch(Ground(int64(0)).As(x))
+
+	clause := odj.toClause()
+	odjc, ok := clause.(*query.OrDefaultJoinClause)
+	if !ok {
+		t.Fatalf("Expected *query.OrDefaultJoinClause, got %T", clause)
+	}
+	if len(odjc.JoinVars) != 1 {
+		t.Errorf("Expected 1 join var, got %d", len(odjc.JoinVars))
+	}
+	if len(odjc.Branches) != 2 {
+		t.Errorf("Expected 2 branches, got %d", len(odjc.Branches))
+	}
+}
+
 // TestOrderSpecs tests ordering specifications
 func TestOrderSpecs(t *testing.T) {
 	name := NewVar("name")

--- a/datalog/query/clause.go
+++ b/datalog/query/clause.go
@@ -17,8 +17,10 @@ func (*Expression) clause()        {}
 func (*Subquery) clause()          {}
 func (*NotClause) clause()         {}
 func (*NotJoinClause) clause()     {}
-func (*OrClause) clause()          {}
-func (*OrJoinClause) clause()      {}
+func (*OrClause) clause()              {}
+func (*OrJoinClause) clause()          {}
+func (*OrDefaultClause) clause()       {}
+func (*OrDefaultJoinClause) clause()   {}
 
 // Expression wraps a Function with an optional binding
 type Expression struct {
@@ -120,41 +122,65 @@ type OrJoinClause struct {
 	Branches [][]Clause // Each branch is a list of clauses
 }
 
-// BranchHasExpressions checks if any clause in a branch is an expression type.
-// This is used to determine whether an OR clause should use fallback semantics
-// (Clojure-style first-non-empty-wins) vs union semantics (Datalog-style).
-func BranchHasExpressions(branch []Clause) bool {
-	for _, c := range branch {
-		switch c.(type) {
-		case *Expression, *Subquery, *SubqueryPattern:
-			return true
-		case *GroundPredicate:
-			return true
-		case Predicate:
-			// Predicates that require input symbols (e.g., DatabaseFunctionPredicate
-			// for missing?, Comparison for [(< ?x 5)]) need outer bindings to
-			// evaluate — union mode passes nil. Predicates with no required symbols
-			// (e.g., HistoryPredicate) can work in union mode.
-			if pred, ok := c.(Predicate); ok && len(pred.RequiredSymbols()) > 0 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// OrHasExpressions checks if any branch in an OR clause contains expressions.
-func OrHasExpressions(branches [][]Clause) bool {
-	for _, branch := range branches {
-		if BranchHasExpressions(branch) {
-			return true
-		}
-	}
-	return false
-}
 
 func (o *OrJoinClause) String() string {
 	result := "(or-join ["
+	for i, v := range o.JoinVars {
+		if i > 0 {
+			result += " "
+		}
+		result += v.String()
+	}
+	result += "]"
+	for _, branch := range o.Branches {
+		if len(branch) == 1 {
+			result += " " + branch[0].String()
+		} else {
+			result += " (and"
+			for _, c := range branch {
+				result += " " + c.String()
+			}
+			result += ")"
+		}
+	}
+	result += ")"
+	return result
+}
+
+// OrDefaultClause represents a disjunction with fallback semantics:
+// (or-default branch1 branch2 ...)
+// For each outer tuple, tries branches in order until one returns results.
+// This is a janus-datalog extension for the "data with default" pattern.
+type OrDefaultClause struct {
+	Branches [][]Clause
+}
+
+func (o *OrDefaultClause) String() string {
+	result := "(or-default"
+	for _, branch := range o.Branches {
+		if len(branch) == 1 {
+			result += " " + branch[0].String()
+		} else {
+			result += " (and"
+			for _, c := range branch {
+				result += " " + c.String()
+			}
+			result += ")"
+		}
+	}
+	result += ")"
+	return result
+}
+
+// OrDefaultJoinClause represents an or-default-join with explicit variable binding:
+// (or-default-join [vars] branch1 branch2 ...)
+type OrDefaultJoinClause struct {
+	JoinVars []Symbol
+	Branches [][]Clause
+}
+
+func (o *OrDefaultJoinClause) String() string {
+	result := "(or-default-join ["
 	for i, v := range o.JoinVars {
 		if i > 0 {
 			result += " "

--- a/datalog/storage/algebra_integration_test.go
+++ b/datalog/storage/algebra_integration_test.go
@@ -175,7 +175,7 @@ func TestAlgebraIntegration_OrFallbackWithSubquery(t *testing.T) {
 	q := `[:find ?e ?count
 	       :where [?e :entity/type :entity.type/scenario]
 	              (not [?e :entity/deleted true])
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/root ?s]
 	                              [?t :task/status :status/complete]]
@@ -220,7 +220,7 @@ func TestAlgebraIntegration_SubqueryWithNot(t *testing.T) {
 	q := `[:find ?e ?count
 	       :where [?e :entity/type :entity.type/scenario]
 	              (not [?e :entity/deleted true])
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/root ?s]
 	                              [?t :task/status :status/complete]
@@ -260,7 +260,7 @@ func TestAlgebraIntegration_SequentialQueries(t *testing.T) {
 		{"with_subquery", `[:find ?e ?count
 			:where [?e :entity/type :entity.type/scenario]
 			       (not [?e :entity/deleted true])
-			       (or [(q [:find (count ?t) :in $ ?s
+			       (or-default [(q [:find (count ?t) :in $ ?s
 			                :where [?t :task/root ?s] [?t :task/status :status/complete]
 			                       (not [?t :entity/deleted true])]
 			               $ ?e) [[?count]]]
@@ -328,7 +328,7 @@ func TestAlgebraIntegration_PrefetchInDecorrelatedSubquery(t *testing.T) {
 	// Pattern 1 (:task/status) should benefit from prefetch after pattern 0 (:task/root).
 	q := `[:find ?e ?count
 	       :where [?e :entity/type :entity.type/scenario]
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/root ?s]
 	                              [?t :task/status :status/complete]]
@@ -370,7 +370,7 @@ func TestAlgebraIntegration_MultipleOrFallbacks(t *testing.T) {
 	q := `[:find ?e ?count ?total
 	       :where [?e :entity/type :entity.type/scenario]
 	              (not [?e :entity/deleted true])
-	              (or [(q [:find (count ?t) (sum ?tok)
+	              (or-default [(q [:find (count ?t) (sum ?tok)
 	                       :in $ ?s
 	                       :where [?t :task/root ?s]
 	                              [?t :task/status :status/complete]

--- a/datalog/storage/correlated_subquery_perf_test.go
+++ b/datalog/storage/correlated_subquery_perf_test.go
@@ -104,7 +104,7 @@ func TestCorrelatedSubqueryPerformance(t *testing.T) {
 	  [?scenario :scenario/created-at ?createdAt]
 
 	  ;; Subquery 1: task stats (count, sum tokens, sum duration)
-	  (or [(q [:find (count ?t) (sum ?tok) (sum ?dur)
+	  (or-default [(q [:find (count ?t) (sum ?tok) (sum ?dur)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]
@@ -114,7 +114,7 @@ func TestCorrelatedSubqueryPerformance(t *testing.T) {
 	      [(ground [0 0 0]) [[?taskCount ?totalTokens ?totalDuration]]])
 
 	  ;; Subquery 2: opening count (determines completeness)
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/key :task/opening]
@@ -124,7 +124,7 @@ func TestCorrelatedSubqueryPerformance(t *testing.T) {
 	  [[(> ?openingCount 0)] ?complete]
 
 	  ;; Subquery 3: last task key (nested subquery for max timestamp)
-	  (or [(q [:find ?key ?ca
+	  (or-default [(q [:find ?key ?ca
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]
@@ -225,7 +225,7 @@ func BenchmarkCorrelatedSubqueryPattern(b *testing.B) {
 			  [?scenario :entity/type :entity.type/scenario]
 			  [?scenario :scenario/title ?title]
 			  [?scenario :scenario/created-at ?createdAt]
-			  (or [(q [:find (count ?t) (sum ?tok) (sum ?dur)
+			  (or-default [(q [:find (count ?t) (sum ?tok) (sum ?dur)
 			           :in $ ?s
 			           :where [?t :task/root ?s]
 			                  [?t :task/status :status/complete]
@@ -233,7 +233,7 @@ func BenchmarkCorrelatedSubqueryPattern(b *testing.B) {
 			                  [(get-else $ ?t :task/duration 0) ?dur]]
 			          $ ?scenario) [[?taskCount ?totalTokens ?totalDuration]]]
 			      [(ground [0 0 0]) [[?taskCount ?totalTokens ?totalDuration]]])
-			  (or [(q [:find (count ?t)
+			  (or-default [(q [:find (count ?t)
 			           :in $ ?s
 			           :where [?t :task/root ?s]
 			                  [?t :task/key :task/opening]
@@ -241,7 +241,7 @@ func BenchmarkCorrelatedSubqueryPattern(b *testing.B) {
 			          $ ?scenario) [[?openingCount]]]
 			      [(ground 0) ?openingCount])
 			  [[(> ?openingCount 0)] ?complete]
-			  (or [(q [:find ?key ?ca
+			  (or-default [(q [:find ?key ?ca
 			           :in $ ?s
 			           :where [?t :task/root ?s]
 			                  [?t :task/status :status/complete]
@@ -349,7 +349,7 @@ func TestCorrelatedSubqueryAlgebraOptimizer(t *testing.T) {
 	  [?scenario :entity/type :entity.type/scenario]
 	  [?scenario :scenario/title ?title]
 	  [?scenario :scenario/created-at ?createdAt]
-	  (or [(q [:find (count ?t) (sum ?tok) (sum ?dur)
+	  (or-default [(q [:find (count ?t) (sum ?tok) (sum ?dur)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]
@@ -357,7 +357,7 @@ func TestCorrelatedSubqueryAlgebraOptimizer(t *testing.T) {
 	                  [(get-else $ ?t :task/duration 0) ?dur]]
 	          $ ?scenario) [[?taskCount ?totalTokens ?totalDuration]]]
 	      [(ground [0 0 0]) [[?taskCount ?totalTokens ?totalDuration]]])
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/key :task/opening]
@@ -365,7 +365,7 @@ func TestCorrelatedSubqueryAlgebraOptimizer(t *testing.T) {
 	          $ ?scenario) [[?openingCount]]]
 	      [(ground 0) ?openingCount])
 	  [[(> ?openingCount 0)] ?complete]
-	  (or [(q [:find ?key ?ca
+	  (or-default [(q [:find ?key ?ca
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]
@@ -508,7 +508,7 @@ func TestCorrelatedSubqueryAlgebraOptimizerWithDefaults(t *testing.T) {
 	  [?scenario :entity/type :entity.type/scenario]
 	  [?scenario :scenario/title ?title]
 	  [?scenario :scenario/created-at ?createdAt]
-	  (or [(q [:find (count ?t) (sum ?tok) (sum ?dur)
+	  (or-default [(q [:find (count ?t) (sum ?tok) (sum ?dur)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]
@@ -516,7 +516,7 @@ func TestCorrelatedSubqueryAlgebraOptimizerWithDefaults(t *testing.T) {
 	                  [(get-else $ ?t :task/duration 0) ?dur]]
 	          $ ?scenario) [[?taskCount ?totalTokens ?totalDuration]]]
 	      [(ground [0 0 0]) [[?taskCount ?totalTokens ?totalDuration]]])
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/key :task/opening]
@@ -524,7 +524,7 @@ func TestCorrelatedSubqueryAlgebraOptimizerWithDefaults(t *testing.T) {
 	          $ ?scenario) [[?openingCount]]]
 	      [(ground 0) ?openingCount])
 	  [[(> ?openingCount 0)] ?complete]
-	  (or [(q [:find ?key ?ca
+	  (or-default [(q [:find ?key ?ca
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]
@@ -703,7 +703,7 @@ func TestCorrelatedSubqueryAlgebraOptimizerProductionStructure(t *testing.T) {
 	  [(get-else $ ?project :project/region "") ?region]
 	  [(get-else $ ?project :project/owner "") ?owner]
 	  [(get-else $ ?project :project/notes "") ?notes]
-	  (or [(q [:find (count ?i) (sum ?c) (sum ?w) (sum ?iu) (sum ?ou)
+	  (or-default [(q [:find (count ?i) (sum ?c) (sum ?w) (sum ?iu) (sum ?ou)
 	           :in $ ?p
 	           :where [?i :item/project ?p]
 	                  [?i :item/status :status/done]
@@ -714,7 +714,7 @@ func TestCorrelatedSubqueryAlgebraOptimizerProductionStructure(t *testing.T) {
 	                  [(get-else $ ?i :item/output-units 0) ?ou]]
 	          $ ?project) [[?itemCount ?totalCost ?totalWeight ?inputUnits ?outputUnits]]]
 	      [(ground [0 0 0 0 0]) [[?itemCount ?totalCost ?totalWeight ?inputUnits ?outputUnits]]])
-	  (or [(q [:find (count ?i)
+	  (or-default [(q [:find (count ?i)
 	           :in $ ?p
 	           :where [?i :item/project ?p]
 	                  [?i :item/key :step/init]
@@ -723,7 +723,7 @@ func TestCorrelatedSubqueryAlgebraOptimizerProductionStructure(t *testing.T) {
 	          $ ?project) [[?initCount]]]
 	      [(ground 0) ?initCount])
 	  [[(> ?initCount 0)] ?ready]
-	  (or [(q [:find ?key ?ca
+	  (or-default [(q [:find ?key ?ca
 	           :in $ ?p
 	           :where [?i :item/project ?p]
 	                  [?i :item/status :status/done]

--- a/datalog/storage/crdt_vector_test.go
+++ b/datalog/storage/crdt_vector_test.go
@@ -2446,7 +2446,7 @@ func TestVectorLiteralMatch(t *testing.T) {
 }
 
 // TestVectorLiteralWithOr verifies the (or ...) scenario from the bug report:
-// (or [(missing? $ ?e :attr)] [?e :attr []]) should return entities where the
+// (or-default [(missing? $ ?e :attr)] [?e :attr []]) should return entities where the
 // attribute is missing OR empty, but NOT entities with non-empty vectors.
 func TestVectorLiteralWithOr(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "vector-literal-or-test")
@@ -2507,7 +2507,7 @@ func TestVectorLiteralWithOr(t *testing.T) {
 	results, err := executor.CollectTuples(db.Query(
 		`[:find ?name :where
 		  [?e :entity/name ?name]
-		  (or [(missing? $ ?e :entity/lore)]
+		  (or-default [(missing? $ ?e :entity/lore)]
 		      [?e :entity/lore []])]`))
 	require.NoError(t, err)
 	t.Logf("or combined: %v", results)

--- a/datalog/storage/decorrelated_debug_test.go
+++ b/datalog/storage/decorrelated_debug_test.go
@@ -45,7 +45,7 @@ func TestDecorrelatedOrJoinBranchResults(t *testing.T) {
 		[:find ?scenario ?taskCount ?totalTokens
 		 :where
 		 [?scenario :scenario/id ?id]
-		 (or [(q [:find (count ?t) (sum ?tok)
+		 (or-default [(q [:find (count ?t) (sum ?tok)
 		          :in $ ?s
 		          :where [?t :task/scenario ?s]
 		                 [?t :task/status :status/complete]

--- a/datalog/storage/optimization_matrix_test.go
+++ b/datalog/storage/optimization_matrix_test.go
@@ -63,7 +63,7 @@ func TestOptimizationMatrix(t *testing.T) {
 	  [?scenario :entity/type :entity.type/scenario]
 	  [?scenario :scenario/title ?title]
 	  [?scenario :scenario/created-at ?createdAt]
-	  (or [(q [:find (count ?t) (sum ?tok) (sum ?dur)
+	  (or-default [(q [:find (count ?t) (sum ?tok) (sum ?dur)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]
@@ -71,7 +71,7 @@ func TestOptimizationMatrix(t *testing.T) {
 	                  [(get-else $ ?t :task/duration 0) ?dur]]
 	          $ ?scenario) [[?taskCount ?totalTokens ?totalDuration]]]
 	      [(ground [0 0 0]) [[?taskCount ?totalTokens ?totalDuration]]])
-	  (or [(q [:find (count ?t)
+	  (or-default [(q [:find (count ?t)
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/key :task/opening]
@@ -79,7 +79,7 @@ func TestOptimizationMatrix(t *testing.T) {
 	          $ ?scenario) [[?openingCount]]]
 	      [(ground 0) ?openingCount])
 	  [[(> ?openingCount 0)] ?complete]
-	  (or [(q [:find ?key ?ca
+	  (or-default [(q [:find ?key ?ca
 	           :in $ ?s
 	           :where [?t :task/root ?s]
 	                  [?t :task/status :status/complete]

--- a/datalog/storage/or_subquery_regression_test.go
+++ b/datalog/storage/or_subquery_regression_test.go
@@ -54,7 +54,7 @@ func TestOrClauseWithCorrelatedSubquery_E2E(t *testing.T) {
 	// This is the exact pattern that fails in user's code
 	queryStr := `[:find ?scenario ?count
 	              :where [?scenario :scenario/name ?name]
-	                     (or [(q [:find (count ?t)
+	                     (or-default [(q [:find (count ?t)
 	                              :in $ ?s
 	                              :where [?t :task/scenario ?s]
 	                                     [?t :task/status :status/complete]]
@@ -118,7 +118,7 @@ func TestScenarioSummaryQuery_E2E(t *testing.T) {
 	queryStr := `[:find ?scenario ?taskCount
 	              :where
 	              [?scenario :scenario/id ?id]
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/scenario ?s]
 	                              [?t :task/status :status/complete]]
@@ -154,7 +154,7 @@ const scenarioSummaryQueryFull = `
  [(get-else $ ?scenario :idea/setting "") ?setting]
 
  ;; Task stats with OR fallback for scenarios with no completed tasks
- (or [(q [:find (count ?t) (sum ?tok) (sum ?dur) (sum ?cc) (sum ?cr)
+ (or-default [(q [:find (count ?t) (sum ?tok) (sum ?dur) (sum ?cc) (sum ?cr)
           :in $ ?s
           :where [?t :task/scenario ?s]
                  [?t :task/status :status/complete]
@@ -170,7 +170,7 @@ const scenarioSummaryQueryFull = `
           [(ground 0) ?cacheRead]))
 
  ;; Opening count: count completed opening tasks
- (or [(q [:find (count ?t)
+ (or-default [(q [:find (count ?t)
           :in $ ?s
           :where [?t :task/scenario ?s]
                  [?t :task/key :task/opening]
@@ -182,7 +182,7 @@ const scenarioSummaryQueryFull = `
  [(> ?openingCount 0) ?complete]
 
  ;; Last task key: find the task with max completed-at timestamp
- (or [(q [:find ?key
+ (or-default [(q [:find ?key
           :in $ ?s
           :where [?t :task/scenario ?s]
                  [?t :task/status :status/complete]
@@ -233,7 +233,7 @@ func TestNestedSubqueryInOr_E2E(t *testing.T) {
 	              :where
 	              [?scenario :scenario/id ?id]
 
-	              (or [(q [:find ?key
+	              (or-default [(q [:find ?key
 	                       :in $ ?s
 	                       :where [?t :task/scenario ?s]
 	                              [?t :task/status :status/complete]
@@ -301,7 +301,7 @@ func TestProductionQueryStructure_E2E(t *testing.T) {
 	              [(get-else $ ?scenario :scenario/pov "") ?pov]
 
 	              ;; First OR - task count
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/scenario ?s]
 	                              [?t :task/status :status/complete]]
@@ -309,7 +309,7 @@ func TestProductionQueryStructure_E2E(t *testing.T) {
 	                  [(ground 0) ?taskCount])
 
 	              ;; Second OR - opening count
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/scenario ?s]
 	                              [?t :task/key :task/opening]
@@ -364,7 +364,7 @@ func TestGetElseBeforeOrClause_E2E(t *testing.T) {
 	              [?scenario :scenario/id ?id]
 	              [(get-else $ ?scenario :scenario/title "") ?title]
 
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/scenario ?s]
 	                              [?t :task/status :status/complete]]
@@ -413,7 +413,7 @@ func TestMultipleSequentialOrClauses_E2E(t *testing.T) {
 	              [?scenario :scenario/id ?id]
 
 	              ;; First OR clause
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/scenario ?s]
 	                              [?t :task/status :status/complete]]
@@ -421,7 +421,7 @@ func TestMultipleSequentialOrClauses_E2E(t *testing.T) {
 	                  [(ground 0) ?count1])
 
 	              ;; Second OR clause (same pattern)
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/scenario ?s]
 	                              [?t :task/status :status/complete]]
@@ -468,7 +468,7 @@ func TestOrWithGetElseInsideSubquery_E2E(t *testing.T) {
 	queryStr := `[:find ?scenario ?taskCount ?totalTokens
 	              :where
 	              [?scenario :scenario/id ?id]
-	              (or [(q [:find (count ?t) (sum ?tok)
+	              (or-default [(q [:find (count ?t) (sum ?tok)
 	                       :in $ ?s
 	                       :where [?t :task/scenario ?s]
 	                              [?t :task/status :status/complete]
@@ -518,7 +518,7 @@ func TestOrWithMultipleAggregations_E2E(t *testing.T) {
 	queryStr := `[:find ?scenario ?taskCount ?totalTokens
 	              :where
 	              [?scenario :scenario/id ?id]
-	              (or [(q [:find (count ?t) (sum ?tok)
+	              (or-default [(q [:find (count ?t) (sum ?tok)
 	                       :in $ ?s
 	                       :where [?t :task/scenario ?s]
 	                              [?t :task/status :status/complete]

--- a/datalog/storage/or_union_expressions_test.go
+++ b/datalog/storage/or_union_expressions_test.go
@@ -69,7 +69,7 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 		results, err := executor.CollectTuples(db.Query(`
 			[:find ?name ?score
 			 :where [?e :entity/name ?name]
-			        (or-join [?e ?score]
+			        (or-default-join [?e ?score]
 			          [?e :entity/score ?score]
 			          (and (not [?e :entity/score _])
 			               [(ground 0) ?score]))]`))
@@ -92,7 +92,7 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 		results, err := executor.CollectTuples(db.Query(`
 			[:find ?name ?score
 			 :where [?e :entity/name ?name]
-			        (or [?e :entity/score ?score]
+			        (or-default [?e :entity/score ?score]
 			            (and (not [?e :entity/score _])
 			                 [(ground 0) ?score]))]`))
 		require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 			[:find ?self-name ?related-name
 			 :where [?self :entity/name ?self-name]
 			        [?self :entity/type ?stype]
-			        (or-join [?related ?self ?stype]
+			        (or-default-join [?related ?self ?stype]
 			          (and [(ground :type/parent) ?stype]
 			               (or-join [?related ?self]
 			                 [?related :child/parent ?self]
@@ -220,7 +220,7 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 			 :where
 			 [?self :entity/name "A1"]
 			 [?self :entity/type ?stype]
-			 (or-join [?related ?self ?stype]
+			 (or-default-join [?related ?self ?stype]
 			   (and [(ground :type/alpha) ?stype]
 			        (or-join [?related ?self]
 			          [?related :rel/location ?self]
@@ -270,7 +270,7 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 			[:find ?name ?stype
 			 :where [?e :entity/name ?name]
 			        [?e :entity/type ?stype]
-			        (or-join [?e ?stype]
+			        (or-default-join [?e ?stype]
 			          (and [(ground :type/parent) ?stype]
 			               [?e :entity/friend _])
 			          (and [(ground :type/child) ?stype]
@@ -287,7 +287,7 @@ func TestOrUnionWithExpressionBranches(t *testing.T) {
 		results, err := executor.CollectTuples(db.Query(`
 			[:find ?name ?count
 			 :where [?e :entity/name ?name]
-			        (or-join [?e ?count]
+			        (or-default-join [?e ?count]
 			          [(q [:find ?e (count ?c)
 			               :in $
 			               :where [?c :child/parent ?e]]

--- a/datalog/storage/or_union_left_join_test.go
+++ b/datalog/storage/or_union_left_join_test.go
@@ -100,7 +100,7 @@ func TestOrUnionAsLeftJoin(t *testing.T) {
 			[:find ?name ?count
 			 :where [?p :entity/type :type/parent]
 			        [?p :parent/name ?name]
-			        (or [(q [:find (count ?c)
+			        (or-default [(q [:find (count ?c)
 			                 :in $ ?p
 			                 :where [?c :child/parent ?p]]
 			                $ ?p) [[?count]]]

--- a/datalog/storage/scan_sharing_integration_test.go
+++ b/datalog/storage/scan_sharing_integration_test.go
@@ -56,7 +56,7 @@ func TestScanSharing_DecorrelatedSubqueries(t *testing.T) {
 
 	q := `[:find ?e ?count ?total
 	       :where [?e :entity/type :entity.type/scenario]
-	              (or [(q [:find (count ?t) (sum ?tok)
+	              (or-default [(q [:find (count ?t) (sum ?tok)
 	                       :in $ ?s
 	                       :where [?t :task/root ?s]
 	                              [?t :task/status :status/complete]
@@ -112,7 +112,7 @@ func TestScanSharing_CorrectnessDifferential(t *testing.T) {
 
 	q := `[:find ?e ?count
 	       :where [?e :entity/type :entity.type/scenario]
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/root ?s]
 	                              [?t :task/status :status/complete]]
@@ -157,7 +157,7 @@ func TestScanSharing_DisabledByDefault(t *testing.T) {
 
 	q := `[:find ?e ?count
 	       :where [?e :entity/type :entity.type/scenario]
-	              (or [(q [:find (count ?t)
+	              (or-default [(q [:find (count ?t)
 	                       :in $ ?s
 	                       :where [?t :task/root ?s]
 	                              [?t :task/status :status/complete]]

--- a/docs/ALGEBRA.md
+++ b/docs/ALGEBRA.md
@@ -180,7 +180,7 @@ decompile(left) ++
                <default branch>)
 ```
 
-Left side clauses followed by an or-join:
+Left side clauses followed by an or-default-join:
 - Branch 1: decompiled right side (the Aggregate → SubqueryPattern)
 - Branch 2: default expressions for non-join symbols only (join keys subtracted)
 
@@ -193,13 +193,13 @@ The or-join evaluates per outer tuple. Branch 1 returns all subquery results;
 `filterBranchToOuterTuple` matches to the current outer tuple on shared symbols.
 Non-matching tuples get branch 2 (defaults).
 
-**Round-trip invariant:** Left clauses preserved. Right side becomes an or-join
-SubqueryPattern. Default values map to ground or get-else expressions. Join
-symbols are explicit on the or-join clause.
+**Round-trip invariant:** Left clauses preserved. Right side becomes an
+or-default-join SubqueryPattern. Default values map to ground or get-else
+expressions. Join symbols are explicit on the or-default-join clause.
 
 **Test:** Build LeftOuterJoin(defaults=[0]) over an outer Scan and an inner
-Aggregate. Decompile. Verify: outer DataPattern + OrJoinClause with SubqueryPattern
-branch and default branch.
+Aggregate. Decompile. Verify: outer DataPattern + OrDefaultJoinClause with
+SubqueryPattern branch and default branch.
 
 ### AntiJoin
 
@@ -219,9 +219,13 @@ DataPattern + NotClause.
 
 ### Union
 
-**Compile:** `(or [?e :a ?x] [?e :b ?x])` (pattern-only OR) → `Union(output=[?e, ?x])(branch1, branch2)`
+**Compile:** `(or [?e :a ?x] [?e :b ?x])` → `Union(output=[?e, ?x])(branch1, branch2)`
 
 For `or-join`: `(or-join [?e] ...)` → `Union(output=[?e, ?x], joinVars=[?e])(branch1, branch2)`
+
+When an `(or ...)` or `(or-join ...)` branch contains correlated predicates
+(NOT, missing?) that require outer context, the compiler detects this via
+`branchesRequireOuterContext()` and routes to the LateralUnion path instead.
 
 **Decompile:**
 - `Union(joinVars=nil)(children...)` → `(or <decompile(child1)> <decompile(child2)> ...)`
@@ -233,9 +237,31 @@ For `or-join`: `(or-join [?e] ...)` → `Union(output=[?e, ?x], joinVars=[?e])(b
 **Test:** Compile pattern-only OR and or-join, decompile, assert correct clause
 type with branches and join vars.
 
+### LateralUnion
+
+**Compile:** `(or-default [?e :a ?x] [(ground 0) ?x])` (general fallback) →
+`LateralUnion(output=[?e, ?x])(branch1, branch2)`
+
+For `or-default-join`: `(or-default-join [?x] ...)` →
+`LateralUnion(output=[?e, ?x], joinVars=[?x])(branch1, branch2)`
+
+Also produced when `(or ...)` / `(or-join ...)` branches contain correlated
+predicates (NOT, missing?) that require per-tuple evaluation against the outer
+relation. Independent Union compilation cannot express anti-joins without context.
+
+**Decompile:**
+- `LateralUnion(joinVars=nil)(children...)` → `(or-default <decompile(child1)> <decompile(child2)> ...)`
+- `LateralUnion(joinVars=[?x])(children...)` → `(or-default-join [?x] <decompile(child1)> <decompile(child2)> ...)`
+
+**Round-trip invariant:** Each branch's clauses preserved. `or-default` ↔
+OrDefaultClause, `or-default-join` ↔ OrDefaultJoinClause with join vars preserved.
+
+**Test:** Compile OR-default with ground fallback, decompile, assert
+OrDefaultClause/OrDefaultJoinClause with correct branches.
+
 ### LateralJoin
 
-**Compile:** `(or [(q [...] $ ?x) [[?count]]] [(ground 0) ?count])` →
+**Compile:** `(or-default [(q [...] $ ?x) [[?count]]] [(ground 0) ?count])` →
 
 ```
 LateralJoin(
@@ -250,23 +276,23 @@ LateralJoin(
 
 ```
 decompile(outer) ++
-(or-join [?x] [(q <innerQuery> $ ?x) <binding>]
-               [(ground 0) ?count])
+(or-default-join [?x] [(q <innerQuery> $ ?x) <binding>]
+                       [(ground 0) ?count])
 ```
 
 Join vars come from correlation vars (correlated) or shared symbols between
 binding and outer relation (uncorrelated). Default branch binds only non-join
-symbols — join keys come from the outer relation via or-join.
+symbols — join keys come from the outer relation via or-default-join.
 
 Without defaults: `decompile(outer) ++ [(q <innerQuery> $ ?x) <binding>]`
 
 **Round-trip invariant:** Inner query, binding form, correlation variables, and
 default values all preserved. Correlation variables appear as SubqueryPattern
-inputs. Defaults produce or-join with ground branch. Join vars ensure the
-phaser doesn't reorder the OR before the patterns that provide the join keys.
+inputs. Defaults produce or-default-join with ground branch. Join vars ensure
+the phaser doesn't reorder the OR before the patterns that provide the join keys.
 
 **Test:** Compile an OR-fallback with correlated subquery + ground, decompile,
-assert OrJoinClause (not OrClause) with correct join vars.
+assert OrDefaultJoinClause (not OrJoinClause) with correct join vars.
 
 ---
 
@@ -930,10 +956,12 @@ key-only iterators make redundant scans cheap.
 | NotClause | AntiJoin | ✅ |
 | NotJoinClause | AntiJoin (explicit) | ✅ |
 | OR (pattern-only) | Union | ✅ |
-| OR (subquery+ground) | LateralJoin+defaults | ✅ |
-| OR (NOT+ground fallback) | Union via compileOrFallbackExclusive | ✅ |
-| OR (subquery+NOT+ground) | LateralJoin+defaults (NOT skipped) | ✅ |
+| OR (with correlated predicates) | LateralUnion (detected, routed) | ✅ |
 | or-join | Union with JoinVars preserved | ✅ |
+| or-default (subquery+ground) | LateralJoin+defaults | ✅ |
+| or-default (NOT+ground fallback) | LateralUnion via compileOrFallbackExclusive | ✅ |
+| or-default (subquery+NOT+ground) | LateralJoin+defaults (NOT skipped) | ✅ |
+| or-default-join | LateralUnion with JoinVars preserved | ✅ |
 | SubqueryPattern (correlated) | LateralJoin | ✅ |
 | SubqueryPattern (uncorrelated) | LateralJoin (no correlation vars) | ✅ |
 

--- a/docs/bugs/BUG-OR-FALLBACK-DROPS-EXPRESSION-BRANCHES.md
+++ b/docs/bugs/BUG-OR-FALLBACK-DROPS-EXPRESSION-BRANCHES.md
@@ -1,0 +1,122 @@
+# OR clause drops expression-only branches (fallback short-circuit)
+
+## Trigger
+
+A query uses `(or ...)` to combine a data pattern with an expression branch, expecting **union** semantics (both branches contribute results):
+
+```clojure
+[:find ?rname
+ :where
+ [?self :entity/name "Guard Chamber"]
+ [?self :entity/area ?target]
+ (or [?related :entity/area ?target]
+     [(identity ?target) ?related])
+ [?related :entity/name ?rname]]
+```
+
+**Expected**: 7 results — 6 sibling rooms sharing `:entity/area` + "Coastal Caves" (the area entity itself, bound via `identity`).
+
+**Actual**: 6 results — only the sibling rooms. The `identity` branch is silently dropped.
+
+Verified individually:
+- `[?related :entity/area ?target]` alone → 6 rooms (correct)
+- `[(identity ?target) ?related]` alone → "Coastal Caves" (correct)
+- `(or ...)` combining them → only the 6 rooms
+
+## Root cause
+
+The OR executor has two modes, selected by a binary check at `query_executor.go:1229`:
+
+```go
+if query.OrHasExpressions(clause.Branches) {
+    result, err = e.executeOrClauseFallback(ctx, clause, groups)
+} else {
+    result, err = e.executeOrClauseUnion(ctx, clause, groups)
+}
+```
+
+`OrHasExpressions()` returns `true` because Branch 1 contains an `Expression` (`IdentityFunction`). This forces **fallback semantics**: for each outer tuple, try branches in order and **short-circuit on the first success**.
+
+### The short-circuit
+
+In `or_fallback_relation.go:629-753`, the fallback iterator loops over branches per outer tuple:
+
+1. Branch 0 (`[?related :entity/area ?target]`) — finds 6 rooms sharing the area → **non-empty result**
+2. Short-circuit at line 749: `return true` — Branch 1 is **never evaluated**
+
+Since Branch 0 always succeeds (the area has rooms), Branch 1 (`identity`) is never tried for any outer tuple.
+
+### Union mode wouldn't help either
+
+Even if union mode were forced, it calls branches with **no outer binding** (`query_executor.go:1464`):
+
+```go
+branchResult, err := e.executeInnerClauses(ctx, branch, nil)
+```
+
+The expression `[(identity ?target) ?related]` requires `?target` from outer context. With `nil` binding, `?target` is unbound. In `executeExpression`, this hits the early-exit at line 621-622:
+
+```go
+// Skip expression if no relevant relations and expression needs symbols
+return groups, nil
+```
+
+The expression branch returns `nil` and is skipped.
+
+## Design gap
+
+The codebase has two OR execution modes:
+
+| Mode | Outer binding? | Evaluates all branches? |
+|------|---------------|------------------------|
+| **Union** | No (`nil`) | Yes |
+| **Fallback** | Yes (per-tuple) | No (short-circuits) |
+
+This query needs a third combination: **correlated union** — outer binding YES + evaluate all branches YES. Neither existing mode supports it.
+
+Fallback semantics were designed for the "try data first, use default if not found" pattern:
+
+```clojure
+(or [?scenario :task/count ?count]
+    [(ground 0) ?count])
+```
+
+The `identity` pattern is fundamentally different — it's not a default, it's an alternative data source whose results should be unioned with the data pattern branch.
+
+## Affected queries
+
+Any `(or ...)` where:
+1. One branch is a data pattern that typically succeeds
+2. Another branch uses an expression referencing an outer variable
+3. The user wants **union** (both branches contribute results), not **fallback** (default value)
+
+The `[(identity ?target) ?related]` pattern — "include the bound entity itself alongside pattern matches" — is the canonical example.
+
+## Key files
+
+| File | Lines | Role |
+|------|-------|------|
+| `executor/query_executor.go` | 1229 | Binary fallback/union routing decision |
+| `executor/query_executor.go` | 1443-1520 | Union mode (no outer binding) |
+| `executor/query_executor.go` | 1265-1319 | Fallback mode (short-circuits) |
+| `executor/or_fallback_relation.go` | 629-753 | Per-tuple short-circuit loop |
+| `query/clause.go` | 123-154 | `BranchHasExpressions()` / `OrHasExpressions()` |
+
+## Fix (implemented)
+
+Split `(or ...)` into two distinct clause types with explicit semantics:
+
+- **`(or ...)`** — always **correlated union** (Datomic semantics). All branches contribute results.
+- **`(or-default ...)`** — **fallback** (janus extension). First matching branch wins.
+
+The `OrHasExpressions()` heuristic was deleted. Semantics are now explicit in the clause type.
+
+### Changes
+
+- **New types**: `OrDefaultClause`, `OrDefaultJoinClause` in `query/clause.go`
+- **New syntax**: `(or-default ...)`, `(or-default-join ...)` parsed in `parser/parser.go`
+- **New IR node**: `LateralUnion` in `algebra/types.go` — the algebraic representation of correlated per-tuple branch evaluation, distinct from independent `Union`
+- **Executor**: `OrFallbackRelation` parameterized with `shortCircuit` bool. `(or ...)` uses correlated union when branches have expressions; uncorrelated union for pattern-only. `(or-default ...)` always uses fallback.
+- **Algebra compiler**: `compileOr` detects correlated predicates (NOT, missing?) and routes to `LateralUnion`. `compileOrDefault` always uses `LateralUnion`.
+- **Query builder**: `OrDefault()`, `OrDefaultJoin()` builders
+- **Deleted**: `BranchHasExpressions()`, `OrHasExpressions()` — the root cause heuristic

--- a/docs/reference/OR_FALLBACK_SEMANTICS.md
+++ b/docs/reference/OR_FALLBACK_SEMANTICS.md
@@ -1,156 +1,124 @@
-# OR Clause Fallback Semantics
+# OR Clause Semantics
 
-This document describes the extended OR clause semantics that allow expressions (including `ground` and arithmetic) to be used as fallback values when pattern branches return no results.
+This document describes the OR clause variants and their semantics.
 
-## Overview
+## Two Clause Types, Two Semantics
 
-Standard Datalog OR clauses use **union semantics**: all branches are executed and results are merged. This works well for pattern matching but doesn't support providing default values when queries return empty.
+| Clause | Semantics | Behavior |
+|--------|-----------|----------|
+| `(or ...)` / `(or-join ...)` | **Union** (Datomic-compatible) | All branches execute, results merged |
+| `(or-default ...)` / `(or-default-join ...)` | **Fallback** (janus extension) | Branches tried in order, first non-empty wins |
 
-When an OR clause contains expression branches (e.g., `ground`, arithmetic), janus-datalog switches to **fallback semantics**: branches are tried in order, and the first non-empty result is returned.
+## Union Semantics: `(or ...)`
 
-## Motivation
-
-Consider a scenario where you want to count tasks but return 0 when none exist:
-
-```clojure
-;; Standard subquery - returns empty when no tasks match
-[(q [:find (count ?t)
-     :in $ ?scenario
-     :where [?t :task/scenario ?scenario]
-            [?t :task/status :status/complete]]
-   $ ?scenario) [[?count]]]
-```
-
-When no matching tasks exist, this subquery returns empty (no tuples), causing the outer query tuple to be excluded entirely.
-
-With OR fallback semantics, you can provide a default:
+Standard Datalog/Datomic union. All branches are evaluated and results are combined.
 
 ```clojure
-(or [(q [:find (count ?t) ...] $ ?scenario) [[?count]]]
-    [(ground 0) ?count])
-```
-
-Now when the subquery returns empty, the ground expression provides `0` as the fallback.
-
-## Semantics
-
-### Pattern-Only OR (Union Semantics)
-
-When all branches contain only patterns, standard Datalog union semantics apply:
-
-```clojure
-;; Union: returns ALL users who are either active OR premium
+;; Returns ALL users who are active OR premium (both branches contribute)
 (or [?e :user/active true]
     [?e :user/premium true])
 ```
 
-Both branches execute, and results are merged (deduplicated on common symbols).
-
-### OR with Expressions (Fallback Semantics)
-
-When any branch contains an expression, fallback semantics apply:
+Expression branches work in union mode — both data patterns and expressions contribute:
 
 ```clojure
-;; Fallback: returns first non-empty result
-(or [?e :user/name ?name]           ;; Try pattern first
-    [(ground "Unknown") ?name])      ;; Fallback if no match
+;; Returns rooms sharing the area AND the area entity itself
+(or [?related :entity/area ?target]
+    [(identity ?target) ?related])
 ```
 
-Branches are tried in order:
-1. If branch 1 returns results, return immediately
+When branches reference symbols from the outer query context, the executor uses **correlated union**: each outer tuple evaluates all branches, and results are unioned per tuple.
+
+When branches are independent (no outer symbol references), the executor uses **uncorrelated union**: branches execute independently and results are merged.
+
+### or-join
+
+Explicit join variables control which symbols are exposed:
+
+```clojure
+(or-join [?e]
+  [?e :user/status "active"]
+  [?e :admin/status "enabled"])
+```
+
+## Fallback Semantics: `(or-default ...)`
+
+A janus-datalog extension for the "data with default" pattern. Branches are tried in order, and the first non-empty result is returned.
+
+```clojure
+;; Return "Unknown" if no name exists
+(or-default [?e :user/name ?name]
+            [(ground "Unknown") ?name])
+```
+
+Evaluation order:
+1. If branch 1 returns results, return immediately (short-circuit)
 2. If branch 1 is empty, try branch 2
 3. Continue until a non-empty result or all branches exhausted
 
-## Supported Expression Types
+### Common Patterns
 
-The following expressions can be used in OR branches:
-
-### Ground Expressions
-
-Bind a constant value to a variable:
-
-```clojure
-(or [?e :config/value ?v]
-    [(ground "default") ?v])
-```
-
-### Arithmetic Expressions
-
-Compute values when patterns don't match:
-
-```clojure
-(or [?e :item/discount ?discount]
-    [(* ?price 0) ?discount])  ;; 0 discount if none specified
-```
-
-### Subquery Expressions
-
-Use subqueries as branches with fallbacks:
-
-```clojure
-(or [(q [:find (sum ?amount) :where ...] $) [[?total]]]
-    [(ground 0) ?total])
-```
-
-## Examples
-
-### Default Value for Missing Attribute
+**Default value for missing attribute:**
 
 ```clojure
 [:find ?name ?status
  :where [?e :user/name ?name]
-        (or [?e :user/status ?status]
-            [(ground :status/unknown) ?status])]
+        (or-default [?e :user/status ?status]
+                    [(ground :status/unknown) ?status])]
 ```
 
-### Count with Zero Default
+**Count with zero default:**
 
 ```clojure
 [:find ?category ?count
  :where [?c :category/name ?category]
-        (or [(q [:find (count ?p)
-                 :in $ ?c
-                 :where [?p :product/category ?c]]
-               $ ?c) [[?count]]]
-            [(ground 0) ?count])]
+        (or-default [(q [:find (count ?p)
+                         :in $ ?c
+                         :where [?p :product/category ?c]]
+                        $ ?c) [[?count]]]
+                    [(ground 0) ?count])]
 ```
 
-### Multiple Fallback Levels
+**Multiple fallback levels:**
 
 ```clojure
-;; Try multiple sources in priority order
-(or [?e :user/nickname ?display]
-    [?e :user/fullname ?display]
-    [?e :user/email ?display]
-    [(ground "Anonymous") ?display])
+(or-default [?e :user/nickname ?display]
+            [?e :user/fullname ?display]
+            [?e :user/email ?display]
+            [(ground "Anonymous") ?display])
 ```
 
-## OR-JOIN with Fallback
+### or-default-join
 
-The same semantics apply to `or-join` when expressions are present:
+Explicit join variables for fallback:
 
 ```clojure
-(or-join [?x]
+(or-default-join [?x]
   [?e :source1/value ?x]
   [?e :source2/value ?x]
   [(ground 0) ?x])
 ```
 
-## Implementation Notes
+## Algebra IR Representation
 
-- Fallback semantics require materializing branch results to check for emptiness
-- Pattern-only OR continues to use efficient union/streaming semantics
-- Detection is automatic based on branch contents - no explicit syntax needed
-- Predicates are also supported within expression branches
+| Clause | IR Node | Description |
+|--------|---------|-------------|
+| `(or ...)` / `(or-join ...)` | `Union` | Independent branch evaluation |
+| `(or-default ...)` / `(or-default-join ...)` | `LateralUnion` | Correlated per-tuple evaluation |
+| `(or-default ...)` with subquery+ground | `LateralJoin` | Correlated subquery with defaults |
+
+When `(or ...)` contains correlated predicates (NOT, missing?) that require
+outer context, the compiler detects this and routes to `LateralUnion` instead
+of `Union`, since independent union branches cannot express anti-joins.
 
 ## Comparison with Datomic
 
-Datomic's OR clauses use pure union semantics and do not support this fallback pattern directly. The workaround in Datomic is typically application-level code:
+| Feature | Datomic | janus-datalog |
+|---------|---------|---------------|
+| `(or ...)` union | Yes | Yes (identical semantics) |
+| `(or-join ...)` union | Yes | Yes (identical semantics) |
+| Default values in query | No (application-level) | Yes via `(or-default ...)` |
+| `get-else` for single attr | Yes | Yes |
 
-```clojure
-;; Datomic workaround
-(or (seq (d/q [:find ...] db))
-    [[0]])  ;; application-level default
-```
-
-janus-datalog's fallback semantics provide this capability within the query itself, enabling more declarative queries.
+Datomic users who need "default if missing" handle it in application code.
+janus-datalog's `(or-default ...)` provides this within the query itself.


### PR DESCRIPTION
The (or ...) clause was overloaded with two incompatible semantics selected by an OrHasExpressions() heuristic. Expression branches like [(identity ?target) ?related] triggered fallback mode (first-match-wins) when union was needed, silently dropping results.

Fix: (or ...) always means correlated union (Datomic semantics). New (or-default ...) / (or-default-join ...) clauses carry fallback semantics explicitly. The OrHasExpressions() heuristic is deleted.

New algebra IR node: LateralUnion — represents correlated per-tuple branch evaluation, distinct from independent Union. Produced when or-default is compiled, or when (or ...) branches contain correlated predicates (NOT, missing?) that require outer context for anti-joins.

Types:
- Add OrDefaultClause, OrDefaultJoinClause in query/clause.go
- Add LateralUnion IR node in algebra/types.go
- Delete BranchHasExpressions(), OrHasExpressions()

Parser: recognize (or-default ...) and (or-default-join ...) keywords

Executor:
- OrFallbackRelation parameterized with shortCircuit bool
- nextCorrelatedUnion() streams all branches per outer tuple (no buffering)
- (or ...) routes by branchesNeedCorrelatedExecution(): expression/predicate branches get correlated union, pattern-only get uncorrelated union
- (or-default ...) always uses fallback (shortCircuit=true)

Algebra compiler:
- compileOr/compileOrJoin detect correlated predicates (NOT, missing?) via branchesRequireOuterContext() and route to LateralUnion path
- compileOrDefault/compileOrDefaultJoin always use LateralUnion
- compileOrFallbackExclusive produces LateralUnion (was Union+IsDefault)

Algebra decompiler:
- Union → OrClause/OrJoinClause (independent union)
- LateralUnion → OrDefaultClause/OrDefaultJoinClause (correlated fallback)
- LateralJoin/LeftOuterJoin with defaults → OrDefaultClause/OrDefaultJoinClause

Planner:
- OrClause always uses INTERSECTION for provides (all branches execute)
- OrDefaultClause uses UNION for provides (one branch executes)
- New extractOrDefaultClauseSymbols/extractOrDefaultJoinClauseSymbols

Query builder: OrDefault(), OrDefaultJoin() builders

Tests migrated: existing fallback tests use OrDefaultClause, EDN queries with subquery+ground patterns use (or-default ...) syntax

Docs updated: ALGEBRA.md, DATOMIC_COMPATIBILITY.md, CLAUDE.md, OR_FALLBACK_SEMANTICS.md, BUG-OR-FALLBACK-DROPS-EXPRESSION-BRANCHES.md