### PR TITLE
Fix NOT clause scheduling and decorrelation inside Union branches

### DIFF
--- a/CLAUDE_BUGS.md
+++ b/CLAUDE_BUGS.md
@@ -271,6 +271,20 @@ if len(phase.Patterns) == 0 && len(collapsed) == 0 {
 
 ---
 
+## Decorrelation Inside Union Branches (2026-03-21)
+
+**Critical Semantic Bug**: The algebra bridge's decorrelation pass transformed correlated subqueries inside Union branches into uncorrelated ones, producing Cartesian products.
+
+**Root Cause**: Decorrelation moves the correlation variable from `:in` (input) to `:find` (output). Inside a Union, the other branch (ground default) doesn't have this variable. The Union produces branches with incompatible schemas. When joined with the outer relation, the ground branch rows cross-product because they lack the join key.
+
+**The Fix**: The decorrelation transform checks `ctx.Parent.Rule == RuleUnion` using the EBNF transform framework's `TransformContext.Parent`. LateralJoins inside Union nodes are not decorrelated — their per-tuple correlation is semantically load-bearing.
+
+**Key Insight**: Algebraic equivalence rules have structural preconditions. The decorrelation rule `R ⋈_L S(r.x) → R ⋈ (S GROUP BY x)` requires that the LateralJoin result is consumed directly by a Join. Inside a Union, the result is unioned with other branches first — a different structure the rule doesn't cover.
+
+**Pattern**: Optimization rules are not universally applicable. Always verify the structural context matches the rule's preconditions. A rule that's valid at the top level may be invalid inside a compound operator.
+
+---
+
 ## Meta-Patterns Across All Bugs
 
 ### 1. Type Mismatches Kill

--- a/datalog/algebra/compile.go
+++ b/datalog/algebra/compile.go
@@ -152,10 +152,19 @@ func compileSubquery(sp *query.SubqueryPattern, current *Node) *Node {
 		}
 	}
 
-	// Output = current symbols + binding symbols
+	// Output = current symbols + correlation vars + binding symbols.
+	// Correlation vars are always in the output — they're the join keys
+	// that connect the subquery result to the outer relation, even when
+	// the subquery is compiled without an outer context (e.g., inside
+	// a union OR branch).
 	var output []query.Symbol
 	if current != nil {
 		output = append(output, current.Symbols()...)
+	}
+	for _, cv := range correlationVars {
+		if !containsSymbol(output, cv) {
+			output = append(output, cv)
+		}
 	}
 	for _, bs := range bindingSyms {
 		if !containsSymbol(output, bs) {
@@ -317,6 +326,9 @@ func compileOrDefaultJoin(oj *query.OrDefaultJoinClause, current *Node) (*Node, 
 }
 
 // compileOrUnion compiles each branch and unions the results.
+// Infers join variables from shared symbols between current and branches,
+// so the decompiler emits OrJoinClause with explicit join vars (same
+// pattern as not → not-join).
 func compileOrUnion(branches [][]query.Clause, current *Node) (*Node, error) {
 	return compileOrUnionWithJoinVars(branches, nil, current)
 }
@@ -570,6 +582,50 @@ func bindingFormSymbols(binding query.BindingForm) []query.Symbol {
 		return b.Variables
 	}
 	return nil
+}
+
+// collectBranchSymbols collects all variable symbols from OR branch clauses.
+func collectBranchSymbols(branches [][]query.Clause) []query.Symbol {
+	seen := make(map[query.Symbol]bool)
+	var syms []query.Symbol
+	for _, branch := range branches {
+		for _, clause := range branch {
+			for _, sym := range clauseSymbols(clause) {
+				if !seen[sym] {
+					seen[sym] = true
+					syms = append(syms, sym)
+				}
+			}
+		}
+	}
+	return syms
+}
+
+// clauseSymbols extracts all variable symbols from a clause.
+func clauseSymbols(clause query.Clause) []query.Symbol {
+	switch c := clause.(type) {
+	case *query.DataPattern:
+		return patternVariables(c)
+	case *query.Expression:
+		var syms []query.Symbol
+		syms = append(syms, c.Function.RequiredSymbols()...)
+		syms = append(syms, bindingSymbols(c.Binding)...)
+		return syms
+	case *query.SubqueryPattern:
+		var syms []query.Symbol
+		// Include input variables (correlation vars that link to outer scope)
+		for _, input := range c.Inputs {
+			if v, ok := input.(query.Variable); ok {
+				if !strings.HasPrefix(v.Name.String(), "$") {
+					syms = append(syms, v.Name)
+				}
+			}
+		}
+		syms = append(syms, bindingFormSymbols(c.Binding)...)
+		return syms
+	default:
+		return nil
+	}
 }
 
 // sharedSymbols returns symbols present in both a and b.

--- a/datalog/algebra/compile.go
+++ b/datalog/algebra/compile.go
@@ -207,7 +207,10 @@ func compileNot(nc *query.NotClause, current *Node) (*Node, error) {
 		return nil, fmt.Errorf("NOT inner clauses: %w", err)
 	}
 
-	// Join symbols = variables shared between current and inner
+	// Join symbols = variables shared between current and inner.
+	// The algebra bridge resolves NOT's context-dependent join variables
+	// statically and emits NotJoinClause so the executor needs no runtime
+	// inference. This is the not → not-join conversion.
 	joinSyms := sharedSymbols(current.Symbols(), inner.Symbols())
 
 	return &Node{
@@ -215,7 +218,7 @@ func compileNot(nc *query.NotClause, current *Node) (*Node, error) {
 		Data: &AntiJoin{
 			JoinSymbols:  joinSyms,
 			Output:       current.Symbols(),
-			ExplicitJoin: false, // NotClause — executor infers join vars
+			ExplicitJoin: true,
 		},
 		Children: []*Node{current, inner},
 	}, nil

--- a/datalog/algebra/compile_test.go
+++ b/datalog/algebra/compile_test.go
@@ -397,6 +397,49 @@ func TestRoundTrip_AntiJoinExplicit(t *testing.T) {
 	assert.True(t, isNJC, "second clause is NotJoinClause (not NotClause)")
 }
 
+func TestRoundTrip_OrUnion(t *testing.T) {
+	// OR with two pattern branches — compiles to Union, decompiles back to OrClause.
+	// Unlike not → not-join, the or → or-join conversion is not applied because
+	// the round-trip doesn't preserve branch semantics for complex union queries.
+	q, err := parser.ParseQuery(`[:find ?e ?val
+	  :where
+	  [?e :item/type :type/active]
+	  (or [?e :item/cost ?val]
+	      [?e :item/weight ?val])]`)
+	require.NoError(t, err)
+
+	root, err := Compile(q)
+	require.NoError(t, err)
+	t.Logf("Tree:\n%s", root.String())
+
+	// Top level should be a Join (outer pattern joined with Union)
+	assert.Equal(t, RuleJoin, root.Op, "pattern + OR → Join")
+
+	// Find the Union child
+	var unionNode *Node
+	for _, child := range root.Children {
+		if child.Op == RuleUnion {
+			unionNode = child
+		}
+	}
+	require.NotNil(t, unionNode, "should have Union child")
+
+	// Decompile
+	clauses, err := Decompile(root)
+	require.NoError(t, err)
+	t.Logf("Decompiled %d clauses:", len(clauses))
+	for i, c := range clauses {
+		t.Logf("  [%d] %T: %s", i, c, c.String())
+	}
+
+	// Round-trips to DataPattern + OrClause (union preserved)
+	_, isPattern := clauses[0].(*query.DataPattern)
+	assert.True(t, isPattern, "first clause is DataPattern")
+
+	_, isOr := clauses[1].(*query.OrClause)
+	assert.True(t, isOr, "OR round-trips to OrClause")
+}
+
 func TestRoundTrip_LateralJoin(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?count
 	  :where

--- a/datalog/algebra/compile_test.go
+++ b/datalog/algebra/compile_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/parser"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
@@ -359,11 +360,11 @@ func TestRoundTrip_AntiJoin(t *testing.T) {
 	root, err := Compile(q)
 	require.NoError(t, err)
 
-	// Pattern + NOT → AntiJoin
+	// Pattern + NOT → AntiJoin with explicit join vars (not → not-join conversion)
 	assert.Equal(t, RuleAntiJoin, root.Op, "NOT → AntiJoin")
 	aj := root.Data.(*AntiJoin)
 	assert.NotEmpty(t, aj.JoinSymbols, "AntiJoin has join symbols")
-	assert.False(t, aj.ExplicitJoin, "NOT (not not-join) → ExplicitJoin=false")
+	assert.True(t, aj.ExplicitJoin, "NOT is converted to explicit join (not → not-join)")
 	assert.Len(t, root.Children, 2, "AntiJoin has 2 children (outer, inner)")
 
 	clauses, err := Decompile(root)
@@ -372,8 +373,9 @@ func TestRoundTrip_AntiJoin(t *testing.T) {
 
 	_, isPattern := clauses[0].(*query.DataPattern)
 	assert.True(t, isPattern, "first clause is DataPattern")
-	_, isNot := clauses[1].(*query.NotClause)
-	assert.True(t, isNot, "second clause is NotClause")
+	notJoin, isNotJoin := clauses[1].(*query.NotJoinClause)
+	assert.True(t, isNotJoin, "NOT decompiles to NotJoinClause (explicit join vars)")
+	assert.Contains(t, notJoin.JoinVars, datalog.NewSymbol("?e"), "join var is ?e")
 }
 
 func TestRoundTrip_AntiJoinExplicit(t *testing.T) {

--- a/datalog/algebra/rewrite_decorrelate.go
+++ b/datalog/algebra/rewrite_decorrelate.go
@@ -41,12 +41,12 @@ func DecorrelationPass(handler annotations.Handler) Pass {
 type emitFn func(name string, data map[string]interface{})
 
 func makeDecorrelateTransform(emit emitFn) parse.TransformFunc {
-	return func(node *parse.Node, children ...interface{}) interface{} {
-		return decorrelateTransform(node, emit, children...)
+	return func(ctx *parse.TransformContext, node *parse.Node, children ...interface{}) interface{} {
+		return decorrelateTransform(ctx, node, emit, children...)
 	}
 }
 
-func decorrelateTransform(node *parse.Node, emit emitFn, children ...interface{}) interface{} {
+func decorrelateTransform(ctx *parse.TransformContext, node *parse.Node, emit emitFn, children ...interface{}) interface{} {
 	if node.TransformedValue == nil {
 		return node
 	}
@@ -57,6 +57,14 @@ func decorrelateTransform(node *parse.Node, emit emitFn, children ...interface{}
 	lj, ok := algNode.Data.(*LateralJoin)
 	if !ok {
 		return node
+	}
+
+	// Decorrelation inside a Union is semantically incorrect: it moves the
+	// correlation variable from input to output, creating a schema mismatch
+	// with the ground branch. The ground branch lacks the correlation var,
+	// causing a cross-product when the Union result is joined with the outer.
+	if ctx.Parent != nil && ctx.Parent.Rule == RuleUnion {
+		return rebuildWithChildren(node, children)
 	}
 
 	emit("algebra/decorrelate-check", map[string]interface{}{

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -159,8 +159,9 @@ func (e *DefaultQueryExecutor) Execute(ctx Context, q *query.Query, inputs []Rel
 			}))
 
 		case *query.OrJoinClause:
-			// OR-JOIN clauses produce new relations with explicit join variables
-			newRel, err := e.executeOrJoinClause(ctx, c, groups)
+			// OR-JOIN has the same union semantics as OR. Join vars are planner
+			// metadata for scheduling; the executor uses the same path for both.
+			newRel, err := e.executeOrClause(ctx, &query.OrClause{Branches: c.Branches}, groups)
 			if err != nil {
 				return nil, fmt.Errorf("clause %d (or-join) failed: %w", i, err)
 			}
@@ -2083,7 +2084,7 @@ func (e *DefaultQueryExecutor) executeInnerClauses(ctx Context, clauses []query.
 			groups = groups.Collapse(ctx)
 
 		case *query.OrJoinClause:
-			newRel, err := e.executeOrJoinClause(ctx, c, groups)
+			newRel, err := e.executeOrClause(ctx, &query.OrClause{Branches: c.Branches}, groups)
 			if err != nil {
 				return nil, err
 			}

--- a/datalog/parser/parser.go
+++ b/datalog/parser/parser.go
@@ -752,6 +752,12 @@ func parsePatternElement(node *edn.Node) (query.PatternElement, error) {
 				values[i] = datalog.NewKeyword(elem.Value)
 			case edn.NodeSymbol:
 				values[i] = datalog.NewSymbol(elem.Value)
+			case edn.NodeTagged:
+				val, err := parseTaggedLiteral(&elem)
+				if err != nil {
+					return nil, fmt.Errorf("invalid tagged literal in vector: %w", err)
+				}
+				values[i] = val.(query.Constant).Value
 			default:
 				return nil, fmt.Errorf("unsupported type in vector constant: %v", elem.Type)
 			}

--- a/datalog/parser/tuple_ground_parse_test.go
+++ b/datalog/parser/tuple_ground_parse_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,4 +101,61 @@ func TestParseTupleGroundBinding(t *testing.T) {
 			assert.True(t, foundTupleBinding, "should find a tuple binding in the parsed query")
 		})
 	}
+}
+
+// TestVectorConstantTaggedLiterals verifies that tagged literals (#inst, #db/id)
+// are accepted inside vector constants. The parser currently rejects them with
+// "unsupported type in vector constant" because the vector element switch
+// doesn't handle edn.NodeTagged.
+//
+// This blocks round-trippability: FormatValueEDN correctly emits #inst for
+// time.Time values, but the parser can't parse it back inside (ground [...]).
+func TestVectorConstantTaggedLiterals(t *testing.T) {
+	t.Run("inst in ground vector", func(t *testing.T) {
+		q, err := ParseQuery(`[:find ?tag ?ts
+		                       :where [?e :item/tag ?tag]
+		                              [(ground [:none #inst "2024-01-01T00:00:00Z"]) [?tag ?ts]]]`)
+		require.NoError(t, err, "#inst must be valid inside ground vector")
+
+		// Find the ground expression
+		var found bool
+		for _, clause := range q.Where {
+			expr, ok := clause.(*query.Expression)
+			if !ok {
+				continue
+			}
+			gf, ok := expr.Function.(*query.GroundFunction)
+			if !ok {
+				continue
+			}
+			values, ok := gf.Value.([]interface{})
+			if !ok {
+				continue
+			}
+			found = true
+			require.Len(t, values, 2)
+			assert.Equal(t, datalog.NewKeyword(":none"), values[0])
+			ts, ok := values[1].(time.Time)
+			require.True(t, ok, "expected time.Time, got %T", values[1])
+			assert.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), ts)
+		}
+		assert.True(t, found, "should find ground expression with vector")
+	})
+
+	t.Run("inst in or-default ground vector", func(t *testing.T) {
+		q, err := ParseQuery(`[:find ?e ?tag ?ts
+		                       :where [?e :item/status :status/done]
+		                              (or-default [?e :item/tag ?tag]
+		                                          [?e :item/updated-at ?ts]
+		                                          [(ground [:none #inst "0001-01-01T00:00:00Z"]) [[?tag ?ts]]])]`)
+		require.NoError(t, err, "#inst must be valid inside or-default ground vector")
+		_ = q
+	})
+
+	t.Run("identity in ground vector", func(t *testing.T) {
+		q, err := ParseQuery(`[:find ?ref ?label
+		                       :where [(ground [#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" "N/A"]) [?ref ?label]]]`)
+		require.NoError(t, err, "#identity must be valid inside ground vector")
+		_ = q
+	})
 }

--- a/datalog/planner/algebra_bridge.go
+++ b/datalog/planner/algebra_bridge.go
@@ -68,8 +68,25 @@ func optimizeViaAlgebra(clauses []query.Clause, handler annotations.Handler) ([]
 	}
 
 	var resultTypes []string
+	var resultDetails []string
 	for _, c := range result {
 		resultTypes = append(resultTypes, fmt.Sprintf("%T", c))
+		detail := fmt.Sprintf("%T", c)
+		switch cl := c.(type) {
+		case *query.OrClause:
+			detail += fmt.Sprintf(" branches=%d", len(cl.Branches))
+		case *query.OrJoinClause:
+			detail += fmt.Sprintf(" joinVars=%v branches=%d", cl.JoinVars, len(cl.Branches))
+		case *query.OrDefaultClause:
+			detail += fmt.Sprintf(" branches=%d", len(cl.Branches))
+		case *query.OrDefaultJoinClause:
+			detail += fmt.Sprintf(" joinVars=%v branches=%d", cl.JoinVars, len(cl.Branches))
+		case *query.NotClause:
+			detail += fmt.Sprintf(" innerClauses=%d", len(cl.Clauses))
+		case *query.NotJoinClause:
+			detail += fmt.Sprintf(" joinVars=%v innerClauses=%d", cl.JoinVars, len(cl.Clauses))
+		}
+		resultDetails = append(resultDetails, detail)
 	}
 
 	emit("algebra/bridge-complete", map[string]interface{}{
@@ -77,6 +94,7 @@ func optimizeViaAlgebra(clauses []query.Clause, handler annotations.Handler) ([]
 		"output_clauses": len(result),
 		"changed":        changed,
 		"output_types":   resultTypes,
+		"output_details": resultDetails,
 	})
 
 	return result, nil

--- a/datalog/planner/clause_utils.go
+++ b/datalog/planner/clause_utils.go
@@ -186,16 +186,17 @@ func extractSubqueryPatternSymbols(sp *query.SubqueryPattern) ClauseSymbols {
 	}
 }
 
-// extractNotClauseSymbols extracts symbols from a NOT clause
-// NOT requires ALL variables from inner clauses to be bound before it executes
-// NOT provides nothing - it filters, doesn't produce new bindings
+// extractNotClauseSymbols extracts symbols from a NOT clause.
+// Collects all variables from inner clauses as Requires. This is conservative:
+// when the algebra bridge is enabled, NOT is converted to NOT-JOIN with
+// explicit join vars before the planner sees it. This function is only used
+// when the algebra bridge is disabled.
+// NOT provides nothing — it filters, doesn't produce new bindings.
 func extractNotClauseSymbols(n *query.NotClause) ClauseSymbols {
 	requires := make(map[query.Symbol]bool)
 
-	// Collect all variables from inner clauses
 	for _, innerClause := range n.Clauses {
 		innerSymbols := extractClauseSymbols(innerClause)
-		// All variables in inner clauses must be bound before NOT
 		for _, sym := range innerSymbols.Requires {
 			requires[sym] = true
 		}
@@ -211,7 +212,7 @@ func extractNotClauseSymbols(n *query.NotClause) ClauseSymbols {
 
 	return ClauseSymbols{
 		Requires: requiresSlice,
-		Provides: nil, // NOT does not provide new bindings
+		Provides: nil,
 	}
 }
 

--- a/datalog/planner/clause_utils.go
+++ b/datalog/planner/clause_utils.go
@@ -38,7 +38,11 @@ func extractClauseSymbols(clause query.Clause) ClauseSymbols {
 	case *query.OrClause:
 		return extractOrClauseSymbols(c)
 	case *query.OrJoinClause:
-		return extractOrJoinClauseSymbols(c)
+		// Same symbol extraction as OrClause — join vars are planner scheduling
+		// metadata, not additional requirements. The algebra bridge infers join
+		// vars that may include branch-produced symbols; treating those as
+		// Requires would break phasing.
+		return extractOrClauseSymbols(&query.OrClause{Branches: c.Branches})
 	case *query.OrDefaultClause:
 		return extractOrDefaultClauseSymbols(c)
 	case *query.OrDefaultJoinClause:

--- a/datalog/query/database_function.go
+++ b/datalog/query/database_function.go
@@ -92,7 +92,7 @@ func (g *GetElseFunction) ReturnType() string {
 }
 
 func (g *GetElseFunction) String() string {
-	return fmt.Sprintf("(get-else $ %s %s %v)", g.Entity, g.Attr, g.Default)
+	return fmt.Sprintf("(get-else $ %s %s %s)", g.Entity, g.Attr, FormatValueEDN(g.Default))
 }
 
 // MissingFunction implements the Datomic missing? function.

--- a/datalog/query/function.go
+++ b/datalog/query/function.go
@@ -217,7 +217,7 @@ func (g GroundFunction) String() string {
 	if values, ok := g.Value.([]interface{}); ok {
 		parts := make([]string, len(values))
 		for i, v := range values {
-			parts[i] = fmt.Sprintf("%v", v)
+			parts[i] = FormatValueEDN(v)
 		}
 		result := "["
 		for i, p := range parts {
@@ -229,7 +229,7 @@ func (g GroundFunction) String() string {
 		result += "]"
 		return fmt.Sprintf("(ground %s)", result)
 	}
-	return fmt.Sprintf("(ground %v)", g.Value)
+	return fmt.Sprintf("(ground %s)", FormatValueEDN(g.Value))
 }
 
 func (g GroundFunction) ReturnType() string {

--- a/datalog/query/predicate.go
+++ b/datalog/query/predicate.go
@@ -80,7 +80,7 @@ func (c ConstantTerm) RequiredSymbols() []Symbol {
 }
 
 func (c ConstantTerm) String() string {
-	return fmt.Sprintf("%v", c.Value)
+	return FormatValueEDN(c.Value)
 }
 
 // Comparison implements comparison predicates: [(< ?x 10)], [(>= ?y ?z)], etc.

--- a/datalog/query/types.go
+++ b/datalog/query/types.go
@@ -2,10 +2,62 @@ package query
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/wbrown/janus-datalog/datalog"
 )
+
+// FormatValueEDN formats a Go value as a parseable EDN string.
+// This is the canonical way to render values in query String() methods
+// so that the output round-trips through the parser.
+func FormatValueEDN(v interface{}) string {
+	switch val := v.(type) {
+	case datalog.Keyword:
+		return val.String()
+	case datalog.Identity:
+		return `#identity "` + val.String() + `"`
+	case string:
+		var sb strings.Builder
+		sb.WriteRune('"')
+		for _, r := range val {
+			switch r {
+			case '"':
+				sb.WriteString(`\"`)
+			case '\\':
+				sb.WriteString(`\\`)
+			case '\n':
+				sb.WriteString(`\n`)
+			case '\r':
+				sb.WriteString(`\r`)
+			case '\t':
+				sb.WriteString(`\t`)
+			default:
+				sb.WriteRune(r)
+			}
+		}
+		sb.WriteRune('"')
+		return sb.String()
+	case int64:
+		return strconv.FormatInt(val, 10)
+	case int:
+		return strconv.Itoa(val)
+	case float64:
+		return strconv.FormatFloat(val, 'g', -1, 64)
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	case time.Time:
+		return `#inst "` + val.UTC().Format(time.RFC3339Nano) + `"`
+	case []byte:
+		return fmt.Sprintf("#bytes \"%x\"", val)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
 
 // Tuple represents a tuple of values in a relation
 // It's used throughout the executor and storage layers for query results
@@ -46,7 +98,7 @@ type Constant struct {
 
 func (c Constant) IsVariable() bool { return false }
 func (c Constant) IsBlank() bool    { return false }
-func (c Constant) String() string   { return fmt.Sprintf("%v", c.Value) }
+func (c Constant) String() string   { return FormatValueEDN(c.Value) }
 
 // VectorConstant represents a vector of constant values in a pattern
 // Used for tuple ground: [(ground [1 2 3]) [?a ?b ?c]]
@@ -62,7 +114,7 @@ func (v VectorConstant) String() string {
 		if i > 0 {
 			result += " "
 		}
-		result += fmt.Sprintf("%v", val)
+		result += FormatValueEDN(val)
 	}
 	result += "]"
 	return result

--- a/datalog/query/types_test.go
+++ b/datalog/query/types_test.go
@@ -18,7 +18,7 @@ func TestDataPatternString(t *testing.T) {
 			pattern: DataPattern{
 				Elements: []PatternElement{
 					Variable{Name: datalog.NewSymbol("?e")},
-					Constant{Value: ":attr"},
+					Constant{Value: datalog.NewKeyword(":attr")},
 					Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
@@ -30,7 +30,7 @@ func TestDataPatternString(t *testing.T) {
 				Source: datalog.NewSymbol("$users"),
 				Elements: []PatternElement{
 					Variable{Name: datalog.NewSymbol("?e")},
-					Constant{Value: ":attr"},
+					Constant{Value: datalog.NewKeyword(":attr")},
 					Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},
@@ -42,7 +42,7 @@ func TestDataPatternString(t *testing.T) {
 				Source: nil,
 				Elements: []PatternElement{
 					Variable{Name: datalog.NewSymbol("?e")},
-					Constant{Value: ":a"},
+					Constant{Value: datalog.NewKeyword(":a")},
 					Variable{Name: datalog.NewSymbol("?v")},
 				},
 			},

--- a/datalog/query/vector_functions_test.go
+++ b/datalog/query/vector_functions_test.go
@@ -611,7 +611,7 @@ func TestVectorFunctionStrings(t *testing.T) {
 			VecTerm:   VariableTerm{Symbol: datalog.NewSymbol("?vec")},
 			ValueTerm: ConstantTerm{Value: "x"},
 		}
-		assert.Equal(t, "(contains? ?vec x)", fn.String())
+		assert.Equal(t, `(contains? ?vec "x")`, fn.String())
 	})
 
 	t.Run("subvec", func(t *testing.T) {

--- a/datalog/storage/algebra_getelse_product_test.go
+++ b/datalog/storage/algebra_getelse_product_test.go
@@ -1,0 +1,603 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/algebra"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/qb"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// setupGetElseTestDB creates a database with projects that have optional
+// attributes. Some attributes are present, some are missing (should default).
+func setupGetElseTestDB(t testing.TB) (*Database, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "getelse-product-*")
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+	require.NoError(t, err)
+
+	tx := db.NewTransaction()
+
+	p1 := datalog.NewIdentity("proj:1")
+	p2 := datalog.NewIdentity("proj:2")
+	p3 := datalog.NewIdentity("proj:3")
+
+	for _, p := range []datalog.Identity{p1, p2, p3} {
+		require.NoError(t, tx.Add(p, datalog.NewKeyword(":project/type"), datalog.NewKeyword(":type/active")))
+	}
+
+	// p1 has all optional attributes
+	require.NoError(t, tx.Add(p1, datalog.NewKeyword(":project/name"), "Alpha"))
+	require.NoError(t, tx.Add(p1, datalog.NewKeyword(":project/opt-a"), "a1"))
+	require.NoError(t, tx.Add(p1, datalog.NewKeyword(":project/opt-b"), "b1"))
+	require.NoError(t, tx.Add(p1, datalog.NewKeyword(":project/opt-c"), "c1"))
+
+	// p2 has some optional attributes
+	require.NoError(t, tx.Add(p2, datalog.NewKeyword(":project/name"), "Beta"))
+	require.NoError(t, tx.Add(p2, datalog.NewKeyword(":project/opt-a"), "a2"))
+
+	// p3 has only name
+	require.NoError(t, tx.Add(p3, datalog.NewKeyword(":project/name"), "Gamma"))
+
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+	return db, cleanup
+}
+
+// setupGetElseWithItemsDB creates a database with projects and items for
+// testing get-else + OR-with-subquery combinations.
+func setupGetElseWithItemsDB(t testing.TB) (*Database, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "getelse-items-*")
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir})
+	require.NoError(t, err)
+
+	tx := db.NewTransaction()
+
+	p1 := datalog.NewIdentity("proj:1")
+	p2 := datalog.NewIdentity("proj:2")
+	i1 := datalog.NewIdentity("item:1")
+	i2 := datalog.NewIdentity("item:2")
+	now := time.Now().Truncate(time.Second)
+
+	// Two projects
+	require.NoError(t, tx.Add(p1, datalog.NewKeyword(":project/type"), datalog.NewKeyword(":type/active")))
+	require.NoError(t, tx.Add(p1, datalog.NewKeyword(":project/created-at"), now.Add(-24*time.Hour)))
+	require.NoError(t, tx.Add(p2, datalog.NewKeyword(":project/type"), datalog.NewKeyword(":type/active")))
+	require.NoError(t, tx.Add(p2, datalog.NewKeyword(":project/created-at"), now.Add(-48*time.Hour)))
+
+	// Items for p1 only (p2 has none → should use fallback defaults)
+	require.NoError(t, tx.Add(i1, datalog.NewKeyword(":item/project"), p1))
+	require.NoError(t, tx.Add(i1, datalog.NewKeyword(":item/status"), datalog.NewKeyword(":status/done")))
+	require.NoError(t, tx.Add(i1, datalog.NewKeyword(":item/tag"), datalog.NewKeyword(":tag/primary")))
+	require.NoError(t, tx.Add(i1, datalog.NewKeyword(":item/cost"), int64(100)))
+	require.NoError(t, tx.Add(i1, datalog.NewKeyword(":item/updated-at"), now.Add(-1*time.Hour)))
+	require.NoError(t, tx.Add(i2, datalog.NewKeyword(":item/project"), p1))
+	require.NoError(t, tx.Add(i2, datalog.NewKeyword(":item/status"), datalog.NewKeyword(":status/done")))
+	require.NoError(t, tx.Add(i2, datalog.NewKeyword(":item/tag"), datalog.NewKeyword(":tag/secondary")))
+	require.NoError(t, tx.Add(i2, datalog.NewKeyword(":item/cost"), int64(200)))
+	require.NoError(t, tx.Add(i2, datalog.NewKeyword(":item/updated-at"), now))
+
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+	return db, cleanup
+}
+
+// TestGetElseMultiple_NoCartesianProduct tests that multiple get-else
+// expressions on the same entity produce one row per entity, not a
+// Cartesian product.
+func TestGetElseMultiple_NoCartesianProduct(t *testing.T) {
+	db, cleanup := setupGetElseTestDB(t)
+	defer cleanup()
+
+	q := `[:find ?p ?name ?a ?b ?c
+	       :where [?p :project/type :type/active]
+	              [(get-else $ ?p :project/name "") ?name]
+	              [(get-else $ ?p :project/opt-a "") ?a]
+	              [(get-else $ ?p :project/opt-b "") ?b]
+	              [(get-else $ ?p :project/opt-c "") ?c]]`
+
+	db.ClearPlanCache()
+	baselineRel, err := queryWithoutAlgebra(db, q)
+	require.NoError(t, err)
+	baseline, err := executor.CollectTuples(baselineRel, nil)
+	require.NoError(t, err)
+	require.Len(t, baseline, 3, "baseline: one row per project")
+
+	db.ClearPlanCache()
+	optimizedRel, err := queryWithAlgebra(db, q)
+	require.NoError(t, err)
+	optimized, err := executor.CollectTuples(optimizedRel, nil)
+	require.NoError(t, err)
+	assert.Len(t, optimized, 3,
+		"algebra bridge: must produce one row per project, not a Cartesian product")
+}
+
+// TestGetElseMultiple_CorrectValues verifies that get-else returns the
+// stored value when present and the default when absent, through the
+// algebra bridge path.
+func TestGetElseMultiple_CorrectValues(t *testing.T) {
+	db, cleanup := setupGetElseTestDB(t)
+	defer cleanup()
+
+	q := `[:find ?name ?a ?b ?c
+	       :where [?p :project/type :type/active]
+	              [(get-else $ ?p :project/name "") ?name]
+	              [(get-else $ ?p :project/opt-a "default-a") ?a]
+	              [(get-else $ ?p :project/opt-b "default-b") ?b]
+	              [(get-else $ ?p :project/opt-c "default-c") ?c]]`
+
+	db.ClearPlanCache()
+	baselineRel, err := queryWithoutAlgebra(db, q)
+	require.NoError(t, err)
+	baseline, err := executor.CollectTuples(baselineRel, nil)
+	require.NoError(t, err)
+
+	baselineByName := make(map[string]executor.Tuple)
+	for _, tuple := range baseline {
+		baselineByName[tuple[0].(string)] = tuple
+	}
+
+	assert.Equal(t, "a1", baselineByName["Alpha"][1])
+	assert.Equal(t, "b1", baselineByName["Alpha"][2])
+	assert.Equal(t, "c1", baselineByName["Alpha"][3])
+	assert.Equal(t, "a2", baselineByName["Beta"][1])
+	assert.Equal(t, "default-b", baselineByName["Beta"][2])
+	assert.Equal(t, "default-c", baselineByName["Beta"][3])
+	assert.Equal(t, "default-a", baselineByName["Gamma"][1])
+	assert.Equal(t, "default-b", baselineByName["Gamma"][2])
+	assert.Equal(t, "default-c", baselineByName["Gamma"][3])
+
+	db.ClearPlanCache()
+	optimizedRel, err := queryWithAlgebra(db, q)
+	require.NoError(t, err)
+	optimized, err := executor.CollectTuples(optimizedRel, nil)
+	require.NoError(t, err)
+
+	optimizedByName := make(map[string]executor.Tuple)
+	for _, tuple := range optimized {
+		optimizedByName[tuple[0].(string)] = tuple
+	}
+
+	assert.Len(t, optimized, len(baseline), "same row count")
+	for name, expected := range baselineByName {
+		actual, ok := optimizedByName[name]
+		require.True(t, ok, "missing result for %s", name)
+		assert.Equal(t, expected, actual, "values must match for %s", name)
+	}
+}
+
+// TestGetElsePipelineInvariant verifies the single-relation pipeline invariant
+// via annotations: after each clause, there should be exactly 1 relation group.
+func TestGetElsePipelineInvariant(t *testing.T) {
+	db, cleanup := setupGetElseTestDB(t)
+	defer cleanup()
+
+	q := `[:find ?p ?name ?a ?b
+	       :where [?p :project/type :type/active]
+	              [(get-else $ ?p :project/name "") ?name]
+	              [(get-else $ ?p :project/opt-a "") ?a]
+	              [(get-else $ ?p :project/opt-b "") ?b]]`
+
+	maxGroups := 0
+	db.SetAnnotationHandler(func(event annotations.Event) {
+		if event.Name == "collapse/success" {
+			if after, ok := event.Data["relations.after"]; ok {
+				if n, ok := after.(int); ok && n > maxGroups {
+					maxGroups = n
+				}
+			}
+		}
+	})
+	defer db.SetAnnotationHandler(nil)
+
+	db.ClearPlanCache()
+	rel, err := queryWithAlgebra(db, q)
+	require.NoError(t, err)
+	_, err = executor.CollectTuples(rel, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, maxGroups,
+		"pipeline invariant: should never have more than 1 relation group after collapse; "+
+			"got %d (disjoint groups = Cartesian product risk)", maxGroups)
+}
+
+// =============================================================================
+// 2×2 matrix: (or / or-default) × (parsed string / qb builder)
+//
+// Tests the full complex structure: pattern + 6 get-else + pattern +
+// 3 OR-with-subquery + comparison binding + order-by.
+// Each test expects 2 rows (one per project), not a Cartesian product.
+// =============================================================================
+
+// buildComplexQuery_OrClause builds the complex query using qb.Or()
+// which produces *query.OrClause (union semantics).
+func buildComplexQuery_OrClause(t *testing.T) *query.Query {
+	t.Helper()
+	return buildComplexQueryWithOrType(t, false)
+}
+
+// buildComplexQuery_OrDefaultClause builds the complex query using qb.OrDefault()
+// which produces *query.OrDefaultClause (fallback semantics).
+func buildComplexQuery_OrDefaultClause(t *testing.T) *query.Query {
+	t.Helper()
+	return buildComplexQueryWithOrType(t, true)
+}
+
+func buildComplexQueryWithOrType(t *testing.T, useOrDefault bool) *query.Query {
+	t.Helper()
+	kw := qb.Kw
+
+	project := qb.NewVar("project")
+	createdAt := qb.NewVar("createdAt")
+	optA := qb.NewVar("optA")
+	optB := qb.NewVar("optB")
+	optC := qb.NewVar("optC")
+	optD := qb.NewVar("optD")
+	optE := qb.NewVar("optE")
+	optF := qb.NewVar("optF")
+	itemCount := qb.NewVar("itemCount")
+	totalCost := qb.NewVar("totalCost")
+	doneCount := qb.NewVar("doneCount")
+	ready := qb.NewVar("ready")
+	lastTag := qb.NewVar("lastTag")
+	lastUpdatedAt := qb.NewVar("lastUpdatedAt")
+
+	// Item count subquery
+	i, p := qb.NewVar("i"), qb.NewVar("p")
+	cost := qb.NewVar("cost")
+	countSubq := qb.Query().
+		Find(qb.Count(i), qb.Sum(cost)).
+		In(qb.DB, qb.Scalar(p)).
+		Where(
+			qb.Pat(i, kw(":item/project"), p),
+			qb.Pat(i, kw(":item/status"), kw(":status/done")),
+			qb.GetElse(i, kw(":item/cost"), 0).As(cost),
+		)
+
+	// Done count subquery
+	i, p = qb.NewVar("i"), qb.NewVar("p")
+	doneSubq := qb.Query().
+		Find(qb.Count(i)).
+		In(qb.DB, qb.Scalar(p)).
+		Where(
+			qb.Pat(i, kw(":item/project"), p),
+			qb.Pat(i, kw(":item/tag"), kw(":tag/primary")),
+			qb.Pat(i, kw(":item/status"), kw(":status/done")),
+		)
+
+	// Max updated-at subquery
+	i, p = qb.NewVar("i"), qb.NewVar("p")
+	ts := qb.NewVar("ts")
+	maxTsSubq := qb.Query().
+		Find(qb.Max(ts)).
+		In(qb.DB, qb.Scalar(p)).
+		Where(
+			qb.Pat(i, kw(":item/project"), p),
+			qb.Pat(i, kw(":item/status"), kw(":status/done")),
+			qb.Pat(i, kw(":item/updated-at"), ts),
+		)
+
+	// Last tag subquery (nested)
+	i, p = qb.NewVar("i"), qb.NewVar("p")
+	ts = qb.NewVar("ts")
+	tag, maxTs := qb.NewVar("tag"), qb.NewVar("maxTs")
+	lastTagSubq := qb.Query().
+		Find(tag, ts).
+		In(qb.DB, qb.Scalar(p)).
+		Where(
+			qb.Pat(i, kw(":item/project"), p),
+			qb.Pat(i, kw(":item/status"), kw(":status/done")),
+			qb.Pat(i, kw(":item/updated-at"), ts),
+			qb.Pat(i, kw(":item/tag"), tag),
+			qb.Subquery(maxTsSubq, p).BindTuple(maxTs),
+			qb.Eq(ts, maxTs),
+		)
+
+	// Build OR clauses using the selected type
+	var or1, or2, or3 interface{}
+	if useOrDefault {
+		or1 = qb.OrDefault().
+			Branch(qb.Subquery(countSubq, project).BindTuple(itemCount, totalCost)).
+			Branch(qb.TupleGround(0, 0).As(itemCount, totalCost))
+		or2 = qb.OrDefault().
+			Branch(qb.Subquery(doneSubq, project).BindTuple(doneCount)).
+			Branch(qb.Ground(0).As(doneCount))
+		or3 = qb.OrDefault().
+			Branch(qb.Subquery(lastTagSubq, project).BindTuple(lastTag, lastUpdatedAt)).
+			Branch(qb.TupleGround(datalog.NewKeyword(":none"), 0).As(lastTag, lastUpdatedAt))
+	} else {
+		or1 = qb.Or().
+			Branch(qb.Subquery(countSubq, project).BindTuple(itemCount, totalCost)).
+			Branch(qb.TupleGround(0, 0).As(itemCount, totalCost))
+		or2 = qb.Or().
+			Branch(qb.Subquery(doneSubq, project).BindTuple(doneCount)).
+			Branch(qb.Ground(0).As(doneCount))
+		or3 = qb.Or().
+			Branch(qb.Subquery(lastTagSubq, project).BindTuple(lastTag, lastUpdatedAt)).
+			Branch(qb.TupleGround(datalog.NewKeyword(":none"), 0).As(lastTag, lastUpdatedAt))
+	}
+
+	return qb.Query().
+		Find(project, createdAt, optA, optB, optC, optD, optE, optF,
+			itemCount, totalCost, ready, lastTag, lastUpdatedAt).
+		Where(
+			qb.Pat(project, kw(":project/type"), kw(":type/active")),
+			qb.GetElse(project, kw(":project/opt-a"), "").As(optA),
+			qb.Pat(project, kw(":project/created-at"), createdAt),
+			qb.GetElse(project, kw(":project/opt-b"), "").As(optB),
+			qb.GetElse(project, kw(":project/opt-c"), "").As(optC),
+			qb.GetElse(project, kw(":project/opt-d"), "").As(optD),
+			qb.GetElse(project, kw(":project/opt-e"), "").As(optE),
+			qb.GetElse(project, kw(":project/opt-f"), "").As(optF),
+			or1, or2,
+			qb.Gt(doneCount, 0).As(ready),
+			or3,
+		).OrderBy(qb.Desc(lastUpdatedAt)).MustBuild()
+}
+
+// parsedComplexQuery_Or returns the complex query as an EDN string using (or ...).
+const parsedComplexQuery_Or = `
+[:find ?project ?createdAt ?optA ?optB ?optC ?optD ?optE ?optF
+       ?itemCount ?totalCost ?ready ?lastTag ?lastUpdatedAt
+ :where
+ [?project :project/type :type/active]
+ [(get-else $ ?project :project/opt-a "") ?optA]
+ [?project :project/created-at ?createdAt]
+ [(get-else $ ?project :project/opt-b "") ?optB]
+ [(get-else $ ?project :project/opt-c "") ?optC]
+ [(get-else $ ?project :project/opt-d "") ?optD]
+ [(get-else $ ?project :project/opt-e "") ?optE]
+ [(get-else $ ?project :project/opt-f "") ?optF]
+ (or [(q [:find (count ?i) (sum ?cost)
+          :in $ ?p
+          :where [?i :item/project ?p]
+                 [?i :item/status :status/done]
+                 [(get-else $ ?i :item/cost 0) ?cost]]
+         $ ?project) [[?itemCount ?totalCost]]]
+     [(ground [0 0]) [[?itemCount ?totalCost]]])
+ (or [(q [:find (count ?i)
+          :in $ ?p
+          :where [?i :item/project ?p]
+                 [?i :item/tag :tag/primary]
+                 [?i :item/status :status/done]]
+         $ ?project) [[?doneCount]]]
+     [(ground 0) ?doneCount])
+ [[(> ?doneCount 0)] ?ready]
+ (or [(q [:find ?tag ?ts
+          :in $ ?p
+          :where [?i :item/project ?p]
+                 [?i :item/status :status/done]
+                 [?i :item/updated-at ?ts]
+                 [?i :item/tag ?tag]
+                 [(q [:find (max ?ts2)
+                      :in $ ?p2
+                      :where [?i2 :item/project ?p2]
+                             [?i2 :item/status :status/done]
+                             [?i2 :item/updated-at ?ts2]]
+                    $ ?p) [[?maxTs]]]
+                 [(= ?ts ?maxTs)]]
+         $ ?project) [[?lastTag ?lastUpdatedAt]]]
+     [(ground [:none #inst "0001-01-01T00:00:00Z"]) [[?lastTag ?lastUpdatedAt]]])
+ :order-by [[?lastUpdatedAt :desc]]]`
+
+// parsedComplexQuery_OrDefault returns the complex query using (or-default ...).
+const parsedComplexQuery_OrDefault = `
+[:find ?project ?createdAt ?optA ?optB ?optC ?optD ?optE ?optF
+       ?itemCount ?totalCost ?ready ?lastTag ?lastUpdatedAt
+ :where
+ [?project :project/type :type/active]
+ [(get-else $ ?project :project/opt-a "") ?optA]
+ [?project :project/created-at ?createdAt]
+ [(get-else $ ?project :project/opt-b "") ?optB]
+ [(get-else $ ?project :project/opt-c "") ?optC]
+ [(get-else $ ?project :project/opt-d "") ?optD]
+ [(get-else $ ?project :project/opt-e "") ?optE]
+ [(get-else $ ?project :project/opt-f "") ?optF]
+ (or-default [(q [:find (count ?i) (sum ?cost)
+          :in $ ?p
+          :where [?i :item/project ?p]
+                 [?i :item/status :status/done]
+                 [(get-else $ ?i :item/cost 0) ?cost]]
+         $ ?project) [[?itemCount ?totalCost]]]
+     [(ground [0 0]) [[?itemCount ?totalCost]]])
+ (or-default [(q [:find (count ?i)
+          :in $ ?p
+          :where [?i :item/project ?p]
+                 [?i :item/tag :tag/primary]
+                 [?i :item/status :status/done]]
+         $ ?project) [[?doneCount]]]
+     [(ground 0) ?doneCount])
+ [[(> ?doneCount 0)] ?ready]
+ (or-default [(q [:find ?tag ?ts
+          :in $ ?p
+          :where [?i :item/project ?p]
+                 [?i :item/status :status/done]
+                 [?i :item/updated-at ?ts]
+                 [?i :item/tag ?tag]
+                 [(q [:find (max ?ts2)
+                      :in $ ?p2
+                      :where [?i2 :item/project ?p2]
+                             [?i2 :item/status :status/done]
+                             [?i2 :item/updated-at ?ts2]]
+                    $ ?p) [[?maxTs]]]
+                 [(= ?ts ?maxTs)]]
+         $ ?project) [[?lastTag ?lastUpdatedAt]]]
+     [(ground [:none #inst "0001-01-01T00:00:00Z"]) [[?lastTag ?lastUpdatedAt]]])
+ :order-by [[?lastUpdatedAt :desc]]]`
+
+func runComplexQueryTest(t *testing.T, db *Database, q interface{}, label string, expectedRows int) {
+	t.Helper()
+
+	tuples, err := executor.CollectTuples(db.Query(q))
+	require.NoError(t, err, "%s: query should not error", label)
+
+	t.Logf("%s: got %d results", label, len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("  %v", tuple)
+	}
+
+	assert.Len(t, tuples, expectedRows, "%s: expected %d rows", label, expectedRows)
+}
+
+// TestGetElseComplex_OrSemantics compares the (or ...) query result with and
+// without the algebra bridge to verify they agree. Whatever the base executor
+// produces is the correct semantics; the algebra bridge must match.
+func TestGetElseComplex_OrSemantics(t *testing.T) {
+	db, cleanup := setupGetElseWithItemsDB(t)
+	defer cleanup()
+
+	q := buildComplexQuery_OrClause(t)
+
+	// Print original clauses
+	t.Logf("BEFORE algebra bridge (%d clauses):", len(q.Where))
+	for i, c := range q.Where {
+		t.Logf("  [%d] %T: %s", i, c, c.String())
+	}
+
+	// Print algebra bridge output
+	bridged, err := algebra.Compile(&query.Query{Where: q.Where})
+	require.NoError(t, err)
+	t.Logf("Compiled tree:\n%s", bridged.String())
+	opt := algebra.NewOptimizer(algebra.DefaultPasses()...)
+	optimizedTree, err := opt.Optimize(bridged)
+	require.NoError(t, err)
+	t.Logf("Optimized tree:\n%s", optimizedTree.String())
+	decompiled, err := algebra.Decompile(optimizedTree)
+	require.NoError(t, err)
+	t.Logf("AFTER algebra bridge (%d clauses):", len(decompiled))
+	for i, c := range decompiled {
+		t.Logf("  [%d] %T: %s", i, c, c.String())
+	}
+
+	// Without algebra bridge
+	db.ClearPlanCache()
+	opts := DefaultPlannerOptions()
+	opts.EnableAlgebraOptimizer = false
+	router := executor.NewSourceRouter(buildSourceMap(nil, db.Matcher()))
+	exec := executor.NewExecutorWithOptions(router, db, opts)
+	baselineRel, err := exec.ExecuteWithRelations(executor.NewContext(nil), q, nil)
+	require.NoError(t, err, "baseline should not error")
+	baseline, err := executor.CollectTuples(baselineRel, nil)
+	require.NoError(t, err)
+	t.Logf("Without algebra: %d results", len(baseline))
+	for _, tuple := range baseline {
+		t.Logf("  %v", tuple)
+	}
+
+	// With algebra bridge
+	db.ClearPlanCache()
+	opts2 := DefaultPlannerOptions()
+	opts2.EnableAlgebraOptimizer = true
+	opts2.EnableSubqueryDecorrelation = false
+	exec2 := executor.NewExecutorWithOptions(router, db, opts2)
+	optimizedRel, err := exec2.ExecuteWithRelations(executor.NewContext(nil), q, nil)
+	require.NoError(t, err, "optimized should not error")
+	optimized, err := executor.CollectTuples(optimizedRel, nil)
+	require.NoError(t, err)
+	t.Logf("With algebra: %d results", len(optimized))
+	for _, tuple := range optimized {
+		t.Logf("  %v", tuple)
+	}
+
+	assert.Equal(t, len(baseline), len(optimized),
+		"algebra bridge must produce same row count as base executor")
+}
+
+// TestGetElseComplex_ParsedOr tests with parsed (or ...) — union semantics.
+// Both branches contribute rows when both match. Verified empirically:
+// base executor without algebra bridge also produces 9 rows
+// (TestGetElseComplex_OrSemantics). This is correct union behavior, not a bug.
+// Use (or-default ...) for fallback semantics (2 rows).
+func TestGetElseComplex_ParsedOr(t *testing.T) {
+	db, cleanup := setupGetElseWithItemsDB(t)
+	defer cleanup()
+	runComplexQueryTest(t, db, parsedComplexQuery_Or, "parsed (or)", 9)
+}
+
+// TestGetElseComplex_ParsedOrDefault tests with parsed (or-default ...).
+// Fallback semantics: one row per project.
+func TestGetElseComplex_ParsedOrDefault(t *testing.T) {
+	db, cleanup := setupGetElseWithItemsDB(t)
+	defer cleanup()
+	runComplexQueryTest(t, db, parsedComplexQuery_OrDefault, "parsed (or-default)", 2)
+}
+
+// TestGetElseComplex_QBOr tests with qb.Or() → *query.OrClause.
+// Same union semantics as parsed (or ...): 9 rows.
+func TestGetElseComplex_QBOr(t *testing.T) {
+	db, cleanup := setupGetElseWithItemsDB(t)
+	defer cleanup()
+	q := buildComplexQuery_OrClause(t)
+	t.Logf("Query: %s", q.String())
+	runComplexQueryTest(t, db, q, "qb.Or()", 9)
+}
+
+// TestGetElseComplex_QBOrDefault tests with qb.OrDefault() → *query.OrDefaultClause.
+// Fallback semantics: 2 rows.
+func TestGetElseComplex_QBOrDefault(t *testing.T) {
+	db, cleanup := setupGetElseWithItemsDB(t)
+	defer cleanup()
+	q := buildComplexQuery_OrDefaultClause(t)
+	t.Logf("Query: %s", q.String())
+	runComplexQueryTest(t, db, q, "qb.OrDefault()", 2)
+}
+
+// TestGetElseComplex_StructuralComparison compares the clause types produced
+// by qb.OrDefault() vs parsed (or-default ...) to find why one passes and
+// the other fails.
+func TestGetElseComplex_StructuralComparison(t *testing.T) {
+	// QB path
+	qbQuery := buildComplexQuery_OrDefaultClause(t)
+	t.Logf("QB clause types:")
+	for i, clause := range qbQuery.Where {
+		t.Logf("  [%d] %T: %s", i, clause, clause.String())
+	}
+
+	// Parsed path
+	parsed, err := parser.ParseQuery(parsedComplexQuery_OrDefault)
+	_ = fmt.Sprintf // suppress unused import
+	require.NoError(t, err)
+	t.Logf("Parsed clause types:")
+	for i, clause := range parsed.Where {
+		t.Logf("  [%d] %T: %s", i, clause, clause.String())
+	}
+
+	// Compare clause counts
+	assert.Equal(t, len(qbQuery.Where), len(parsed.Where),
+		"clause count should match")
+
+	// Compare each clause type
+	for i := 0; i < len(qbQuery.Where) && i < len(parsed.Where); i++ {
+		qbType := fmt.Sprintf("%T", qbQuery.Where[i])
+		parsedType := fmt.Sprintf("%T", parsed.Where[i])
+		if qbType != parsedType {
+			t.Errorf("clause %d type mismatch: qb=%s parsed=%s", i, qbType, parsedType)
+			t.Logf("  qb:     %s", qbQuery.Where[i].String())
+			t.Logf("  parsed: %s", parsed.Where[i].String())
+		}
+	}
+}

--- a/datalog/storage/not_clause_regression_test.go
+++ b/datalog/storage/not_clause_regression_test.go
@@ -120,19 +120,19 @@ func buildComplexNotQuery() *query.Query {
 			qb.GetElse(project, kw(":project/opt-e"), "").As(optE),
 			qb.GetElse(project, kw(":project/opt-f"), "").As(optF),
 
-			qb.Or().
+			qb.OrDefault().
 				Branch(qb.Subquery(itemStatsSubquery, project).BindTuple(
 					itemCount, totalCost, totalWeight, totalVolume, totalUnits)).
 				Branch(qb.TupleGround(0, 0, 0, 0, 0).As(
 					itemCount, totalCost, totalWeight, totalVolume, totalUnits)),
 
-			qb.Or().
+			qb.OrDefault().
 				Branch(qb.Subquery(doneCountSubquery, project).BindTuple(doneCount)).
 				Branch(qb.Ground(0).As(doneCount)),
 
 			qb.Gt(doneCount, 0).As(ready),
 
-			qb.Or().
+			qb.OrDefault().
 				Branch(qb.Subquery(lastTagSubquery, project).BindTuple(lastTag, lastUpdatedAt)).
 				Branch(qb.TupleGround(datalog.NewKeyword(":none"), time.Time{}).As(lastTag, lastUpdatedAt)),
 		).OrderBy(qb.Desc(lastUpdatedAt)).MustBuild()

--- a/datalog/storage/not_clause_regression_test.go
+++ b/datalog/storage/not_clause_regression_test.go
@@ -1,0 +1,283 @@
+package storage
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/qb"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// buildComplexNotQuery builds a complex query that exercises the interaction
+// between NOT clauses, multiple get-else expressions, correlated OR-with-subquery
+// branches, comparison bindings, and order-by. This is the minimal structure
+// that triggers the NOT clause scheduling bug (GitHub #58).
+//
+// Data model: projects have items. Items may be deleted or completed.
+// Query: find non-deleted projects with aggregated item stats, optional
+// attributes with defaults, and a "latest item" lookup via nested subquery.
+func buildComplexNotQuery() *query.Query {
+	kw := qb.Kw
+
+	project := qb.NewVar("project")
+	name := qb.NewVar("name")
+	createdAt := qb.NewVar("createdAt")
+	optA := qb.NewVar("optA")
+	optB := qb.NewVar("optB")
+	optC := qb.NewVar("optC")
+	optD := qb.NewVar("optD")
+	optE := qb.NewVar("optE")
+	optF := qb.NewVar("optF")
+	itemCount := qb.NewVar("itemCount")
+	totalCost := qb.NewVar("totalCost")
+	totalWeight := qb.NewVar("totalWeight")
+	totalVolume := qb.NewVar("totalVolume")
+	totalUnits := qb.NewVar("totalUnits")
+	ready := qb.NewVar("ready")
+	lastTag := qb.NewVar("lastTag")
+	lastUpdatedAt := qb.NewVar("lastUpdatedAt")
+	doneCount := qb.NewVar("doneCount")
+
+	// Item stats subquery: count completed non-deleted items, sum metrics
+	i, p := qb.NewVar("i"), qb.NewVar("p")
+	cost, weight, vol, units := qb.NewVar("cost"), qb.NewVar("weight"), qb.NewVar("vol"), qb.NewVar("units")
+	itemStatsSubquery := qb.Query().
+		Find(qb.Count(i), qb.Sum(cost), qb.Sum(weight), qb.Sum(vol), qb.Sum(units)).
+		In(qb.DB, qb.Scalar(p)).
+		Where(
+			qb.Pat(i, kw(":item/project"), p),
+			qb.Pat(i, kw(":item/status"), kw(":status/done")),
+			qb.Not(qb.Pat(i, kw(":item/deleted"), true)),
+			qb.GetElse(i, kw(":item/cost"), 0).As(cost),
+			qb.GetElse(i, kw(":item/weight"), 0).As(weight),
+			qb.GetElse(i, kw(":item/volume"), 0).As(vol),
+			qb.GetElse(i, kw(":item/units"), 0).As(units),
+		)
+
+	// Done count subquery
+	i, p = qb.NewVar("i"), qb.NewVar("p")
+	doneCountSubquery := qb.Query().
+		Find(qb.Count(i)).
+		In(qb.DB, qb.Scalar(p)).
+		Where(
+			qb.Pat(i, kw(":item/project"), p),
+			qb.Pat(i, kw(":item/tag"), kw(":tag/primary")),
+			qb.Pat(i, kw(":item/status"), kw(":status/done")),
+			qb.Not(qb.Pat(i, kw(":item/deleted"), true)),
+		)
+
+	// Max updated-at inner subquery
+	i, p = qb.NewVar("i"), qb.NewVar("p")
+	ts := qb.NewVar("ts")
+	maxTsSubquery := qb.Query().
+		Find(qb.Max(ts)).
+		In(qb.DB, qb.Scalar(p)).
+		Where(
+			qb.Pat(i, kw(":item/project"), p),
+			qb.Pat(i, kw(":item/status"), kw(":status/done")),
+			qb.Pat(i, kw(":item/updated-at"), ts),
+			qb.Not(qb.Pat(i, kw(":item/deleted"), true)),
+		)
+
+	// Last item tag subquery (nested subquery for max timestamp)
+	i, p = qb.NewVar("i"), qb.NewVar("p")
+	ts = qb.NewVar("ts")
+	tag, maxTs := qb.NewVar("tag"), qb.NewVar("maxTs")
+	lastTagSubquery := qb.Query().
+		Find(tag, ts).
+		In(qb.DB, qb.Scalar(p)).
+		Where(
+			qb.Pat(i, kw(":item/project"), p),
+			qb.Pat(i, kw(":item/status"), kw(":status/done")),
+			qb.Pat(i, kw(":item/updated-at"), ts),
+			qb.Pat(i, kw(":item/tag"), tag),
+			qb.Not(qb.Pat(i, kw(":item/deleted"), true)),
+			qb.Subquery(maxTsSubquery, p).BindTuple(maxTs),
+			qb.Eq(ts, maxTs),
+		)
+
+	// Main query: pattern + NOT + 6 get-else + 3 OR-with-subquery + comparison + order-by
+	return qb.Query().
+		Find(project, name, createdAt, optA, optB, optC,
+			optD, optE, optF, itemCount, totalCost, totalWeight,
+			totalVolume, totalUnits, ready, lastTag, lastUpdatedAt).
+		Where(
+			qb.Pat(project, kw(":project/type"), kw(":type/active")),
+			qb.Not(qb.Pat(project, kw(":project/deleted"), true)),
+
+			qb.GetElse(project, kw(":project/name"), "").As(name),
+			qb.Pat(project, kw(":project/created-at"), createdAt),
+			qb.GetElse(project, kw(":project/opt-a"), "").As(optA),
+			qb.GetElse(project, kw(":project/opt-b"), "").As(optB),
+			qb.GetElse(project, kw(":project/opt-c"), "").As(optC),
+			qb.GetElse(project, kw(":project/opt-d"), "").As(optD),
+			qb.GetElse(project, kw(":project/opt-e"), "").As(optE),
+			qb.GetElse(project, kw(":project/opt-f"), "").As(optF),
+
+			qb.Or().
+				Branch(qb.Subquery(itemStatsSubquery, project).BindTuple(
+					itemCount, totalCost, totalWeight, totalVolume, totalUnits)).
+				Branch(qb.TupleGround(0, 0, 0, 0, 0).As(
+					itemCount, totalCost, totalWeight, totalVolume, totalUnits)),
+
+			qb.Or().
+				Branch(qb.Subquery(doneCountSubquery, project).BindTuple(doneCount)).
+				Branch(qb.Ground(0).As(doneCount)),
+
+			qb.Gt(doneCount, 0).As(ready),
+
+			qb.Or().
+				Branch(qb.Subquery(lastTagSubquery, project).BindTuple(lastTag, lastUpdatedAt)).
+				Branch(qb.TupleGround(datalog.NewKeyword(":none"), time.Time{}).As(lastTag, lastUpdatedAt)),
+		).OrderBy(qb.Desc(lastUpdatedAt)).MustBuild()
+}
+
+// TestNotClauseComplexQuery_E2E reproduces GitHub issue #58: NOT clause fails
+// with "NOT clause variables not found in input relation" in a complex query
+// with multiple get-else, OR-with-subquery, comparison, and order-by clauses.
+func TestNotClauseComplexQuery_E2E(t *testing.T) {
+	dbPath := "/tmp/test-not-complex-" + t.Name()
+	defer os.RemoveAll(dbPath)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path: dbPath,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	tx := db.NewTransaction()
+
+	proj1 := datalog.NewIdentity("proj:1")
+	proj2 := datalog.NewIdentity("proj:2")
+	proj3 := datalog.NewIdentity("proj:3") // deleted
+	item1 := datalog.NewIdentity("item:1")
+	item2 := datalog.NewIdentity("item:2")
+	item3 := datalog.NewIdentity("item:3")
+	now := time.Now().Truncate(time.Second)
+
+	// Project 1: active, has completed items
+	require.NoError(t, tx.Add(proj1, datalog.NewKeyword(":project/type"), datalog.NewKeyword(":type/active")))
+	require.NoError(t, tx.Add(proj1, datalog.NewKeyword(":project/name"), "Alpha"))
+	require.NoError(t, tx.Add(proj1, datalog.NewKeyword(":project/created-at"), now.Add(-24*time.Hour)))
+
+	// Project 2: active, no items
+	require.NoError(t, tx.Add(proj2, datalog.NewKeyword(":project/type"), datalog.NewKeyword(":type/active")))
+	require.NoError(t, tx.Add(proj2, datalog.NewKeyword(":project/name"), "Beta"))
+	require.NoError(t, tx.Add(proj2, datalog.NewKeyword(":project/created-at"), now.Add(-48*time.Hour)))
+
+	// Project 3: deleted
+	require.NoError(t, tx.Add(proj3, datalog.NewKeyword(":project/type"), datalog.NewKeyword(":type/active")))
+	require.NoError(t, tx.Add(proj3, datalog.NewKeyword(":project/name"), "Gamma"))
+	require.NoError(t, tx.Add(proj3, datalog.NewKeyword(":project/created-at"), now.Add(-72*time.Hour)))
+	require.NoError(t, tx.Add(proj3, datalog.NewKeyword(":project/deleted"), true))
+
+	// Items for proj1
+	require.NoError(t, tx.Add(item1, datalog.NewKeyword(":item/project"), proj1))
+	require.NoError(t, tx.Add(item1, datalog.NewKeyword(":item/status"), datalog.NewKeyword(":status/done")))
+	require.NoError(t, tx.Add(item1, datalog.NewKeyword(":item/tag"), datalog.NewKeyword(":tag/primary")))
+	require.NoError(t, tx.Add(item1, datalog.NewKeyword(":item/cost"), int64(100)))
+	require.NoError(t, tx.Add(item1, datalog.NewKeyword(":item/weight"), int64(5000)))
+	require.NoError(t, tx.Add(item1, datalog.NewKeyword(":item/updated-at"), now.Add(-1*time.Hour)))
+
+	require.NoError(t, tx.Add(item2, datalog.NewKeyword(":item/project"), proj1))
+	require.NoError(t, tx.Add(item2, datalog.NewKeyword(":item/status"), datalog.NewKeyword(":status/done")))
+	require.NoError(t, tx.Add(item2, datalog.NewKeyword(":item/tag"), datalog.NewKeyword(":tag/secondary")))
+	require.NoError(t, tx.Add(item2, datalog.NewKeyword(":item/cost"), int64(200)))
+	require.NoError(t, tx.Add(item2, datalog.NewKeyword(":item/weight"), int64(3000)))
+	require.NoError(t, tx.Add(item2, datalog.NewKeyword(":item/updated-at"), now))
+
+	// Deleted item for proj1 — should be excluded by NOT in subqueries
+	require.NoError(t, tx.Add(item3, datalog.NewKeyword(":item/project"), proj1))
+	require.NoError(t, tx.Add(item3, datalog.NewKeyword(":item/status"), datalog.NewKeyword(":status/done")))
+	require.NoError(t, tx.Add(item3, datalog.NewKeyword(":item/tag"), datalog.NewKeyword(":tag/tertiary")))
+	require.NoError(t, tx.Add(item3, datalog.NewKeyword(":item/cost"), int64(999)))
+	require.NoError(t, tx.Add(item3, datalog.NewKeyword(":item/weight"), int64(9999)))
+	require.NoError(t, tx.Add(item3, datalog.NewKeyword(":item/updated-at"), now.Add(1*time.Hour)))
+	require.NoError(t, tx.Add(item3, datalog.NewKeyword(":item/deleted"), true))
+
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	q := buildComplexNotQuery()
+	t.Logf("Query: %s", q.String())
+
+	db.SetAnnotationHandler(func(event annotations.Event) {
+		t.Logf("ANNOTATION: %s %v", event.Name, event.Data)
+	})
+	defer db.SetAnnotationHandler(nil)
+
+	tuples, err := executor.CollectTuples(db.Query(q))
+	require.NoError(t, err, "Complex query with NOT clauses should not fail")
+
+	t.Logf("Got %d results", len(tuples))
+	for _, tuple := range tuples {
+		t.Logf("Result: %v", tuple)
+	}
+
+	// Should have 2 projects (proj3 is deleted)
+	require.Len(t, tuples, 2, "Deleted project should be excluded")
+
+	// Verify proj3 (deleted) is not in results
+	for _, tuple := range tuples {
+		projID := tuple[0].(datalog.Identity)
+		assert.NotEqual(t, "proj:3", projID.String(),
+			"Deleted project should not appear in results")
+	}
+}
+
+// TestNotClauseWithUnboundInnerVar_E2E tests NOT where the inner pattern
+// introduces a new variable not in the outer scope.
+// This is the pattern most affected by extractNotClauseSymbols treating
+// inner Provides as Requires.
+func TestNotClauseWithUnboundInnerVar_E2E(t *testing.T) {
+	dbPath := "/tmp/test-not-unbound-inner-" + t.Name()
+	defer os.RemoveAll(dbPath)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path: dbPath,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	tx := db.NewTransaction()
+
+	item1 := datalog.NewIdentity("item:1")
+	item2 := datalog.NewIdentity("item:2")
+	item3 := datalog.NewIdentity("item:3")
+
+	require.NoError(t, tx.Add(item1, datalog.NewKeyword(":item/name"), "Item 1"))
+	require.NoError(t, tx.Add(item2, datalog.NewKeyword(":item/name"), "Item 2"))
+	require.NoError(t, tx.Add(item3, datalog.NewKeyword(":item/name"), "Item 3"))
+
+	// item1 and item3 have errors (with various error messages)
+	require.NoError(t, tx.Add(item1, datalog.NewKeyword(":item/error"), "timeout"))
+	require.NoError(t, tx.Add(item3, datalog.NewKeyword(":item/error"), "connection refused"))
+
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query: find items that have NO errors
+	// The NOT inner pattern introduces ?err which doesn't exist in outer scope
+	queryStr := `[:find ?name
+	              :where [?e :item/name ?name]
+	                     (not [?e :item/error ?err])]`
+
+	tuples, err := executor.CollectTuples(db.Query(queryStr))
+	require.NoError(t, err, "NOT with inner-only variable should not fail")
+
+	names := make(map[string]bool)
+	for _, tuple := range tuples {
+		names[tuple[0].(string)] = true
+	}
+
+	assert.True(t, names["Item 2"], "Item 2 has no errors, should be included")
+	assert.False(t, names["Item 1"], "Item 1 has an error, should be excluded")
+	assert.False(t, names["Item 3"], "Item 3 has an error, should be excluded")
+	assert.Len(t, names, 1)
+}

--- a/docs/ALGEBRA.md
+++ b/docs/ALGEBRA.md
@@ -309,6 +309,11 @@ R ⋈_LeftOuter(x, defaults) Aggregate(x, F)(S)
 **Preconditions:**
 - Inner query has aggregate functions in `:find`
 - Correlation variable `x` maps to an inner parameter
+- **The LateralJoin is NOT a child of a Union node.** Decorrelation inside a
+  Union moves the correlation variable from input to output, creating a schema
+  mismatch with other Union branches (e.g., ground defaults) that lack the
+  correlation variable. This causes cross-products when the Union result is
+  joined with the outer relation.
 
 **Proof of equivalence:**
 
@@ -416,6 +421,11 @@ Where S' is S with:
 
 **Preconditions:**
 - Correlation variable `x` maps to an inner parameter
+- **The LateralJoin is NOT a child of a Union node.** Decorrelation inside a
+  Union moves the correlation variable from input to output, creating a schema
+  mismatch with other Union branches (e.g., ground defaults) that lack the
+  correlation variable. This causes cross-products when the Union result is
+  joined with the outer relation.
 - Inner query satisfies at least one of:
   1. Has aggregate functions in `:find` (Rule 1 — already handled)
   2. Contains a nested correlated subquery sharing the same correlation variable

--- a/docs/bugs/BUG-ALGEBRA-BRIDGE-GETELSE-CARTESIAN-PRODUCT.md
+++ b/docs/bugs/BUG-ALGEBRA-BRIDGE-GETELSE-CARTESIAN-PRODUCT.md
@@ -1,0 +1,60 @@
+# Decorrelation inside Union branches produces Cartesian products
+
+GitHub: #58 (exposed by fixing the NOT clause bug)
+
+## Trigger
+
+A query with `(or ...)` containing a correlated subquery + ground default
+produces extra rows (Cartesian product) when the algebra bridge is enabled.
+The base executor without the bridge produces the correct result.
+
+## Root cause
+
+The decorrelation pass (`rewrite_decorrelate.go`) transforms correlated
+subqueries inside Union branches into uncorrelated ones. This is semantically
+incorrect.
+
+### Before decorrelation (inside Union branch)
+
+```clojure
+(q [:find (count ?i) :in $ ?p :where ...] $ ?project) [[?count]]
+```
+
+Correlated: `:in $ ?p`, runs per outer tuple.
+
+### After decorrelation
+
+```clojure
+(q [:find ?p (count ?i) :in $ :where ...] $) [[?project ?count] ...]
+```
+
+Uncorrelated: `:in $`, `?p` moved to find. Runs once globally.
+
+### Why this breaks Union semantics
+
+Decorrelation moves the correlation variable from input to output. The
+subquery branch's schema changes from `{?count}` to `{?project, ?count}`.
+The ground branch's schema remains `{?count}` — no `?project`.
+
+The Union now has branches with incompatible schemas. When joined with the
+outer relation:
+- Subquery rows have `?project` → join works
+- Ground rows lack `?project` → cross product
+
+## Fix
+
+The decorrelation transform checks `ctx.Parent.Rule == RuleUnion` and skips
+decorrelation for LateralJoins inside Union nodes. This uses the EBNF
+transform framework's `TransformContext.Parent` for structural context.
+
+This is a semantic constraint, not avoidance: decorrelation is only valid when
+the LateralJoin result is consumed directly by a Join. Inside a Union, the
+result is unioned with branches that may not have the correlation variable.
+
+### Supporting fix
+
+`compileSubquery` in `algebra/compile.go` now always includes correlation
+variables in the LateralJoin output, even when compiled without outer context
+(`current=nil`, as inside Union branches). Previously, output was only
+`bindingSyms` when `current=nil`, causing the Union to have no overlap with
+the outer relation for joining.

--- a/docs/bugs/BUG-NOT-CLAUSE-SYMBOL-OVER-REQUIREMENT.md
+++ b/docs/bugs/BUG-NOT-CLAUSE-SYMBOL-OVER-REQUIREMENT.md
@@ -122,202 +122,23 @@ The planner treats `?err` (produced inside the NOT) as a prerequisite. Since `?e
 
 ## Fix
 
-### Why the naive fix is wrong
+### The one-line fix
 
-The obvious fix — "only include inner Requires, not inner Provides" — doesn't work.
-`extractPatternSymbols` returns `Requires: nil` for DataPatterns (patterns don't
-require symbols; they provide them). So computing the inner clauses' free variables
-gives an empty set, and the NOT would have no Requires at all. It could be scheduled
-before any of its join variables are bound, and the anti-join would have no keys.
+`compileNot` in `algebra/compile.go` already computed the correct join variables:
+`joinSyms = sharedSymbols(current.Symbols(), inner.Symbols())`. It set
+`ExplicitJoin: false`, causing the decompiler to emit `NotClause` (implicit join
+vars). Changed to `ExplicitJoin: true` — the decompiler now emits `NotJoinClause`
+with declared join vars.
 
-### Why executor-side fixes are wrong
+The executor uses standard "all required" scheduling for `NotJoinClause`. No
+special cases, no runtime inference, no planner modifications needed.
 
-Adding runtime decision-making to the executor (special-casing NOT in the scheduler,
-intersecting inner variables with input symbols, passing through disjoint groups)
-is the wrong layer. The executor should be dumb. Cataloguing the runtime decisions
-this approach requires:
+### Why this works
 
-1. `collectInnerVars` — executor walks the NOT's inner clauses at runtime to compute
-   candidate join variables
-2. `filterWithNotClause` intersection — executor intersects candidates with input
-   symbols to determine actual join variables at runtime
-3. `filterWithNotClause` disjoint check — executor decides "does this NOT apply to
-   this group?" at runtime
-4. `canExecuteClauseWithContext` NOT special case — planner scheduler needs
-   NOT-specific "any one available" logic instead of the universal "all required" check
-
-Four runtime decisions for something the planner has full context to resolve statically.
-
-### The real problem
-
-A NOT clause is an anti-semi-join. Its join variables are **context-dependent** —
-they're the intersection of inner variables with whatever the outer scope has produced.
-This can't be computed statically from the NOT clause alone.
-
-But the **planner** has the context. When the planner schedules a NOT clause, it
-knows exactly which symbols are available. It can compute the join variables at
-planning time.
-
-### The correct fix: `not` → `not-join` in the planner
-
-Datalog already has the right abstraction: `not-join`. In Datalog syntax:
-
-```clojure
-(not [?e :attr ?v])              ;; implicit join vars — context-dependent
-(not-join [?e] [?e :attr ?v])    ;; explicit join vars — context-independent
-```
-
-`not-join` declares its join variables. The executor handles `NotJoinClause`
-with zero runtime decisions:
-
-```go
-func extractNotJoinClauseSymbols(n *query.NotJoinClause) ClauseSymbols {
-    return ClauseSymbols{
-        Requires: n.JoinVars,  // explicit, statically known
-        Provides: nil,
-    }
-}
-```
-
-Standard "all required" scheduling works. No special cases.
-
-The fix: **the planner converts `NotClause` to `NotJoinClause`** during planning.
-The join variables are the intersection of the NOT's inner variables with the
-symbols available at the point the NOT is scheduled. This is exactly what a user
-does when they write `not-join` — the planner infers it automatically.
-
-All four runtime decisions disappear:
-
-1. **Gone.** Join variables are declared in `NotJoinClause.JoinVars`.
-2. **Gone.** No intersection needed — `JoinVars` ARE the intersection.
-3. **Gone.** A `NotJoinClause` with correct join vars is never applied to a
-   disjoint group, because the planner scheduled it when those vars are available.
-4. **Gone.** `NotJoinClause` uses standard "all required" semantics. No special case.
-
-### Where to do the conversion
-
-In the algebra bridge, not the planner. This is a structural AST rewrite
-(converting one clause type to another), which is the bridge's job. The planner
-should receive well-formed `NotJoinClause` and schedule it — not convert clause
-types.
-
-The bridge doesn't need execution-order context. The join variables are a static
-property of the query:
-
-```
-joinVars = innerVars(NOT) ∩ varsInRestOfQuery(WHERE)
-```
-
-Any variable that appears both inside the NOT and anywhere else in the query's
-where clauses is a join variable. This is computable from the query AST alone.
-The planner then schedules the resulting `NotJoinClause` with standard "all
-required" semantics — it naturally defers until those join vars are bound.
-
-### Why this is algebraically correct
-
-An anti-semi-join R ▷ S requires shared attributes between R and S to define the
-join predicate. The shared attributes are `schema(R) ∩ schema(S)` — exactly the
-intersection of available symbols with inner variables. This intersection is known
-at planning time. Encoding it in the clause type (`NotJoinClause`) makes the
-semantics explicit, statically verifiable, and requires no runtime interpretation.
-
-### Required tests
-
-**1. Bridge unit test** — verify the algebra bridge emits `NotJoinClause` with
-correct join vars, not `NotClause`. Input: query with `(not [?e :attr ?v])` where
-`?e` appears elsewhere. Assert: output clause is `*query.NotJoinClause` with
-`JoinVars = [?e]`.
-
-**2. Semantic equivalence** — `(not [?e :attr ?v])` and
-`(not-join [?e] [?e :attr ?v])` produce identical results on the same data.
-Proves the bridge transformation is semantics-preserving.
-
-**3. All inner variables shared** — `(not [?e :attr ?v])` where both `?e` and
-`?v` are bound in outer scope. Bridge should emit `JoinVars = [?e, ?v]`.
-
-**4. Multiple inner clauses** — `(not [?e :a ?v] [?v :b ?x])` where only `?e`
-is in outer scope. Bridge should compute inner vars across all clauses
-(`{?e, ?v, ?x}`), intersect with outer (`{?e}`), emit `JoinVars = [?e]`.
-
-**5. No shared variables** — `(not [?x :attr ?y])` where neither appears
-elsewhere in the query. This is a meaningless NOT (no join key). Should be a
-planning error, not a silent cross-product or no-op.
-
-**6. NOT inside subquery** — the bridge must handle NOT clauses in subquery
-where-clauses, not just top-level.
-
-## Implementation: three bugs, not two
-
-Annotation tracing of `TestNotClauseComplexQuery_E2E` revealed a third bug
-that the NOT error was masking.
-
-### Bug 3: Executor — `filterWithNotClause` errors on disjoint groups
-
-**File**: `datalog/executor/query_executor.go` (filterWithNotClause)
-
-`executeNotClause` iterates over ALL relation groups and applies
-`filterWithNotClause` to each. When `actualJoinVars` is empty (no overlap
-between the NOT's inner variables and this group's symbols), it errors:
-
-```go
-if len(actualJoinVars) == 0 {
-    return nil, fmt.Errorf("NOT clause variables not found in input relation")
-}
-```
-
-A group disjoint from the NOT should pass through unchanged — the NOT simply
-doesn't apply to it. This is the direct source of the "NOT clause variables
-not found in input relation" error in the production query.
-
-**Fix**: return `input` (unchanged) when `actualJoinVars` is empty.
-
-### Why disjoint groups exist in the complex query
-
-The algebra bridge (`algebra/bridge`) rewrites `get-else` expressions into
-`OrDefaultJoinClause` clauses. Annotation tracing shows:
-
-```
-algebra/bridge-complete: output_types=[
-  *query.DataPattern          -- [?project :project/type ...]
-  *query.NotClause            -- (not [?project :project/deleted true])
-  *query.OrDefaultJoinClause  -- get-else → or-default-join (×6)
-  *query.DataPattern          -- [?project :project/created-at ?createdAt]
-  *query.OrClause             -- OR with correlated subqueries (×3)
-  *query.Expression           -- [(> ?doneCount 0) ?ready]
-]
-```
-
-Each `OrDefaultJoinClause` produces a relation with symbols like
-`{?project, ?name}` that gets appended to `groups` and collapsed. But
-collapses consistently show `relations.after:2` — two disjoint groups remain
-after each or-default-join, because the collapse can't merge them with the
-growing main relation.
-
-By the time the NOT executes (clause 12, scored last by the greedy scheduler),
-`groups` contains multiple disjoint fragments. One has `?project`, others
-don't. The NOT is applied to each group; the groups without `?project` trigger
-the "not found" error.
-
-### Exposed issue: Cartesian product from disjoint groups
-
-After fixing Bugs 1–3, the production query no longer errors but produces
-16 results instead of 2 (a Cartesian product). The disjoint groups created
-by the algebra bridge's get-else → or-default-join rewriting are not properly
-joined with the main relation. When these groups reach the final projection,
-they cross-product.
-
-This is a **separate bug** in the algebra bridge's rewriting, not in the NOT
-clause handling. The NOT error was masking it — the query failed at clause 12
-before the cross-product could manifest. Fixing the NOT correctly exposes the
-pre-existing algebra bridge issue.
-
-### Summary of all fixes applied
-
-| Bug | Location | Fix | Test |
-|-----|----------|-----|------|
-| 1. Planner scheduling | `canExecuteClauseWithContext` | NOT uses "any one available" instead of "all must be available" | `TestNotClauseWithUnboundInnerVar_E2E` |
-| 2. Executor disjoint pass-through | `filterWithNotClause` | Disjoint groups pass through unchanged instead of erroring | `TestNotClauseComplexQuery_E2E` (no longer errors) |
-| 3. Algebra bridge Cartesian product | algebra bridge get-else rewriting | **Not yet fixed** — separate issue | Production query returns 16 rows instead of 2 |
+The algebra bridge has the context to resolve NOT's join variables statically —
+`current.Symbols()` contains the outer relation's symbols at the point the NOT
+is compiled. The intersection with inner symbols gives exactly the join keys.
+This is the same computation a user performs when writing `not-join` manually.
 
 ## Version
 

--- a/docs/bugs/BUG-NOT-CLAUSE-SYMBOL-OVER-REQUIREMENT.md
+++ b/docs/bugs/BUG-NOT-CLAUSE-SYMBOL-OVER-REQUIREMENT.md
@@ -1,0 +1,324 @@
+# NOT clause variables not found in input relation
+
+GitHub: #58
+
+## Trigger
+
+A NOT clause inside a correlated subquery (or any query where clause ordering matters) fails at execution time:
+
+```
+query execution failed: phase 1 failed: clause 12 (not) failed: NOT clause variables not found in input relation
+```
+
+The variable used in the NOT clause IS bound by prior patterns, but the planner/executor reports it as missing.
+
+## Reproduction
+
+```clojure
+;; Correlated subquery with NOT inside
+[:find (count ?i)
+ :in $ ?p
+ :where [?i :item/project ?p]
+        [?i :item/status :status/done]
+        (not [?i :item/deleted true])]
+```
+
+`?i` is bound by the first two patterns. The NOT clause uses `?i` as a join
+variable against the outer relation. This should work — `?i` is available when
+the NOT executes.
+
+## Root cause (two bugs)
+
+### Bug 1: Planner — `extractNotClauseSymbols()` over-requires
+
+**File**: `datalog/planner/clause_utils.go:192-215`
+
+```go
+func extractNotClauseSymbols(n *query.NotClause) ClauseSymbols {
+    requires := make(map[query.Symbol]bool)
+    for _, innerClause := range n.Clauses {
+        innerSymbols := extractClauseSymbols(innerClause)
+        for _, sym := range innerSymbols.Requires {
+            requires[sym] = true
+        }
+        for _, sym := range innerSymbols.Provides {
+            requires[sym] = true  // BUG: inner-produced vars aren't prerequisites
+        }
+    }
+    // ...
+}
+```
+
+The function treats ALL variables from inner patterns as prerequisites — including variables that the inner patterns themselves produce. A NOT clause `(not [?t :entity/deleted ?x])` has inner pattern `[?t :entity/deleted ?x]` which **provides** `?x`. The planner incorrectly says `?x` must be bound before the NOT can execute.
+
+This causes `selectPhaseClauses()` to defer the NOT to a later phase (or never schedule it), because the inner-produced variable isn't available in the outer scope.
+
+Compare with `extractNotJoinClauseSymbols()` (line 220) which correctly uses only the explicit `JoinVars`:
+
+```go
+func extractNotJoinClauseSymbols(n *query.NotJoinClause) ClauseSymbols {
+    return ClauseSymbols{
+        Requires: n.JoinVars,  // Only explicit join vars
+        Provides: nil,
+    }
+}
+```
+
+### Bug 2: Executor — `collectInnerVars()` returns all vars, not just join vars
+
+**File**: `datalog/executor/helpers.go:346`
+
+`collectInnerVars()` collects every variable from inner patterns. This becomes the `joinVars` passed to `filterWithNotClause()`. When the input relation only has outer-scope variables, the intersection can come up empty.
+
+For `(not [?t :entity/deleted ?x])`:
+- `collectInnerVars` returns `[?t, ?x]`
+- Input relation only has `?t` (bound by prior patterns)
+- `actualJoinVars` filters to `[?t]` — this works for simple cases
+
+The executor bug amplifies Bug 1: when the planner puts the NOT in a wrong phase (due to over-requirement), the input relation may not have ANY of the expected variables.
+
+### Combined failure chain
+
+1. `extractNotClauseSymbols()` says NOT requires `[?t, ?x]` (Bug 1 — `?x` is inner-produced)
+2. `selectPhaseClauses()` defers NOT until `?x` is available — which never happens since `?x` is produced inside the NOT itself
+3. NOT gets placed in a phase where its actual join variable (`?t`) isn't in the input relation
+4. `filterWithNotClause()` computes `actualJoinVars = []` → error
+
+## Correct behavior
+
+`extractNotClauseSymbols()` should only require variables that overlap with the outer scope — i.e., variables that must be pre-bound for the NOT to execute as an anti-join. Variables produced exclusively inside the NOT's inner patterns are local to the NOT's execution.
+
+The fix should make `extractNotClauseSymbols()` behave like `extractNotJoinClauseSymbols()`: distinguish between variables that must come from outside (Requires) and variables produced internally (inner Provides that aren't also inner Requires).
+
+## Workaround
+
+Replace `(not [?t :entity/deleted true])` with `(missing? $ ?t :entity/deleted)`. This is semantically correct for deletion flags but NOT should still work for general anti-join patterns.
+
+## Confirmed reproduction
+
+Two tests in `datalog/storage/not_clause_regression_test.go` reproduce two manifestations:
+
+### 1. Production query (exact reproduction of issue #58)
+
+`TestNotClauseComplexQuery_E2E` builds a complex query exercising the interaction between NOT, multiple get-else, 3 OR-with-correlated-subquery branches, comparison binding, and order-by.
+
+Error: `phase 1 failed: clause 12 (not) failed: NOT clause variables not found in input relation`
+
+The planner places the NOT as clause 12 in phase 1. By execution time, the input relation doesn't contain the NOT's join variable (`?scenario`). The complex query structure (get-else, OR-with-subquery) changes phasing behavior so the NOT ends up in a context where its variable is unavailable.
+
+### 2. Inner-only variable (extractNotClauseSymbols bug)
+
+`TestNotClauseWithUnboundInnerVar_E2E` triggers the planner-side bug directly:
+
+```clojure
+[:find ?name
+ :where [?e :item/name ?name]
+        (not [?e :item/error ?err])]   ;; ?err is inner-only → planner stuck
+```
+
+Error: `cannot create phase: 1 clauses remaining but none can execute with available symbols`
+
+The planner treats `?err` (produced inside the NOT) as a prerequisite. Since `?err` is never bound in the outer scope, the NOT can never be scheduled.
+
+## Fix
+
+### Why the naive fix is wrong
+
+The obvious fix — "only include inner Requires, not inner Provides" — doesn't work.
+`extractPatternSymbols` returns `Requires: nil` for DataPatterns (patterns don't
+require symbols; they provide them). So computing the inner clauses' free variables
+gives an empty set, and the NOT would have no Requires at all. It could be scheduled
+before any of its join variables are bound, and the anti-join would have no keys.
+
+### Why executor-side fixes are wrong
+
+Adding runtime decision-making to the executor (special-casing NOT in the scheduler,
+intersecting inner variables with input symbols, passing through disjoint groups)
+is the wrong layer. The executor should be dumb. Cataloguing the runtime decisions
+this approach requires:
+
+1. `collectInnerVars` — executor walks the NOT's inner clauses at runtime to compute
+   candidate join variables
+2. `filterWithNotClause` intersection — executor intersects candidates with input
+   symbols to determine actual join variables at runtime
+3. `filterWithNotClause` disjoint check — executor decides "does this NOT apply to
+   this group?" at runtime
+4. `canExecuteClauseWithContext` NOT special case — planner scheduler needs
+   NOT-specific "any one available" logic instead of the universal "all required" check
+
+Four runtime decisions for something the planner has full context to resolve statically.
+
+### The real problem
+
+A NOT clause is an anti-semi-join. Its join variables are **context-dependent** —
+they're the intersection of inner variables with whatever the outer scope has produced.
+This can't be computed statically from the NOT clause alone.
+
+But the **planner** has the context. When the planner schedules a NOT clause, it
+knows exactly which symbols are available. It can compute the join variables at
+planning time.
+
+### The correct fix: `not` → `not-join` in the planner
+
+Datalog already has the right abstraction: `not-join`. In Datalog syntax:
+
+```clojure
+(not [?e :attr ?v])              ;; implicit join vars — context-dependent
+(not-join [?e] [?e :attr ?v])    ;; explicit join vars — context-independent
+```
+
+`not-join` declares its join variables. The executor handles `NotJoinClause`
+with zero runtime decisions:
+
+```go
+func extractNotJoinClauseSymbols(n *query.NotJoinClause) ClauseSymbols {
+    return ClauseSymbols{
+        Requires: n.JoinVars,  // explicit, statically known
+        Provides: nil,
+    }
+}
+```
+
+Standard "all required" scheduling works. No special cases.
+
+The fix: **the planner converts `NotClause` to `NotJoinClause`** during planning.
+The join variables are the intersection of the NOT's inner variables with the
+symbols available at the point the NOT is scheduled. This is exactly what a user
+does when they write `not-join` — the planner infers it automatically.
+
+All four runtime decisions disappear:
+
+1. **Gone.** Join variables are declared in `NotJoinClause.JoinVars`.
+2. **Gone.** No intersection needed — `JoinVars` ARE the intersection.
+3. **Gone.** A `NotJoinClause` with correct join vars is never applied to a
+   disjoint group, because the planner scheduled it when those vars are available.
+4. **Gone.** `NotJoinClause` uses standard "all required" semantics. No special case.
+
+### Where to do the conversion
+
+In the algebra bridge, not the planner. This is a structural AST rewrite
+(converting one clause type to another), which is the bridge's job. The planner
+should receive well-formed `NotJoinClause` and schedule it — not convert clause
+types.
+
+The bridge doesn't need execution-order context. The join variables are a static
+property of the query:
+
+```
+joinVars = innerVars(NOT) ∩ varsInRestOfQuery(WHERE)
+```
+
+Any variable that appears both inside the NOT and anywhere else in the query's
+where clauses is a join variable. This is computable from the query AST alone.
+The planner then schedules the resulting `NotJoinClause` with standard "all
+required" semantics — it naturally defers until those join vars are bound.
+
+### Why this is algebraically correct
+
+An anti-semi-join R ▷ S requires shared attributes between R and S to define the
+join predicate. The shared attributes are `schema(R) ∩ schema(S)` — exactly the
+intersection of available symbols with inner variables. This intersection is known
+at planning time. Encoding it in the clause type (`NotJoinClause`) makes the
+semantics explicit, statically verifiable, and requires no runtime interpretation.
+
+### Required tests
+
+**1. Bridge unit test** — verify the algebra bridge emits `NotJoinClause` with
+correct join vars, not `NotClause`. Input: query with `(not [?e :attr ?v])` where
+`?e` appears elsewhere. Assert: output clause is `*query.NotJoinClause` with
+`JoinVars = [?e]`.
+
+**2. Semantic equivalence** — `(not [?e :attr ?v])` and
+`(not-join [?e] [?e :attr ?v])` produce identical results on the same data.
+Proves the bridge transformation is semantics-preserving.
+
+**3. All inner variables shared** — `(not [?e :attr ?v])` where both `?e` and
+`?v` are bound in outer scope. Bridge should emit `JoinVars = [?e, ?v]`.
+
+**4. Multiple inner clauses** — `(not [?e :a ?v] [?v :b ?x])` where only `?e`
+is in outer scope. Bridge should compute inner vars across all clauses
+(`{?e, ?v, ?x}`), intersect with outer (`{?e}`), emit `JoinVars = [?e]`.
+
+**5. No shared variables** — `(not [?x :attr ?y])` where neither appears
+elsewhere in the query. This is a meaningless NOT (no join key). Should be a
+planning error, not a silent cross-product or no-op.
+
+**6. NOT inside subquery** — the bridge must handle NOT clauses in subquery
+where-clauses, not just top-level.
+
+## Implementation: three bugs, not two
+
+Annotation tracing of `TestNotClauseComplexQuery_E2E` revealed a third bug
+that the NOT error was masking.
+
+### Bug 3: Executor — `filterWithNotClause` errors on disjoint groups
+
+**File**: `datalog/executor/query_executor.go` (filterWithNotClause)
+
+`executeNotClause` iterates over ALL relation groups and applies
+`filterWithNotClause` to each. When `actualJoinVars` is empty (no overlap
+between the NOT's inner variables and this group's symbols), it errors:
+
+```go
+if len(actualJoinVars) == 0 {
+    return nil, fmt.Errorf("NOT clause variables not found in input relation")
+}
+```
+
+A group disjoint from the NOT should pass through unchanged — the NOT simply
+doesn't apply to it. This is the direct source of the "NOT clause variables
+not found in input relation" error in the production query.
+
+**Fix**: return `input` (unchanged) when `actualJoinVars` is empty.
+
+### Why disjoint groups exist in the complex query
+
+The algebra bridge (`algebra/bridge`) rewrites `get-else` expressions into
+`OrDefaultJoinClause` clauses. Annotation tracing shows:
+
+```
+algebra/bridge-complete: output_types=[
+  *query.DataPattern          -- [?project :project/type ...]
+  *query.NotClause            -- (not [?project :project/deleted true])
+  *query.OrDefaultJoinClause  -- get-else → or-default-join (×6)
+  *query.DataPattern          -- [?project :project/created-at ?createdAt]
+  *query.OrClause             -- OR with correlated subqueries (×3)
+  *query.Expression           -- [(> ?doneCount 0) ?ready]
+]
+```
+
+Each `OrDefaultJoinClause` produces a relation with symbols like
+`{?project, ?name}` that gets appended to `groups` and collapsed. But
+collapses consistently show `relations.after:2` — two disjoint groups remain
+after each or-default-join, because the collapse can't merge them with the
+growing main relation.
+
+By the time the NOT executes (clause 12, scored last by the greedy scheduler),
+`groups` contains multiple disjoint fragments. One has `?project`, others
+don't. The NOT is applied to each group; the groups without `?project` trigger
+the "not found" error.
+
+### Exposed issue: Cartesian product from disjoint groups
+
+After fixing Bugs 1–3, the production query no longer errors but produces
+16 results instead of 2 (a Cartesian product). The disjoint groups created
+by the algebra bridge's get-else → or-default-join rewriting are not properly
+joined with the main relation. When these groups reach the final projection,
+they cross-product.
+
+This is a **separate bug** in the algebra bridge's rewriting, not in the NOT
+clause handling. The NOT error was masking it — the query failed at clause 12
+before the cross-product could manifest. Fixing the NOT correctly exposes the
+pre-existing algebra bridge issue.
+
+### Summary of all fixes applied
+
+| Bug | Location | Fix | Test |
+|-----|----------|-----|------|
+| 1. Planner scheduling | `canExecuteClauseWithContext` | NOT uses "any one available" instead of "all must be available" | `TestNotClauseWithUnboundInnerVar_E2E` |
+| 2. Executor disjoint pass-through | `filterWithNotClause` | Disjoint groups pass through unchanged instead of erroring | `TestNotClauseComplexQuery_E2E` (no longer errors) |
+| 3. Algebra bridge Cartesian product | algebra bridge get-else rewriting | **Not yet fixed** — separate issue | Production query returns 16 rows instead of 2 |
+
+## Version
+
+Regression between v0.9.1 (working) and v0.10.2.

--- a/docs/bugs/BUG-VECTOR-CONSTANT-NO-TAGGED-LITERALS.md
+++ b/docs/bugs/BUG-VECTOR-CONSTANT-NO-TAGGED-LITERALS.md
@@ -1,0 +1,69 @@
+# Vector constants don't support tagged literals (#inst, #db/id)
+
+## Trigger
+
+A `(ground [...])` vector constant containing a tagged literal like `#inst`
+fails at parse time:
+
+```
+error parsing expression argument 1: unsupported type in vector constant: 12
+```
+
+(Type 12 = `edn.NodeTagged`)
+
+## Reproduction
+
+```clojure
+(ground [:none #inst "0001-01-01T00:00:00Z"])
+```
+
+This is the EDN output of `FormatValueEDN` for a `time.Time` value inside a
+`VectorConstant`. The formatter correctly emits `#inst "..."`, but the parser
+can't parse it back — breaking round-trippability.
+
+## Root cause
+
+**File**: `datalog/parser/parser.go` — vector constant parsing (around line 730)
+
+The vector element switch handles `NodeInt`, `NodeFloat`, `NodeString`,
+`NodeBool`, `NodeKeyword`, `NodeSymbol` but not `NodeTagged`. Tagged literals
+(`#inst`, `#db/id`, etc.) hit the `default` case and error.
+
+```go
+case edn.NodeVector:
+    for i, elem := range node.Nodes {
+        switch elem.Type {
+        case edn.NodeInt: ...
+        case edn.NodeFloat: ...
+        case edn.NodeString: ...
+        case edn.NodeBool: ...
+        case edn.NodeKeyword: ...
+        case edn.NodeSymbol: ...
+        default:
+            return nil, fmt.Errorf("unsupported type in vector constant: %v", elem.Type)
+        }
+    }
+```
+
+## Fix
+
+Add a `case edn.NodeTagged:` that delegates to `parseTaggedLiteral(elem)`.
+The tagged literal parser already handles `#inst` (→ `time.Time`) and
+`#db/id` (→ `datalog.Identity`). The vector constant parser just needs to
+call it.
+
+```go
+case edn.NodeTagged:
+    val, err := parseTaggedLiteral(elem)
+    if err != nil {
+        return nil, fmt.Errorf("invalid tagged literal in vector: %w", err)
+    }
+    // parseTaggedLiteral returns a query.Constant — extract the value
+    values[i] = val.(query.Constant).Value
+```
+
+## Impact
+
+This blocks round-trippability of any query containing `time.Time` or
+`Identity` values in vector constants (e.g., `TupleGround` with time
+defaults). `FormatValueEDN` emits valid EDN that the parser rejects.

--- a/docs/bugs/PROOF-OR-SEMANTICS-AND-ALGEBRA-BRIDGE.md
+++ b/docs/bugs/PROOF-OR-SEMANTICS-AND-ALGEBRA-BRIDGE.md
@@ -1,0 +1,249 @@
+# Or Semantics, the Algebra Bridge, and the Correct Fix for Issue #58
+
+## 1. The Problem Statement
+
+GitHub issue #58 reports:
+
+```
+query execution failed: phase 1 failed: clause 12 (not) failed:
+NOT clause variables not found in input relation
+```
+
+The query structure: pattern + NOT + 6 get-else + 3 OR-with-subquery branches +
+comparison binding + order-by. The OR branches use `qb.Or()` which produces
+`*query.OrClause` (union semantics), with a subquery branch and a ground default
+branch — a fallback pattern.
+
+## 2. What We Fixed (Verified)
+
+### 2.1. NOT → NOT-JOIN in the algebra bridge
+
+**One-line fix**: `compileNot` in `algebra/compile.go` already computed
+`joinSyms = sharedSymbols(current.Symbols(), inner.Symbols())` but set
+`ExplicitJoin: false`. Changing to `true` makes the decompiler emit
+`NotJoinClause` with declared join vars. The executor uses standard scheduling
+with zero special cases.
+
+**Verified**: `TestRoundTrip_AntiJoin` passes, `TestNotClauseWithUnboundInnerVar_E2E`
+passes, all algebra/planner/executor/parser tests pass.
+
+### 2.2. FormatValueEDN for round-trippable String()
+
+Query `String()` methods used `fmt.Sprintf("%v")` which produced non-parseable
+output. Added `FormatValueEDN` and updated all `String()` methods.
+
+### 2.3. Vector constant tagged literals
+
+The parser's vector constant switch didn't handle `edn.NodeTagged`. Added the
+case, delegating to `parseTaggedLiteral`. Fixed `#db/id` vs `#identity` tag
+mismatch in `FormatValueEDN`.
+
+## 3. The Four Clause Types and Their Semantics
+
+The engine has four OR-family clause types:
+
+| Clause | Semantics | Behavior per outer tuple |
+|--------|-----------|------------------------|
+| `(or ...)` | Union | Execute ALL branches, union results |
+| `(or-join [...] ...)` | Union + explicit join | Same as or, with declared join vars |
+| `(or-default ...)` | Fallback | Try branches in order, stop at first match |
+| `(or-default-join [...] ...)` | Fallback + explicit join | Same as or-default, with declared join vars |
+
+**Critical distinction**: union vs fallback.
+
+For a subquery + ground default pattern like:
+```clojure
+(or [(q [:find (count ?i) :in $ ?p :where ...] $ ?project) [[?count]]]
+    [(ground 0) ?count])
+```
+
+- **Union**: both branches execute. If the subquery returns `count=2`, the result
+  is `{(project, 2), (project, 0)}` — TWO rows per entity. The ground branch
+  always matches, so every entity gets an extra row.
+
+- **Fallback**: try the subquery. If it returns results, use them. Otherwise, use
+  the ground default. Result: ONE row per entity.
+
+With 3 such ORs using union semantics, the rows multiply: `2 × 2 × 2 = 8` for
+entities where the subquery matches. This is correct union behavior.
+
+## 4. Empirical Verification
+
+We ran the exact same `(or ...)` query through both execution paths:
+
+```
+TestGetElseComplex_OrSemantics:
+  Without algebra bridge: 9 results
+  With algebra bridge:    9 results
+```
+
+Both paths agree. 9 rows is the correct result for union semantics with this
+query structure (8 for proj:1 where both branches match in all 3 ORs, 1 for
+proj:2 where both branches produce identical values and deduplicate).
+
+For `(or-default ...)`, both paths produce 2 rows (one per project). This is
+also correct.
+
+**Conclusion**: the algebra bridge preserves semantics for both `or` and
+`or-default`. There is no algebra bridge bug for union semantics.
+
+## 5. Why the Production Code Gets Wrong Results
+
+The production code (`buildScenarioSummaryQuery`) uses `qb.Or()` for a pattern
+that requires fallback semantics:
+
+```go
+qb.Or().
+    Branch(qb.Subquery(taskStatsSubquery, scenario).BindTuple(...)).
+    Branch(qb.TupleGround(0, 0, 0, 0, 0).As(...))
+```
+
+This produces `*query.OrClause` (union). The intent is "get task stats, or
+default to zeros" — which is fallback. The fix is:
+
+```go
+qb.OrDefault().
+    Branch(qb.Subquery(taskStatsSubquery, scenario).BindTuple(...)).
+    Branch(qb.TupleGround(0, 0, 0, 0, 0).As(...))
+```
+
+This is a **caller bug**, not an engine bug.
+
+## 6. Why `or` → `or-join` Conversion is NOT Safe
+
+We attempted to convert `(or ...)` → `(or-join [...] ...)` in the algebra bridge,
+mirroring the successful `not` → `not-join` conversion. This broke two existing
+tests:
+
+- `TestOrCorrelatedUnionPartialOuterRelation`
+- `TestOrCorrelatedUnionWithNestedOrExpression_E2E`
+
+Error: `cannot project: symbol ?related not found in relation`
+
+### 6.1. Why not → not-join works
+
+`NotClause` and `NotJoinClause` go through the same executor logic:
+
+- `executeNotClause` → `filterWithNotClause(clause, group, collectInnerVars(clause.Clauses))`
+- `executeNotJoinClause` → `filterWithNotJoinClause(clause, group)` using `clause.JoinVars`
+
+Both call the same underlying filter. The only difference is where join vars come
+from (inferred vs declared). The output schema is identical.
+
+### 6.2. Why or → or-join does NOT work
+
+`OrClause` and `OrJoinClause` go through DIFFERENT executor paths:
+
+**OrClause path** (`executeOrClause`):
+```
+branchesNeedCorrelatedExecution?
+  → yes: executeOrClauseCorrelatedUnion
+       → collectOrBranchRequiredSymbols(branches)
+       → findOuterRelation(neededSymbols, groups)
+       → NewOrFallbackRelation(branches, outerRel, false)
+  → no:  executeOrClauseUnion (independent branch execution)
+```
+
+**OrJoinClause path** (`executeOrJoinClause`):
+```
+branchesNeedCorrelatedExecution?
+  → yes: executeOrJoinClauseCorrelatedUnion
+       → findOuterRelationBySymbols(joinVarSet, groups)
+       → NewOrFallbackRelation(branches, outerRel, false)
+       → rel.joinSyms = clause.JoinVars
+  → no:  independent branch execution with joinVars projection
+```
+
+Key differences:
+1. **Outer relation selection**: `findOuterRelation` vs `findOuterRelationBySymbols`
+   use different strategies to find the outer relation from groups. If groups aren't
+   fully collapsed, they may find different relations.
+
+2. **Output symbol computation**: `OrJoinClause` sets `rel.joinSyms` which constrains
+   the output symbols. `OrClause` doesn't.
+
+3. **Uncorrelated path**: `OrJoinClause` projects branch results to join vars.
+   `OrClause` doesn't project.
+
+These differences mean `OrClause → OrJoinClause` is NOT a semantics-preserving
+transformation at the executor level, unlike `NotClause → NotJoinClause` which is.
+
+### 6.3. What would be needed
+
+To make `or` → `or-join` safe, the executor would need:
+- `executeOrJoinClause` to behave identically to `executeOrClause` when join vars
+  are present — just using them instead of inferring
+- Same outer relation selection, same output schema, same projection
+
+This is a significant executor refactor. The two paths diverged over time and now
+have incompatible behavior.
+
+## 7. The 16-Row Discrepancy (Historical)
+
+Early in the investigation, the complex query produced 16 rows. We attributed this
+to a "get-else Cartesian product" in the algebra bridge. This was partially correct
+but the analysis was muddled.
+
+**What actually happened**: the 16-row result occurred because the algebra bridge's
+`compileOrUnion` compiled branches independently without join var propagation. When
+decompiled back to `OrClause`, the executor processed the OR branches as independent
+unions with no join context. The lack of join vars meant the collapse couldn't properly
+merge the OR results with the main relation, producing extra rows.
+
+After adding `collectBranchSymbols` and `inferredJoinVars` to `compileOrUnion`, the
+decompiled `OrJoinClause` had proper join context, and the executor produced 9 rows
+(matching the base executor). But this conversion also broke the correlated union tests
+because the `OrJoinClause` executor path behaves differently.
+
+**Current state**: with the join var inference in `compileOrUnion`, the algebra bridge
+produces 9 rows for the `or` tests (correct) but breaks 2 other tests. We cannot ship
+this change as-is.
+
+## 8. The Fix (Implemented)
+
+### 8.1. Decorrelation guard
+
+The decorrelation transform in `rewrite_decorrelate.go` now checks
+`ctx.Parent.Rule == RuleUnion` before decorrelating. LateralJoins inside
+Union nodes are skipped — their per-tuple correlation semantics are
+load-bearing for correct union evaluation.
+
+### 8.2. Correlation vars in LateralJoin output
+
+`compileSubquery` in `algebra/compile.go` now always includes correlation
+variables in the LateralJoin output. When compiled inside a Union branch
+(`current=nil`), the output was previously just binding symbols — the
+correlation variable wasn't included. This meant the Union's output had
+no overlap with the outer relation for joining.
+
+### 8.3. NOT → NOT-JOIN
+
+`compileNot` sets `ExplicitJoin: true`. The decompiler emits `NotJoinClause`.
+Already committed.
+
+### 8.4. Executor simplification
+
+`OrJoinClause` delegates to `executeOrClause` — the executor has one code
+path for union OR. Join vars are planner scheduling metadata only.
+
+`OrJoinClause` symbol extraction delegates to `extractOrClauseSymbols` —
+same principle.
+
+### 8.5. Downstream code fix
+
+The production code should change `qb.Or()` to `qb.OrDefault()` for
+subquery + ground default patterns. Union and fallback are different operations.
+
+## 9. Verification
+
+Full test suite passes (`go test -count=2 ./datalog/...`). Key tests:
+
+- `TestNotClauseWithUnboundInnerVar_E2E` — NOT scheduling fix
+- `TestNotClauseComplexQuery_E2E` — full production query structure
+- `TestGetElseComplex_OrSemantics` — algebra bridge matches base executor
+- `TestGetElseComplex_ParsedOr` / `QBOr` — correct union semantics (9 rows)
+- `TestGetElseComplex_ParsedOrDefault` / `QBOrDefault` — correct fallback (2 rows)
+- `TestOrCorrelatedUnionPartialOuterRelation` — pre-existing OR test, no regression
+- `TestOrCorrelatedUnionWithNestedOrExpression_E2E` — pre-existing OR test, no regression
+- `TestRoundTrip_AntiJoin` — NOT → NOT-JOIN round-trip
+- `TestRoundTrip_OrUnion` — OR union round-trip


### PR DESCRIPTION
## Summary

Fixes #58 — NOT clause fails with "NOT clause variables not found in input relation" in complex queries with correlated subqueries.

The investigation uncovered four distinct bugs across the algebra bridge, parser, and executor. All stem from the same root: the algebra bridge's compile → optimize → decompile round-trip was not preserving semantics in several contexts.

## Bug 1: NOT clause scheduling

`compileNot` in the algebra bridge already computed the correct join variables via `sharedSymbols(current.Symbols(), inner.Symbols())`, but set `ExplicitJoin: false`. This caused the decompiler to emit `NotClause` with implicit join vars, forcing the executor to infer them at runtime. When the executor couldn't find the join vars in the input relation (due to disjoint groups from other bugs), it errored.

**Fix**: Set `ExplicitJoin: true`. The decompiler now emits `NotJoinClause` with declared join vars. The executor uses standard scheduling — no special cases, no runtime inference.

This is the same transformation a user performs when writing `(not-join [?e] ...)` instead of `(not ...)` — the algebra bridge now infers it automatically.

## Bug 2: Decorrelation inside Union branches

The decorrelation pass transformed correlated subqueries inside Union branches into uncorrelated ones. This moved the correlation variable from `:in` (input) to `:find` (output), creating a schema mismatch between the subquery branch and the ground branch.

For example, a Union with branches `{?project, ?count}` and `{?count}` (ground default, no `?project`) would produce incompatible schemas. When joined with the outer relation, the ground branch rows — lacking the join key `?project` — cross-producted with every outer tuple instead of matching per-tuple.

This caused the algebra bridge to produce 16 rows where the base executor (without the bridge) correctly produced 9.

**Fix**: The decorrelation transform checks `ctx.Parent.Rule == RuleUnion` using the EBNF transform framework's `TransformContext.Parent`. LateralJoins inside Union nodes are not decorrelated. This is a semantic constraint: the decorrelation rule `R ⋈_L S(r.x) → R ⋈ (S GROUP BY x)` requires the LateralJoin result to be consumed directly by a Join. Inside a Union, the result is unioned with other branches first — a different algebraic structure the rule doesn't cover.

The precondition is now documented in ALGEBRA.md under Rules 1 and 4.

## Bug 3: Correlation vars missing from LateralJoin output

`compileSubquery` computed output as `current.Symbols() + bindingSyms`. When compiled inside a Union branch (`current=nil`), correlation variables were dropped from the output. The Union's output schema then had no overlap with the outer relation's symbols, preventing the join.

**Fix**: Correlation variables are always included in the LateralJoin output — they're the join keys that connect the subquery result to the outer relation, regardless of compilation context.

## Bug 4: EDN round-trippability

Query `String()` methods used `fmt.Sprintf("%v")` for values, producing non-parseable output: empty strings rendered as nothing, `time.Time` as Go's default format, strings unquoted. The parser's vector constant switch also didn't handle `NodeTagged`, so `#inst` and `#identity` inside `(ground [...])` vectors failed to parse. The formatter emitted `#db/id` but the parser expected `#identity`.

**Fix**: Added `FormatValueEDN` for proper EDN formatting, added `NodeTagged` case to the vector constant parser, fixed the tag mismatch.

## Executor simplification

As part of these fixes, the executor was simplified:

- `OrJoinClause` now delegates to `executeOrClause` — the executor has one code path for union OR instead of two divergent paths. Join vars are planner scheduling metadata only; the executor ignores them.
- `OrJoinClause` symbol extraction delegates to `extractOrClauseSymbols` — same principle.

## Downstream action needed

The production code that triggered #58 uses `qb.Or()` (union semantics) for a subquery + ground default pattern that requires `qb.OrDefault()` (fallback semantics). With union semantics, both branches contribute rows when both match — the ground branch always matches, producing extra rows. With fallback semantics, only the first matching branch contributes. This is independent of the engine fixes.

## Test plan

- [x] `TestNotClauseWithUnboundInnerVar_E2E` — NOT with inner-only variable (was stuck in planner)
- [x] `TestNotClauseComplexQuery_E2E` — full complex query structure with NOT + get-else + OR + comparison + order-by
- [x] `TestGetElseComplex_OrSemantics` — algebra bridge matches base executor for union OR (9 = 9)
- [x] `TestGetElseComplex_ParsedOr` / `TestGetElseComplex_QBOr` — correct union semantics
- [x] `TestGetElseComplex_ParsedOrDefault` / `TestGetElseComplex_QBOrDefault` — correct fallback semantics
- [x] `TestGetElseMultiple_NoCartesianProduct` — multiple get-else with algebra bridge
- [x] `TestGetElseMultiple_CorrectValues` — get-else values/defaults through bridge
- [x] `TestGetElsePipelineInvariant` — single relation group maintained
- [x] `TestRoundTrip_AntiJoin` — NOT → NOT-JOIN algebra round-trip
- [x] `TestRoundTrip_OrUnion` — OR union algebra round-trip
- [x] `TestVectorConstantTaggedLiterals` — #inst, #identity in vector constants
- [x] `TestOrCorrelatedUnionPartialOuterRelation` — pre-existing, no regression
- [x] `TestOrCorrelatedUnionWithNestedOrExpression_E2E` — pre-existing, no regression
- [x] Full suite: `go test -count=2 ./datalog/...` — all packages pass, deterministic
