### PR TITLE
Add LZJ transparent value compression with three-tier storage

### DIFF
--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -24,6 +24,7 @@ The Janus Datalog engine delivers production-ready performance through architect
 - ✅ **CRDT storage**: **~25-35µs writes** across all cardinalities, **O(1) LWW resolution** (965ns for 1000 versions), linear vector scaling (verified 2026-01-31)
 - ✅ **CRDT allocation optimization**: **90% faster** (1.9×), **2.2× less memory** than pre-CRDT main branch while adding full CRDT semantics (verified 2026-02-02)
 - ✅ **AETV index & value elimination**: **5% faster**, **19% less memory**, **17% fewer allocations** (geomean); complex queries see **35% memory reduction** (verified 2026-02-06)
+- ✅ **LZ77+FSE compression codec**: **2.1-2.4 GB/s decompression** (7 allocs), **3.6x on prose**, **10-13x on structured/repetitive** data (verified 2026-03-28)
 
 ### Claims Requiring Qualification
 - ⚠️ **Plan quality**: "13% better plans" not supported by current benchmarks (planners perform identically)
@@ -1393,6 +1394,52 @@ For relations and iterators—called millions of times during query execution—
 - Achieved 4× speedup on hourly OHLC (41s → 10.2s)
 - Fixed daily OHLC regression with size check
 - Optimized extractTimeRanges: 4.7× faster, 108× fewer allocations
+
+### 2026-03-28: LZ77+FSE Compression Codec (Phase 1-3)
+
+Custom-owned LZ77+FSE compression codec for transparent value compression in storage keys.
+Implementation: `datalog/codec/compress.go`, `fse.go`, `lz77.go`, `sequences.go`.
+Design: `docs/proposals/COMPRESSED_STRING_VALUES.md`, `docs/proposals/COMPRESSION_RESEARCH.md`.
+
+**Compression Ratios (LZ77 + FSE, verified):**
+
+| Data Type | Ratio |
+|-----------|-------|
+| English prose 1KB | 3.6× |
+| EDN structured data | 12.9× |
+| Source code | 10.6× |
+| Repetitive binary | 12.7× |
+| All-same bytes | 13.3× |
+| Repeated text 50KB | 110× |
+
+**Full Pipeline Throughput (Apple M5 Max, verified):**
+
+| Operation | 256B | 1KB | 4KB | 16KB |
+|-----------|------|-----|-----|------|
+| Compress | 14 MB/s | 43 MB/s | 112 MB/s | 284 MB/s |
+| Decompress | 1.7 GB/s | 2.1 GB/s | 2.3 GB/s | 2.4 GB/s |
+
+**Per-Value Latency:**
+
+| Operation | 256B | 1KB | 4KB |
+|-----------|------|-----|-----|
+| Compress | 18μs | 24μs | 37μs |
+| Decompress | 153ns | 477ns | 1.8μs |
+
+**Allocations:**
+
+| Operation | 256B | 1KB | 4KB | 16KB |
+|-----------|------|-----|-----|------|
+| Compress | 38 | 56 | 74 | 103 |
+| Decompress | 6 | 7 | 7 | 9 |
+
+**Key optimizations:**
+- FSE decode table cached via `sync.Map` — eliminates table reconstruction on repeated decompressions
+- Encode work buffers pooled via `sync.Pool` — reduces GC pressure on write path
+- LZ77 reconstruct: 2.6 GB/s, 1 alloc (just output buffer)
+- Determinism verified: 1000× repeated compression + concurrent goroutine compression produce identical output
+
+**Test coverage:** 185 tests including round-trip fuzz (500 random + 200 text + 100 structured), determinism stress, golden byte-level output assertions, safety net validation, and compression ratio assertions.
 
 ### 2025-10-04: Parallel Execution & Intern Optimization
 - Identified intern cache as 35% CPU bottleneck

--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -28,6 +28,7 @@ func main() {
 	var enableDecorrelation bool
 	var exportPath string
 	var importPath string
+	var compressedExport bool
 
 	var inputValues ednSliceFlag
 
@@ -38,6 +39,7 @@ func main() {
 	flag.StringVar(&queryStr, "query", "", "run a single query and exit")
 	flag.BoolVar(&enableDecorrelation, "decorrelate", true, "enable subquery decorrelation optimization (default: true)")
 	flag.StringVar(&exportPath, "export", "", "export database to EDN file")
+	flag.BoolVar(&compressedExport, "compressed", false, "use #lzj compressed tagged literals in export")
 	flag.StringVar(&importPath, "import", "", "import database from EDN file")
 	flag.Var(&inputValues, "in", "input parameter as EDN value (repeatable, one per :in binding)")
 	flag.Usage = func() {
@@ -82,7 +84,7 @@ func main() {
 
 	// Handle export mode
 	if exportPath != "" {
-		runExport(dbPath, exportPath)
+		runExport(dbPath, exportPath, compressedExport)
 		return
 	}
 
@@ -398,7 +400,7 @@ func isDatabaseEmpty(db *storage.Database) bool {
 }
 
 // runExport exports the database to an EDN file
-func runExport(dbPath, exportPath string) {
+func runExport(dbPath, exportPath string, compressed bool) {
 	// Check if database exists
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		log.Fatalf("Database does not exist: %s", dbPath)
@@ -419,7 +421,7 @@ func runExport(dbPath, exportPath string) {
 	defer f.Close()
 
 	// Export database
-	if err := db.Export(f); err != nil {
+	if err := db.Export(f, storage.ExportOptions{Compressed: compressed}); err != nil {
 		log.Fatalf("Failed to export database: %v", err)
 	}
 

--- a/cmd/ednstats/main.go
+++ b/cmd/ednstats/main.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/codec"
 	"github.com/wbrown/janus-datalog/datalog/storage"
 )
 
@@ -53,6 +55,9 @@ func main() {
 		if line == "" || strings.HasPrefix(line, ";") {
 			continue
 		}
+
+		// Scan raw line for #lzj compression stats before parsing
+		stats.recordLZJ(line)
 
 		datom, err := storage.ParseDatomEDN(line)
 		if err != nil {
@@ -86,6 +91,12 @@ type attrStats struct {
 	sizes      []int
 }
 
+type lzjEntry struct {
+	attr             string
+	compressedSize   int // L85-decoded compressed bytes
+	decompressedSize int // original string length
+}
+
 type stats struct {
 	totalDatoms int
 	parseErrors int
@@ -105,6 +116,10 @@ type stats struct {
 	// RGA vector groups: (entity, attribute) → list of value sizes
 	// Only tracks string values with rga-insert ops
 	rgaGroups map[entityAttrKey]*rgaGroup
+
+	// #lzj compression stats (from raw EDN lines)
+	lzjEntries []lzjEntry
+	lzjByAttr  map[string][]lzjEntry
 }
 
 type rgaGroup struct {
@@ -121,6 +136,39 @@ func newStats() *stats {
 		attrString: make(map[string]*attrStats),
 		attrBytes:  make(map[string]*attrStats),
 		rgaGroups:  make(map[entityAttrKey]*rgaGroup),
+		lzjByAttr:  make(map[string][]lzjEntry),
+	}
+}
+
+// lzjPattern matches #lzj "..." in a raw EDN line.
+// Captures the attribute keyword and the L85-encoded payload.
+var lzjPattern = regexp.MustCompile(`(:\S+)\s+#lzj\s+"([^"]*)"`)
+
+// recordLZJ scans a raw EDN line for #lzj tagged literals and records
+// compressed vs decompressed sizes.
+func (s *stats) recordLZJ(line string) {
+	matches := lzjPattern.FindAllStringSubmatch(line, -1)
+	for _, m := range matches {
+		attr := m[1]
+		l85Data := m[2]
+
+		compressed, err := codec.DecodeL85(l85Data)
+		if err != nil {
+			continue
+		}
+
+		decompressed, err := codec.Decompress(compressed)
+		if err != nil {
+			continue
+		}
+
+		entry := lzjEntry{
+			attr:             attr,
+			compressedSize:   len(compressed),
+			decompressedSize: len(decompressed),
+		}
+		s.lzjEntries = append(s.lzjEntries, entry)
+		s.lzjByAttr[attr] = append(s.lzjByAttr[attr], entry)
 	}
 }
 
@@ -458,6 +506,82 @@ func (s *stats) report(topN int) {
 			totalSavings := 100.0 * float64(totalOrig-totalStored) / float64(totalOrig)
 			fmt.Printf("| **Total** | %d | %s | %s | **%.0f%%** |\n",
 				tier1Count+tier2Count, humanBytes(totalOrig), humanBytes(totalStored), totalSavings)
+		}
+		fmt.Println()
+	}
+
+	// LZJ compression analysis (from raw #lzj tagged literals)
+	if len(s.lzjEntries) > 0 {
+		fmt.Println("## LZJ Compression Analysis")
+		fmt.Println()
+
+		totalCompressed := 0
+		totalDecompressed := 0
+		var ratios []float64
+		for _, e := range s.lzjEntries {
+			totalCompressed += e.compressedSize
+			totalDecompressed += e.decompressedSize
+			if e.compressedSize > 0 {
+				ratios = append(ratios, float64(e.decompressedSize)/float64(e.compressedSize))
+			}
+		}
+		sort.Float64s(ratios)
+
+		overallRatio := float64(totalDecompressed) / float64(totalCompressed)
+		savings := 100.0 * float64(totalDecompressed-totalCompressed) / float64(totalDecompressed)
+
+		fmt.Printf("- Compressed values: %d of %d datoms (%.1f%%)\n",
+			len(s.lzjEntries), s.totalDatoms,
+			100.0*float64(len(s.lzjEntries))/float64(s.totalDatoms))
+		fmt.Printf("- Total decompressed: %s\n", humanBytes(totalDecompressed))
+		fmt.Printf("- Total compressed: %s\n", humanBytes(totalCompressed))
+		fmt.Printf("- Overall ratio: %.1fx (%.0f%% savings)\n", overallRatio, savings)
+		fmt.Println()
+
+		fmt.Println("**Compression ratio distribution:**")
+		fmt.Println()
+		fmt.Printf("| P50 | P75 | P90 | P95 | Max |\n")
+		fmt.Printf("|-----|-----|-----|-----|-----|\n")
+		fmt.Printf("| %.1fx | %.1fx | %.1fx | %.1fx | %.1fx |\n",
+			percentileFloat(ratios, 50),
+			percentileFloat(ratios, 75),
+			percentileFloat(ratios, 90),
+			percentileFloat(ratios, 95),
+			ratios[len(ratios)-1])
+		fmt.Println()
+
+		// Per-attribute breakdown
+		fmt.Println("**Per-attribute compression:**")
+		fmt.Println()
+		fmt.Println("| Attribute | Count | Decompressed | Compressed | Ratio | Savings |")
+		fmt.Println("|-----------|-------|--------------|------------|-------|---------|")
+
+		// Sort by decompressed size descending
+		type attrLZJ struct {
+			attr         string
+			count        int
+			decompressed int
+			compressed   int
+		}
+		var attrs []attrLZJ
+		for attr, entries := range s.lzjByAttr {
+			a := attrLZJ{attr: attr, count: len(entries)}
+			for _, e := range entries {
+				a.decompressed += e.decompressedSize
+				a.compressed += e.compressedSize
+			}
+			attrs = append(attrs, a)
+		}
+		sort.Slice(attrs, func(i, j int) bool {
+			return attrs[i].decompressed > attrs[j].decompressed
+		})
+		for _, a := range attrs {
+			ratio := float64(a.decompressed) / float64(a.compressed)
+			sav := 100.0 * float64(a.decompressed-a.compressed) / float64(a.decompressed)
+			fmt.Printf("| %s | %d | %s | %s | %.1fx | %.0f%% |\n",
+				a.attr, a.count,
+				humanBytes(a.decompressed), humanBytes(a.compressed),
+				ratio, sav)
 		}
 		fmt.Println()
 	}

--- a/cmd/ednstats/main.go
+++ b/cmd/ednstats/main.go
@@ -1,0 +1,610 @@
+// ednstats analyzes value sizes and distribution in janus-datalog EDN exports.
+//
+// Usage:
+//
+//	go run ./cmd/ednstats -input data.edn
+//
+// Produces statistics including:
+//   - Value type distribution (counts, total bytes)
+//   - String/bytes size percentiles (P50, P95, P99, max)
+//   - Per-attribute breakdown for large value types
+//   - []string vector analysis (same entity+attribute RGA groups)
+//   - Compression tier projections at various thresholds
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+func main() {
+	inputPath := flag.String("input", "", "path to EDN export file")
+	topN := flag.Int("top", 20, "number of top attributes to show")
+	flag.Parse()
+
+	if *inputPath == "" {
+		fmt.Fprintln(os.Stderr, "usage: ednstats -input <file.edn>")
+		os.Exit(1)
+	}
+
+	f, err := os.Open(*inputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening file: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	stats := newStats()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1MB buffer
+
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, ";") {
+			continue
+		}
+
+		datom, err := storage.ParseDatomEDN(line)
+		if err != nil {
+			if lineNum <= 10 {
+				fmt.Fprintf(os.Stderr, "line %d: parse error: %v\n", lineNum, err)
+			}
+			stats.parseErrors++
+			continue
+		}
+
+		stats.record(datom)
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "scanner error: %v\n", err)
+		os.Exit(1)
+	}
+
+	stats.report(*topN)
+}
+
+// entityAttrKey identifies a unique (entity, attribute) pair for vector grouping.
+type entityAttrKey struct {
+	entityL85 string
+	attr      string
+}
+
+type attrStats struct {
+	count      int
+	totalBytes int
+	sizes      []int
+}
+
+type stats struct {
+	totalDatoms int
+	parseErrors int
+
+	// Per value type
+	typeCounts map[string]int
+	typeBytes  map[string]int
+
+	// All string sizes and bytes sizes for percentile calculation
+	stringSizes []int
+	bytesSizes  []int
+
+	// Per attribute stats for string and bytes values
+	attrString map[string]*attrStats
+	attrBytes  map[string]*attrStats
+
+	// RGA vector groups: (entity, attribute) → list of value sizes
+	// Only tracks string values with rga-insert ops
+	rgaGroups map[entityAttrKey]*rgaGroup
+}
+
+type rgaGroup struct {
+	attr       string
+	sizes      []int
+	totalBytes int
+	values     []string // actual string values for entropy calculation
+}
+
+func newStats() *stats {
+	return &stats{
+		typeCounts: make(map[string]int),
+		typeBytes:  make(map[string]int),
+		attrString: make(map[string]*attrStats),
+		attrBytes:  make(map[string]*attrStats),
+		rgaGroups:  make(map[entityAttrKey]*rgaGroup),
+	}
+}
+
+func (s *stats) record(d *datalog.Datom) {
+	s.totalDatoms++
+
+	typeName, size := valueTypeAndSize(d.V)
+	s.typeCounts[typeName]++
+	s.typeBytes[typeName] += size
+
+	switch typeName {
+	case "string":
+		s.stringSizes = append(s.stringSizes, size)
+		attr := d.A.String()
+		as, ok := s.attrString[attr]
+		if !ok {
+			as = &attrStats{}
+			s.attrString[attr] = as
+		}
+		as.count++
+		as.totalBytes += size
+		as.sizes = append(as.sizes, size)
+
+		// Track RGA groups for vector analysis
+		if d.Op == datalog.OpRGAInsert {
+			key := entityAttrKey{
+				entityL85: d.E.L85(),
+				attr:      attr,
+			}
+			rg, ok := s.rgaGroups[key]
+			if !ok {
+				rg = &rgaGroup{attr: attr}
+				s.rgaGroups[key] = rg
+			}
+			rg.sizes = append(rg.sizes, size)
+			rg.totalBytes += size
+			if str, ok := d.V.(string); ok {
+				rg.values = append(rg.values, str)
+			}
+		}
+
+	case "bytes":
+		s.bytesSizes = append(s.bytesSizes, size)
+		attr := d.A.String()
+		as, ok := s.attrBytes[attr]
+		if !ok {
+			as = &attrStats{}
+			s.attrBytes[attr] = as
+		}
+		as.count++
+		as.totalBytes += size
+		as.sizes = append(as.sizes, size)
+	}
+}
+
+func valueTypeAndSize(v interface{}) (string, int) {
+	if v == nil {
+		return "nil", 0
+	}
+	switch val := v.(type) {
+	case string:
+		return "string", len(val)
+	case int64:
+		return "int64", 8
+	case int:
+		return "int", 8
+	case float64:
+		return "float64", 8
+	case bool:
+		return "bool", 1
+	case []byte:
+		return "bytes", len(val)
+	case datalog.Identity:
+		return "identity", 20
+	case datalog.Keyword:
+		return "keyword", len(val.String())
+	case datalog.ElementID:
+		return "elementid", 16
+	default:
+		return fmt.Sprintf("unknown(%T)", v), 0
+	}
+}
+
+func (s *stats) report(topN int) {
+	fmt.Println("# EDN Value Statistics")
+	fmt.Println()
+
+	// Overall counts
+	fmt.Printf("Total datoms: %d\n", s.totalDatoms)
+	if s.parseErrors > 0 {
+		fmt.Printf("Parse errors: %d\n", s.parseErrors)
+	}
+	fmt.Println()
+
+	// Type distribution
+	fmt.Println("## Value Type Distribution")
+	fmt.Println()
+	fmt.Println("| Type | Count | Total Bytes | Avg Size |")
+	fmt.Println("|------|-------|-------------|----------|")
+
+	typeNames := sortedKeys(s.typeCounts)
+	for _, tn := range typeNames {
+		count := s.typeCounts[tn]
+		total := s.typeBytes[tn]
+		avg := 0.0
+		if count > 0 {
+			avg = float64(total) / float64(count)
+		}
+		fmt.Printf("| %s | %d | %s | %.1f |\n", tn, count, humanBytes(total), avg)
+	}
+	fmt.Println()
+
+	// String size distribution (overall)
+	if len(s.stringSizes) > 0 {
+		fmt.Println("## String Value Size Distribution (All Attributes)")
+		fmt.Println()
+		printPercentiles(s.stringSizes)
+		fmt.Println()
+		printHistogram(s.stringSizes)
+		fmt.Println()
+	}
+
+	// Bytes size distribution (overall)
+	if len(s.bytesSizes) > 0 {
+		fmt.Println("## Bytes Value Size Distribution (All Attributes)")
+		fmt.Println()
+		printPercentiles(s.bytesSizes)
+		fmt.Println()
+	}
+
+	// Build per-attribute RGA summaries for cross-referencing
+	type attrRGASummary struct {
+		groupCount  int
+		totalElems  int
+		totalBytes  int
+		groupSizes  []int // elements per group
+		concatSizes []int // concatenated bytes per group
+	}
+	attrRGA := make(map[string]*attrRGASummary)
+	for _, rg := range s.rgaGroups {
+		ar, ok := attrRGA[rg.attr]
+		if !ok {
+			ar = &attrRGASummary{}
+			attrRGA[rg.attr] = ar
+		}
+		ar.groupCount++
+		ar.totalElems += len(rg.sizes)
+		ar.totalBytes += rg.totalBytes
+		ar.groupSizes = append(ar.groupSizes, len(rg.sizes))
+		ar.concatSizes = append(ar.concatSizes, rg.totalBytes)
+	}
+
+	// Per-attribute detailed report for ALL string attributes
+	fmt.Println("## Per-Attribute String Analysis")
+	fmt.Println()
+
+	allStringAttrs := topAttrsByBytes(s.attrString, len(s.attrString))
+	for _, attr := range allStringAttrs {
+		as := s.attrString[attr]
+		sort.Ints(as.sizes)
+
+		fmt.Printf("### %s\n\n", attr)
+
+		// Check if this attribute has RGA groups
+		rga := attrRGA[attr]
+
+		// Count non-RGA datoms for this attribute
+		nonRGACount := as.count
+		nonRGABytes := as.totalBytes
+		if rga != nil {
+			nonRGACount = as.count - rga.totalElems
+			nonRGABytes = as.totalBytes - rga.totalBytes
+		}
+
+		fmt.Printf("- Total datoms: %d, total bytes: %s\n", as.count, humanBytes(as.totalBytes))
+		if rga != nil {
+			fmt.Printf("- RGA vector elements: %d (%s), non-RGA: %d (%s)\n",
+				rga.totalElems, humanBytes(rga.totalBytes),
+				nonRGACount, humanBytes(nonRGABytes))
+			fmt.Printf("- RGA groups (unique entities): %d\n", rga.groupCount)
+		}
+		fmt.Println()
+
+		// Individual element sizes
+		fmt.Println("**Individual value sizes:**")
+		fmt.Println()
+		fmt.Printf("| Min | P50 | P75 | P90 | P95 | P99 | Max |\n")
+		fmt.Printf("|-----|-----|-----|-----|-----|-----|-----|\n")
+		fmt.Printf("| %s | %s | %s | %s | %s | %s | %s |\n",
+			humanBytes(as.sizes[0]),
+			humanBytes(percentile(as.sizes, 50)),
+			humanBytes(percentile(as.sizes, 75)),
+			humanBytes(percentile(as.sizes, 90)),
+			humanBytes(percentile(as.sizes, 95)),
+			humanBytes(percentile(as.sizes, 99)),
+			humanBytes(as.sizes[len(as.sizes)-1]))
+		fmt.Println()
+
+		// Size histogram for this attribute
+		printHistogram(as.sizes)
+		fmt.Println()
+
+		// RGA group details if present
+		if rga != nil && rga.groupCount > 0 {
+			sort.Ints(rga.groupSizes)
+			sort.Ints(rga.concatSizes)
+
+			fmt.Println("**RGA vector group analysis:**")
+			fmt.Println()
+			fmt.Printf("| Metric | P50 | P95 | P99 | Max |\n")
+			fmt.Printf("|--------|-----|-----|-----|-----|\n")
+			fmt.Printf("| Elements/group | %d | %d | %d | %d |\n",
+				percentile(rga.groupSizes, 50),
+				percentile(rga.groupSizes, 95),
+				percentile(rga.groupSizes, 99),
+				rga.groupSizes[len(rga.groupSizes)-1])
+			fmt.Printf("| Concat size/group | %s | %s | %s | %s |\n",
+				humanBytes(percentile(rga.concatSizes, 50)),
+				humanBytes(percentile(rga.concatSizes, 95)),
+				humanBytes(percentile(rga.concatSizes, 99)),
+				humanBytes(rga.concatSizes[len(rga.concatSizes)-1]))
+			fmt.Println()
+
+			// Entropy analysis on joined groups
+			var groupEntropies []float64
+			var origDatoms, projDatoms int
+			var origBytes int
+			var projBytesSum float64
+
+			for _, rg := range s.rgaGroups {
+				if rg.attr != attr {
+					continue
+				}
+				origDatoms += len(rg.sizes)
+				projDatoms++
+				origBytes += rg.totalBytes
+
+				// Join all values in this group
+				joined := strings.Join(rg.values, "\n\n")
+				if len(joined) > 0 {
+					ent := shannonEntropy([]byte(joined))
+					groupEntropies = append(groupEntropies, ent)
+					// Theoretical compressed size: (entropy/8) * len
+					projBytesSum += (ent / 8.0) * float64(len(joined))
+				}
+			}
+
+			if len(groupEntropies) > 0 {
+				sort.Float64s(groupEntropies)
+				fmt.Println("**Entropy of joined groups (bits/byte, lower = more compressible):**")
+				fmt.Println()
+				fmt.Printf("| P50 | P95 | P99 | Max | Theoretical ratio |\n")
+				fmt.Printf("|-----|-----|-----|-----|-------------------|\n")
+				p50 := percentileFloat(groupEntropies, 50)
+				fmt.Printf("| %.2f | %.2f | %.2f | %.2f | %.1fx |\n",
+					p50,
+					percentileFloat(groupEntropies, 95),
+					percentileFloat(groupEntropies, 99),
+					groupEntropies[len(groupEntropies)-1],
+					8.0/p50)
+				fmt.Println()
+
+				fmt.Println("**If consolidated into single compressed values (using measured entropy):**")
+				fmt.Println()
+				projBytes := int(projBytesSum)
+				if origBytes > 0 {
+					savings := 100.0 * float64(origBytes-projBytes) / float64(origBytes)
+					fmt.Printf("- %d datoms → %d datoms (%.1fx reduction)\n",
+						origDatoms, projDatoms, float64(origDatoms)/float64(projDatoms))
+					fmt.Printf("- %s → %s (%.0f%% byte savings)\n",
+						humanBytes(origBytes), humanBytes(projBytes), savings)
+				}
+			}
+			fmt.Println()
+		}
+	}
+
+	// Per-attribute bytes analysis (if any significant)
+	if len(s.bytesSizes) > 0 {
+		fmt.Println("## Per-Attribute Bytes Analysis")
+		fmt.Println()
+		allBytesAttrs := topAttrsByBytes(s.attrBytes, len(s.attrBytes))
+		for _, attr := range allBytesAttrs {
+			as := s.attrBytes[attr]
+			sort.Ints(as.sizes)
+			fmt.Printf("### %s\n\n", attr)
+			fmt.Printf("- Datoms: %d, total bytes: %s\n", as.count, humanBytes(as.totalBytes))
+			fmt.Printf("- P50: %s, P95: %s, Max: %s\n\n",
+				humanBytes(percentile(as.sizes, 50)),
+				humanBytes(percentile(as.sizes, 95)),
+				humanBytes(as.sizes[len(as.sizes)-1]))
+		}
+	}
+
+	// Overall compression projections
+	fmt.Println("## Overall Compression Projections")
+	fmt.Println()
+	fmt.Println("Assuming 4x compression ratio on text.")
+	fmt.Println()
+
+	thresholds := []int{256, 512, 1024, 2048}
+	for _, threshold := range thresholds {
+		fmt.Printf("### Threshold: %d bytes\n\n", threshold)
+
+		var tier1Count, tier2Count int
+		var tier1Bytes, tier2Bytes, tier2Compressed int
+
+		for _, size := range s.stringSizes {
+			if size < threshold {
+				tier1Count++
+				tier1Bytes += size
+			} else {
+				tier2Count++
+				tier2Bytes += size
+				compressed := size / 4
+				if compressed < 1 {
+					compressed = 1
+				}
+				tier2Compressed += compressed
+			}
+		}
+
+		fmt.Printf("| Tier | Count | Original | Stored | Savings |\n")
+		fmt.Printf("|------|-------|----------|--------|----------|\n")
+		fmt.Printf("| Tier 1 (raw) | %d | %s | %s | 0%% |\n",
+			tier1Count, humanBytes(tier1Bytes), humanBytes(tier1Bytes))
+		if tier2Count > 0 {
+			savings := 100.0 * float64(tier2Bytes-tier2Compressed) / float64(tier2Bytes)
+			fmt.Printf("| Tier 2 (compressed) | %d | %s | %s | %.0f%% |\n",
+				tier2Count, humanBytes(tier2Bytes), humanBytes(tier2Compressed), savings)
+		}
+		totalOrig := tier1Bytes + tier2Bytes
+		totalStored := tier1Bytes + tier2Compressed
+		if totalOrig > 0 {
+			totalSavings := 100.0 * float64(totalOrig-totalStored) / float64(totalOrig)
+			fmt.Printf("| **Total** | %d | %s | %s | **%.0f%%** |\n",
+				tier1Count+tier2Count, humanBytes(totalOrig), humanBytes(totalStored), totalSavings)
+		}
+		fmt.Println()
+	}
+}
+
+func printPercentiles(sizes []int) {
+	sort.Ints(sizes)
+	fmt.Printf("| Count | Min | P50 | P75 | P90 | P95 | P99 | Max | Total |\n")
+	fmt.Printf("|-------|-----|-----|-----|-----|-----|-----|-----|-------|\n")
+	fmt.Printf("| %d | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+		len(sizes),
+		humanBytes(sizes[0]),
+		humanBytes(percentile(sizes, 50)),
+		humanBytes(percentile(sizes, 75)),
+		humanBytes(percentile(sizes, 90)),
+		humanBytes(percentile(sizes, 95)),
+		humanBytes(percentile(sizes, 99)),
+		humanBytes(sizes[len(sizes)-1]),
+		humanBytes(sum(sizes)))
+}
+
+func printHistogram(sizes []int) {
+	buckets := []struct {
+		label string
+		min   int
+		max   int
+	}{
+		{"0-64B", 0, 64},
+		{"64-256B", 64, 256},
+		{"256-512B", 256, 512},
+		{"512B-1KB", 512, 1024},
+		{"1-4KB", 1024, 4096},
+		{"4-16KB", 4096, 16384},
+		{"16-64KB", 16384, 65536},
+		{"64KB+", 65536, math.MaxInt},
+	}
+
+	fmt.Println("| Range | Count | Total Bytes | % of Total Bytes |")
+	fmt.Println("|-------|-------|-------------|------------------|")
+
+	totalBytes := sum(sizes)
+	for _, b := range buckets {
+		count := 0
+		bytes := 0
+		for _, s := range sizes {
+			if s >= b.min && s < b.max {
+				count++
+				bytes += s
+			}
+		}
+		if count > 0 {
+			pct := 100.0 * float64(bytes) / float64(totalBytes)
+			fmt.Printf("| %s | %d | %s | %.1f%% |\n", b.label, count, humanBytes(bytes), pct)
+		}
+	}
+}
+
+func shannonEntropy(data []byte) float64 {
+	if len(data) == 0 {
+		return 0
+	}
+	var counts [256]int
+	for _, b := range data {
+		counts[b]++
+	}
+	n := float64(len(data))
+	entropy := 0.0
+	for _, c := range counts {
+		if c == 0 {
+			continue
+		}
+		p := float64(c) / n
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}
+
+func percentileFloat(sorted []float64, p int) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(float64(p)/100.0*float64(len(sorted)-1) + 0.5)
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func percentile(sorted []int, p int) int {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(float64(p)/100.0*float64(len(sorted)-1) + 0.5)
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func sum(sizes []int) int {
+	total := 0
+	for _, s := range sizes {
+		total += s
+	}
+	return total
+}
+
+func humanBytes(b int) string {
+	switch {
+	case b >= 1024*1024*1024:
+		return fmt.Sprintf("%.1fGB", float64(b)/(1024*1024*1024))
+	case b >= 1024*1024:
+		return fmt.Sprintf("%.1fMB", float64(b)/(1024*1024))
+	case b >= 1024:
+		return fmt.Sprintf("%.1fKB", float64(b)/1024)
+	default:
+		return fmt.Sprintf("%dB", b)
+	}
+}
+
+func sortedKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func topAttrsByBytes(m map[string]*attrStats, n int) []string {
+	type kv struct {
+		key   string
+		bytes int
+	}
+	var sorted []kv
+	for k, v := range m {
+		sorted = append(sorted, kv{k, v.totalBytes})
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].bytes > sorted[j].bytes
+	})
+	if len(sorted) > n {
+		sorted = sorted[:n]
+	}
+	result := make([]string, len(sorted))
+	for i, s := range sorted {
+		result[i] = s.key
+	}
+	return result
+}

--- a/datalog/codec/compress.go
+++ b/datalog/codec/compress.go
@@ -1,0 +1,311 @@
+package codec
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// Compression version. This byte is embedded in every compressed output.
+// If the algorithm changes, increment this. The decompressor rejects
+// unknown versions. The format is frozen per version — same input must
+// always produce same output for a given version.
+const CompressionVersion byte = 0x01
+
+// Compress compresses input using LZ77 + FSE.
+// Returns compressed bytes with header, or nil if compression provides
+// no size benefit (safety net).
+func Compress(input []byte) []byte {
+	if len(input) == 0 {
+		return nil
+	}
+
+	// LZ77 match finding
+	sb := FindMatches(input)
+
+	// Encode sequences into parallel streams
+	es := EncodeSequences(sb.Sequences)
+
+	// Count matches (sequences with Offset > 0)
+	numMatches := 0
+	for _, seq := range sb.Sequences {
+		if seq.Offset > 0 {
+			numMatches++
+		}
+	}
+
+	// Build extra bits bitstream
+	extraBW := &bitWriter{}
+	matchIdx := 0
+	for i, seq := range sb.Sequences {
+		if es.LitLenBits[i] > 0 {
+			extraBW.writeBits(es.LitLenExtra[i], es.LitLenBits[i])
+		}
+		if seq.Offset > 0 && matchIdx < len(es.MatchLenBits) {
+			if es.MatchLenBits[matchIdx] > 0 {
+				extraBW.writeBits(es.MatchLenExtra[matchIdx], es.MatchLenBits[matchIdx])
+			}
+			if es.OffsetBits[matchIdx] > 0 {
+				extraBW.writeBits(es.OffsetExtra[matchIdx], es.OffsetBits[matchIdx])
+			}
+			matchIdx++
+		}
+	}
+	extraBits := extraBW.flush()
+
+	// FSE compress each stream (falls back to raw if no benefit)
+	litBlock := compressOrRaw(sb.Literals)
+	litLenBlock := compressOrRaw(es.LitLenCodes)
+	matchLenBlock := compressOrRaw(es.MatchLenCodes)
+	offsetBlock := compressOrRaw(es.OffsetCodes)
+	extraBlock := rawBlock(extraBits)
+
+	// Assemble output
+	// Header: [version:1][originalLen:4 BE][numSequences:2][numMatches:2][numLiterals:4]
+	result := make([]byte, 0, len(input))
+	result = append(result, CompressionVersion)
+	result = binary.BigEndian.AppendUint32(result, uint32(len(input)))
+	result = binary.BigEndian.AppendUint16(result, uint16(len(sb.Sequences)))
+	result = binary.BigEndian.AppendUint16(result, uint16(numMatches))
+	result = binary.BigEndian.AppendUint32(result, uint32(len(sb.Literals)))
+
+	// Blocks
+	result = append(result, litBlock...)
+	result = append(result, litLenBlock...)
+	result = append(result, matchLenBlock...)
+	result = append(result, offsetBlock...)
+	result = append(result, extraBlock...)
+
+	// Safety net: compressed must be strictly smaller
+	if len(result) >= len(input) {
+		return nil
+	}
+
+	return result
+}
+
+// Decompress decompresses data produced by Compress.
+func Decompress(compressed []byte) ([]byte, error) {
+	if len(compressed) < 13 { // minimum header
+		return nil, errors.New("compress: data too short")
+	}
+
+	// Parse header
+	version := compressed[0]
+	if version != CompressionVersion {
+		return nil, fmt.Errorf("compress: unsupported version %d (expected %d)", version, CompressionVersion)
+	}
+	originalLen := int(binary.BigEndian.Uint32(compressed[1:5]))
+	numSequences := int(binary.BigEndian.Uint16(compressed[5:7]))
+	numMatches := int(binary.BigEndian.Uint16(compressed[7:9]))
+	numLiterals := int(binary.BigEndian.Uint32(compressed[9:13]))
+
+	pos := 13
+
+	// Read and decompress blocks
+	literals, n, err := readDecompressBlock(compressed, pos, numLiterals)
+	if err != nil {
+		return nil, fmt.Errorf("compress: literals: %w", err)
+	}
+	pos += n
+
+	litLenCodes, n, err := readDecompressBlock(compressed, pos, numSequences)
+	if err != nil {
+		return nil, fmt.Errorf("compress: litLen codes: %w", err)
+	}
+	pos += n
+
+	matchLenCodes, n, err := readDecompressBlock(compressed, pos, numMatches)
+	if err != nil {
+		return nil, fmt.Errorf("compress: matchLen codes: %w", err)
+	}
+	pos += n
+
+	offsetCodes, n, err := readDecompressBlock(compressed, pos, numMatches)
+	if err != nil {
+		return nil, fmt.Errorf("compress: offset codes: %w", err)
+	}
+	pos += n
+
+	extraBitsData, n, err := readRawBlock(compressed, pos)
+	if err != nil {
+		return nil, fmt.Errorf("compress: extra bits: %w", err)
+	}
+	_ = n
+
+	// Validate stream lengths
+	if len(litLenCodes) != numSequences {
+		return nil, fmt.Errorf("compress: litLen count %d != numSequences %d", len(litLenCodes), numSequences)
+	}
+	if len(matchLenCodes) != numMatches {
+		return nil, fmt.Errorf("compress: matchLen count %d != numMatches %d", len(matchLenCodes), numMatches)
+	}
+	if len(offsetCodes) != numMatches {
+		return nil, fmt.Errorf("compress: offset count %d != numMatches %d", len(offsetCodes), numMatches)
+	}
+
+	// Decode sequences from codes + extra bits
+	extraBR := newBitReader(extraBitsData)
+	matchIdx := 0
+
+	sequences := make([]Sequence, numSequences)
+	for i := 0; i < numSequences; i++ {
+		// Decode litLen
+		llCode := litLenCodes[i]
+		_, _, llNBits := encodeLitLen(decodeLitLen(llCode, 0))
+		llExtra := uint32(0)
+		if llNBits > 0 {
+			llExtra = extraBR.readBits(llNBits)
+		}
+		sequences[i].LitLen = decodeLitLen(llCode, llExtra)
+
+		// Decode match (if this sequence has one)
+		if matchIdx < numMatches {
+			mlCode := matchLenCodes[matchIdx]
+			_, _, mlNBits := encodeMatchLen(decodeMatchLen(mlCode, 0))
+			mlExtra := uint32(0)
+			if mlNBits > 0 {
+				mlExtra = extraBR.readBits(mlNBits)
+			}
+			sequences[i].MatchLen = decodeMatchLen(mlCode, mlExtra) + lz77MinMatch
+
+			offCode := offsetCodes[matchIdx]
+			offNBits := int(offCode) // offset code N has N extra bits
+			offExtra := uint32(0)
+			if offNBits > 0 {
+				offExtra = extraBR.readBits(offNBits)
+			}
+			sequences[i].Offset = decodeOffset(offCode, offExtra)
+			matchIdx++
+		}
+	}
+
+	// Reconstruct via LZ77
+	result := Reconstruct(&SequenceBlock{
+		Literals:  literals,
+		Sequences: sequences,
+	})
+
+	if len(result) != originalLen {
+		return nil, fmt.Errorf("compress: output length %d != expected %d", len(result), originalLen)
+	}
+
+	return result, nil
+}
+
+// CompressedHeader parses just the header without decompressing.
+// Returns version and original length.
+func CompressedHeader(data []byte) (version byte, originalLen int, err error) {
+	if len(data) < 5 {
+		return 0, 0, errors.New("compress: header too short")
+	}
+	return data[0], int(binary.BigEndian.Uint32(data[1:5])), nil
+}
+
+// ---- Block format ----
+//
+// Each block:
+//   [originalLen:4 BE]     -- decompressed byte count
+//   [flag:1]               -- 0x00 = FSE compressed, 0x01 = raw
+//   [dataLen:4 BE]         -- bytes of data following
+//   [data:dataLen]         -- FSE compressed bytes or raw bytes
+//
+// Total overhead per block: 9 bytes + data
+
+// compressOrRaw FSE-compresses data, or returns a raw block if FSE doesn't help.
+func compressOrRaw(data []byte) []byte {
+	if len(data) == 0 {
+		return rawBlock(nil)
+	}
+
+	compressed, err := FSECompress(data)
+	if err != nil || compressed == nil {
+		return rawBlock(data)
+	}
+
+	// FSE block
+	buf := make([]byte, 0, 9+len(compressed))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(data)))
+	buf = append(buf, 0x00) // FSE flag
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(compressed)))
+	buf = append(buf, compressed...)
+	return buf
+}
+
+// rawBlock creates a raw (uncompressed) block.
+func rawBlock(data []byte) []byte {
+	buf := make([]byte, 0, 9+len(data))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(data)))
+	buf = append(buf, 0x01) // raw flag
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(data)))
+	buf = append(buf, data...)
+	return buf
+}
+
+// readDecompressBlock reads a block, FSE-decompresses if needed, and returns
+// the decompressed bytes. expectedLen is the expected decompressed length.
+func readDecompressBlock(data []byte, pos int, expectedLen int) ([]byte, int, error) {
+	if pos+9 > len(data) {
+		return nil, 0, errors.New("block header truncated")
+	}
+
+	origLen := int(binary.BigEndian.Uint32(data[pos:]))
+	flag := data[pos+4]
+	dataLen := int(binary.BigEndian.Uint32(data[pos+5:]))
+	consumed := 9 + dataLen
+
+	if pos+consumed > len(data) {
+		return nil, 0, errors.New("block data truncated")
+	}
+
+	blockData := data[pos+9 : pos+9+dataLen]
+
+	if flag == 0x01 {
+		// Raw block — return data as-is
+		if origLen != dataLen {
+			return nil, 0, fmt.Errorf("raw block size mismatch: origLen=%d dataLen=%d", origLen, dataLen)
+		}
+		result := make([]byte, dataLen)
+		copy(result, blockData)
+		return result, consumed, nil
+	}
+
+	if flag != 0x00 {
+		return nil, 0, fmt.Errorf("unknown block flag 0x%02x", flag)
+	}
+
+	// FSE compressed — decompress
+	decompressed, err := FSEDecompress(blockData, origLen)
+	if err != nil {
+		return nil, 0, fmt.Errorf("FSE decompress: %w", err)
+	}
+	if len(decompressed) != expectedLen {
+		return nil, 0, fmt.Errorf("decompressed length %d != expected %d", len(decompressed), expectedLen)
+	}
+
+	return decompressed, consumed, nil
+}
+
+// readRawBlock reads a block without FSE decompression (for extra bits).
+func readRawBlock(data []byte, pos int) ([]byte, int, error) {
+	if pos+9 > len(data) {
+		return nil, 0, errors.New("block header truncated")
+	}
+
+	_ = binary.BigEndian.Uint32(data[pos:]) // origLen (same as dataLen for raw)
+	flag := data[pos+4]
+	dataLen := int(binary.BigEndian.Uint32(data[pos+5:]))
+	consumed := 9 + dataLen
+
+	if pos+consumed > len(data) {
+		return nil, 0, errors.New("block data truncated")
+	}
+
+	_ = flag // extra bits block is always raw
+	if dataLen == 0 {
+		return nil, consumed, nil
+	}
+	result := make([]byte, dataLen)
+	copy(result, data[pos+9:pos+9+dataLen])
+	return result, consumed, nil
+}

--- a/datalog/codec/compress_test.go
+++ b/datalog/codec/compress_test.go
@@ -1,0 +1,514 @@
+package codec
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	mathrand "math/rand"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- Round-Trip Tests ----
+
+func TestCompress_RoundTrip_EnglishText(t *testing.T) {
+	input := []byte(strings.Repeat(
+		"To be or not to be, that is the question. Whether tis nobler in the mind "+
+			"to suffer the slings and arrows of outrageous fortune, or to take arms "+
+			"against a sea of troubles, and by opposing end them. ", 5))
+
+	compressed := Compress(input)
+	require.NotNil(t, compressed, "English text should compress")
+	t.Logf("English text: %d → %d bytes (%.1fx)", len(input), len(compressed),
+		float64(len(input))/float64(len(compressed)))
+
+	decompressed, err := Decompress(compressed)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, decompressed))
+}
+
+func TestCompress_RoundTrip_EDN(t *testing.T) {
+	input := []byte(strings.Repeat(
+		"[#identity \"abc123\" :task/content \"The butler did it.\" [100 1] :op/none]\n", 30))
+
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+	t.Logf("EDN: %d → %d bytes (%.1fx)", len(input), len(compressed),
+		float64(len(input))/float64(len(compressed)))
+
+	decompressed, err := Decompress(compressed)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, decompressed))
+}
+
+func TestCompress_RoundTrip_Code(t *testing.T) {
+	input := []byte(strings.Repeat(
+		"func main() {\n\tfmt.Println(\"hello world\")\n\tfor i := 0; i < 10; i++ {\n\t\tfmt.Println(i)\n\t}\n}\n", 20))
+
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+	t.Logf("Code: %d → %d bytes (%.1fx)", len(input), len(compressed),
+		float64(len(input))/float64(len(compressed)))
+
+	decompressed, err := Decompress(compressed)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, decompressed))
+}
+
+func TestCompress_RoundTrip_AllSame(t *testing.T) {
+	input := bytes.Repeat([]byte{'a'}, 1000)
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+	t.Logf("All same: %d → %d bytes (%.1fx)", len(input), len(compressed),
+		float64(len(input))/float64(len(compressed)))
+
+	decompressed, err := Decompress(compressed)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, decompressed))
+}
+
+func TestCompress_RoundTrip_Repetitive(t *testing.T) {
+	input := bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 250)
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+	t.Logf("Repetitive: %d → %d bytes (%.1fx)", len(input), len(compressed),
+		float64(len(input))/float64(len(compressed)))
+
+	decompressed, err := Decompress(compressed)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, decompressed))
+}
+
+func TestCompress_RoundTrip_TwoAlternating(t *testing.T) {
+	input := bytes.Repeat([]byte{'a', 'b'}, 500)
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+
+	decompressed, err := Decompress(compressed)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, decompressed))
+}
+
+func TestCompress_RoundTrip_BinaryRamp(t *testing.T) {
+	input := make([]byte, 512)
+	for i := range input {
+		input[i] = byte(i % 256)
+	}
+	compressed := Compress(input)
+	if compressed != nil {
+		decompressed, err := Decompress(compressed)
+		require.NoError(t, err)
+		assert.True(t, bytes.Equal(input, decompressed))
+	}
+}
+
+func TestCompress_RoundTrip_SizeSweep(t *testing.T) {
+	sizes := []int{256, 300, 500, 1000, 2000, 4096, 8000, 16000, 50000}
+	for _, size := range sizes {
+		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+			base := []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", size/45+2))
+			input := base[:size]
+
+			compressed := Compress(input)
+			require.NotNil(t, compressed, "size=%d should compress", size)
+
+			decompressed, err := Decompress(compressed)
+			require.NoError(t, err)
+			assert.True(t, bytes.Equal(input, decompressed),
+				"size=%d: round-trip failed", size)
+
+			ratio := float64(size) / float64(len(compressed))
+			t.Logf("size=%d: %d → %d bytes (%.1fx)", size, size, len(compressed), ratio)
+		})
+	}
+}
+
+// ---- Safety Net Tests ----
+
+func TestCompress_SafetyNet_HighEntropy(t *testing.T) {
+	input := make([]byte, 1000)
+	rand.Read(input)
+	compressed := Compress(input)
+	assert.Nil(t, compressed, "truly random data should not compress")
+}
+
+func TestCompress_SafetyNet_Empty(t *testing.T) {
+	compressed := Compress(nil)
+	assert.Nil(t, compressed)
+}
+
+func TestCompress_SafetyNet_TooSmall(t *testing.T) {
+	// Very small inputs have too much header overhead
+	compressed := Compress([]byte("hi"))
+	assert.Nil(t, compressed, "2 bytes should not compress (header overhead)")
+}
+
+// ---- Header Tests ----
+
+func TestCompress_Header_Parse(t *testing.T) {
+	input := []byte(strings.Repeat("header test content ", 50))
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+
+	version, origLen, err := CompressedHeader(compressed)
+	require.NoError(t, err)
+	assert.Equal(t, CompressionVersion, version)
+	assert.Equal(t, len(input), origLen)
+}
+
+func TestCompress_Header_Truncated(t *testing.T) {
+	_, _, err := CompressedHeader([]byte{0x01, 0x00})
+	assert.Error(t, err)
+}
+
+func TestCompress_Header_WrongVersion(t *testing.T) {
+	data := make([]byte, 20)
+	data[0] = 0x02 // wrong version
+	binary.BigEndian.PutUint32(data[1:], 100)
+	_, err := Decompress(data)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported version")
+}
+
+func TestCompress_Header_Corrupted(t *testing.T) {
+	input := []byte(strings.Repeat("valid input for corruption test ", 50))
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+
+	// Flip a byte in the middle of the compressed data
+	corrupted := make([]byte, len(compressed))
+	copy(corrupted, compressed)
+	corrupted[len(corrupted)/2] ^= 0xFF
+
+	_, err := Decompress(corrupted)
+	// Should fail — either FSE decompress error or data mismatch
+	assert.Error(t, err, "corrupted data should fail decompression")
+}
+
+func TestCompress_Header_VersionByte(t *testing.T) {
+	input := []byte(strings.Repeat("version check ", 50))
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+	assert.Equal(t, CompressionVersion, compressed[0])
+}
+
+// ---- Determinism Stress Tests ----
+
+func TestCompress_Determinism_Repeated(t *testing.T) {
+	input := []byte(strings.Repeat("This is a determinism test. ", 100))
+	golden := Compress(input)
+	require.NotNil(t, golden)
+
+	for i := 0; i < 1000; i++ {
+		compressed := Compress(input)
+		require.True(t, bytes.Equal(golden, compressed), "iteration %d: output differs", i)
+	}
+}
+
+func TestCompress_Determinism_LargeRepeated(t *testing.T) {
+	base := []byte(strings.Repeat(
+		"To be or not to be, that is the question. Whether tis nobler in the mind to suffer. ", 600))
+	input := base[:50000]
+	golden := Compress(input)
+	require.NotNil(t, golden)
+
+	for i := 0; i < 100; i++ {
+		compressed := Compress(input)
+		require.True(t, bytes.Equal(golden, compressed), "iteration %d: output differs", i)
+	}
+}
+
+func TestCompress_Determinism_Concurrent(t *testing.T) {
+	input := []byte(strings.Repeat("concurrent test payload ", 100))
+	golden := Compress(input)
+	require.NotNil(t, golden)
+
+	var wg sync.WaitGroup
+	errs := make(chan string, 100)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			compressed := Compress(input)
+			if !bytes.Equal(golden, compressed) {
+				errs <- fmt.Sprintf("goroutine %d: output differs (len %d vs %d)",
+					idx, len(compressed), len(golden))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+	for msg := range errs {
+		t.Error(msg)
+	}
+}
+
+// ---- Fuzz Round-Trip Tests ----
+
+func TestCompress_Fuzz_RandomInputs(t *testing.T) {
+	rng := mathrand.New(mathrand.NewSource(42))
+	for i := 0; i < 500; i++ {
+		size := rng.Intn(10000) + 100
+		input := make([]byte, size)
+		rng.Read(input)
+
+		compressed := Compress(input)
+		if compressed == nil {
+			continue // safety net
+		}
+
+		decompressed, err := Decompress(compressed)
+		require.NoError(t, err, "input %d (size %d)", i, size)
+		require.True(t, bytes.Equal(input, decompressed),
+			"input %d (size %d): round-trip failed", i, size)
+	}
+}
+
+func TestCompress_Fuzz_TextLike(t *testing.T) {
+	words := []string{"the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog",
+		"and", "then", "sat", "down", "by", "river", "to", "rest", "a", "in", "on"}
+	rng := mathrand.New(mathrand.NewSource(43))
+
+	for i := 0; i < 200; i++ {
+		numWords := rng.Intn(500) + 50
+		var sb strings.Builder
+		for j := 0; j < numWords; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(words[rng.Intn(len(words))])
+		}
+		input := []byte(sb.String())
+
+		compressed := Compress(input)
+		if compressed == nil {
+			continue
+		}
+
+		decompressed, err := Decompress(compressed)
+		require.NoError(t, err, "sentence %d (len %d)", i, len(input))
+		require.True(t, bytes.Equal(input, decompressed),
+			"sentence %d: round-trip failed (len %d)", i, len(input))
+	}
+}
+
+func TestCompress_Fuzz_StructuredData(t *testing.T) {
+	rng := mathrand.New(mathrand.NewSource(44))
+
+	for i := 0; i < 100; i++ {
+		// Generate EDN-like lines
+		var sb strings.Builder
+		numLines := rng.Intn(20) + 5
+		for j := 0; j < numLines; j++ {
+			fmt.Fprintf(&sb, "[#identity \"%06d\" :attr/name-%d \"value-%d\" [%d 1] :op/none]\n",
+				rng.Intn(999999), rng.Intn(10), rng.Intn(1000), rng.Intn(10000))
+		}
+		input := []byte(sb.String())
+
+		compressed := Compress(input)
+		if compressed == nil {
+			continue
+		}
+
+		decompressed, err := Decompress(compressed)
+		require.NoError(t, err, "edn %d", i)
+		require.True(t, bytes.Equal(input, decompressed),
+			"edn %d: round-trip failed (len %d)", i, len(input))
+	}
+}
+
+// ---- Compression Ratio Tests ----
+
+func makeTestInput(pattern string, targetSize int) []byte {
+	reps := targetSize/len(pattern) + 2
+	base := []byte(strings.Repeat(pattern, reps))
+	return base[:targetSize]
+}
+
+func TestCompress_Ratio_EnglishProse(t *testing.T) {
+	input := makeTestInput(
+		"To be or not to be, that is the question. Whether tis nobler in the mind "+
+			"to suffer the slings and arrows of outrageous fortune, or to take arms "+
+			"against a sea of troubles, and by opposing end them. ", 10000)
+
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+	ratio := float64(len(input)) / float64(len(compressed))
+	t.Logf("English prose 10KB: %.2fx (%d → %d bytes)", ratio, len(input), len(compressed))
+	assert.Greater(t, ratio, 2.5, "expected at least 2.5x on English prose")
+}
+
+func TestCompress_Ratio_StructuredEDN(t *testing.T) {
+	input := makeTestInput(
+		"[#identity \"abc123\" :task/content \"The butler did it in the library.\" [100 1] :op/none]\n", 10000)
+
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+	ratio := float64(len(input)) / float64(len(compressed))
+	t.Logf("EDN 10KB: %.2fx (%d → %d bytes)", ratio, len(input), len(compressed))
+	assert.Greater(t, ratio, 2.0, "expected at least 2x on structured EDN")
+}
+
+func TestCompress_Ratio_SourceCode(t *testing.T) {
+	input := makeTestInput(
+		"func processItem(ctx context.Context, item *Item) error {\n"+
+			"\tif item == nil {\n\t\treturn fmt.Errorf(\"nil item\")\n\t}\n"+
+			"\tresult, err := db.Query(ctx, item.ID)\n"+
+			"\tif err != nil {\n\t\treturn err\n\t}\n"+
+			"\treturn result.Apply(item)\n}\n\n", 10000)
+
+	compressed := Compress(input)
+	require.NotNil(t, compressed)
+	ratio := float64(len(input)) / float64(len(compressed))
+	t.Logf("Source code 10KB: %.2fx (%d → %d bytes)", ratio, len(input), len(compressed))
+	assert.Greater(t, ratio, 2.0, "expected at least 2x on source code")
+}
+
+// ---- Golden Tests ----
+// These record the exact compressed output for specific inputs.
+// If ANY golden test fails after a code change, the change MUST be rejected.
+// The golden outputs are as immutable as the L85 alphabet.
+//
+// Golden outputs are recorded by running the test once with -update-golden
+// (or manually). Once recorded, they are frozen forever.
+
+// goldenTest defines a golden test case.
+type goldenTest struct {
+	name           string
+	input          []byte
+	expectedHex    string // hex-encoded expected compressed output (empty = not yet recorded)
+	minRatio       float64
+}
+
+// The golden tests are initially run without expectedHex to record the outputs.
+// Once recorded, the hex strings are frozen.
+var goldenTests = []goldenTest{
+	{
+		name:     "paragraph_500",
+		input:    []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", 11))[:500],
+		minRatio: 2.0,
+	},
+	{
+		name:     "prose_1kb",
+		input:    []byte(strings.Repeat("To be or not to be, that is the question. Whether tis nobler in the mind to suffer the slings and arrows. ", 10))[:1024],
+		minRatio: 2.0,
+	},
+	{
+		name:     "edn_1kb",
+		input:    []byte(strings.Repeat("[#identity \"hash25\" :test/attr \"some value here\" [42 1] :op/none]\n", 16))[:1024],
+		minRatio: 2.0,
+	},
+	{
+		name:     "repetitive_1kb",
+		input:    bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 256),
+		minRatio: 5.0,
+	},
+	{
+		name:     "all_same_1kb",
+		input:    bytes.Repeat([]byte{'a'}, 1024),
+		minRatio: 10.0,
+	},
+}
+
+func TestCompress_Golden_Record(t *testing.T) {
+	// This test records golden outputs. Run once to capture, then
+	// copy the hex strings into goldenTests above and freeze them.
+	for _, gt := range goldenTests {
+		t.Run(gt.name, func(t *testing.T) {
+			compressed := Compress(gt.input)
+			require.NotNil(t, compressed, "%s should compress", gt.name)
+
+			// Verify round-trip
+			decompressed, err := Decompress(compressed)
+			require.NoError(t, err)
+			require.True(t, bytes.Equal(gt.input, decompressed), "round-trip failed")
+
+			ratio := float64(len(gt.input)) / float64(len(compressed))
+			t.Logf("%s: %d → %d bytes (%.1fx)", gt.name, len(gt.input), len(compressed), ratio)
+			assert.GreaterOrEqual(t, ratio, gt.minRatio,
+				"%s: ratio %.1f below minimum %.1f", gt.name, ratio, gt.minRatio)
+
+			// Print hex for recording
+			t.Logf("GOLDEN %s: %s", gt.name, hex.EncodeToString(compressed))
+
+			// If expectedHex is set, verify it matches
+			if gt.expectedHex != "" {
+				expected, err := hex.DecodeString(gt.expectedHex)
+				require.NoError(t, err)
+				assert.True(t, bytes.Equal(compressed, expected),
+					"%s: compressed output changed!\nGot:    %s\nExpect: %s",
+					gt.name, hex.EncodeToString(compressed), gt.expectedHex)
+			}
+		})
+	}
+}
+
+func TestCompress_Determinism_Golden(t *testing.T) {
+	// Each golden input compressed 100 times must produce identical output
+	for _, gt := range goldenTests {
+		t.Run(gt.name, func(t *testing.T) {
+			golden := Compress(gt.input)
+			require.NotNil(t, golden)
+
+			for i := 0; i < 100; i++ {
+				compressed := Compress(gt.input)
+				require.True(t, bytes.Equal(golden, compressed),
+					"%s: iteration %d differs", gt.name, i)
+			}
+		})
+	}
+}
+
+// ---- Benchmarks ----
+
+func BenchmarkCompress(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"256B", 256}, {"1KB", 1024}, {"4KB", 4096}, {"16KB", 16384},
+	}
+	for _, s := range sizes {
+		base := []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", s.size/45+2))
+		input := base[:s.size]
+		b.Run(s.name, func(b *testing.B) {
+			b.SetBytes(int64(s.size))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				Compress(input)
+			}
+		})
+	}
+}
+
+func BenchmarkDecompress(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"256B", 256}, {"1KB", 1024}, {"4KB", 4096}, {"16KB", 16384},
+	}
+	for _, s := range sizes {
+		base := []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", s.size/45+2))
+		input := base[:s.size]
+		compressed := Compress(input)
+		if compressed == nil {
+			continue
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.SetBytes(int64(s.size))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				Decompress(compressed)
+			}
+		})
+	}
+}

--- a/datalog/codec/compress_test.go
+++ b/datalog/codec/compress_test.go
@@ -388,33 +388,39 @@ type goldenTest struct {
 	minRatio       float64
 }
 
-// The golden tests are initially run without expectedHex to record the outputs.
-// Once recorded, the hex strings are frozen.
+// Golden tests: frozen compressed outputs. If ANY of these change, the codec
+// determinism guarantee is broken and the change MUST be rejected.
+// Recorded 2026-03-28 from CompressionVersion 0x01.
 var goldenTests = []goldenTest{
 	{
-		name:     "paragraph_500",
-		input:    []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", 11))[:500],
-		minRatio: 2.0,
+		name:        "paragraph_500",
+		input:       []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", 11))[:500],
+		minRatio:    2.0,
+		expectedHex: "01000001f4000300030000002e0000002e010000002e54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f672e2000000000030100000003140001000000030100000003171701000000030100000003050500000000040100000004fd6ead06",
 	},
 	{
-		name:     "prose_1kb",
-		input:    []byte(strings.Repeat("To be or not to be, that is the question. Whether tis nobler in the mind to suffer the slings and arrows. ", 10))[:1024],
-		minRatio: 2.0,
+		name:        "prose_1kb",
+		input:       []byte(strings.Repeat("To be or not to be, that is the question. Whether tis nobler in the mind to suffer the slings and arrows. ", 10))[:1024],
+		minRatio:    2.0,
+		expectedHex: "01000004000008000800000059000000590100000059546f206265206f72206e6f7420742c207468617420697320746865207175657374696f6e2e205768657468657220746973206e6f626c657220696e6d696e6473756666686520736c696e677320616e64206172726f77732e200000000801000000080e14040412000000000000080100000008010201011717171600000008010000000803050505060606060000000a010000000a6dc2836ff5adbed55e05",
 	},
 	{
-		name:     "edn_1kb",
-		input:    []byte(strings.Repeat("[#identity \"hash25\" :test/attr \"some value here\" [42 1] :op/none]\n", 16))[:1024],
-		minRatio: 2.0,
+		name:        "edn_1kb",
+		input:       []byte(strings.Repeat("[#identity \"hash25\" :test/attr \"some value here\" [42 1] :op/none]\n", 16))[:1024],
+		minRatio:    2.0,
+		expectedHex: "010000040000040004000000420000004201000000425b236964656e74697479202268617368323522203a746573742f617474722022736f6d652076616c7565206865726522205b343220315d203a6f702f6e6f6e655d0a000000040100000004150000000000000401000000041717171700000004010000000406060606000000080100000008f22dbc85b7501200",
 	},
 	{
-		name:     "repetitive_1kb",
-		input:    bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 256),
-		minRatio: 5.0,
+		name:        "repetitive_1kb",
+		input:       bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 256),
+		minRatio:    5.0,
+		expectedHex: "01000004000004000400000004000000040100000004deadbeef0000000401000000040400000000000004010000000417171717000000040100000004020202020000000501000000056fdebc1903",
 	},
 	{
-		name:     "all_same_1kb",
-		input:    bytes.Repeat([]byte{'a'}, 1024),
-		minRatio: 10.0,
+		name:        "all_same_1kb",
+		input:       bytes.Repeat([]byte{'a'}, 1024),
+		minRatio:    10.0,
+		expectedHex: "0100000400000400040000000100000001010000000161000000040100000004010000000000000401000000041717171700000004010000000400000000000000040100000004eff7db0c",
 	},
 }
 

--- a/datalog/codec/fse.go
+++ b/datalog/codec/fse.go
@@ -1,0 +1,684 @@
+// Package codec provides encoding utilities for janus-datalog storage.
+//
+// FSE (Finite State Entropy) implements tANS (table-based Asymmetric Numeral
+// Systems) for near-optimal entropy coding. This is a custom, owned
+// implementation for deterministic compression in storage keys.
+//
+// The implementation is frozen: same input must always produce same output,
+// forever. Do not change the algorithm without updating the compression
+// version byte.
+package codec
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/bits"
+	"sync"
+)
+
+// FSE constants
+const (
+	fseMaxTableLog    = 12
+	fseMinTableLog    = 5
+	fseDefaultTableLog = 8 // good default for byte-alphabet data
+	fseMaxSymbolValue = 255
+)
+
+// ---- Bit I/O ----
+
+// bitWriter accumulates bits LSB-first and flushes to a byte slice.
+type bitWriter struct {
+	buf   uint64
+	nbits int // valid bits in buf (0-63)
+	out   []byte
+}
+
+// writeBits writes the low nbits of value to the stream, LSB first.
+func (w *bitWriter) writeBits(value uint32, nbits int) {
+	w.buf |= uint64(value) << uint(w.nbits)
+	w.nbits += nbits
+	for w.nbits >= 8 {
+		w.out = append(w.out, byte(w.buf))
+		w.buf >>= 8
+		w.nbits -= 8
+	}
+}
+
+// flush writes any remaining partial byte and returns the output.
+func (w *bitWriter) flush() []byte {
+	if w.nbits > 0 {
+		w.out = append(w.out, byte(w.buf))
+	}
+	return w.out
+}
+
+// bitReader reads bits LSB-first from a byte slice.
+type bitReader struct {
+	data  []byte
+	buf   uint64
+	nbits int // valid bits in buf
+	pos   int // next byte to read from data
+}
+
+func newBitReader(data []byte) *bitReader {
+	r := &bitReader{data: data}
+	r.refill()
+	return r
+}
+
+// refill loads more bytes into the buffer.
+func (r *bitReader) refill() {
+	for r.nbits <= 56 && r.pos < len(r.data) {
+		r.buf |= uint64(r.data[r.pos]) << uint(r.nbits)
+		r.nbits += 8
+		r.pos++
+	}
+}
+
+// readBits reads nbits from the stream, LSB first.
+func (r *bitReader) readBits(nbits int) uint32 {
+	if nbits == 0 {
+		return 0
+	}
+	val := uint32(r.buf) & ((1 << uint(nbits)) - 1)
+	r.buf >>= uint(nbits)
+	r.nbits -= nbits
+	r.refill()
+	return val
+}
+
+// bitsRemaining returns the number of unread bits.
+func (r *bitReader) bitsRemaining() int {
+	return r.nbits + (len(r.data)-r.pos)*8
+}
+
+// ---- Count Normalization ----
+
+// normalizeCount converts raw symbol frequencies to normalized counts that
+// sum to exactly tableSize = 1 << tableLog. Every symbol with non-zero
+// raw count gets at least 1 in the normalized output.
+func normalizeCount(counts []int, tableLog int) ([]int16, int, error) {
+	tableSize := 1 << tableLog
+
+	// Find total and max symbol
+	total := 0
+	maxSymbol := 0
+	nonZero := 0
+	for i, c := range counts {
+		if c > 0 {
+			total += c
+			maxSymbol = i
+			nonZero++
+		}
+	}
+	if total == 0 {
+		return nil, 0, errors.New("fse: no symbols")
+	}
+	if nonZero == 1 {
+		// Single symbol: special case
+		norm := make([]int16, maxSymbol+1)
+		norm[maxSymbol] = int16(tableSize)
+		return norm, maxSymbol, nil
+	}
+	if nonZero > tableSize {
+		return nil, 0, fmt.Errorf("fse: too many symbols (%d) for tableLog %d", nonZero, tableLog)
+	}
+
+	norm := make([]int16, maxSymbol+1)
+
+	// Two-pass allocation:
+	// Pass 1: Give every non-zero symbol max(1, floor(count * tableSize / total)).
+	// Pass 2: Distribute remaining capacity to symbols proportionally, largest first.
+	assigned := 0
+	largestSymbol := -1
+	largestCount := 0
+
+	for i := 0; i <= maxSymbol; i++ {
+		if counts[i] == 0 {
+			continue
+		}
+		n := counts[i] * tableSize / total // floor division
+		if n < 1 {
+			n = 1
+		}
+		norm[i] = int16(n)
+		assigned += n
+
+		if counts[i] > largestCount {
+			largestCount = counts[i]
+			largestSymbol = i
+		}
+	}
+
+	// Distribute remaining slots (or reclaim excess) via the largest symbol
+	diff := tableSize - assigned
+	norm[largestSymbol] += int16(diff)
+
+	// If the largest symbol was driven below 1 (too many symbols forced to 1),
+	// steal from the next-largest symbols to fix it.
+	if norm[largestSymbol] < 1 {
+		// Sort non-zero symbols by their norm descending, steal from them
+		type symCount struct {
+			sym   int
+			count int16
+		}
+		var syms []symCount
+		for i := 0; i <= maxSymbol; i++ {
+			if norm[i] > 1 && i != largestSymbol {
+				syms = append(syms, symCount{i, norm[i]})
+			}
+		}
+		// Sort by count descending so we steal from the richest first
+		for i := 0; i < len(syms)-1; i++ {
+			for j := i + 1; j < len(syms); j++ {
+				if syms[j].count > syms[i].count {
+					syms[i], syms[j] = syms[j], syms[i]
+				}
+			}
+		}
+		for _, sc := range syms {
+			if norm[largestSymbol] >= 1 {
+				break
+			}
+			steal := int16(1) // steal 1 at a time
+			if norm[sc.sym]-steal < 1 {
+				continue
+			}
+			norm[sc.sym] -= steal
+			norm[largestSymbol] += steal
+		}
+		if norm[largestSymbol] < 1 {
+			return nil, 0, errors.New("fse: normalization failed - cannot fit all symbols")
+		}
+	}
+
+	// Verify sum
+	sum := 0
+	for i := 0; i <= maxSymbol; i++ {
+		sum += int(norm[i])
+		if norm[i] < 0 {
+			return nil, 0, fmt.Errorf("fse: negative normalized count for symbol %d", i)
+		}
+	}
+	if sum != tableSize {
+		return nil, 0, fmt.Errorf("fse: normalized sum %d != tableSize %d", sum, tableSize)
+	}
+
+	return norm, maxSymbol, nil
+}
+
+// ---- Table Construction ----
+
+// fseDecodeEntry is one entry in the FSE decode table.
+type fseDecodeEntry struct {
+	newState uint16
+	symbol   uint8
+	nbBits   uint8
+}
+
+// symbolTransform holds precomputed encoding parameters for one symbol.
+type symbolTransform struct {
+	deltaNbBits    uint32 // (maxBitsOut << 16) - minStatePlus
+	deltaFindState int32  // offset into stateTable
+}
+
+// fseTable holds both encode and decode tables for FSE.
+type fseTable struct {
+	tableLog    int
+	maxSymbol   int
+	normCounts  []int16          // normalized counts per symbol
+	decodeTable []fseDecodeEntry // indexed by state [0, tableSize)
+	stateTable  []uint16         // encode: maps reduced state + offset → full state
+	symbolTT    []symbolTransform // encode: per-symbol transform parameters
+}
+
+// buildFSETable builds both encode and decode tables from normalized counts.
+func buildFSETable(normCounts []int16, maxSymbol int, tableLog int) (*fseTable, error) {
+	tableSize := 1 << tableLog
+
+	// Verify counts sum to tableSize
+	sum := 0
+	for i := 0; i <= maxSymbol; i++ {
+		sum += int(normCounts[i])
+	}
+	if sum != tableSize {
+		return nil, fmt.Errorf("fse: counts sum %d != tableSize %d", sum, tableSize)
+	}
+
+	t := &fseTable{
+		tableLog:   tableLog,
+		maxSymbol:  maxSymbol,
+		normCounts: normCounts,
+	}
+
+	// Step 1: Build spread table
+	spread := make([]byte, tableSize)
+	step := (tableSize >> 1) + (tableSize >> 3) + 3
+	mask := tableSize - 1
+	pos := 0
+	for s := 0; s <= maxSymbol; s++ {
+		for i := 0; i < int(normCounts[s]); i++ {
+			spread[pos] = byte(s)
+			pos = (pos + step) & mask
+		}
+	}
+
+	// Step 2: Build decode table
+	t.decodeTable = make([]fseDecodeEntry, tableSize)
+	symbolCounter := make([]int, maxSymbol+1)
+	for s := 0; s <= maxSymbol; s++ {
+		symbolCounter[s] = int(normCounts[s])
+	}
+
+	for x := 0; x < tableSize; x++ {
+		s := spread[x]
+		nextState := symbolCounter[s]
+		symbolCounter[s]++
+
+		// highBit of nextState
+		highBit := bits.Len(uint(nextState)) - 1
+		nbBits := tableLog - highBit
+		newState := uint16((nextState << uint(nbBits)) - tableSize)
+
+		t.decodeTable[x] = fseDecodeEntry{
+			newState: newState,
+			symbol:   s,
+			nbBits:   uint8(nbBits),
+		}
+	}
+
+	// Step 3: Build encode state table
+	// For each position u in spread, stateTable[cumul[s]++] = tableSize + u
+	t.stateTable = make([]uint16, tableSize)
+	cumul := make([]int, maxSymbol+2)
+	for s := 0; s <= maxSymbol; s++ {
+		cumul[s+1] = cumul[s] + int(normCounts[s])
+	}
+	// working copy of cumulative counters
+	cumulCopy := make([]int, maxSymbol+2)
+	copy(cumulCopy, cumul)
+
+	for u := 0; u < tableSize; u++ {
+		s := spread[u]
+		t.stateTable[cumulCopy[s]] = uint16(tableSize + u)
+		cumulCopy[s]++
+	}
+
+	// Step 4: Build symbolTT (encode parameters)
+	t.symbolTT = make([]symbolTransform, maxSymbol+1)
+	cumulRunning := 0
+	for s := 0; s <= maxSymbol; s++ {
+		count := int(normCounts[s])
+		if count == 0 {
+			// Unused: deltaNbBits won't be used, but set to safe value
+			t.symbolTT[s].deltaNbBits = (uint32(tableLog) << 16) + uint32(tableSize)
+			t.symbolTT[s].deltaFindState = int32(-cumulRunning)
+			continue
+		}
+
+		if count == 1 {
+			t.symbolTT[s].deltaNbBits = (uint32(tableLog) << 16) - uint32(tableSize)
+			t.symbolTT[s].deltaFindState = int32(cumulRunning - 1)
+		} else {
+			maxBitsOut := tableLog - (bits.Len(uint(count-1)) - 1)
+			minStatePlus := count << uint(maxBitsOut)
+			t.symbolTT[s].deltaNbBits = (uint32(maxBitsOut) << 16) - uint32(minStatePlus)
+			t.symbolTT[s].deltaFindState = int32(cumulRunning - count)
+		}
+		cumulRunning += count
+	}
+
+	return t, nil
+}
+
+// ---- Table Cache ----
+
+// fseTableCache caches decoded FSE tables by their serialized header bytes.
+// The decode path hits this on every FSEDecompress call, avoiding full table
+// reconstruction for repeated table descriptions (common when many values
+// share similar byte distributions).
+var fseTableCache sync.Map // map[string]*fseTable
+
+// getCachedTable looks up or builds an FSE table from serialized header bytes.
+func getCachedTable(headerBytes []byte) (*fseTable, error) {
+	key := string(headerBytes) // safe: used as map key only
+
+	if cached, ok := fseTableCache.Load(key); ok {
+		return cached.(*fseTable), nil
+	}
+
+	// Build fresh table
+	t, _, err := deserializeTableDirect(headerBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache it (Store is idempotent — concurrent builds are fine)
+	fseTableCache.Store(key, t)
+	return t, nil
+}
+
+// ---- Encode Working Memory Pool ----
+
+type encodeWork struct {
+	pairs []struct {
+		value uint32
+		nbits int
+	}
+}
+
+var encodeWorkPool = sync.Pool{
+	New: func() interface{} {
+		return &encodeWork{
+			pairs: make([]struct {
+				value uint32
+				nbits int
+			}, 0, 1024),
+		}
+	},
+}
+
+// ---- Table Serialization ----
+
+// serializeTable writes the FSE table description to bytes.
+// Format: [tableLog:1][maxSymbol:1][count0:2][count1:2]...[countN:2]
+func serializeTable(t *fseTable) []byte {
+	buf := make([]byte, 2+2*(t.maxSymbol+1))
+	buf[0] = byte(t.tableLog)
+	buf[1] = byte(t.maxSymbol)
+	for i := 0; i <= t.maxSymbol; i++ {
+		binary.LittleEndian.PutUint16(buf[2+i*2:], uint16(t.normCounts[i]))
+	}
+	return buf
+}
+
+// fseHeaderSize returns the header size for the given data, or an error.
+func fseHeaderSize(data []byte) (int, error) {
+	if len(data) < 2 {
+		return 0, errors.New("fse: table header too short")
+	}
+	tableLog := int(data[0])
+	maxSymbol := int(data[1])
+	if tableLog < fseMinTableLog || tableLog > fseMaxTableLog {
+		return 0, fmt.Errorf("fse: invalid tableLog %d", tableLog)
+	}
+	if maxSymbol > fseMaxSymbolValue {
+		return 0, fmt.Errorf("fse: invalid maxSymbol %d", maxSymbol)
+	}
+	headerSize := 2 + 2*(maxSymbol+1)
+	if len(data) < headerSize {
+		return 0, errors.New("fse: table data too short")
+	}
+	return headerSize, nil
+}
+
+// deserializeTableDirect builds an fseTable from serialized header bytes.
+// This is the uncached path — use getCachedTable for the hot path.
+func deserializeTableDirect(data []byte) (*fseTable, int, error) {
+	headerSize, err := fseHeaderSize(data)
+	if err != nil {
+		return nil, 0, err
+	}
+	tableLog := int(data[0])
+	maxSymbol := int(data[1])
+
+	normCounts := make([]int16, maxSymbol+1)
+	for i := 0; i <= maxSymbol; i++ {
+		normCounts[i] = int16(binary.LittleEndian.Uint16(data[2+i*2:]))
+	}
+
+	t, err := buildFSETable(normCounts, maxSymbol, tableLog)
+	if err != nil {
+		return nil, 0, err
+	}
+	return t, headerSize, nil
+}
+
+// deserializeTable reads an FSE table description from bytes (cached).
+func deserializeTable(data []byte) (*fseTable, int, error) {
+	headerSize, err := fseHeaderSize(data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	t, err := getCachedTable(data[:headerSize])
+	if err != nil {
+		return nil, 0, err
+	}
+	return t, headerSize, nil
+}
+
+// ---- Compress ----
+
+// FSECompress compresses a byte slice using Finite State Entropy coding.
+// Returns compressed bytes including the table description, or nil if
+// compression provides no size benefit.
+func FSECompress(src []byte) ([]byte, error) {
+	if len(src) == 0 {
+		return nil, nil
+	}
+
+	// Count symbol frequencies
+	var counts [256]int
+	for _, b := range src {
+		counts[b]++
+	}
+
+	// Choose tableLog based on input size and symbol count
+	tableLog := chooseTableLog(len(src), &counts)
+
+	// Normalize counts
+	normCounts, maxSymbol, err := normalizeCount(counts[:], tableLog)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for single symbol (RLE case)
+	nonZero := 0
+	for _, c := range normCounts {
+		if c > 0 {
+			nonZero++
+		}
+	}
+	if nonZero == 1 {
+		// RLE: compact encoding [0xFF marker][symbol:1][length:4] = 6 bytes
+		var rleSymbol byte
+		for i, c := range normCounts {
+			if c > 0 {
+				rleSymbol = byte(i)
+				break
+			}
+		}
+		result := make([]byte, 6)
+		result[0] = 0xFF // RLE marker (invalid as tableLog, signals RLE)
+		result[1] = rleSymbol
+		binary.LittleEndian.PutUint32(result[2:], uint32(len(src)))
+		if len(result) >= len(src) {
+			return nil, nil // no benefit
+		}
+		return result, nil
+	}
+
+	// Build tables
+	t, err := buildFSETable(normCounts, maxSymbol, tableLog)
+	if err != nil {
+		return nil, err
+	}
+
+	// Encode symbols in reverse order, collecting bit pairs
+	tableSize := 1 << tableLog
+	state := tableSize // initial encoder state
+
+	work := encodeWorkPool.Get().(*encodeWork)
+	work.pairs = work.pairs[:0] // reset length, keep capacity
+
+	for i := len(src) - 1; i >= 0; i-- {
+		s := src[i]
+
+		// Compute number of bits to output
+		nbBitsOut := int((uint32(state) + t.symbolTT[s].deltaNbBits) >> 16)
+
+		// Record bits to output
+		bitsValue := uint32(state) & ((1 << uint(nbBitsOut)) - 1)
+		work.pairs = append(work.pairs, struct {
+			value uint32
+			nbits int
+		}{bitsValue, nbBitsOut})
+
+		// Transition state
+		reducedState := state >> uint(nbBitsOut)
+		state = int(t.stateTable[int32(reducedState)+t.symbolTT[s].deltaFindState])
+	}
+
+	// Build output: [tableHeader][initialState:tableLog bits][bits in decoder order][sentinel]
+	header := serializeTable(t)
+
+	bw := &bitWriter{out: make([]byte, 0, len(header)+len(src))}
+	// Pre-write header so we assemble in one buffer
+	bw.out = append(bw.out, header...)
+
+	// Write initial state for decoder (encoder's final state, minus tableSize)
+	bw.writeBits(uint32(state-tableSize), tableLog)
+
+	// Write bit pairs in REVERSE order (so decoder reads them forward)
+	pairs := work.pairs
+	for i := len(pairs) - 1; i >= 0; i-- {
+		if pairs[i].nbits > 0 {
+			bw.writeBits(pairs[i].value, pairs[i].nbits)
+		}
+	}
+
+	// Return pooled work memory
+	encodeWorkPool.Put(work)
+
+	// Write sentinel bit (1 followed by zero padding to byte boundary)
+	// Decoder finds the highest set bit in the last byte to determine data end.
+	bw.writeBits(1, 1)
+	result := bw.flush()
+
+	if len(result) >= len(src) {
+		return nil, nil // no compression benefit
+	}
+
+	return result, nil
+}
+
+// chooseTableLog picks an appropriate tableLog for the given input.
+func chooseTableLog(srcLen int, counts *[256]int) int {
+	// Count non-zero symbols
+	nonZero := 0
+	for _, c := range counts {
+		if c > 0 {
+			nonZero++
+		}
+	}
+
+	// tableLog should be at least log2(nonZero) + 2
+	minLog := bits.Len(uint(nonZero-1)) + 2
+	if minLog < fseMinTableLog {
+		minLog = fseMinTableLog
+	}
+
+	// For small inputs, use smaller tableLog
+	maxLog := fseDefaultTableLog
+	if srcLen < 256 {
+		maxLog = 7
+	}
+	if srcLen < 64 {
+		maxLog = 6
+	}
+
+	if minLog > maxLog {
+		return minLog
+	}
+	return maxLog
+}
+
+// ---- Decompress ----
+
+// FSEDecompress decompresses FSE-compressed data.
+// originalLen is the expected output length.
+func FSEDecompress(compressed []byte, originalLen int) ([]byte, error) {
+	if originalLen == 0 {
+		return nil, nil
+	}
+	if len(compressed) == 0 {
+		return nil, errors.New("fse: empty compressed data")
+	}
+
+	// Check for RLE marker (0xFF in first byte)
+	if compressed[0] == 0xFF {
+		if len(compressed) < 6 {
+			return nil, errors.New("fse: truncated RLE data")
+		}
+		rleSymbol := compressed[1]
+		rleLen := int(binary.LittleEndian.Uint32(compressed[2:]))
+		if rleLen != originalLen {
+			return nil, fmt.Errorf("fse: RLE length mismatch: %d vs %d", rleLen, originalLen)
+		}
+		out := make([]byte, originalLen)
+		for i := range out {
+			out[i] = rleSymbol
+		}
+		return out, nil
+	}
+
+	// Deserialize table
+	t, headerSize, err := deserializeTable(compressed)
+	if err != nil {
+		return nil, fmt.Errorf("fse: %w", err)
+	}
+
+	// Read bitstream (after header)
+	bitData := compressed[headerSize:]
+	if len(bitData) == 0 {
+		return nil, errors.New("fse: no bitstream data")
+	}
+
+	// Find sentinel bit: scan from the end of the last byte
+	lastByte := bitData[len(bitData)-1]
+	if lastByte == 0 {
+		return nil, errors.New("fse: invalid bitstream (last byte is 0, no sentinel)")
+	}
+	sentinelPos := bits.Len(uint(lastByte)) - 1 // position of highest set bit
+
+	// Calculate total valid bits: all bytes except last provide 8 bits,
+	// last byte provides sentinelPos bits (the sentinel itself is not data)
+	totalBits := (len(bitData)-1)*8 + sentinelPos
+
+	// Create a bit reader for the valid bits
+	// We need to read exactly totalBits of data
+	br := newBitReader(bitData)
+
+	// Read initial state
+	tableLog := t.tableLog
+	state := int(br.readBits(tableLog))
+
+	// Decode symbols
+	out := make([]byte, originalLen)
+	bitsRead := tableLog
+
+	for i := 0; i < originalLen; i++ {
+		// Decode symbol from current state
+		entry := t.decodeTable[state]
+		out[i] = entry.symbol
+
+		if i == originalLen-1 {
+			break // last symbol, no need to transition
+		}
+
+		// Read bits and transition to next state
+		nbBits := int(entry.nbBits)
+		addBits := int(br.readBits(nbBits))
+		state = int(entry.newState) + addBits
+		bitsRead += nbBits
+	}
+
+	// Verify we consumed the right amount of bits
+	if bitsRead > totalBits {
+		return nil, fmt.Errorf("fse: consumed %d bits but only %d available", bitsRead, totalBits)
+	}
+
+	return out, nil
+}

--- a/datalog/codec/fse_bench_test.go
+++ b/datalog/codec/fse_bench_test.go
@@ -1,0 +1,109 @@
+package codec
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func BenchmarkFSECompress_EnglishText(b *testing.B) {
+	input := []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", 100))
+	b.SetBytes(int64(len(input)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		FSECompress(input)
+	}
+}
+
+func BenchmarkFSEDecompress_EnglishText(b *testing.B) {
+	input := []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", 100))
+	compressed, _ := FSECompress(input)
+	b.SetBytes(int64(len(input)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		FSEDecompress(compressed, len(input))
+	}
+}
+
+func BenchmarkFSECompress_Skewed1KB(b *testing.B) {
+	rng := rand.New(rand.NewSource(42))
+	input := make([]byte, 1024)
+	for i := range input {
+		if rng.Intn(20) == 0 {
+			input[i] = 'b'
+		} else {
+			input[i] = 'a'
+		}
+	}
+	b.SetBytes(int64(len(input)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		FSECompress(input)
+	}
+}
+
+func BenchmarkFSEDecompress_Skewed1KB(b *testing.B) {
+	rng := rand.New(rand.NewSource(42))
+	input := make([]byte, 1024)
+	for i := range input {
+		if rng.Intn(20) == 0 {
+			input[i] = 'b'
+		} else {
+			input[i] = 'a'
+		}
+	}
+	compressed, _ := FSECompress(input)
+	b.SetBytes(int64(len(input)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		FSEDecompress(compressed, len(input))
+	}
+}
+
+func BenchmarkFSECompress_Sizes(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"256B", 256}, {"1KB", 1024}, {"4KB", 4096}, {"16KB", 16384},
+	}
+	for _, s := range sizes {
+		base := []byte(strings.Repeat("The quick brown fox jumps. ", s.size/27+2))
+		input := base[:s.size]
+		b.Run(s.name, func(b *testing.B) {
+			b.SetBytes(int64(s.size))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				FSECompress(input)
+			}
+		})
+	}
+}
+
+func BenchmarkFSEDecompress_Sizes(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"256B", 256}, {"1KB", 1024}, {"4KB", 4096}, {"16KB", 16384},
+	}
+	for _, s := range sizes {
+		base := []byte(strings.Repeat("The quick brown fox jumps. ", s.size/27+2))
+		input := base[:s.size]
+		compressed, _ := FSECompress(input)
+		if compressed == nil {
+			continue
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.SetBytes(int64(s.size))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				FSEDecompress(compressed, s.size)
+			}
+		})
+	}
+}

--- a/datalog/codec/fse_test.go
+++ b/datalog/codec/fse_test.go
@@ -1,0 +1,829 @@
+package codec
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- Bit Reader/Writer Tests ----
+
+func TestBitWriter_SingleBits(t *testing.T) {
+	w := &bitWriter{}
+	// Write bits: 1,0,1,1,0,1,0,0 (LSB first → byte 0x2D = 00101101)
+	// Actually LSB first: bit 0=1, bit 1=0, bit 2=1, bit 3=1, bit 4=0, bit 5=1, bit 6=0, bit 7=0
+	// = 0b00101101 = 0x2D
+	for _, b := range []uint32{1, 0, 1, 1, 0, 1, 0, 0} {
+		w.writeBits(b, 1)
+	}
+	out := w.flush()
+	require.Len(t, out, 1)
+	assert.Equal(t, byte(0x2D), out[0])
+
+	// Read back
+	r := newBitReader(out)
+	for _, expected := range []uint32{1, 0, 1, 1, 0, 1, 0, 0} {
+		got := r.readBits(1)
+		assert.Equal(t, expected, got)
+	}
+}
+
+func TestBitWriter_MultiBit(t *testing.T) {
+	w := &bitWriter{}
+	// Write 3 bits (value 5 = 101), then 5 bits (value 19 = 10011)
+	w.writeBits(5, 3)  // bits 0-2: 101
+	w.writeBits(19, 5) // bits 3-7: 10011
+	// Combined: 10011_101 = 0x9D? No, LSB first:
+	// bits 0-2: 101 (value 5)
+	// bits 3-7: 10011 (value 19)
+	// byte = 10011_101 → reading right to left: bit7..bit0 = 1,0,0,1,1,1,0,1 = 0x9D
+	out := w.flush()
+	require.Len(t, out, 1)
+	assert.Equal(t, byte(0x9D), out[0])
+
+	// Read back
+	r := newBitReader(out)
+	assert.Equal(t, uint32(5), r.readBits(3))
+	assert.Equal(t, uint32(19), r.readBits(5))
+}
+
+func TestBitWriter_CrossByte(t *testing.T) {
+	w := &bitWriter{}
+	// Write 6 bits, then 6 bits = 12 bits total = straddles 2 bytes
+	w.writeBits(0x3F, 6) // 111111
+	w.writeBits(0x15, 6) // 010101
+	out := w.flush()
+	require.Len(t, out, 2)
+
+	// Read back
+	r := newBitReader(out)
+	assert.Equal(t, uint32(0x3F), r.readBits(6))
+	assert.Equal(t, uint32(0x15), r.readBits(6))
+}
+
+func TestBitWriter_LargeValues(t *testing.T) {
+	w := &bitWriter{}
+	w.writeBits(0xABCD, 16)
+	w.writeBits(0x1234, 16)
+	out := w.flush()
+	require.Len(t, out, 4)
+
+	r := newBitReader(out)
+	assert.Equal(t, uint32(0xABCD), r.readBits(16))
+	assert.Equal(t, uint32(0x1234), r.readBits(16))
+}
+
+func TestBitWriter_WidthRange(t *testing.T) {
+	for nbits := 1; nbits <= 25; nbits++ {
+		w := &bitWriter{}
+		val := uint32((1 << uint(nbits)) - 1) // all ones
+		w.writeBits(val, nbits)
+		out := w.flush()
+
+		r := newBitReader(out)
+		got := r.readBits(nbits)
+		assert.Equal(t, val, got, "nbits=%d", nbits)
+	}
+}
+
+func TestBitWriter_Empty(t *testing.T) {
+	w := &bitWriter{}
+	out := w.flush()
+	assert.Empty(t, out)
+}
+
+func TestBitWriter_FlushPadding(t *testing.T) {
+	w := &bitWriter{}
+	w.writeBits(5, 3) // 3 bits → flush produces 1 byte with 5 zero-padded bits
+	out := w.flush()
+	require.Len(t, out, 1)
+	// Low 3 bits = 101 (5), high 5 bits = 0
+	assert.Equal(t, byte(0x05), out[0])
+
+	r := newBitReader(out)
+	assert.Equal(t, uint32(5), r.readBits(3))
+}
+
+func TestBitWriter_ManySmallWrites(t *testing.T) {
+	// Write 100 values of 3 bits each = 300 bits = 37.5 bytes → 38 bytes
+	w := &bitWriter{}
+	values := make([]uint32, 100)
+	rng := rand.New(rand.NewSource(42))
+	for i := range values {
+		values[i] = uint32(rng.Intn(8)) // 0-7 in 3 bits
+		w.writeBits(values[i], 3)
+	}
+	out := w.flush()
+	require.True(t, len(out) >= 37 && len(out) <= 38)
+
+	r := newBitReader(out)
+	for i, expected := range values {
+		got := r.readBits(3)
+		assert.Equal(t, expected, got, "index %d", i)
+	}
+}
+
+// ---- Count Normalization Tests ----
+
+func TestNormalize_Uniform(t *testing.T) {
+	counts := make([]int, 4)
+	for i := range counts {
+		counts[i] = 10
+	}
+	norm, maxSym, err := normalizeCount(counts, 6) // tableSize=64
+	require.NoError(t, err)
+	assert.Equal(t, 3, maxSym)
+
+	sum := 0
+	for _, c := range norm {
+		sum += int(c)
+	}
+	assert.Equal(t, 64, sum)
+	// Each should be 16 (64/4)
+	for i := 0; i < 4; i++ {
+		assert.Equal(t, int16(16), norm[i])
+	}
+}
+
+func TestNormalize_SingleSymbol(t *testing.T) {
+	counts := make([]int, 256)
+	counts[42] = 100
+	norm, maxSym, err := normalizeCount(counts, 8) // tableSize=256
+	require.NoError(t, err)
+	assert.Equal(t, 42, maxSym)
+	assert.Equal(t, int16(256), norm[42])
+}
+
+func TestNormalize_HighlySkewed(t *testing.T) {
+	counts := []int{990, 5, 3, 1, 1}
+	norm, maxSym, err := normalizeCount(counts, 8) // tableSize=256
+	require.NoError(t, err)
+	assert.Equal(t, 4, maxSym)
+
+	sum := 0
+	for _, c := range norm {
+		sum += int(c)
+	}
+	assert.Equal(t, 256, sum)
+
+	// Every non-zero symbol must have count >= 1
+	for i := 0; i < 5; i++ {
+		assert.GreaterOrEqual(t, norm[i], int16(1), "symbol %d", i)
+	}
+	// Dominant symbol should have most of the count
+	assert.GreaterOrEqual(t, norm[0], int16(240))
+}
+
+func TestNormalize_AllByteValues(t *testing.T) {
+	counts := make([]int, 256)
+	for i := range counts {
+		counts[i] = i + 1 // triangular distribution
+	}
+	norm, maxSym, err := normalizeCount(counts, 12) // tableSize=4096
+	require.NoError(t, err)
+	assert.Equal(t, 255, maxSym)
+
+	sum := 0
+	for _, c := range norm {
+		sum += int(c)
+	}
+	assert.Equal(t, 4096, sum)
+
+	// Every symbol must have count >= 1
+	for i := 0; i < 256; i++ {
+		assert.GreaterOrEqual(t, norm[i], int16(1), "symbol %d", i)
+	}
+	// Higher symbols should generally have higher counts
+	assert.Greater(t, norm[255], norm[0])
+}
+
+func TestNormalize_TwoSymbols(t *testing.T) {
+	counts := []int{75, 25}
+	norm, _, err := normalizeCount(counts, 8) // tableSize=256
+	require.NoError(t, err)
+
+	sum := int(norm[0]) + int(norm[1])
+	assert.Equal(t, 256, sum)
+	// Ratio should be roughly 3:1
+	assert.InDelta(t, 192, int(norm[0]), 5)
+	assert.InDelta(t, 64, int(norm[1]), 5)
+}
+
+func TestNormalize_ManyZeros(t *testing.T) {
+	counts := make([]int, 256)
+	// Only 6 non-zero
+	counts[10] = 100
+	counts[50] = 80
+	counts[100] = 60
+	counts[150] = 40
+	counts[200] = 15
+	counts[250] = 5
+
+	norm, maxSym, err := normalizeCount(counts, 8) // tableSize=256
+	require.NoError(t, err)
+	assert.Equal(t, 250, maxSym)
+
+	sum := 0
+	nonZeroCount := 0
+	for _, c := range norm {
+		sum += int(c)
+		if c > 0 {
+			nonZeroCount++
+		}
+	}
+	assert.Equal(t, 256, sum)
+	assert.Equal(t, 6, nonZeroCount)
+}
+
+func TestNormalize_MinimumGuarantee(t *testing.T) {
+	counts := []int{10000, 1, 1, 1, 1, 1}
+	norm, _, err := normalizeCount(counts, 6) // tableSize=64
+	require.NoError(t, err)
+
+	sum := 0
+	for _, c := range norm {
+		sum += int(c)
+	}
+	assert.Equal(t, 64, sum)
+
+	// Each rare symbol must have >= 1
+	for i := 1; i < 6; i++ {
+		assert.GreaterOrEqual(t, norm[i], int16(1), "symbol %d", i)
+	}
+	// Dominant symbol gets the rest
+	assert.Equal(t, int16(64-5), norm[0])
+}
+
+func TestNormalize_NoSymbols(t *testing.T) {
+	counts := make([]int, 10)
+	_, _, err := normalizeCount(counts, 8)
+	assert.Error(t, err)
+}
+
+// ---- State Table Construction Tests ----
+
+func TestTableBuild_Simple(t *testing.T) {
+	// 2 symbols: counts [24, 8], tableLog=5, tableSize=32
+	normCounts := []int16{24, 8}
+	tbl, err := buildFSETable(normCounts, 1, 5)
+	require.NoError(t, err)
+
+	// Verify decode table has correct symbol distribution
+	symbolCounts := make(map[byte]int)
+	for _, entry := range tbl.decodeTable {
+		symbolCounts[entry.symbol]++
+	}
+	assert.Equal(t, 24, symbolCounts[0])
+	assert.Equal(t, 8, symbolCounts[1])
+}
+
+func TestTableBuild_Uniform4(t *testing.T) {
+	normCounts := []int16{8, 8, 8, 8}
+	tbl, err := buildFSETable(normCounts, 3, 5) // tableSize=32
+	require.NoError(t, err)
+
+	symbolCounts := make(map[byte]int)
+	for _, entry := range tbl.decodeTable {
+		symbolCounts[entry.symbol]++
+	}
+	for s := byte(0); s < 4; s++ {
+		assert.Equal(t, 8, symbolCounts[s], "symbol %d", s)
+	}
+}
+
+func TestTableBuild_Skewed(t *testing.T) {
+	normCounts := []int16{252, 2, 1, 1}
+	tbl, err := buildFSETable(normCounts, 3, 8) // tableSize=256
+	require.NoError(t, err)
+
+	symbolCounts := make(map[byte]int)
+	for _, entry := range tbl.decodeTable {
+		symbolCounts[entry.symbol]++
+	}
+	assert.Equal(t, 252, symbolCounts[0])
+	assert.Equal(t, 2, symbolCounts[1])
+	assert.Equal(t, 1, symbolCounts[2])
+	assert.Equal(t, 1, symbolCounts[3])
+}
+
+func TestTableBuild_InverseProperty(t *testing.T) {
+	// The fundamental correctness property: encode then decode returns the same symbol
+	distributions := []struct {
+		name   string
+		counts []int16
+		tLog   int
+	}{
+		{"uniform4", []int16{8, 8, 8, 8}, 5},
+		{"skewed", []int16{28, 2, 1, 1}, 5},
+		{"binary", []int16{200, 56}, 8},
+	}
+
+	for _, dist := range distributions {
+		t.Run(dist.name, func(t *testing.T) {
+			maxSym := len(dist.counts) - 1
+			tbl, err := buildFSETable(dist.counts, maxSym, dist.tLog)
+			require.NoError(t, err)
+
+			tableSize := 1 << dist.tLog
+
+			// For each symbol, test encode→decode cycle
+			for s := 0; s <= maxSym; s++ {
+				if dist.counts[s] == 0 {
+					continue
+				}
+
+				// Try encoding from various valid states
+				for state := tableSize; state < 2*tableSize; state++ {
+					// Encode
+					nbBitsOut := int((uint32(state) + tbl.symbolTT[s].deltaNbBits) >> 16)
+					bitsValue := uint32(state) & ((1 << uint(nbBitsOut)) - 1)
+					reducedState := state >> uint(nbBitsOut)
+					newState := int(tbl.stateTable[int32(reducedState)+tbl.symbolTT[s].deltaFindState])
+
+					// newState should be in [tableSize, 2*tableSize)
+					assert.GreaterOrEqual(t, newState, tableSize,
+						"symbol=%d state=%d", s, state)
+					assert.Less(t, newState, 2*tableSize,
+						"symbol=%d state=%d", s, state)
+
+					// Decode from newState
+					decState := newState - tableSize
+					entry := tbl.decodeTable[decState]
+					assert.Equal(t, byte(s), entry.symbol,
+						"symbol=%d state=%d → decState=%d", s, state, decState)
+
+					// Reconstruct original state from bits
+					reconstructed := int(entry.newState) + int(bitsValue)
+					// The reconstructed decode state should map back to a valid state
+					// (it may not equal the original state exactly due to the many-to-one
+					// nature of the encode mapping, but the round-trip through the full
+					// compress/decompress pipeline will be exact)
+					assert.GreaterOrEqual(t, reconstructed, 0)
+					assert.Less(t, reconstructed, tableSize)
+				}
+			}
+		})
+	}
+}
+
+// ---- Table Serialization Tests ----
+
+func TestTableSerialize_RoundTrip(t *testing.T) {
+	normCounts := []int16{128, 64, 32, 16, 8, 4, 2, 2}
+	tbl, err := buildFSETable(normCounts, 7, 8)
+	require.NoError(t, err)
+
+	serialized := serializeTable(tbl)
+
+	tbl2, consumed, err := deserializeTable(serialized)
+	require.NoError(t, err)
+	assert.Equal(t, len(serialized), consumed)
+	assert.Equal(t, tbl.tableLog, tbl2.tableLog)
+	assert.Equal(t, tbl.maxSymbol, tbl2.maxSymbol)
+
+	for i := 0; i <= tbl.maxSymbol; i++ {
+		assert.Equal(t, tbl.normCounts[i], tbl2.normCounts[i], "symbol %d", i)
+	}
+
+	// Decode tables should be identical
+	for i := range tbl.decodeTable {
+		assert.Equal(t, tbl.decodeTable[i], tbl2.decodeTable[i], "decode entry %d", i)
+	}
+}
+
+func TestTableSerialize_Determinism(t *testing.T) {
+	normCounts := []int16{128, 64, 32, 16, 8, 4, 2, 2}
+	tbl, err := buildFSETable(normCounts, 7, 8)
+	require.NoError(t, err)
+
+	golden := serializeTable(tbl)
+	for i := 0; i < 100; i++ {
+		got := serializeTable(tbl)
+		assert.True(t, bytes.Equal(golden, got), "iteration %d", i)
+	}
+}
+
+func TestTableSerialize_AllDistributions(t *testing.T) {
+	distributions := []struct {
+		name   string
+		counts []int16
+		tLog   int
+	}{
+		{"uniform-small", []int16{8, 8, 8, 8}, 5},
+		{"skewed-3", []int16{28, 2, 1, 1}, 5},
+		{"binary", []int16{200, 56}, 8},
+		{"triangular-8", []int16{1, 2, 3, 4, 5, 6, 7, 4}, 5},
+	}
+
+	for _, dist := range distributions {
+		t.Run(dist.name, func(t *testing.T) {
+			maxSym := len(dist.counts) - 1
+			tbl, err := buildFSETable(dist.counts, maxSym, dist.tLog)
+			require.NoError(t, err)
+
+			ser := serializeTable(tbl)
+			tbl2, _, err := deserializeTable(ser)
+			require.NoError(t, err)
+
+			assert.Equal(t, tbl.tableLog, tbl2.tableLog)
+			assert.Equal(t, tbl.maxSymbol, tbl2.maxSymbol)
+			for i := 0; i <= tbl.maxSymbol; i++ {
+				assert.Equal(t, tbl.normCounts[i], tbl2.normCounts[i])
+			}
+		})
+	}
+}
+
+func TestTableSerialize_TooShort(t *testing.T) {
+	_, _, err := deserializeTable([]byte{8})
+	assert.Error(t, err)
+}
+
+func TestTableSerialize_InvalidTableLog(t *testing.T) {
+	_, _, err := deserializeTable([]byte{20, 1, 0, 0, 0, 4}) // tableLog=20 > max
+	assert.Error(t, err)
+}
+
+// ---- FSE Compress/Decompress Round-Trip Tests ----
+
+func TestFSE_RoundTrip_Empty(t *testing.T) {
+	compressed, err := FSECompress(nil)
+	require.NoError(t, err)
+	assert.Nil(t, compressed)
+}
+
+func TestFSE_RoundTrip_SingleByte(t *testing.T) {
+	// Single byte may not compress (overhead > savings)
+	compressed, err := FSECompress([]byte{0x42})
+	require.NoError(t, err)
+	if compressed != nil {
+		out, err := FSEDecompress(compressed, 1)
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x42}, out)
+	}
+}
+
+func TestFSE_RoundTrip_AllSame(t *testing.T) {
+	input := bytes.Repeat([]byte{0x41}, 1000)
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, compressed, "1000 identical bytes should compress")
+	assert.Less(t, len(compressed), 100, "expected excellent compression for identical bytes")
+
+	out, err := FSEDecompress(compressed, 1000)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, out))
+}
+
+func TestFSE_RoundTrip_UniformRandom(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	input := make([]byte, 1000)
+	rng.Read(input)
+
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	// Random data may not compress (that's OK, safety net returns nil)
+	if compressed != nil {
+		out, err := FSEDecompress(compressed, 1000)
+		require.NoError(t, err)
+		assert.True(t, bytes.Equal(input, out))
+	}
+}
+
+func TestFSE_RoundTrip_EnglishText(t *testing.T) {
+	input := []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", 20))
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, compressed, "English text should compress")
+	assert.Less(t, len(compressed), len(input), "compressed should be smaller")
+
+	out, err := FSEDecompress(compressed, len(input))
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, out))
+}
+
+func TestFSE_RoundTrip_BinaryRamp(t *testing.T) {
+	input := make([]byte, 512)
+	for i := range input {
+		input[i] = byte(i % 256)
+	}
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	if compressed != nil {
+		out, err := FSEDecompress(compressed, len(input))
+		require.NoError(t, err)
+		assert.True(t, bytes.Equal(input, out))
+	}
+}
+
+func TestFSE_RoundTrip_SizeSweep(t *testing.T) {
+	sizes := []int{1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 100, 255, 256, 512, 1000, 4096, 10000}
+	for _, size := range sizes {
+		t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(int64(size)))
+			input := make([]byte, size)
+			rng.Read(input)
+
+			compressed, err := FSECompress(input)
+			require.NoError(t, err)
+			if compressed != nil {
+				out, err := FSEDecompress(compressed, size)
+				require.NoError(t, err)
+				assert.True(t, bytes.Equal(input, out), "size=%d", size)
+			}
+		})
+	}
+}
+
+func TestFSE_RoundTrip_HighlySkewed(t *testing.T) {
+	// Build input: 950 'a', 30 'b', 15 'c', 5 'd' — shuffled deterministically
+	var input []byte
+	input = append(input, bytes.Repeat([]byte{'a'}, 950)...)
+	input = append(input, bytes.Repeat([]byte{'b'}, 30)...)
+	input = append(input, bytes.Repeat([]byte{'c'}, 15)...)
+	input = append(input, bytes.Repeat([]byte{'d'}, 5)...)
+
+	rng := rand.New(rand.NewSource(99))
+	rng.Shuffle(len(input), func(i, j int) {
+		input[i], input[j] = input[j], input[i]
+	})
+
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, compressed, "skewed data should compress")
+	assert.Less(t, len(compressed), len(input)/2, "expected significant compression")
+
+	out, err := FSEDecompress(compressed, len(input))
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, out))
+}
+
+func TestFSE_RoundTrip_TwoAlternating(t *testing.T) {
+	input := bytes.Repeat([]byte{'a', 'b'}, 500) // 1000 bytes
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, compressed)
+
+	out, err := FSEDecompress(compressed, len(input))
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, out))
+}
+
+func TestFSE_RoundTrip_AllByteValues(t *testing.T) {
+	// Every byte value appears at least once
+	input := make([]byte, 512)
+	for i := range input {
+		input[i] = byte(i % 256)
+	}
+	// Add extra copies of some values for non-uniform distribution
+	input = append(input, bytes.Repeat([]byte{0}, 100)...)
+	input = append(input, bytes.Repeat([]byte{255}, 50)...)
+
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	if compressed != nil {
+		out, err := FSEDecompress(compressed, len(input))
+		require.NoError(t, err)
+		assert.True(t, bytes.Equal(input, out))
+	}
+}
+
+func TestFSE_RoundTrip_RepetitivePhrases(t *testing.T) {
+	// Simulates structured data with repeated patterns
+	input := []byte(strings.Repeat("[#identity \"abc\" :test/name \"value\" [1 1] :op/none]\n", 50))
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, compressed)
+	assert.Less(t, len(compressed), len(input))
+
+	out, err := FSEDecompress(compressed, len(input))
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(input, out))
+}
+
+// ---- FSE Determinism Tests ----
+
+func TestFSE_Determinism(t *testing.T) {
+	input := []byte(strings.Repeat("determinism test payload ", 40))
+	golden, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, golden)
+
+	for i := 0; i < 100; i++ {
+		compressed, err := FSECompress(input)
+		require.NoError(t, err)
+		assert.True(t, bytes.Equal(golden, compressed), "iteration %d: output differs", i)
+	}
+}
+
+func TestFSE_Determinism_Concurrent(t *testing.T) {
+	input := []byte(strings.Repeat("concurrent determinism ", 40))
+	golden, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, golden)
+
+	var wg sync.WaitGroup
+	errs := make(chan string, 20)
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			compressed, err := FSECompress(input)
+			if err != nil {
+				errs <- fmt.Sprintf("goroutine %d: error: %v", idx, err)
+				return
+			}
+			if !bytes.Equal(golden, compressed) {
+				errs <- fmt.Sprintf("goroutine %d: output differs (len %d vs %d)",
+					idx, len(compressed), len(golden))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for msg := range errs {
+		t.Error(msg)
+	}
+}
+
+func TestFSE_Determinism_DifferentSizes(t *testing.T) {
+	// Verify determinism across a range of sizes
+	sizes := []int{50, 100, 256, 500, 1000, 5000}
+	for _, size := range sizes {
+		t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(int64(size + 7)))
+			input := make([]byte, size)
+			// Use text-like data (biased distribution)
+			for i := range input {
+				input[i] = byte(rng.Intn(26)) + 'a'
+			}
+
+			golden, err := FSECompress(input)
+			require.NoError(t, err)
+			if golden == nil {
+				return // safety net, skip
+			}
+
+			for j := 0; j < 50; j++ {
+				compressed, err := FSECompress(input)
+				require.NoError(t, err)
+				assert.True(t, bytes.Equal(golden, compressed),
+					"size=%d iter=%d: output differs", size, j)
+			}
+		})
+	}
+}
+
+// ---- Fuzz-style Round-Trip Tests ----
+
+func TestFSE_Fuzz_RandomInputs(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 500; i++ {
+		size := rng.Intn(5000) + 10 // 10 to 5010
+		input := make([]byte, size)
+		rng.Read(input)
+
+		compressed, err := FSECompress(input)
+		require.NoError(t, err, "input %d (size %d)", i, size)
+		if compressed == nil {
+			continue // safety net
+		}
+
+		out, err := FSEDecompress(compressed, size)
+		require.NoError(t, err, "input %d (size %d)", i, size)
+		assert.True(t, bytes.Equal(input, out),
+			"input %d (size %d): round-trip failed", i, size)
+	}
+}
+
+func TestFSE_Fuzz_TextLikeInputs(t *testing.T) {
+	words := []string{"the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog",
+		"and", "then", "sat", "down", "by", "river", "to", "rest", "a", "in", "on"}
+	rng := rand.New(rand.NewSource(43))
+
+	for i := 0; i < 200; i++ {
+		// Generate random sentence
+		numWords := rng.Intn(200) + 20
+		var sb strings.Builder
+		for j := 0; j < numWords; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(words[rng.Intn(len(words))])
+		}
+		input := []byte(sb.String())
+
+		compressed, err := FSECompress(input)
+		require.NoError(t, err, "sentence %d", i)
+		if compressed == nil {
+			continue
+		}
+
+		out, err := FSEDecompress(compressed, len(input))
+		require.NoError(t, err, "sentence %d", i)
+		assert.True(t, bytes.Equal(input, out),
+			"sentence %d: round-trip failed (len %d)", i, len(input))
+	}
+}
+
+func TestFSE_Fuzz_SkewedDistributions(t *testing.T) {
+	rng := rand.New(rand.NewSource(44))
+
+	for i := 0; i < 100; i++ {
+		// Generate input with varying skew
+		numSymbols := rng.Intn(10) + 2 // 2-11 symbols
+		size := rng.Intn(3000) + 100
+
+		input := make([]byte, size)
+		for j := range input {
+			// Zipf-like: lower symbols more likely
+			sym := rng.Intn(numSymbols * numSymbols)
+			sym = int(float64(numSymbols) - float64(numSymbols)/float64(sym/numSymbols+1))
+			if sym >= numSymbols {
+				sym = numSymbols - 1
+			}
+			input[j] = byte(sym)
+		}
+
+		compressed, err := FSECompress(input)
+		require.NoError(t, err, "skewed %d", i)
+		if compressed == nil {
+			continue
+		}
+
+		out, err := FSEDecompress(compressed, size)
+		require.NoError(t, err, "skewed %d", i)
+		assert.True(t, bytes.Equal(input, out),
+			"skewed %d: round-trip failed (len %d, symbols %d)", i, size, numSymbols)
+	}
+}
+
+// ---- Compression Ratio Tests (Informational) ----
+
+func TestFSE_Ratio_HighlySkewed(t *testing.T) {
+	// 95% one symbol, 5% another
+	input := make([]byte, 10000)
+	for i := range input {
+		if i%20 == 0 {
+			input[i] = 'b'
+		} else {
+			input[i] = 'a'
+		}
+	}
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, compressed)
+
+	ratio := float64(len(input)) / float64(len(compressed))
+	t.Logf("Highly skewed (95/5): %.2fx compression (10000 → %d bytes)", ratio, len(compressed))
+	assert.Greater(t, ratio, 2.0, "expected at least 2x on highly skewed data")
+}
+
+func TestFSE_Ratio_EnglishText(t *testing.T) {
+	input := []byte(strings.Repeat(
+		"To be or not to be, that is the question. Whether tis nobler in the mind "+
+			"to suffer the slings and arrows of outrageous fortune, or to take arms "+
+			"against a sea of troubles, and by opposing end them. ", 10))
+
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, compressed)
+
+	ratio := float64(len(input)) / float64(len(compressed))
+	t.Logf("English text: %.2fx compression (%d → %d bytes)", ratio, len(input), len(compressed))
+	// FSE alone (no LZ77) on English text: expect ~1.5-2x
+	assert.Greater(t, ratio, 1.2, "expected some compression on English text")
+}
+
+// ---- Error Handling Tests ----
+
+func TestFSE_Decompress_Empty(t *testing.T) {
+	_, err := FSEDecompress(nil, 10)
+	assert.Error(t, err)
+
+	_, err = FSEDecompress([]byte{}, 10)
+	assert.Error(t, err)
+}
+
+func TestFSE_Decompress_Truncated(t *testing.T) {
+	input := []byte(strings.Repeat("test data ", 100))
+	compressed, err := FSECompress(input)
+	require.NoError(t, err)
+	require.NotNil(t, compressed)
+
+	// Truncate at various points
+	for _, cutoff := range []int{1, 2, 5, len(compressed) / 2} {
+		_, err := FSEDecompress(compressed[:cutoff], len(input))
+		assert.Error(t, err, "cutoff=%d should error", cutoff)
+	}
+}
+

--- a/datalog/codec/lz77.go
+++ b/datalog/codec/lz77.go
@@ -1,0 +1,293 @@
+package codec
+
+// LZ77 match finder with hash-chain, lazy matching, and repeat offset tracking.
+// Produces Sequence blocks that the FSE entropy coder compresses.
+
+const (
+	lz77HashBits   = 15
+	lz77HashSize   = 1 << lz77HashBits
+	lz77HashMask   = lz77HashSize - 1
+	lz77MinMatch   = 3
+	lz77MaxMatch   = 258
+	lz77MaxChain   = 64        // limit chain traversal to avoid O(n²)
+	lz77WindowSize = 1 << 20   // 1MB default window
+	lz77NoPos      = int32(-1) // sentinel for empty hash slot
+)
+
+// Sequence represents one LZ77 output unit: a run of literal bytes
+// followed by an optional back-reference match.
+type Sequence struct {
+	LitLen   int // number of literal bytes before this match
+	Offset   int // back-reference distance (0 = no match, literals only)
+	MatchLen int // match length (>= lz77MinMatch when Offset > 0)
+}
+
+// SequenceBlock holds the output of LZ77 compression: literal bytes
+// and the sequence of (litLen, offset, matchLen) triples.
+type SequenceBlock struct {
+	Literals  []byte     // all literal bytes concatenated
+	Sequences []Sequence // each sequence consumes LitLen literals then copies MatchLen from Offset
+}
+
+// lz77Encoder holds the working state for LZ77 match finding.
+type lz77Encoder struct {
+	hashTable [lz77HashSize]int32 // hash → most recent position
+	chain     []int32             // chain[pos] = previous position with same hash
+	window    int
+}
+
+// hash4 computes a 4-byte hash for match finding.
+func hash4(b []byte) uint32 {
+	v := uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+	return (v * 2654435761) >> (32 - lz77HashBits)
+}
+
+// FindMatches runs LZ77 match finding on input and returns a SequenceBlock.
+func FindMatches(input []byte) *SequenceBlock {
+	if len(input) < lz77MinMatch {
+		// Too short for any matches
+		return &SequenceBlock{
+			Literals:  append([]byte(nil), input...),
+			Sequences: []Sequence{{LitLen: len(input)}},
+		}
+	}
+
+	enc := &lz77Encoder{
+		chain:  make([]int32, len(input)),
+		window: lz77WindowSize,
+	}
+	// Initialize hash table to no-position
+	for i := range enc.hashTable {
+		enc.hashTable[i] = lz77NoPos
+	}
+
+	sb := &SequenceBlock{
+		Literals:  make([]byte, 0, len(input)),
+		Sequences: make([]Sequence, 0, len(input)/16),
+	}
+
+	litStart := 0 // start of current literal run
+	pos := 0
+	end := len(input) - 3 // need at least 4 bytes for hash4
+
+	for pos < end {
+		// Find best match at current position
+		bestLen, bestOff := enc.findBestMatch(input, pos)
+
+		// Lazy matching: check if next position has a better match
+		if bestLen >= lz77MinMatch && pos+1 < end {
+			nextLen, nextOff := enc.findBestMatch(input, pos+1)
+			if nextLen > bestLen+1 {
+				// Next position is significantly better — emit current as literal
+				enc.updateHash(input, pos)
+				sb.Literals = append(sb.Literals, input[pos])
+				pos++
+				bestLen = nextLen
+				bestOff = nextOff
+			}
+		}
+
+		if bestLen >= lz77MinMatch {
+			// Emit sequence: literals + match
+			litLen := pos - litStart
+			sb.Sequences = append(sb.Sequences, Sequence{
+				LitLen:   litLen,
+				Offset:   bestOff,
+				MatchLen: bestLen,
+			})
+
+			// Update hash table for all positions in the match
+			for i := 0; i < bestLen; i++ {
+				if pos+i < end {
+					enc.updateHash(input, pos+i)
+				}
+			}
+			pos += bestLen
+			litStart = pos
+		} else {
+			// No match — advance one byte
+			enc.updateHash(input, pos)
+			sb.Literals = append(sb.Literals, input[pos])
+			pos++
+		}
+	}
+
+	// Emit remaining bytes as literals
+	for pos < len(input) {
+		sb.Literals = append(sb.Literals, input[pos])
+		pos++
+	}
+
+	// Final sequence for trailing literals (if any)
+	trailingLits := len(input) - litStart
+	if trailingLits > 0 {
+		if len(sb.Sequences) == 0 || sb.Sequences[len(sb.Sequences)-1].Offset > 0 {
+			// Need a new sequence for trailing literals
+			sb.Sequences = append(sb.Sequences, Sequence{LitLen: trailingLits})
+		} else {
+			// Last sequence already has no match — add to it
+			sb.Sequences[len(sb.Sequences)-1].LitLen += trailingLits
+		}
+	}
+
+	return sb
+}
+
+// findBestMatch finds the longest match at pos using the hash chain.
+func (enc *lz77Encoder) findBestMatch(input []byte, pos int) (bestLen, bestOff int) {
+	if pos+4 > len(input) {
+		return 0, 0
+	}
+
+	h := hash4(input[pos:])
+	candidate := enc.hashTable[h]
+
+	chainLen := 0
+	minPos := pos - enc.window
+	if minPos < 0 {
+		minPos = 0
+	}
+
+	for candidate != lz77NoPos && int(candidate) >= minPos && chainLen < lz77MaxChain {
+		cpos := int(candidate)
+
+		// Verify match and measure length
+		matchLen := matchLength(input, cpos, pos)
+		if matchLen >= lz77MinMatch && matchLen > bestLen {
+			bestLen = matchLen
+			bestOff = pos - cpos
+			if bestLen >= lz77MaxMatch {
+				break // can't do better
+			}
+		}
+
+		candidate = enc.chain[cpos]
+		chainLen++
+	}
+
+	return bestLen, bestOff
+}
+
+// matchLength measures how many bytes match starting at positions a and b.
+func matchLength(input []byte, a, b int) int {
+	maxLen := len(input) - b
+	if maxLen > lz77MaxMatch {
+		maxLen = lz77MaxMatch
+	}
+	n := 0
+	for n < maxLen && input[a+n] == input[b+n] {
+		n++
+	}
+	return n
+}
+
+// updateHash inserts pos into the hash chain.
+func (enc *lz77Encoder) updateHash(input []byte, pos int) {
+	if pos+4 > len(input) {
+		return
+	}
+	h := hash4(input[pos:])
+	enc.chain[pos] = enc.hashTable[h]
+	enc.hashTable[h] = int32(pos)
+}
+
+// Reconstruct rebuilds the original input from a SequenceBlock.
+// This is the decode side of LZ77 — used by the decompressor.
+func Reconstruct(sb *SequenceBlock) []byte {
+	// Estimate output size from literals + match lengths
+	size := len(sb.Literals)
+	for _, seq := range sb.Sequences {
+		size += seq.MatchLen
+	}
+	out := make([]byte, 0, size)
+	litPos := 0
+
+	for _, seq := range sb.Sequences {
+		// Copy literal bytes
+		if seq.LitLen > 0 {
+			out = append(out, sb.Literals[litPos:litPos+seq.LitLen]...)
+			litPos += seq.LitLen
+		}
+
+		// Copy match (back-reference)
+		if seq.MatchLen > 0 && seq.Offset > 0 {
+			matchStart := len(out) - seq.Offset
+			// Byte-by-byte copy handles overlapping matches (e.g., offset=1 repeats last byte)
+			for i := 0; i < seq.MatchLen; i++ {
+				out = append(out, out[matchStart+i])
+			}
+		}
+	}
+
+	return out
+}
+
+// ---- Repeat Offset Tracking ----
+
+// RepeatOffsets tracks the 3 most recently used match offsets.
+// When a match reuses a recent offset, it can be encoded as a small
+// code (1, 2, or 3) instead of the full offset value.
+type RepeatOffsets [3]int
+
+// NewRepeatOffsets returns initial repeat offsets (1, 4, 8 — standard defaults).
+func NewRepeatOffsets() RepeatOffsets {
+	return RepeatOffsets{1, 4, 8}
+}
+
+// Offset encoding:
+//   1 = repeat offset 0 (most recent)
+//   2 = repeat offset 1
+//   3 = repeat offset 2
+//   N > 3 = literal offset N-3
+
+// EncodeOffset converts a raw offset to a coded offset, updating the repeat state.
+func (ro *RepeatOffsets) EncodeOffset(offset int) int {
+	if offset == ro[0] {
+		// Most recent — no ring change
+		return 1
+	}
+	if offset == ro[1] {
+		// Second most recent — swap [0] and [1]
+		ro[0], ro[1] = ro[1], ro[0]
+		return 2
+	}
+	if offset == ro[2] {
+		// Third most recent — rotate to front: [C,A,B] from [A,B,C]
+		ro[2] = ro[1]
+		ro[1] = ro[0]
+		ro[0] = offset
+		return 3
+	}
+	// New offset — push to front, shift others
+	ro[2] = ro[1]
+	ro[1] = ro[0]
+	ro[0] = offset
+	return offset + 3
+}
+
+// DecodeOffset converts a coded offset back to a raw offset, updating the repeat state.
+func (ro *RepeatOffsets) DecodeOffset(code int) int {
+	if code == 1 {
+		// Most recent — no ring change
+		return ro[0]
+	}
+	if code == 2 {
+		// Swap [0] and [1]
+		ro[0], ro[1] = ro[1], ro[0]
+		return ro[0]
+	}
+	if code == 3 {
+		// Rotate from [A,B,C] to [C,A,B]
+		offset := ro[2]
+		ro[2] = ro[1]
+		ro[1] = ro[0]
+		ro[0] = offset
+		return offset
+	}
+	// Literal offset — push to front
+	offset := code - 3
+	ro[2] = ro[1]
+	ro[1] = ro[0]
+	ro[0] = offset
+	return offset
+}

--- a/datalog/codec/lz77_test.go
+++ b/datalog/codec/lz77_test.go
@@ -1,0 +1,401 @@
+package codec
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- Match Finding Tests ----
+
+func TestLZ77_NoMatches(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	input := make([]byte, 500)
+	rng.Read(input)
+
+	sb := FindMatches(input)
+	// All output should be literals (random data has no repeats)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed), "random data round-trip failed")
+
+	// All sequences should be literals-only or have short matches
+	totalLits := 0
+	for _, seq := range sb.Sequences {
+		totalLits += seq.LitLen
+	}
+	// Most bytes should be literals for random data
+	assert.Greater(t, totalLits, 400, "expected mostly literals for random data")
+}
+
+func TestLZ77_SimpleRepeat(t *testing.T) {
+	input := []byte("abcdefgh abcdefgh")
+	sb := FindMatches(input)
+
+	// Must round-trip
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+
+	// Should find at least one match
+	hasMatch := false
+	for _, seq := range sb.Sequences {
+		if seq.MatchLen >= 3 {
+			hasMatch = true
+			break
+		}
+	}
+	assert.True(t, hasMatch, "expected a match for repeated 'abcdefgh'")
+}
+
+func TestLZ77_OverlappingMatch(t *testing.T) {
+	input := []byte("aaaaaaaaaaaa") // 12 a's — match overlaps with itself
+	sb := FindMatches(input)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+
+	// Should find a match (offset=1, length up to 11)
+	hasMatch := false
+	for _, seq := range sb.Sequences {
+		if seq.MatchLen >= 3 && seq.Offset == 1 {
+			hasMatch = true
+			break
+		}
+	}
+	assert.True(t, hasMatch, "expected overlapping match at offset 1")
+}
+
+func TestLZ77_MinMatchLength(t *testing.T) {
+	input := []byte("ab ab") // "ab" repeats but length=2 < minimum=3
+	sb := FindMatches(input)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+
+	// Should NOT find a match (2-byte repeat below minimum)
+	for _, seq := range sb.Sequences {
+		if seq.MatchLen > 0 {
+			assert.GreaterOrEqual(t, seq.MatchLen, lz77MinMatch,
+				"match length %d below minimum %d", seq.MatchLen, lz77MinMatch)
+		}
+	}
+}
+
+func TestLZ77_ExactMinMatch(t *testing.T) {
+	input := []byte("abc abc") // "abc" repeats, length=3 == minimum
+	sb := FindMatches(input)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+}
+
+func TestLZ77_WindowBoundary(t *testing.T) {
+	// Create input where a pattern repeats beyond the window
+	// Use a small window for testing
+	pattern := []byte("PATTERN!")
+	gap := make([]byte, 200)
+	for i := range gap {
+		gap[i] = byte('0' + i%10)
+	}
+
+	// Pattern appears at position 0 and position 208
+	input := make([]byte, 0, 300)
+	input = append(input, pattern...)
+	input = append(input, gap...)
+	input = append(input, pattern...)
+
+	// With default window (1MB), match should be found
+	sb := FindMatches(input)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+}
+
+func TestLZ77_LazyMatch(t *testing.T) {
+	// Position 10: "abcd" matches (length 4)
+	// Position 11: "bcdefgh" could match longer if we skip one literal
+	input := []byte("___abcdefgh___abcdefgh")
+	sb := FindMatches(input)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+
+	// Should find a match of length >= 7 (lazy matching finds the longer one)
+	maxMatch := 0
+	for _, seq := range sb.Sequences {
+		if seq.MatchLen > maxMatch {
+			maxMatch = seq.MatchLen
+		}
+	}
+	assert.GreaterOrEqual(t, maxMatch, 7, "lazy matching should find longer match")
+}
+
+func TestLZ77_MultipleMatches(t *testing.T) {
+	input := []byte("the cat sat on the mat and the cat sat on the mat")
+	sb := FindMatches(input)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+
+	matchCount := 0
+	for _, seq := range sb.Sequences {
+		if seq.MatchLen >= lz77MinMatch {
+			matchCount++
+		}
+	}
+	assert.Greater(t, matchCount, 1, "expected multiple matches in repeated text")
+}
+
+func TestLZ77_Empty(t *testing.T) {
+	sb := FindMatches(nil)
+	reconstructed := Reconstruct(sb)
+	assert.Empty(t, reconstructed)
+}
+
+func TestLZ77_OneByte(t *testing.T) {
+	input := []byte{0x42}
+	sb := FindMatches(input)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+}
+
+func TestLZ77_TwoBytes(t *testing.T) {
+	input := []byte{0x42, 0x43}
+	sb := FindMatches(input)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+}
+
+func TestLZ77_ThreeBytes(t *testing.T) {
+	input := []byte("abc")
+	sb := FindMatches(input)
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+}
+
+// ---- Reconstruction Property (Critical) ----
+
+func TestLZ77_ReconstructProperty(t *testing.T) {
+	inputs := []struct {
+		name  string
+		input []byte
+	}{
+		{"english", []byte("The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.")},
+		{"json", []byte(`{"name":"Alice","age":30,"tags":["admin","user"],"name":"Alice","age":30}`)},
+		{"binary_allsame", bytes.Repeat([]byte{0xAA}, 500)},
+		{"binary_alternating", bytes.Repeat([]byte{0xAA, 0xBB}, 250)},
+		{"code", []byte("func main() {\n\tfmt.Println(\"hello\")\n\tfmt.Println(\"world\")\n}\n")},
+		{"empty", nil},
+		{"one_byte", []byte{0x42}},
+		{"three_bytes", []byte("abc")},
+		{"edn", []byte(strings.Repeat("[#identity \"abc\" :test/name \"value\" [1 1] :op/none]\n", 20))},
+		{"long_prose", []byte(strings.Repeat(
+			"To be or not to be, that is the question. Whether tis nobler in the mind "+
+				"to suffer the slings and arrows of outrageous fortune. ", 20))},
+	}
+
+	for _, tc := range inputs {
+		t.Run(tc.name, func(t *testing.T) {
+			sb := FindMatches(tc.input)
+			reconstructed := Reconstruct(sb)
+			assert.True(t, bytes.Equal(tc.input, reconstructed),
+				"round-trip failed: len(input)=%d len(output)=%d", len(tc.input), len(reconstructed))
+		})
+	}
+}
+
+func TestLZ77_ReconstructProperty_RandomSizes(t *testing.T) {
+	rng := rand.New(rand.NewSource(55))
+	for i := 0; i < 200; i++ {
+		size := rng.Intn(5000) + 1
+		input := make([]byte, size)
+		// Mix of text-like and random data
+		if i%2 == 0 {
+			for j := range input {
+				input[j] = byte(rng.Intn(26)) + 'a'
+			}
+		} else {
+			rng.Read(input)
+		}
+
+		sb := FindMatches(input)
+		reconstructed := Reconstruct(sb)
+		require.True(t, bytes.Equal(input, reconstructed),
+			"round-trip failed: iteration=%d size=%d", i, size)
+	}
+}
+
+// ---- Repeat Offset Tests ----
+
+func TestRepeatOffset_Basic(t *testing.T) {
+	ro := NewRepeatOffsets()
+	assert.Equal(t, RepeatOffsets{1, 4, 8}, ro)
+
+	// Encode offset 10 (new) → code = 10+3 = 13, ring becomes [10, 1, 4]
+	code := ro.EncodeOffset(10)
+	assert.Equal(t, 13, code)
+	assert.Equal(t, RepeatOffsets{10, 1, 4}, ro)
+
+	// Encode offset 10 again (repeat 0) → code = 1, ring unchanged
+	code = ro.EncodeOffset(10)
+	assert.Equal(t, 1, code)
+	assert.Equal(t, RepeatOffsets{10, 1, 4}, ro)
+
+	// Encode offset 1 (repeat 1) → code = 2, swap [0] and [1]
+	code = ro.EncodeOffset(1)
+	assert.Equal(t, 2, code)
+	assert.Equal(t, RepeatOffsets{1, 10, 4}, ro)
+
+	// Encode offset 4 (repeat 2) → code = 3, rotate to front
+	code = ro.EncodeOffset(4)
+	assert.Equal(t, 3, code)
+	assert.Equal(t, RepeatOffsets{4, 1, 10}, ro)
+}
+
+func TestRepeatOffset_RoundTrip(t *testing.T) {
+	offsets := []int{10, 20, 30, 10, 20, 30, 5, 5, 10, 30, 20, 5}
+
+	encRO := NewRepeatOffsets()
+	decRO := NewRepeatOffsets()
+
+	codes := make([]int, len(offsets))
+	for i, off := range offsets {
+		codes[i] = encRO.EncodeOffset(off)
+	}
+
+	for i, code := range codes {
+		decoded := decRO.DecodeOffset(code)
+		assert.Equal(t, offsets[i], decoded, "offset %d: code=%d decoded=%d", i, code, decoded)
+	}
+}
+
+func TestRepeatOffset_ThreeDistinct(t *testing.T) {
+	ro := NewRepeatOffsets()
+
+	// Push three distinct offsets
+	ro.EncodeOffset(100) // ring: [100, 1, 4]
+	ro.EncodeOffset(200) // ring: [200, 100, 1]
+	ro.EncodeOffset(300) // ring: [300, 200, 100]
+
+	// Now 100 is at position 2
+	code := ro.EncodeOffset(100)
+	assert.Equal(t, 3, code) // repeat offset 2 (third most recent)
+	assert.Equal(t, RepeatOffsets{100, 300, 200}, ro)
+}
+
+func TestRepeatOffset_Ring(t *testing.T) {
+	// Pattern: A, B, C, A, B, C — after first three, all should be repeats
+	offsets := []int{10, 20, 30, 10, 20, 30, 10, 20, 30}
+
+	ro := NewRepeatOffsets()
+	codes := make([]int, len(offsets))
+	for i, off := range offsets {
+		codes[i] = ro.EncodeOffset(off)
+	}
+
+	// First three are new offsets (codes > 3)
+	for i := 0; i < 3; i++ {
+		assert.Greater(t, codes[i], 3, "offset %d should be new", i)
+	}
+	// Remaining should be repeat codes (1, 2, or 3)
+	for i := 3; i < len(codes); i++ {
+		assert.LessOrEqual(t, codes[i], 3, "offset %d should be a repeat", i)
+	}
+
+	// Verify round-trip
+	decRO := NewRepeatOffsets()
+	for i, code := range codes {
+		decoded := decRO.DecodeOffset(code)
+		assert.Equal(t, offsets[i], decoded, "offset %d", i)
+	}
+}
+
+func TestRepeatOffset_StructuredData(t *testing.T) {
+	// Simulate structured data where same field spacing recurs
+	// Offsets: 50, 50, 50, 50 — after the first, all are repeat 0
+	ro := NewRepeatOffsets()
+	codes := make([]int, 4)
+	for i := 0; i < 4; i++ {
+		codes[i] = ro.EncodeOffset(50)
+	}
+	assert.Equal(t, 53, codes[0])   // new: 50 + 3
+	assert.Equal(t, 1, codes[1])    // repeat 0
+	assert.Equal(t, 1, codes[2])    // repeat 0
+	assert.Equal(t, 1, codes[3])    // repeat 0
+}
+
+// ---- Compression Effectiveness Tests ----
+
+func TestLZ77_CompressesRepetitiveData(t *testing.T) {
+	input := []byte(strings.Repeat("hello world ", 100)) // 1200 bytes
+	sb := FindMatches(input)
+
+	// Count total match bytes
+	matchBytes := 0
+	for _, seq := range sb.Sequences {
+		matchBytes += seq.MatchLen
+	}
+	// Repetitive data should have lots of matches
+	assert.Greater(t, matchBytes, len(input)/2,
+		"expected >50%% of data to be matches for repetitive input")
+
+	// Literals should be much less than input
+	assert.Less(t, len(sb.Literals), len(input)/2,
+		"expected <50%% literals for repetitive input")
+
+	// Round-trip
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+}
+
+func TestLZ77_RandomDataMostlyLiterals(t *testing.T) {
+	rng := rand.New(rand.NewSource(99))
+	input := make([]byte, 1000)
+	rng.Read(input)
+
+	sb := FindMatches(input)
+
+	// Random data should have very few matches
+	assert.Greater(t, len(sb.Literals), 900,
+		"expected >90%% literals for random data")
+
+	reconstructed := Reconstruct(sb)
+	assert.True(t, bytes.Equal(input, reconstructed))
+}
+
+// ---- LZ77 Benchmark ----
+
+func BenchmarkFindMatches_1KB(b *testing.B) {
+	base := []byte(strings.Repeat("The quick brown fox jumps. ", 40))
+	input := base[:1024]
+	b.SetBytes(1024)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		FindMatches(input)
+	}
+}
+
+func BenchmarkFindMatches_4KB(b *testing.B) {
+	base := []byte(strings.Repeat("The quick brown fox jumps. ", 160))
+	input := base[:4096]
+	b.SetBytes(4096)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		FindMatches(input)
+	}
+}
+
+func BenchmarkReconstruct_1KB(b *testing.B) {
+	base := []byte(strings.Repeat("The quick brown fox jumps. ", 40))
+	input := base[:1024]
+	sb := FindMatches(input)
+	b.SetBytes(1024)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Reconstruct(sb)
+	}
+}
+
+// Helper to keep fmt import used
+var _ = fmt.Sprintf

--- a/datalog/codec/sequences.go
+++ b/datalog/codec/sequences.go
@@ -1,0 +1,212 @@
+package codec
+
+// Sequence encoding: converts LZ77 (litLen, offset, matchLen) triples into
+// three parallel streams suitable for FSE compression. Each value is encoded
+// as a code (for FSE) plus extra bits (written directly to the bitstream).
+
+// ---- Baseline + Extra Bits Tables ----
+//
+// These tables map variable-range values into (code, extraBits, baseline) triples.
+// The code is what FSE compresses. The extra bits refine the value within the
+// code's range: value = baseline + readBits(extraBits).
+//
+// The tables are frozen (determinism requirement). Do not modify.
+
+// litLenTable: literal length codes (0-35)
+// code 0-15: literal values 0-15 (0 extra bits)
+// code 16+: exponentially increasing ranges
+var litLenTable = []struct {
+	maxVal    int
+	extraBits int
+}{
+	{0, 0}, {1, 0}, {2, 0}, {3, 0},     // codes 0-3
+	{4, 0}, {5, 0}, {6, 0}, {7, 0},     // codes 4-7
+	{8, 0}, {9, 0}, {10, 0}, {11, 0},   // codes 8-11
+	{12, 0}, {13, 0}, {14, 0}, {15, 0}, // codes 12-15
+	{17, 1}, {19, 1}, {23, 2}, {31, 3}, // codes 16-19
+	{47, 4}, {79, 5}, {143, 6}, {271, 7},       // codes 20-23
+	{527, 8}, {1039, 9}, {2063, 10}, {4111, 11}, // codes 24-27
+	{8207, 12}, {16399, 13}, {32783, 14}, {65551, 15}, // codes 28-31
+	{131087, 16}, {262159, 17}, {524303, 18}, {1048591, 19}, // codes 32-35
+}
+
+// matchLenTable: match length codes (0-52)
+// Match lengths are stored as matchLen - lz77MinMatch (so 0 = length 3)
+var matchLenTable = []struct {
+	maxVal    int
+	extraBits int
+}{
+	{0, 0}, {1, 0}, {2, 0}, {3, 0},     // codes 0-3 (lengths 3-6)
+	{4, 0}, {5, 0}, {6, 0}, {7, 0},     // codes 4-7 (lengths 7-10)
+	{8, 0}, {9, 0}, {10, 0}, {11, 0},   // codes 8-11 (lengths 11-14)
+	{12, 0}, {13, 0}, {14, 0}, {15, 0}, // codes 12-15 (lengths 15-18)
+	{17, 1}, {19, 1}, {23, 2}, {31, 3}, // codes 16-19
+	{47, 4}, {79, 5}, {143, 6}, {271, 7}, // codes 20-23
+	{527, 8}, {1039, 9}, {2063, 10}, {4111, 11}, // codes 24-27
+}
+
+// offsetTable: offset codes (0-31)
+// Offsets use pure exponential coding: code N covers [2^N, 2^(N+1))
+// Code 0 is special: covers value 1 (offset of 1)
+// This is applied AFTER repeat offset encoding (so values are coded offsets, not raw)
+
+// EncodedStreams holds the three parallel streams produced from sequences,
+// ready for FSE compression.
+type EncodedStreams struct {
+	LitLenCodes  []byte   // FSE-compressible codes for literal lengths
+	LitLenExtra  []uint32 // extra bits values for literal lengths
+	LitLenBits   []int    // number of extra bits per literal length
+
+	MatchLenCodes []byte   // FSE-compressible codes for match lengths
+	MatchLenExtra []uint32 // extra bits values for match lengths
+	MatchLenBits  []int    // number of extra bits per match length
+
+	OffsetCodes  []byte   // FSE-compressible codes for offsets
+	OffsetExtra  []uint32 // extra bits values for offsets
+	OffsetBits   []int    // number of extra bits per offset
+}
+
+// EncodeSequences converts a slice of Sequences into three parallel streams.
+// Sequences with Offset == 0 (trailing literals) are skipped for match/offset streams.
+func EncodeSequences(seqs []Sequence) *EncodedStreams {
+	es := &EncodedStreams{}
+
+	for _, seq := range seqs {
+		// Encode literal length
+		code, extra, nbits := encodeLitLen(seq.LitLen)
+		es.LitLenCodes = append(es.LitLenCodes, code)
+		es.LitLenExtra = append(es.LitLenExtra, extra)
+		es.LitLenBits = append(es.LitLenBits, nbits)
+
+		// Encode match (only if this sequence has a match)
+		if seq.Offset > 0 {
+			// Match length (stored as matchLen - minMatch)
+			mlCode, mlExtra, mlBits := encodeMatchLen(seq.MatchLen - lz77MinMatch)
+			es.MatchLenCodes = append(es.MatchLenCodes, mlCode)
+			es.MatchLenExtra = append(es.MatchLenExtra, mlExtra)
+			es.MatchLenBits = append(es.MatchLenBits, mlBits)
+
+			// Offset (already coded by repeat offset logic or raw)
+			offCode, offExtra, offBits := encodeOffset(seq.Offset)
+			es.OffsetCodes = append(es.OffsetCodes, offCode)
+			es.OffsetExtra = append(es.OffsetExtra, offExtra)
+			es.OffsetBits = append(es.OffsetBits, offBits)
+		}
+	}
+
+	return es
+}
+
+// DecodeSequences reconstructs Sequences from encoded streams.
+func DecodeSequences(es *EncodedStreams) []Sequence {
+	seqs := make([]Sequence, len(es.LitLenCodes))
+	matchIdx := 0
+
+	for i := range es.LitLenCodes {
+		seqs[i].LitLen = decodeLitLen(es.LitLenCodes[i], es.LitLenExtra[i])
+
+		if matchIdx < len(es.MatchLenCodes) {
+			seqs[i].MatchLen = decodeMatchLen(es.MatchLenCodes[matchIdx], es.MatchLenExtra[matchIdx]) + lz77MinMatch
+			seqs[i].Offset = decodeOffset(es.OffsetCodes[matchIdx], es.OffsetExtra[matchIdx])
+			matchIdx++
+		}
+	}
+
+	return seqs
+}
+
+// ---- Literal Length Encoding ----
+
+func encodeLitLen(val int) (code byte, extra uint32, nbits int) {
+	if val <= 15 {
+		return byte(val), 0, 0
+	}
+	baseline := 0
+	for i := 16; i < len(litLenTable); i++ {
+		prevMax := litLenTable[i-1].maxVal
+		baseline = prevMax + 1
+		if val <= litLenTable[i].maxVal {
+			return byte(i), uint32(val - baseline), litLenTable[i].extraBits
+		}
+	}
+	// Overflow: use the last code
+	last := len(litLenTable) - 1
+	prevMax := litLenTable[last-1].maxVal
+	return byte(last), uint32(val - prevMax - 1), litLenTable[last].extraBits
+}
+
+func decodeLitLen(code byte, extra uint32) int {
+	c := int(code)
+	if c <= 15 {
+		return c
+	}
+	if c >= len(litLenTable) {
+		c = len(litLenTable) - 1
+	}
+	baseline := litLenTable[c-1].maxVal + 1
+	return baseline + int(extra)
+}
+
+// ---- Match Length Encoding ----
+
+func encodeMatchLen(val int) (code byte, extra uint32, nbits int) {
+	if val <= 15 {
+		return byte(val), 0, 0
+	}
+	baseline := 0
+	for i := 16; i < len(matchLenTable); i++ {
+		prevMax := matchLenTable[i-1].maxVal
+		baseline = prevMax + 1
+		if val <= matchLenTable[i].maxVal {
+			return byte(i), uint32(val - baseline), matchLenTable[i].extraBits
+		}
+	}
+	last := len(matchLenTable) - 1
+	prevMax := matchLenTable[last-1].maxVal
+	return byte(last), uint32(val - prevMax - 1), matchLenTable[last].extraBits
+}
+
+func decodeMatchLen(code byte, extra uint32) int {
+	c := int(code)
+	if c <= 15 {
+		return c
+	}
+	if c >= len(matchLenTable) {
+		c = len(matchLenTable) - 1
+	}
+	baseline := matchLenTable[c-1].maxVal + 1
+	return baseline + int(extra)
+}
+
+// ---- Offset Encoding ----
+// Offsets use exponential coding: code = floor(log2(offset)), extra = offset - 2^code
+// Code 0 = offset 1 (no extra bits)
+// Code 1 = offsets 2-3 (1 extra bit)
+// Code N = offsets [2^N, 2^(N+1)) (N extra bits)
+
+func encodeOffset(offset int) (code byte, extra uint32, nbits int) {
+	if offset <= 0 {
+		return 0, 0, 0
+	}
+	if offset == 1 {
+		return 0, 0, 0
+	}
+	// code = floor(log2(offset))
+	c := 0
+	v := offset
+	for v > 1 {
+		v >>= 1
+		c++
+	}
+	baseline := 1 << c
+	return byte(c), uint32(offset - baseline), c
+}
+
+func decodeOffset(code byte, extra uint32) int {
+	c := int(code)
+	if c == 0 {
+		return 1
+	}
+	baseline := 1 << c
+	return baseline + int(extra)
+}

--- a/datalog/codec/sequences_test.go
+++ b/datalog/codec/sequences_test.go
@@ -1,0 +1,229 @@
+package codec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- Literal Length Encoding Tests ----
+
+func TestSequenceEncode_LitLen_Small(t *testing.T) {
+	// Values 0-15 are direct codes, 0 extra bits
+	for val := 0; val <= 15; val++ {
+		code, extra, nbits := encodeLitLen(val)
+		assert.Equal(t, byte(val), code, "val=%d", val)
+		assert.Equal(t, uint32(0), extra, "val=%d", val)
+		assert.Equal(t, 0, nbits, "val=%d", val)
+
+		decoded := decodeLitLen(code, extra)
+		assert.Equal(t, val, decoded, "val=%d round-trip", val)
+	}
+}
+
+func TestSequenceEncode_LitLen_Large(t *testing.T) {
+	// Test values in the exponential range
+	testValues := []int{16, 17, 18, 19, 20, 23, 24, 31, 32, 47, 48, 100, 255, 500, 1000, 5000, 10000, 100000}
+	for _, val := range testValues {
+		code, extra, nbits := encodeLitLen(val)
+		decoded := decodeLitLen(code, extra)
+		assert.Equal(t, val, decoded, "litLen=%d code=%d extra=%d nbits=%d", val, code, extra, nbits)
+	}
+}
+
+func TestSequenceEncode_LitLen_Boundaries(t *testing.T) {
+	// Test at each table boundary
+	for i := 16; i < len(litLenTable); i++ {
+		maxVal := litLenTable[i].maxVal
+		// Test the boundary value
+		code, extra, nbits := encodeLitLen(maxVal)
+		decoded := decodeLitLen(code, extra)
+		assert.Equal(t, maxVal, decoded, "boundary litLen=%d", maxVal)
+		assert.Equal(t, byte(i), code, "boundary litLen=%d should use code %d", maxVal, i)
+		_ = nbits
+
+		// Test one above boundary (should use next code)
+		if i+1 < len(litLenTable) {
+			code2, extra2, _ := encodeLitLen(maxVal + 1)
+			decoded2 := decodeLitLen(code2, extra2)
+			assert.Equal(t, maxVal+1, decoded2, "above boundary litLen=%d", maxVal+1)
+			assert.Equal(t, byte(i+1), code2, "above boundary should use code %d", i+1)
+		}
+	}
+}
+
+// ---- Match Length Encoding Tests ----
+
+func TestSequenceEncode_MatchLen_Small(t *testing.T) {
+	for val := 0; val <= 15; val++ {
+		code, extra, nbits := encodeMatchLen(val)
+		assert.Equal(t, byte(val), code, "val=%d", val)
+		assert.Equal(t, uint32(0), extra, "val=%d", val)
+		assert.Equal(t, 0, nbits, "val=%d", val)
+
+		decoded := decodeMatchLen(code, extra)
+		assert.Equal(t, val, decoded, "val=%d round-trip", val)
+	}
+}
+
+func TestSequenceEncode_MatchLen_Large(t *testing.T) {
+	testValues := []int{16, 17, 20, 31, 47, 100, 255, 500, 1000, 4000}
+	for _, val := range testValues {
+		code, extra, nbits := encodeMatchLen(val)
+		decoded := decodeMatchLen(code, extra)
+		assert.Equal(t, val, decoded, "matchLen=%d code=%d extra=%d nbits=%d", val, code, extra, nbits)
+	}
+}
+
+func TestSequenceEncode_MatchLen_Boundaries(t *testing.T) {
+	for i := 16; i < len(matchLenTable); i++ {
+		maxVal := matchLenTable[i].maxVal
+		code, extra, _ := encodeMatchLen(maxVal)
+		decoded := decodeMatchLen(code, extra)
+		assert.Equal(t, maxVal, decoded, "boundary matchLen=%d", maxVal)
+		assert.Equal(t, byte(i), code, "boundary matchLen=%d should use code %d", maxVal, i)
+	}
+}
+
+// ---- Offset Encoding Tests ----
+
+func TestSequenceEncode_Offset_Small(t *testing.T) {
+	// Offset 1 → code 0, 0 extra bits
+	code, extra, nbits := encodeOffset(1)
+	assert.Equal(t, byte(0), code)
+	assert.Equal(t, uint32(0), extra)
+	assert.Equal(t, 0, nbits)
+	assert.Equal(t, 1, decodeOffset(code, extra))
+}
+
+func TestSequenceEncode_Offset_PowersOf2(t *testing.T) {
+	// Offset 2^N should give code N
+	for n := 1; n <= 20; n++ {
+		offset := 1 << n
+		code, extra, nbits := encodeOffset(offset)
+		assert.Equal(t, byte(n), code, "offset=%d", offset)
+		assert.Equal(t, uint32(0), extra, "offset=%d (exact power of 2, no extra)", offset)
+		assert.Equal(t, n, nbits, "offset=%d", offset)
+
+		decoded := decodeOffset(code, extra)
+		assert.Equal(t, offset, decoded, "offset=%d round-trip", offset)
+	}
+}
+
+func TestSequenceEncode_Offset_Range(t *testing.T) {
+	// Test a range of offsets
+	offsets := []int{1, 2, 3, 4, 5, 7, 8, 15, 16, 31, 32, 63, 64, 100, 255, 1000, 10000, 100000, 1000000}
+	for _, off := range offsets {
+		code, extra, nbits := encodeOffset(off)
+		decoded := decodeOffset(code, extra)
+		assert.Equal(t, off, decoded, "offset=%d code=%d extra=%d nbits=%d", off, code, extra, nbits)
+	}
+}
+
+// ---- Stream Encoding/Decoding Tests ----
+
+func TestSequenceEncode_Streams_Simple(t *testing.T) {
+	seqs := []Sequence{
+		{LitLen: 5, Offset: 10, MatchLen: 7},
+		{LitLen: 0, Offset: 3, MatchLen: 4},
+		{LitLen: 12, Offset: 100, MatchLen: 20},
+	}
+
+	es := EncodeSequences(seqs)
+
+	// Should have 3 litLen codes (one per sequence)
+	require.Len(t, es.LitLenCodes, 3)
+	// Should have 3 match/offset codes (all sequences have matches)
+	require.Len(t, es.MatchLenCodes, 3)
+	require.Len(t, es.OffsetCodes, 3)
+
+	// Decode back
+	decoded := DecodeSequences(es)
+	require.Len(t, decoded, 3)
+
+	assert.Equal(t, 5, decoded[0].LitLen)
+	assert.Equal(t, 10, decoded[0].Offset)
+	assert.Equal(t, 7, decoded[0].MatchLen)
+
+	assert.Equal(t, 0, decoded[1].LitLen)
+	assert.Equal(t, 3, decoded[1].Offset)
+	assert.Equal(t, 4, decoded[1].MatchLen)
+
+	assert.Equal(t, 12, decoded[2].LitLen)
+	assert.Equal(t, 100, decoded[2].Offset)
+	assert.Equal(t, 20, decoded[2].MatchLen)
+}
+
+func TestSequenceEncode_Streams_WithTrailingLiterals(t *testing.T) {
+	seqs := []Sequence{
+		{LitLen: 5, Offset: 10, MatchLen: 7},
+		{LitLen: 20}, // trailing literals, no match
+	}
+
+	es := EncodeSequences(seqs)
+
+	// 2 litLen codes
+	require.Len(t, es.LitLenCodes, 2)
+	// Only 1 match/offset (trailing literals have no match)
+	require.Len(t, es.MatchLenCodes, 1)
+	require.Len(t, es.OffsetCodes, 1)
+
+	decoded := DecodeSequences(es)
+	require.Len(t, decoded, 2)
+
+	assert.Equal(t, 5, decoded[0].LitLen)
+	assert.Equal(t, 10, decoded[0].Offset)
+	assert.Equal(t, 7, decoded[0].MatchLen)
+
+	assert.Equal(t, 20, decoded[1].LitLen)
+	// Second sequence should have no match since we ran out of match codes
+	assert.Equal(t, 0, decoded[1].Offset)
+	assert.Equal(t, 0, decoded[1].MatchLen)
+}
+
+func TestSequenceEncode_Streams_LargeValues(t *testing.T) {
+	seqs := []Sequence{
+		{LitLen: 10000, Offset: 500000, MatchLen: 1000},
+	}
+
+	es := EncodeSequences(seqs)
+	decoded := DecodeSequences(es)
+	require.Len(t, decoded, 1)
+
+	assert.Equal(t, 10000, decoded[0].LitLen)
+	assert.Equal(t, 500000, decoded[0].Offset)
+	assert.Equal(t, 1000, decoded[0].MatchLen)
+}
+
+func TestSequenceEncode_Streams_ManySequences(t *testing.T) {
+	// Generate many sequences with varying values
+	seqs := make([]Sequence, 1000)
+	for i := range seqs {
+		seqs[i] = Sequence{
+			LitLen:   i % 50,
+			Offset:   (i%100 + 1) * 10,
+			MatchLen: (i%20 + 3),
+		}
+	}
+
+	es := EncodeSequences(seqs)
+	decoded := DecodeSequences(es)
+	require.Len(t, decoded, 1000)
+
+	for i, seq := range seqs {
+		assert.Equal(t, seq.LitLen, decoded[i].LitLen, "seq %d litLen", i)
+		assert.Equal(t, seq.Offset, decoded[i].Offset, "seq %d offset", i)
+		assert.Equal(t, seq.MatchLen, decoded[i].MatchLen, "seq %d matchLen", i)
+	}
+}
+
+func TestSequenceEncode_Streams_Empty(t *testing.T) {
+	es := EncodeSequences(nil)
+	assert.Empty(t, es.LitLenCodes)
+	assert.Empty(t, es.MatchLenCodes)
+	assert.Empty(t, es.OffsetCodes)
+
+	decoded := DecodeSequences(es)
+	assert.Empty(t, decoded)
+}

--- a/datalog/db/db.go
+++ b/datalog/db/db.go
@@ -41,12 +41,13 @@ func Open(path string, opts ...Option) (*DB, error) {
 		opt(&cfg)
 	}
 	d, err := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
-		Path:              path,
-		Schema:            cfg.schema,
-		ReplicaID:         cfg.replicaID,
-		AnnotationHandler: cfg.annotationHandler,
-		DisableCache:      cfg.disableCache,
-		PlannerOptions:    cfg.plannerOptions,
+		Path:                 path,
+		Schema:               cfg.schema,
+		ReplicaID:            cfg.replicaID,
+		AnnotationHandler:    cfg.annotationHandler,
+		DisableCache:         cfg.disableCache,
+		PlannerOptions:       cfg.plannerOptions,
+		CompressionThreshold: cfg.compressionThreshold,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("db.Open: %w", err)

--- a/datalog/db/options.go
+++ b/datalog/db/options.go
@@ -10,11 +10,12 @@ import (
 )
 
 type config struct {
-	schema            schema.SchemaProvider
-	replicaID         uint64
-	annotationHandler annotations.Handler
-	disableCache      bool
-	plannerOptions    *planner.PlannerOptions
+	schema               schema.SchemaProvider
+	replicaID            uint64
+	annotationHandler    annotations.Handler
+	disableCache         bool
+	plannerOptions       *planner.PlannerOptions
+	compressionThreshold int
 }
 
 // Option configures a database opened with Open.
@@ -44,6 +45,13 @@ func WithoutCache() Option {
 // WithPlannerOptions overrides the default planner options.
 func WithPlannerOptions(opts planner.PlannerOptions) Option {
 	return func(c *config) { c.plannerOptions = &opts }
+}
+
+// WithCompressionThreshold enables transparent compression for string and
+// []byte values at or above the given size in bytes. Set to 0 to disable.
+// Recommended: 256. See docs/proposals/COMPRESSED_STRING_VALUES.md.
+func WithCompressionThreshold(bytes int) Option {
+	return func(c *config) { c.compressionThreshold = bytes }
 }
 
 // WithVerbose enables query tracing to stdout.

--- a/datalog/db/options.go
+++ b/datalog/db/options.go
@@ -47,11 +47,16 @@ func WithPlannerOptions(opts planner.PlannerOptions) Option {
 	return func(c *config) { c.plannerOptions = &opts }
 }
 
-// WithCompressionThreshold enables transparent compression for string and
-// []byte values at or above the given size in bytes. Set to 0 to disable.
-// Recommended: 256. See docs/proposals/COMPRESSED_STRING_VALUES.md.
+// WithCompressionThreshold sets the compression threshold in bytes.
+// Values at or above this size are transparently compressed.
+// Default is 256 (enabled). Use -1 to disable compression.
 func WithCompressionThreshold(bytes int) Option {
 	return func(c *config) { c.compressionThreshold = bytes }
+}
+
+// WithoutCompression disables transparent value compression.
+func WithoutCompression() Option {
+	return func(c *config) { c.compressionThreshold = -1 }
 }
 
 // WithVerbose enables query tracing to stdout.

--- a/datalog/storage/afterref_heuristic_bug_test.go
+++ b/datalog/storage/afterref_heuristic_bug_test.go
@@ -94,7 +94,7 @@ func TestAfterRefHeuristicBug_Unit(t *testing.T) {
 				"%s: key[73] must be 3 to trigger heuristic", tc.name)
 
 			// Decode must round-trip correctly
-			decoded, err := DatomFromKey(tc.idx, key, encoder)
+			decoded, err := DatomFromKey(tc.idx, key, encoder, nil)
 			require.NoError(t, err, "%s: decode must succeed", tc.name)
 
 			decodedRef, ok := decoded.V.(datalog.Identity)
@@ -260,7 +260,7 @@ func TestAfterRefHeuristicBug_Statistical(t *testing.T) {
 
 		// Test EATV (the primary CRDT index used for reads)
 		key := encoder.EncodeKey(EATV, datom)
-		_, err := DatomFromKey(EATV, key, encoder)
+		_, err := DatomFromKey(EATV, key, encoder, nil)
 		if err != nil {
 			failures++
 			k := key[1:] // skip prefix
@@ -314,7 +314,7 @@ func TestAfterRefHeuristicBug_NonRefValues(t *testing.T) {
 			}
 			for _, idx := range Indices {
 				key := encoder.EncodeKey(idx, datom)
-				_, err := DatomFromKey(idx, key, encoder)
+				_, err := DatomFromKey(idx, key, encoder, nil)
 				assert.NoError(t, err, "non-reference value should always decode in %v", idx)
 			}
 		})

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -63,12 +63,33 @@ func (s *BadgerStore) Assert(datoms []datalog.Datom) error {
 
 // assertDatom adds a single datom to all indices
 func (s *BadgerStore) assertDatom(txn *badger.Txn, d *datalog.Datom) error {
-	// Write to all CRDT indices
-	// Value is nil - all datom information is encoded in the key
-	for _, idx := range Indices {
-		key := s.encoder.EncodeKey(idx, d)
-		if err := txn.Set(key, nil); err != nil {
-			return fmt.Errorf("failed to write to %v index: %w", idx, err)
+	// Pre-encode value bytes once (avoids recomputing compression 7 times)
+	var vBytes []byte
+	if be, ok := s.encoder.(*BinaryKeyEncoder); ok {
+		var blobData *datalog.BlobData
+		vBytes, blobData = be.EncodeValueBytes(d.V)
+
+		// Tier 3: write compressed data to blob store
+		if blobData != nil {
+			if err := putBlob(txn, blobData.Hash, blobData.CompressedBytes); err != nil {
+				return fmt.Errorf("failed to write blob: %w", err)
+			}
+		}
+
+		// Write to all indices using pre-encoded value bytes
+		for _, idx := range Indices {
+			key := be.EncodeKeyWithValueBytes(idx, d, vBytes)
+			if err := txn.Set(key, nil); err != nil {
+				return fmt.Errorf("failed to write to %v index: %w", idx, err)
+			}
+		}
+	} else {
+		// Non-binary encoder (L85): use standard path
+		for _, idx := range Indices {
+			key := s.encoder.EncodeKey(idx, d)
+			if err := txn.Set(key, nil); err != nil {
+				return fmt.Errorf("failed to write to %v index: %w", idx, err)
+			}
 		}
 	}
 
@@ -125,7 +146,7 @@ func (s *BadgerStore) retractDatom(txn *badger.Txn, d *datalog.Datom) error {
 	for _, eavtKey := range keysToDelete {
 		// Decode the EAVT key to get the full datom including Tx
 		// DatomFromKey handles all the complexity of decoding components
-		storedDatom, err := DatomFromKey(EAVT, eavtKey, s.encoder)
+		storedDatom, err := DatomFromKey(EAVT, eavtKey, s.encoder, s.db)
 		if err != nil {
 			return fmt.Errorf("failed to decode key for retraction: %w", err)
 		}
@@ -162,7 +183,8 @@ func (s *BadgerStore) Scan(index IndexType, start, end []byte) (Iterator, error)
 		start:   start,
 		end:     end,
 		index:   index,
-		encoder: s.encoder, // For decoding Op from key
+		encoder: s.encoder,
+		db:      s.db,
 	}
 	runtime.SetFinalizer(iter, (*BadgerIterator).Close)
 	return iter, nil
@@ -180,7 +202,7 @@ func (s *BadgerStore) Get(index IndexType, key []byte) (*datalog.Datom, error) {
 		}
 
 		// Decode datom from key - values are not stored
-		datom, err := DatomFromKey(index, key, s.encoder)
+		datom, err := DatomFromKey(index, key, s.encoder, s.db)
 		if err != nil {
 			return err
 		}
@@ -425,6 +447,7 @@ type BadgerIterator struct {
 	index   IndexType
 	valid   bool
 	encoder KeyEncoder // For decoding Op from key
+	db      *badger.DB // For Tier 3 blob lookups in Datom()
 }
 
 // Next advances the iterator
@@ -465,7 +488,7 @@ func (i *BadgerIterator) Datom() (*datalog.Datom, error) {
 	key := item.KeyCopy(nil)
 
 	// Decode datom from key - all information is in the key
-	datom, err := DatomFromKey(i.index, key, i.encoder)
+	datom, err := DatomFromKey(i.index, key, i.encoder, i.db)
 	if err != nil {
 		return nil, err
 	}

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -98,10 +98,9 @@ func (s *BadgerStore) retractDatom(txn *badger.Txn, d *datalog.Datom) error {
 
 	// Use EAVT index to find matching datoms (E+A+V, any Tx)
 	// Build prefix: index byte + E + A + V (without Tx)
+	// Must encode value the same way EncodeKey does (compression-aware)
 	prefix := []byte{byte(EAVT)}
-	vType := byte(datalog.Type(sd.V))
-	vData := datalog.ValueBytes(sd.V)
-	vBytes := append([]byte{vType}, vData...)
+	vBytes := encodeValueForSearch(sd.V, s.encoder)
 	searchPrefix := concatBytes(prefix, sd.E[:], sd.A[:], vBytes)
 
 	// Iterate to find matching keys with their actual Tx values

--- a/datalog/storage/blob_store.go
+++ b/datalog/storage/blob_store.go
@@ -1,0 +1,47 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+// Blob store: content-addressed storage for Tier 3 compressed values.
+// Values whose compressed representation exceeds the key size limit are
+// stored here, with a SHA1 hash in the index key pointing to the blob.
+//
+// Blob key format: [0xFF][sha1_hash:20]
+// The 0xFF prefix separates blobs from all index keys (0x00-0x06).
+
+const blobKeyPrefix = byte(0xFF)
+
+// putBlob stores compressed data at its content-addressed key.
+// Idempotent: writing the same content twice is a no-op.
+func putBlob(txn *badger.Txn, hash [20]byte, data []byte) error {
+	key := make([]byte, 21)
+	key[0] = blobKeyPrefix
+	copy(key[1:], hash[:])
+	return txn.Set(key, data)
+}
+
+// getBlob retrieves compressed data by its SHA1 hash.
+func getBlob(db *badger.DB, hash [20]byte) ([]byte, error) {
+	key := make([]byte, 21)
+	key[0] = blobKeyPrefix
+	copy(key[1:], hash[:])
+
+	var result []byte
+	err := db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(key)
+		if err != nil {
+			return err
+		}
+		result, err = item.ValueCopy(nil)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("blob not found for hash %x: %w", hash, err)
+	}
+	return result, nil
+}
+

--- a/datalog/storage/blob_store_test.go
+++ b/datalog/storage/blob_store_test.go
@@ -1,0 +1,581 @@
+package storage
+
+import (
+	"crypto/sha1"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// ---- Blob Store Unit Tests ----
+
+func openTestBadger(t *testing.T) (*badger.DB, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "blob-test-*")
+	require.NoError(t, err)
+
+	opts := badger.DefaultOptions(dir)
+	opts.Logger = nil
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	return db, func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+}
+
+func TestBlobStore_PutGet(t *testing.T) {
+	db, cleanup := openTestBadger(t)
+	defer cleanup()
+
+	data := []byte("compressed blob content " + strings.Repeat("x", 100))
+	hash := sha1.Sum(data)
+
+	// Put
+	err := db.Update(func(txn *badger.Txn) error {
+		return putBlob(txn, hash, data)
+	})
+	require.NoError(t, err)
+
+	// Get
+	result, err := getBlob(db, hash)
+	require.NoError(t, err)
+	assert.Equal(t, data, result)
+}
+
+func TestBlobStore_ContentAddressing(t *testing.T) {
+	db, cleanup := openTestBadger(t)
+	defer cleanup()
+
+	data := []byte("deduplicated content")
+	hash := sha1.Sum(data)
+
+	// Put twice
+	for i := 0; i < 2; i++ {
+		err := db.Update(func(txn *badger.Txn) error {
+			return putBlob(txn, hash, data)
+		})
+		require.NoError(t, err)
+	}
+
+	// Should still read correctly
+	result, err := getBlob(db, hash)
+	require.NoError(t, err)
+	assert.Equal(t, data, result)
+
+	// Count blob keys
+	count := 0
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = []byte{blobKeyPrefix}
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			count++
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "should have exactly 1 blob key")
+}
+
+func TestBlobStore_Missing(t *testing.T) {
+	db, cleanup := openTestBadger(t)
+	defer cleanup()
+
+	hash := sha1.Sum([]byte("nonexistent"))
+	_, err := getBlob(db, hash)
+	assert.Error(t, err)
+}
+
+func TestBlobStore_KeyPrefix(t *testing.T) {
+	// Verify blob prefix doesn't collide with any index prefix
+	assert.Greater(t, blobKeyPrefix, byte(TAEV), "blob prefix must be > highest index prefix")
+}
+
+// ---- Tier 3 Integration Tests ----
+
+// makeTier3Data creates a []byte that compresses but stays above 60KB compressed.
+// Uses pseudo-random bytes with limited alphabet (128 values) so FSE provides
+// some compression, but LZ77 finds few matches. This gives ~1.3-1.5x compression,
+// so 100KB of this data compresses to ~70-80KB, exceeding the 60KB Tier 2 limit.
+func makeTier3Data(size int) []byte {
+	data := make([]byte, size)
+	// Linear congruential generator for deterministic pseudo-random bytes
+	state := uint64(42)
+	for i := range data {
+		state = state*6364136223846793005 + 1442695040888963407
+		data[i] = byte((state >> 33) & 0x7F) // 128-value alphabet: compresses ~1.3x
+	}
+	return data
+}
+
+// makeTier3String creates a string version of Tier 3 test data.
+// Uses printable ASCII subset for valid string content.
+func makeTier3String(size int) string {
+	data := make([]byte, size)
+	state := uint64(99)
+	printable := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,;:!?-_"
+	for i := range data {
+		state = state*6364136223846793005 + 1442695040888963407
+		data[i] = printable[int((state>>33))%len(printable)]
+	}
+	return string(data)
+}
+
+func TestTier3_WriteRead(t *testing.T) {
+	dir, err := os.MkdirTemp("", "tier3-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	entity := datalog.NewIdentity("tier3-entity")
+	attr := datalog.NewKeyword(":test/big")
+	bigValue := makeTier3Data(100000) // 100KB of moderate-entropy bytes
+
+	// Check if this actually triggers Tier 3
+	vType, _, blobData := datalog.EncodeValue(bigValue, 256)
+	if vType != datalog.TypeHashedBytes {
+		t.Skipf("value reaches type 0x%02x not TypeHashedBytes (len=%d), skipping Tier 3 test", vType, len(bigValue))
+	}
+	require.NotNil(t, blobData, "Tier 3 should produce BlobData")
+	t.Logf("Tier 3: %d bytes → %d compressed (blob hash %x)", len(bigValue), len(blobData.CompressedBytes), blobData.Hash[:8])
+
+	// Write
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, bigValue)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Read back
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next(), "should find the Tier 3 value")
+	got := iter.Tuple()[0].([]byte)
+	assert.Equal(t, bigValue, got, "Tier 3 value should round-trip correctly")
+	assert.False(t, iter.Next(), "should be exactly one result")
+}
+
+func TestTier3_ContentDedup(t *testing.T) {
+	dir, err := os.MkdirTemp("", "tier3-dedup-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	bigValue := makeTier3Data(100000)
+
+	vType, _, _ := datalog.EncodeValue(bigValue, 256)
+	if vType != datalog.TypeHashedBytes {
+		t.Skipf("value doesn't reach Tier 3, skipping dedup test")
+	}
+
+	// Write same value to two entities
+	for i := 0; i < 2; i++ {
+		entity := datalog.NewIdentity(strings.Repeat("e", i+1))
+		tx := db.NewTransaction()
+		tx.Add(entity, datalog.NewKeyword(":test/big"), bigValue)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	// Count blobs — should be exactly 1 (content-addressed dedup)
+	count := 0
+	err = db.Store().db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = []byte{blobKeyPrefix}
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			count++
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "same content should produce one blob (content-addressed)")
+
+	// Both entities should read back correctly
+	for i := 0; i < 2; i++ {
+		entity := datalog.NewIdentity(strings.Repeat("e", i+1))
+		matcher := NewBadgerMatcher(db.Store())
+		pattern := &query.DataPattern{
+			Elements: []query.PatternElement{
+				query.Constant{Value: entity},
+				query.Constant{Value: datalog.NewKeyword(":test/big")},
+				query.Variable{Name: datalog.NewSymbol("?v")},
+				query.Blank{},
+			},
+		}
+		results, err := matcher.Match(pattern, nil)
+		require.NoError(t, err)
+		iter := results.Iterator()
+		require.True(t, iter.Next(), "entity %d should have the value", i)
+		assert.Equal(t, bigValue, iter.Tuple()[0].([]byte))
+	}
+}
+
+func TestTier3_DatomFromKey_NilDB(t *testing.T) {
+	enc := &BinaryKeyEncoder{CompressionThreshold: 256}
+
+	bigValue := makeTier3Data(100000)
+
+	vType, _, _ := datalog.EncodeValue(bigValue, 256)
+	if vType != datalog.TypeHashedBytes {
+		t.Skipf("value doesn't reach Tier 3")
+	}
+
+	d := &datalog.Datom{
+		E:  datalog.NewIdentity("nil-blob-test"),
+		A:  datalog.NewKeyword(":test/big"),
+		V:  bigValue,
+		Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1},
+	}
+	key := enc.EncodeKey(EAVT, d)
+
+	// Decode with nil blob reader — should error
+	_, err := DatomFromKey(EAVT, key, enc, nil)
+	assert.Error(t, err, "Tier 3 decode with nil blob reader should fail")
+	assert.Contains(t, err.Error(), "blob lookup")
+}
+
+func TestTier3_WriteRead_String(t *testing.T) {
+	dir, err := os.MkdirTemp("", "tier3-str-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	entity := datalog.NewIdentity("tier3-str-entity")
+	attr := datalog.NewKeyword(":test/big-text")
+	bigValue := makeTier3String(100000)
+
+	vType, _, blobData := datalog.EncodeValue(bigValue, 256)
+	if vType != datalog.TypeHashedString {
+		t.Skipf("string value reaches type 0x%02x not TypeHashedString (len=%d), skipping", vType, len(bigValue))
+	}
+	require.NotNil(t, blobData)
+	t.Logf("Tier 3 string: %d bytes → %d compressed", len(bigValue), len(blobData.CompressedBytes))
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, bigValue)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next(), "should find the Tier 3 string value")
+	got := iter.Tuple()[0].(string)
+	assert.Equal(t, bigValue, got, "Tier 3 string should round-trip correctly")
+}
+
+// ---- Tier 3 Query Integration Tests ----
+
+func newTier3DB(t *testing.T, s schema.SchemaProvider) (*Database, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "tier3-query-*")
+	require.NoError(t, err)
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir,
+		Schema:               s,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	return db, func() { db.Close(); os.RemoveAll(dir) }
+}
+
+func skipIfNotTier3Bytes(t *testing.T, data []byte) {
+	t.Helper()
+	vType, _, _ := datalog.EncodeValue(data, 256)
+	if vType != datalog.TypeHashedBytes {
+		t.Skipf("data doesn't reach Tier 3 (type 0x%02x)", vType)
+	}
+}
+
+func skipIfNotTier3String(t *testing.T, data string) {
+	t.Helper()
+	vType, _, _ := datalog.EncodeValue(data, 256)
+	if vType != datalog.TypeHashedString {
+		t.Skipf("data doesn't reach Tier 3 (type 0x%02x)", vType)
+	}
+}
+
+func TestTier3_AVET_ExactMatch(t *testing.T) {
+	db, cleanup := newTier3DB(t, nil)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("avet-tier3")
+	attr := datalog.NewKeyword(":test/big")
+	bigValue := makeTier3Data(100000)
+	skipIfNotTier3Bytes(t, bigValue)
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, bigValue)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// AVET lookup: A+V bound, find E
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: attr},
+			query.Constant{Value: bigValue}, // bound V triggers AVET
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next(), "AVET lookup should find the entity for Tier 3 value")
+	gotEntity := iter.Tuple()[0].(datalog.Identity)
+	assert.Equal(t, entity.L85(), gotEntity.L85())
+	assert.False(t, iter.Next(), "should be exactly one result")
+}
+
+func TestTier3_AVET_NoFalsePositive(t *testing.T) {
+	db, cleanup := newTier3DB(t, nil)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("avet-tier3-fp")
+	attr := datalog.NewKeyword(":test/big")
+	bigValue := makeTier3Data(100000)
+	differentValue := makeTier3Data(100001) // different size → different content
+	skipIfNotTier3Bytes(t, bigValue)
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, bigValue)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Search for different value — should find nothing
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: attr},
+			query.Constant{Value: differentValue},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	assert.False(t, iter.Next(), "AVET search for non-existent Tier 3 value should return nothing")
+}
+
+func TestTier3_CRDT_CardinalityOne_LWW(t *testing.T) {
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":test/big"),
+		ValueType:   schema.TypeBytes,
+		Cardinality: schema.CardinalityOne,
+	})
+	db, cleanup := newTier3DB(t, s)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("lww-tier3")
+	attr := datalog.NewKeyword(":test/big")
+
+	v1 := makeTier3Data(100000)
+	v2 := makeTier3Data(100002) // different content
+	skipIfNotTier3Bytes(t, v1)
+	skipIfNotTier3Bytes(t, v2)
+
+	// Write version 1
+	tx1 := db.NewTransaction()
+	tx1.Set(entity, attr, v1)
+	_, err := tx1.Commit()
+	require.NoError(t, err)
+
+	// Write version 2
+	tx2 := db.NewTransaction()
+	tx2.Set(entity, attr, v2)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Query should return only the latest (v2)
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(s)
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next())
+	got := iter.Tuple()[0].([]byte)
+	assert.Equal(t, v2, got, "LWW should return latest Tier 3 value")
+	assert.False(t, iter.Next(), "LWW should return exactly one result")
+}
+
+func TestTier3_CRDT_CardinalityMany_AddRetract(t *testing.T) {
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":test/blobs"),
+		ValueType:   schema.TypeBytes,
+		Cardinality: schema.CardinalityMany,
+	})
+	db, cleanup := newTier3DB(t, s)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("many-tier3")
+	attr := datalog.NewKeyword(":test/blobs")
+
+	v1 := makeTier3Data(100000)
+	v2 := makeTier3Data(100002)
+	skipIfNotTier3Bytes(t, v1)
+	skipIfNotTier3Bytes(t, v2)
+
+	// Add both
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, v1)
+	tx.Add(entity, attr, v2)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Both should be present
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(s)
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	count := 0
+	iter := results.Iterator()
+	for iter.Next() {
+		count++
+	}
+	assert.Equal(t, 2, count, "cardinality-many should have both Tier 3 values")
+
+	// Retract v2
+	tx2 := db.NewTransaction()
+	tx2.Retract(entity, attr, v2)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Only v1 should remain
+	results2, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	var remaining [][]byte
+	iter2 := results2.Iterator()
+	for iter2.Next() {
+		remaining = append(remaining, iter2.Tuple()[0].([]byte))
+	}
+	assert.Len(t, remaining, 1, "should have one value after retract")
+	if len(remaining) == 1 {
+		assert.Equal(t, v1, remaining[0], "remaining value should be v1")
+	}
+}
+
+func TestTier3_EntityScan_MixedTiers(t *testing.T) {
+	db, cleanup := newTier3DB(t, nil)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("mixed-tier-entity")
+	smallValue := "short name"                                          // Tier 1
+	medValue := strings.Repeat("medium content for tier two. ", 20)     // Tier 2
+	bigValue := makeTier3Data(100000)                                   // Tier 3
+	skipIfNotTier3Bytes(t, bigValue)
+
+	tx := db.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":test/name"), smallValue)
+	tx.Add(entity, datalog.NewKeyword(":test/content"), medValue)
+	tx.Add(entity, datalog.NewKeyword(":test/blob"), bigValue)
+	tx.Add(entity, datalog.NewKeyword(":test/score"), int64(42))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Entity scan: E bound, all A+V
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Variable{Name: datalog.NewSymbol("?a")},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	seen := make(map[string]interface{})
+	iter := results.Iterator()
+	for iter.Next() {
+		tuple := iter.Tuple()
+		attr := tuple[0].(datalog.Keyword).String()
+		seen[attr] = tuple[1]
+	}
+
+	assert.Contains(t, seen, ":test/name")
+	assert.Contains(t, seen, ":test/content")
+	assert.Contains(t, seen, ":test/blob")
+	assert.Contains(t, seen, ":test/score")
+
+	assert.Equal(t, smallValue, seen[":test/name"])
+	assert.Equal(t, medValue, seen[":test/content"])
+	assert.Equal(t, bigValue, seen[":test/blob"])
+	assert.Equal(t, int64(42), seen[":test/score"])
+}

--- a/datalog/storage/blob_store_test.go
+++ b/datalog/storage/blob_store_test.go
@@ -375,8 +375,7 @@ func TestTier3_AVET_ExactMatch(t *testing.T) {
 
 	iter := results.Iterator()
 	require.True(t, iter.Next(), "AVET lookup should find the entity for Tier 3 value")
-	gotEntity := iter.Tuple()[0].(datalog.Identity)
-	assert.Equal(t, entity.L85(), gotEntity.L85())
+	assert.Equal(t, entity, iter.Tuple()[0])
 	assert.False(t, iter.Next(), "should be exactly one result")
 }
 

--- a/datalog/storage/cache.go
+++ b/datalog/storage/cache.go
@@ -20,7 +20,7 @@ type CacheEntry struct {
 
 	// Resolved views (one populated based on cardinality)
 	oneValue    any                 // Cardinality-One: single current value
-	manySet     map[any]bool        // Cardinality-Many: current set members
+	manySet     map[any]any         // Cardinality-Many: hashable key → original value
 	vectorList  []any               // Cardinality-Vector: ordered elements
 	vectorIndex []datalog.ElementID // Cardinality-Vector: position → ElementID for O(1) access
 }
@@ -41,7 +41,7 @@ func (e *CacheEntry) OneValue() any {
 }
 
 // ManySet returns the set for cardinality-many attributes
-func (e *CacheEntry) ManySet() map[any]bool {
+func (e *CacheEntry) ManySet() map[any]any {
 	return e.manySet
 }
 
@@ -365,7 +365,7 @@ type CacheResolver interface {
 
 	// ResolveAddWins returns the current set members for cardinality-many
 	// Returns (members, maxElementID, error)
-	ResolveAddWins(e Entity, a Attribute) (map[any]bool, datalog.ElementID, error)
+	ResolveAddWins(e Entity, a Attribute) (map[any]any, datalog.ElementID, error)
 
 	// ResolveRGA returns the ordered vector for cardinality-vector
 	// Returns (elements, positionIndex, maxElementID, error)

--- a/datalog/storage/cache_integration_test.go
+++ b/datalog/storage/cache_integration_test.go
@@ -324,7 +324,8 @@ func TestCacheResolverInterface(t *testing.T) {
 	// Test ResolveAddWins
 	set, maxID, err := matcher.ResolveAddWins(eBytes, tagsAttr)
 	require.NoError(t, err)
-	assert.True(t, set["dev"])
+	_, hasDev := set["dev"]
+	assert.True(t, hasDev)
 	assert.NotZero(t, maxID.Lamport)
 }
 
@@ -480,8 +481,10 @@ func TestCardinalityManyQueryUsesCache(t *testing.T) {
 
 	entry := db.Cache().GetOrResolve(key, db.Matcher().(*BadgerMatcher))
 	require.NotNil(t, entry, "cache should be populated after cardinality-many query")
-	assert.True(t, entry.ManySet()["developer"])
-	assert.True(t, entry.ManySet()["golang"])
+	_, hasDeveloper := entry.ManySet()["developer"]
+	_, hasGolang := entry.ManySet()["golang"]
+	assert.True(t, hasDeveloper)
+	assert.True(t, hasGolang)
 }
 
 // TestCacheConcurrency verifies that concurrent cache access with real storage

--- a/datalog/storage/cache_resolver.go
+++ b/datalog/storage/cache_resolver.go
@@ -64,7 +64,7 @@ func (m *BadgerMatcher) ResolveLWW(e Entity, a Attribute) (any, datalog.ElementI
 
 // ResolveAddWins returns the current set members for cardinality-many
 // Uses the existing resolveAddWinsSet method and converts to map
-func (m *BadgerMatcher) ResolveAddWins(e Entity, a Attribute) (map[any]bool, datalog.ElementID, error) {
+func (m *BadgerMatcher) ResolveAddWins(e Entity, a Attribute) (map[any]any, datalog.ElementID, error) {
 	result, err := m.resolveAddWinsSet(e[:], a[:])
 	if err != nil {
 		return nil, datalog.ElementID{}, err

--- a/datalog/storage/cache_test.go
+++ b/datalog/storage/cache_test.go
@@ -16,7 +16,7 @@ type mockCacheResolver struct {
 	lwwValue        any
 	lwwMaxID        datalog.ElementID
 	lwwErr          error
-	addWinsSet      map[any]bool
+	addWinsSet      map[any]any
 	addWinsMaxID    datalog.ElementID
 	addWinsErr      error
 	rgaElements     []any
@@ -37,7 +37,7 @@ func (m *mockCacheResolver) ResolveLWW(e Entity, a Attribute) (any, datalog.Elem
 	return m.lwwValue, m.lwwMaxID, m.lwwErr
 }
 
-func (m *mockCacheResolver) ResolveAddWins(e Entity, a Attribute) (map[any]bool, datalog.ElementID, error) {
+func (m *mockCacheResolver) ResolveAddWins(e Entity, a Attribute) (map[any]any, datalog.ElementID, error) {
 	m.resolveAddCalls++
 	return m.addWinsSet, m.addWinsMaxID, m.addWinsErr
 }
@@ -260,7 +260,7 @@ func TestCacheRebuildCardinalityMany(t *testing.T) {
 	cache := NewCache()
 	resolver := &mockCacheResolver{
 		cardinality:  schema.CardinalityMany,
-		addWinsSet:   map[any]bool{"warrior": true, "veteran": true},
+		addWinsSet:   map[any]any{"warrior": "warrior", "veteran": "veteran"},
 		addWinsMaxID: datalog.ElementID{Lamport: 100, ReplicaID: 1},
 	}
 
@@ -274,8 +274,10 @@ func TestCacheRebuildCardinalityMany(t *testing.T) {
 	require.NotNil(t, entry)
 	assert.Equal(t, schema.CardinalityMany, entry.Cardinality())
 	assert.Nil(t, entry.OneValue())
-	assert.True(t, entry.ManySet()["warrior"])
-	assert.True(t, entry.ManySet()["veteran"])
+	_, hasWarrior := entry.ManySet()["warrior"]
+	_, hasVeteran := entry.ManySet()["veteran"]
+	assert.True(t, hasWarrior)
+	assert.True(t, hasVeteran)
 	assert.Nil(t, entry.VectorList())
 }
 
@@ -307,7 +309,7 @@ func TestCacheManySetMembership(t *testing.T) {
 	cache := NewCache()
 	resolver := &mockCacheResolver{
 		cardinality:  schema.CardinalityMany,
-		addWinsSet:   map[any]bool{"a": true, "b": true, "c": true},
+		addWinsSet:   map[any]any{"a": "a", "b": "b", "c": "c"},
 		addWinsMaxID: datalog.ElementID{Lamport: 100, ReplicaID: 1},
 	}
 
@@ -322,17 +324,21 @@ func TestCacheManySetMembership(t *testing.T) {
 
 	// O(1) membership check via map
 	set := entry.ManySet()
-	assert.True(t, set["a"])
-	assert.True(t, set["b"])
-	assert.True(t, set["c"])
-	assert.False(t, set["d"])
+	_, hasA := set["a"]
+	_, hasB := set["b"]
+	_, hasC := set["c"]
+	_, hasD := set["d"]
+	assert.True(t, hasA)
+	assert.True(t, hasB)
+	assert.True(t, hasC)
+	assert.False(t, hasD)
 }
 
 func TestCacheManyEmptyAfterRemoves(t *testing.T) {
 	cache := NewCache()
 	resolver := &mockCacheResolver{
 		cardinality:  schema.CardinalityMany,
-		addWinsSet:   map[any]bool{}, // Empty set after all removes
+		addWinsSet:   map[any]any{}, // Empty set after all removes
 		addWinsMaxID: datalog.ElementID{Lamport: 100, ReplicaID: 1},
 	}
 

--- a/datalog/storage/compressed_export_test.go
+++ b/datalog/storage/compressed_export_test.go
@@ -1,0 +1,430 @@
+package storage
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// ---- Export Tests ----
+
+func TestExport_DefaultUncompressed(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("export-entity")
+	attr := datalog.NewKeyword(":test/content")
+	value := longString("export test", 500)
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Default export — no #lzj tags
+	var buf bytes.Buffer
+	err = db.Export(&buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.NotContains(t, output, "#lzj", "default export should not contain #lzj tags")
+	assert.Contains(t, output, value[:50], "default export should contain the raw string value")
+}
+
+func TestExport_Compressed(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("export-comp")
+	attr := datalog.NewKeyword(":test/content")
+	value := longString("compressed export", 500)
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Compressed export — should have #lzj tags
+	var buf bytes.Buffer
+	err = db.ExportCompressed(&buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "#lzj", "compressed export should contain #lzj tags")
+	assert.NotContains(t, output, value[:50], "compressed export should not contain raw string")
+}
+
+func TestExport_CompressedSmallValue(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("export-small")
+	attr := datalog.NewKeyword(":test/name")
+	value := "Alice" // below threshold
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = db.ExportCompressed(&buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Small values should be plain strings even in compressed export
+	assert.Contains(t, output, "\"Alice\"")
+}
+
+// ---- Import Tests ----
+
+func TestImport_LZJLiteral(t *testing.T) {
+	// Create a database, write a value, export compressed, import into new DB
+	db1, cleanup1 := newCompressedDB(t)
+	defer cleanup1()
+
+	entity := datalog.NewIdentity("import-entity")
+	attr := datalog.NewKeyword(":test/content")
+	value := longString("import test value", 500)
+
+	tx := db1.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Export compressed
+	var buf bytes.Buffer
+	err = db1.ExportCompressed(&buf)
+	require.NoError(t, err)
+	ednData := buf.String()
+	assert.Contains(t, ednData, "#lzj")
+
+	// Import into fresh DB
+	dir2, err := os.MkdirTemp("", "import-lzj-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir2)
+
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir2,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	err = db2.Import(strings.NewReader(ednData))
+	require.NoError(t, err)
+
+	// Query the imported value
+	matcher := NewBadgerMatcher(db2.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next())
+	got := iter.Tuple()[0].(string)
+	assert.Equal(t, value, got, "imported value should match original")
+}
+
+func TestImport_MixedFile(t *testing.T) {
+	// Export a DB with both small and large values using compressed export
+	db1, cleanup1 := newCompressedDB(t)
+	defer cleanup1()
+
+	entity := datalog.NewIdentity("mixed-entity")
+	tx := db1.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":test/name"), "Alice")
+	tx.Add(entity, datalog.NewKeyword(":test/content"), longString("mixed content", 500))
+	tx.Add(entity, datalog.NewKeyword(":test/score"), int64(42))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = db1.ExportCompressed(&buf)
+	require.NoError(t, err)
+
+	// Import into fresh DB
+	dir2, err := os.MkdirTemp("", "import-mixed-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir2)
+
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir2,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	err = db2.Import(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+
+	// Verify all values
+	matcher := NewBadgerMatcher(db2.Store())
+	for _, tc := range []struct {
+		attr     string
+		expected interface{}
+	}{
+		{":test/name", "Alice"},
+		{":test/content", longString("mixed content", 500)},
+		{":test/score", int64(42)},
+	} {
+		pattern := &query.DataPattern{
+			Elements: []query.PatternElement{
+				query.Constant{Value: entity},
+				query.Constant{Value: datalog.NewKeyword(tc.attr)},
+				query.Variable{Name: datalog.NewSymbol("?v")},
+				query.Blank{},
+			},
+		}
+		results, err := matcher.Match(pattern, nil)
+		require.NoError(t, err)
+		iter := results.Iterator()
+		require.True(t, iter.Next(), "should find %s", tc.attr)
+		assert.Equal(t, tc.expected, iter.Tuple()[0], "value mismatch for %s", tc.attr)
+	}
+}
+
+func TestImport_RoundTrip(t *testing.T) {
+	// Write to DB1, export compressed, import to DB2, export default from DB2
+	// Verify DB2's default export has no #lzj tags but same values
+	db1, cleanup1 := newCompressedDB(t)
+	defer cleanup1()
+
+	entity := datalog.NewIdentity("roundtrip")
+	tx := db1.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":test/content"), longString("roundtrip test", 800))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Export compressed from DB1
+	var compBuf bytes.Buffer
+	err = db1.ExportCompressed(&compBuf)
+	require.NoError(t, err)
+	assert.Contains(t, compBuf.String(), "#lzj")
+
+	// Import into DB2
+	dir2, err := os.MkdirTemp("", "roundtrip-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir2)
+
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir2,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	err = db2.Import(strings.NewReader(compBuf.String()))
+	require.NoError(t, err)
+
+	// Export default (uncompressed) from DB2
+	var defaultBuf bytes.Buffer
+	err = db2.Export(&defaultBuf)
+	require.NoError(t, err)
+	assert.NotContains(t, defaultBuf.String(), "#lzj",
+		"default export from DB2 should not have #lzj tags")
+}
+
+func TestImport_AVET_AfterImport(t *testing.T) {
+	// Write compressed value to DB1, export with #lzj, import to DB2,
+	// verify AVET lookup on the imported value works
+	db1, cleanup1 := newCompressedDB(t)
+	defer cleanup1()
+
+	entity := datalog.NewIdentity("avet-import")
+	attr := datalog.NewKeyword(":test/content")
+	value := longString("AVET after import test", 500)
+
+	tx := db1.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Export compressed
+	var buf bytes.Buffer
+	err = db1.Export(&buf, ExportOptions{Compressed: true})
+	require.NoError(t, err)
+
+	// Import into fresh compressed DB
+	dir2, err := os.MkdirTemp("", "avet-import-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir2)
+
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir2,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	err = db2.Import(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+
+	// AVET lookup: search by value
+	matcher := NewBadgerMatcher(db2.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: attr},
+			query.Constant{Value: value}, // bound V → AVET
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next(), "AVET lookup should find entity after import")
+	gotEntity := iter.Tuple()[0].(datalog.Identity)
+	assert.Equal(t, entity.L85(), gotEntity.L85())
+}
+
+func TestImport_Tier3_InlineExport(t *testing.T) {
+	// Write a Tier 3 value (blob in storage), export (inline in EDN),
+	// import to new DB, verify it reads back correctly
+	db1, cleanup1 := newCompressedDB(t)
+	defer cleanup1()
+
+	entity := datalog.NewIdentity("tier3-export")
+	attr := datalog.NewKeyword(":test/big")
+	bigValue := string(makeTier3Data(100000))
+
+	vType, _, _ := datalog.EncodeValue(bigValue, 256)
+	if vType != datalog.TypeHashedString {
+		t.Skipf("value doesn't reach Tier 3 (type 0x%02x)", vType)
+	}
+
+	tx := db1.NewTransaction()
+	tx.Add(entity, attr, bigValue)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Export compressed — Tier 3 value should be inline #lzj
+	var buf bytes.Buffer
+	err = db1.Export(&buf, ExportOptions{Compressed: true})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "#lzj")
+
+	// Import into fresh compressed DB
+	dir2, err := os.MkdirTemp("", "tier3-export-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir2)
+
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir2,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	err = db2.Import(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+
+	// Read back
+	matcher := NewBadgerMatcher(db2.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next(), "should find Tier 3 value after import")
+	got := iter.Tuple()[0].(string)
+	assert.Equal(t, bigValue, got, "Tier 3 value should survive export→import round-trip")
+}
+
+func TestImport_ValueEquality_AcrossBoundary(t *testing.T) {
+	// Write same value to DB1 (compressed) and DB2 (via #lzj import).
+	// Query both — values should be equal.
+	value := longString("cross-boundary equality", 500)
+	entity := datalog.NewIdentity("eq-entity")
+	attr := datalog.NewKeyword(":test/content")
+
+	// DB1: write directly
+	db1, cleanup1 := newCompressedDB(t)
+	defer cleanup1()
+
+	tx := db1.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Export compressed from DB1
+	var buf bytes.Buffer
+	err = db1.Export(&buf, ExportOptions{Compressed: true})
+	require.NoError(t, err)
+
+	// DB2: import from #lzj EDN
+	dir2, err := os.MkdirTemp("", "eq-import-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir2)
+
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir2,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	err = db2.Import(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+
+	// Read from both
+	readValue := func(db *Database) string {
+		matcher := NewBadgerMatcher(db.Store())
+		pattern := &query.DataPattern{
+			Elements: []query.PatternElement{
+				query.Constant{Value: entity},
+				query.Constant{Value: attr},
+				query.Variable{Name: datalog.NewSymbol("?v")},
+				query.Blank{},
+			},
+		}
+		results, err := matcher.Match(pattern, nil)
+		require.NoError(t, err)
+		iter := results.Iterator()
+		require.True(t, iter.Next())
+		return iter.Tuple()[0].(string)
+	}
+
+	v1 := readValue(db1)
+	v2 := readValue(db2)
+	assert.Equal(t, v1, v2, "values should be equal across export→import boundary")
+	assert.Equal(t, value, v1)
+	assert.Equal(t, value, v2)
+}
+
+func TestImport_MalformedLZJ(t *testing.T) {
+	dir, err := os.MkdirTemp("", "malformed-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Malformed #lzj — invalid L85
+	badEDN := `[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :test/x #lzj "!!!INVALID!!!" [1 1] :op/none]`
+	err = db.Import(strings.NewReader(badEDN))
+	assert.Error(t, err, "import of malformed #lzj should fail")
+}

--- a/datalog/storage/compressed_integration_test.go
+++ b/datalog/storage/compressed_integration_test.go
@@ -190,7 +190,7 @@ func TestCompressedIntegration_AVET_ExactMatch(t *testing.T) {
 	iter := results.Iterator()
 	require.True(t, iter.Next(), "AVET lookup should find the entity")
 	gotEntity := iter.Tuple()[0]
-	assert.Equal(t, entity.L85(), gotEntity.(datalog.Identity).L85(),
+	assert.Equal(t, entity, gotEntity,
 		"AVET lookup returned wrong entity")
 	assert.False(t, iter.Next(), "expected exactly one result")
 }

--- a/datalog/storage/compressed_integration_test.go
+++ b/datalog/storage/compressed_integration_test.go
@@ -1,0 +1,640 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// newCompressedDB creates a test database with compression enabled.
+func newCompressedDB(t *testing.T) (*Database, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "compress-integ-*")
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+	return db, cleanup
+}
+
+// newCompressedDBWithSchema creates a test database with compression and schema.
+func newCompressedDBWithSchema(t *testing.T, s schema.SchemaProvider) (*Database, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "compress-integ-*")
+	require.NoError(t, err)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir,
+		Schema:               s,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+	return db, cleanup
+}
+
+// longString creates a compressible string above the threshold.
+func longString(prefix string, size int) string {
+	base := prefix + " " + strings.Repeat("The quick brown fox jumps over the lazy dog. ", size/45+2)
+	if len(base) > size {
+		return base[:size]
+	}
+	return base
+}
+
+// ---- Write and Read Back ----
+
+func TestCompressedIntegration_WriteReadString(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("test-entity")
+	attr := datalog.NewKeyword(":test/content")
+	value := longString("Hello", 500)
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Read back via pattern match
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next(), "expected at least one result")
+	tuple := iter.Tuple()
+	require.Len(t, tuple, 1)
+	assert.Equal(t, value, tuple[0].(string), "read-back value should match written value")
+	assert.False(t, iter.Next(), "expected exactly one result")
+}
+
+func TestCompressedIntegration_WriteReadBytes(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("bytes-entity")
+	attr := datalog.NewKeyword(":test/data")
+	value := []byte(longString("bytes", 500))
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next())
+	got := iter.Tuple()[0].([]byte)
+	assert.Equal(t, value, got, "bytes round-trip failed")
+}
+
+func TestCompressedIntegration_ShortStringUncompressed(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("short-entity")
+	attr := datalog.NewKeyword(":test/name")
+	value := "Alice" // well below 256 threshold
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next())
+	assert.Equal(t, "Alice", iter.Tuple()[0].(string))
+}
+
+// ---- Value Equality via AVET ----
+
+func TestCompressedIntegration_AVET_ExactMatch(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("avet-entity")
+	attr := datalog.NewKeyword(":test/content")
+	value := longString("AVET test", 500)
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Query with both A and V bound — goes through AVET index
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: attr},
+			query.Constant{Value: value}, // bound value triggers AVET
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next(), "AVET lookup should find the entity")
+	gotEntity := iter.Tuple()[0]
+	assert.Equal(t, entity.L85(), gotEntity.(datalog.Identity).L85(),
+		"AVET lookup returned wrong entity")
+	assert.False(t, iter.Next(), "expected exactly one result")
+}
+
+func TestCompressedIntegration_AVET_NoFalsePositive(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("avet-entity")
+	attr := datalog.NewKeyword(":test/content")
+	value := longString("stored value", 500)
+	differentValue := longString("different value", 500)
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, value)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Search for a different value — should find nothing
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: attr},
+			query.Constant{Value: differentValue},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	assert.False(t, iter.Next(), "AVET search for non-existent value should return nothing")
+}
+
+// ---- CRDT Resolution ----
+
+func TestCompressedIntegration_CRDT_CardinalityOne_LWW(t *testing.T) {
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":test/content"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+
+	db, cleanup := newCompressedDBWithSchema(t, s)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("lww-entity")
+	attr := datalog.NewKeyword(":test/content")
+
+	// Write version 1
+	tx1 := db.NewTransaction()
+	tx1.Set(entity, attr, longString("version one", 500))
+	_, err := tx1.Commit()
+	require.NoError(t, err)
+
+	// Write version 2
+	tx2 := db.NewTransaction()
+	tx2.Set(entity, attr, longString("version two", 500))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Query should return only the latest (version 2)
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(s)
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	iter := results.Iterator()
+	require.True(t, iter.Next())
+	got := iter.Tuple()[0].(string)
+	assert.True(t, strings.HasPrefix(got, "version two"),
+		"LWW should return latest version, got: %s...", got[:40])
+	assert.False(t, iter.Next(), "LWW should return exactly one result")
+}
+
+func TestCompressedIntegration_CRDT_CardinalityMany(t *testing.T) {
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":test/tags"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityMany,
+	})
+
+	db, cleanup := newCompressedDBWithSchema(t, s)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("many-entity")
+	attr := datalog.NewKeyword(":test/tags")
+	tag1 := longString("first tag value", 500)
+	tag2 := longString("second tag value", 500)
+
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, tag1)
+	tx.Add(entity, attr, tag2)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Both values should be present
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(s)
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	var values []string
+	iter := results.Iterator()
+	for iter.Next() {
+		values = append(values, iter.Tuple()[0].(string))
+	}
+	assert.Len(t, values, 2, "cardinality-many should return both values")
+
+	// Verify both values are present
+	found1, found2 := false, false
+	for _, v := range values {
+		if v == tag1 {
+			found1 = true
+		}
+		if v == tag2 {
+			found2 = true
+		}
+	}
+	assert.True(t, found1, "first tag value not found")
+	assert.True(t, found2, "second tag value not found")
+}
+
+func TestCompressedIntegration_CRDT_CardinalityMany_Remove(t *testing.T) {
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":test/tags"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityMany,
+	})
+
+	db, cleanup := newCompressedDBWithSchema(t, s)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("remove-entity")
+	attr := datalog.NewKeyword(":test/tags")
+	tag1 := longString("tag to keep", 500)
+	tag2 := longString("tag to remove", 500)
+
+	// Add both
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, tag1)
+	tx.Add(entity, attr, tag2)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Remove tag2
+	tx2 := db.NewTransaction()
+	tx2.Retract(entity, attr, tag2)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Only tag1 should remain
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(s)
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	var values []string
+	iter := results.Iterator()
+	for iter.Next() {
+		values = append(values, iter.Tuple()[0].(string))
+	}
+	assert.Len(t, values, 1, "should have one remaining tag after retract")
+	if len(values) == 1 {
+		assert.Equal(t, tag1, values[0], "remaining tag should be the one not retracted")
+	}
+}
+
+// ---- Mixed Compressed and Uncompressed ----
+
+func TestCompressedIntegration_MixedValues(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("mixed-entity")
+
+	// Write a mix of short (raw) and long (compressed) values
+	tx := db.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":test/name"), "Alice")                     // Tier 1
+	tx.Add(entity, datalog.NewKeyword(":test/content"), longString("content", 500)) // Tier 2
+	tx.Add(entity, datalog.NewKeyword(":test/age"), int64(30))                     // non-string
+	tx.Add(entity, datalog.NewKeyword(":test/active"), true)                       // non-string
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	matcher := NewBadgerMatcher(db.Store())
+
+	// Read each back and verify
+	for _, tc := range []struct {
+		attr     string
+		expected interface{}
+	}{
+		{":test/name", "Alice"},
+		{":test/content", longString("content", 500)},
+		{":test/age", int64(30)},
+		{":test/active", true},
+	} {
+		t.Run(tc.attr, func(t *testing.T) {
+			pattern := &query.DataPattern{
+				Elements: []query.PatternElement{
+					query.Constant{Value: entity},
+					query.Constant{Value: datalog.NewKeyword(tc.attr)},
+					query.Variable{Name: datalog.NewSymbol("?v")},
+					query.Blank{},
+				},
+			}
+			results, err := matcher.Match(pattern, nil)
+			require.NoError(t, err)
+
+			iter := results.Iterator()
+			require.True(t, iter.Next(), "expected result for %s", tc.attr)
+			got := iter.Tuple()[0]
+			assert.Equal(t, tc.expected, got, "value mismatch for %s", tc.attr)
+		})
+	}
+}
+
+// ---- Multiple Entities with Same Compressed Value ----
+
+func TestCompressedIntegration_MultipleEntities(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	attr := datalog.NewKeyword(":test/content")
+	content := longString("shared content", 500)
+
+	// Write same value to 10 different entities
+	for i := 0; i < 10; i++ {
+		entity := datalog.NewIdentity(fmt.Sprintf("entity-%d", i))
+		tx := db.NewTransaction()
+		tx.Add(entity, attr, content)
+		_, err := tx.Commit()
+		require.NoError(t, err)
+	}
+
+	// AVET lookup for the value should find all 10 entities
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: attr},
+			query.Constant{Value: content},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	count := 0
+	iter := results.Iterator()
+	for iter.Next() {
+		count++
+	}
+	assert.Equal(t, 10, count, "AVET lookup should find all 10 entities with same compressed value")
+}
+
+// ---- Value Equality Across Compression Boundary ----
+
+func TestCompressedIntegration_ValueEquality_CrossBoundary(t *testing.T) {
+	// Create two databases: one with compression, one without
+	// Write the same value to both, export, and verify equality
+
+	dir1, err := os.MkdirTemp("", "compress-eq1-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir1)
+
+	dir2, err := os.MkdirTemp("", "compress-eq2-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir2)
+
+	// DB1: compression enabled
+	db1, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir1,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db1.Close()
+
+	// DB2: compression disabled
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path: dir2,
+		// no compression threshold
+	})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	entity := datalog.NewIdentity("eq-test")
+	attr := datalog.NewKeyword(":test/content")
+	value := longString("equality test", 500)
+
+	// Write same value to both
+	tx1 := db1.NewTransaction()
+	tx1.Add(entity, attr, value)
+	_, err = tx1.Commit()
+	require.NoError(t, err)
+
+	tx2 := db2.NewTransaction()
+	tx2.Add(entity, attr, value)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Read back from both — values should be equal
+	readValue := func(db *Database) string {
+		matcher := NewBadgerMatcher(db.Store())
+		pattern := &query.DataPattern{
+			Elements: []query.PatternElement{
+				query.Constant{Value: entity},
+				query.Constant{Value: attr},
+				query.Variable{Name: datalog.NewSymbol("?v")},
+				query.Blank{},
+			},
+		}
+		results, err := matcher.Match(pattern, nil)
+		require.NoError(t, err)
+		iter := results.Iterator()
+		require.True(t, iter.Next())
+		return iter.Tuple()[0].(string)
+	}
+
+	v1 := readValue(db1)
+	v2 := readValue(db2)
+	assert.Equal(t, v1, v2, "values should be equal regardless of compression")
+	assert.Equal(t, value, v1, "compressed read should match original")
+	assert.Equal(t, value, v2, "uncompressed read should match original")
+}
+
+// ---- Scan All Values for an Entity ----
+
+func TestCompressedIntegration_ScanEntity(t *testing.T) {
+	db, cleanup := newCompressedDB(t)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("scan-entity")
+
+	// Write multiple attributes, mix of compressed and raw
+	tx := db.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":test/name"), "Bob")
+	tx.Add(entity, datalog.NewKeyword(":test/bio"), longString("biography", 800))
+	tx.Add(entity, datalog.NewKeyword(":test/notes"), longString("notes", 600))
+	tx.Add(entity, datalog.NewKeyword(":test/score"), int64(95))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Scan all attributes for entity
+	matcher := NewBadgerMatcher(db.Store())
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Variable{Name: datalog.NewSymbol("?a")},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	seen := make(map[string]interface{})
+	iter := results.Iterator()
+	for iter.Next() {
+		tuple := iter.Tuple()
+		attr := tuple[0].(datalog.Keyword).String()
+		seen[attr] = tuple[1]
+	}
+
+	// Should see all 4 attributes (plus :db/txInstant from each commit)
+	assert.Contains(t, seen, ":test/name")
+	assert.Contains(t, seen, ":test/bio")
+	assert.Contains(t, seen, ":test/notes")
+	assert.Contains(t, seen, ":test/score")
+
+	assert.Equal(t, "Bob", seen[":test/name"])
+	assert.Equal(t, longString("biography", 800), seen[":test/bio"])
+	assert.Equal(t, longString("notes", 600), seen[":test/notes"])
+	assert.Equal(t, int64(95), seen[":test/score"])
+}
+
+// ---- Determinism: Same Write Produces Same Keys ----
+
+func TestCompressedIntegration_Determinism(t *testing.T) {
+	// Write the same value twice to two different DBs — matcher should find it in both
+	value := longString("determinism", 500)
+
+	for i := 0; i < 2; i++ {
+		dir, err := os.MkdirTemp("", fmt.Sprintf("compress-det%d-*", i))
+		require.NoError(t, err)
+		defer os.RemoveAll(dir)
+
+		db, err := NewDatabaseWithOptions(DatabaseOptions{
+			Path:                 dir,
+			CompressionThreshold: 256,
+		})
+		require.NoError(t, err)
+
+		entity := datalog.NewIdentity("det-entity")
+		attr := datalog.NewKeyword(":test/content")
+
+		tx := db.NewTransaction()
+		tx.Add(entity, attr, value)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+
+		// AVET lookup
+		matcher := NewBadgerMatcher(db.Store())
+		pattern := &query.DataPattern{
+			Elements: []query.PatternElement{
+				query.Variable{Name: datalog.NewSymbol("?e")},
+				query.Constant{Value: attr},
+				query.Constant{Value: value},
+				query.Blank{},
+			},
+		}
+		results, err := matcher.Match(pattern, nil)
+		require.NoError(t, err)
+
+		iter := results.Iterator()
+		require.True(t, iter.Next(), "DB %d: AVET lookup should find the entity", i)
+		db.Close()
+	}
+}

--- a/datalog/storage/compressed_key_test.go
+++ b/datalog/storage/compressed_key_test.go
@@ -48,7 +48,7 @@ func TestCompressedKey_RoundTrip_AllIndexes(t *testing.T) {
 
 			assert.Equal(t, longStr, decoded.V.(string),
 				"value round-trip failed for %s", idx)
-			assert.Equal(t, d.E.L85(), decoded.E.L85(),
+			assert.Equal(t, d.E, decoded.E,
 				"entity round-trip failed for %s", idx)
 			assert.Equal(t, d.A.String(), decoded.A.String(),
 				"attribute round-trip failed for %s", idx)

--- a/datalog/storage/compressed_key_test.go
+++ b/datalog/storage/compressed_key_test.go
@@ -1,0 +1,241 @@
+package storage
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+func compressedEncoder() *BinaryKeyEncoder {
+	return &BinaryKeyEncoder{CompressionThreshold: 256}
+}
+
+func rawEncoder() *BinaryKeyEncoder {
+	return &BinaryKeyEncoder{} // threshold 0 = disabled
+}
+
+func makeCompressDatom(value interface{}) *datalog.Datom {
+	return &datalog.Datom{
+		E:  datalog.NewIdentity("test-entity"),
+		A:  datalog.NewKeyword(":test/content"),
+		V:  value,
+		Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1},
+	}
+}
+
+// ---- Key Round-Trip Tests (All Indexes) ----
+
+func TestCompressedKey_RoundTrip_AllIndexes(t *testing.T) {
+	enc := compressedEncoder()
+	longStr := strings.Repeat("This is compressible content. ", 25) // ~750 bytes
+
+	d := makeCompressDatom(longStr)
+
+	indexes := []IndexType{EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV}
+	for _, idx := range indexes {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			key := enc.EncodeKey(idx, d)
+			require.NotEmpty(t, key)
+
+			decoded, err := DatomFromKey(idx, key, enc)
+			require.NoError(t, err)
+
+			assert.Equal(t, longStr, decoded.V.(string),
+				"value round-trip failed for %s", idx)
+			assert.Equal(t, d.E.L85(), decoded.E.L85(),
+				"entity round-trip failed for %s", idx)
+			assert.Equal(t, d.A.String(), decoded.A.String(),
+				"attribute round-trip failed for %s", idx)
+		})
+	}
+}
+
+func TestCompressedKey_RoundTrip_Bytes(t *testing.T) {
+	enc := compressedEncoder()
+	longBytes := []byte(strings.Repeat("compressible bytes data. ", 25))
+
+	d := makeCompressDatom(longBytes)
+
+	for _, idx := range []IndexType{EAVT, AEVT, AVET} {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			key := enc.EncodeKey(idx, d)
+			decoded, err := DatomFromKey(idx, key, enc)
+			require.NoError(t, err)
+			assert.True(t, bytes.Equal(longBytes, decoded.V.([]byte)))
+		})
+	}
+}
+
+func TestCompressedKey_TypeTagPosition(t *testing.T) {
+	enc := compressedEncoder()
+	longStr := strings.Repeat("compressed string ", 30) // > 256 bytes
+
+	d := makeCompressDatom(longStr)
+	key := enc.EncodeKey(EAVT, d)
+
+	// In EAVT: [prefix:1][E:20][A:32][V:...][Tx:16][Op:1]
+	// V starts at position 53, first byte is type tag
+	require.Greater(t, len(key), 53)
+	assert.Equal(t, byte(datalog.TypeCompressedString), key[53],
+		"expected TypeCompressedString at position 53")
+}
+
+func TestCompressedKey_SmallValueStaysRaw(t *testing.T) {
+	enc := compressedEncoder()
+	shortStr := "hello" // well below 256 threshold
+
+	d := makeCompressDatom(shortStr)
+	key := enc.EncodeKey(EAVT, d)
+
+	// Value type should be TypeString (raw)
+	require.Greater(t, len(key), 53)
+	assert.Equal(t, byte(datalog.TypeString), key[53],
+		"short string should use TypeString, not compressed")
+
+	// Round-trip
+	decoded, err := DatomFromKey(EAVT, key, enc)
+	require.NoError(t, err)
+	assert.Equal(t, shortStr, decoded.V.(string))
+}
+
+// ---- AVET Lookup Correctness ----
+
+func TestCompressedKey_AVET_SameValueSamePrefix(t *testing.T) {
+	enc := compressedEncoder()
+	longStr := strings.Repeat("The AVET lookup test string. ", 20)
+
+	d := makeCompressDatom(longStr)
+
+	// Encode the datom key
+	datomKey := enc.EncodeKey(AVET, d)
+
+	// Encode a search prefix for the same value
+	vType, vData, _ := datalog.EncodeValue(longStr, 256)
+	searchBytes := append([]byte{byte(vType)}, vData...)
+	attrBytes := ToStorageDatom(*d).A
+	start, end := enc.EncodePrefixRange(AVET, attrBytes[:], searchBytes)
+
+	// The datom key should fall within the search range
+	assert.True(t, bytes.Compare(datomKey, start) >= 0,
+		"datom key should be >= start prefix")
+	assert.True(t, bytes.Compare(datomKey, end) < 0,
+		"datom key should be < end prefix")
+}
+
+func TestCompressedKey_AVET_DifferentValues(t *testing.T) {
+	enc := compressedEncoder()
+
+	str1 := strings.Repeat("value one for AVET test. ", 20)
+	str2 := strings.Repeat("value two for AVET test. ", 20)
+
+	d1 := makeCompressDatom(str1)
+	d2 := &datalog.Datom{
+		E:  datalog.NewIdentity("entity-2"),
+		A:  datalog.NewKeyword(":test/content"),
+		V:  str2,
+		Tx: datalog.ElementID{Lamport: 200, ReplicaID: 1},
+	}
+
+	key1 := enc.EncodeKey(AVET, d1)
+	key2 := enc.EncodeKey(AVET, d2)
+
+	// Keys should be different (different values)
+	assert.False(t, bytes.Equal(key1, key2), "different values should produce different AVET keys")
+
+	// Search for str1 should not match str2
+	vType1, vData1, _ := datalog.EncodeValue(str1, 256)
+	searchBytes1 := append([]byte{byte(vType1)}, vData1...)
+	attrBytes := ToStorageDatom(*d1).A
+	start1, end1 := enc.EncodePrefixRange(AVET, attrBytes[:], searchBytes1)
+
+	assert.True(t, bytes.Compare(key1, start1) >= 0 && bytes.Compare(key1, end1) < 0,
+		"key1 should be in range of search for str1")
+	assert.False(t, bytes.Compare(key2, start1) >= 0 && bytes.Compare(key2, end1) < 0,
+		"key2 should NOT be in range of search for str1")
+}
+
+// ---- Mixed Tier Tests ----
+
+func TestCompressedKey_MixedTiers(t *testing.T) {
+	enc := compressedEncoder()
+
+	shortStr := "short" // Tier 1: raw
+	longStr := strings.Repeat("This is a longer compressible string. ", 20) // Tier 2: compressed
+
+	d1 := makeCompressDatom(shortStr)
+	d2 := makeCompressDatom(longStr)
+
+	// Both should round-trip through EAVT
+	key1 := enc.EncodeKey(EAVT, d1)
+	key2 := enc.EncodeKey(EAVT, d2)
+
+	decoded1, err := DatomFromKey(EAVT, key1, enc)
+	require.NoError(t, err)
+	assert.Equal(t, shortStr, decoded1.V.(string))
+
+	decoded2, err := DatomFromKey(EAVT, key2, enc)
+	require.NoError(t, err)
+	assert.Equal(t, longStr, decoded2.V.(string))
+}
+
+// ---- Backward Compatibility ----
+
+func TestCompressedKey_BackwardCompat(t *testing.T) {
+	// Write with compression disabled, read with compression enabled
+	rawEnc := rawEncoder()
+	compEnc := compressedEncoder()
+
+	longStr := strings.Repeat("backward compat test ", 30)
+	d := makeCompressDatom(longStr)
+
+	// Encode without compression
+	key := rawEnc.EncodeKey(EAVT, d)
+	require.Greater(t, len(key), 53)
+	assert.Equal(t, byte(datalog.TypeString), key[53], "raw encoder should use TypeString")
+
+	// Decode with compression-enabled encoder — should still work
+	decoded, err := DatomFromKey(EAVT, key, compEnc)
+	require.NoError(t, err)
+	assert.Equal(t, longStr, decoded.V.(string),
+		"compression-enabled decoder should read uncompressed keys")
+}
+
+// ---- Compression Disabled ----
+
+func TestCompressedKey_DisabledThreshold(t *testing.T) {
+	enc := rawEncoder() // threshold = 0
+	longStr := strings.Repeat("should not be compressed ", 30)
+
+	d := makeCompressDatom(longStr)
+	key := enc.EncodeKey(EAVT, d)
+
+	// Should use TypeString (raw)
+	require.Greater(t, len(key), 53)
+	assert.Equal(t, byte(datalog.TypeString), key[53])
+
+	// Compressed key should be larger (has the full string in it)
+	compEnc := compressedEncoder()
+	compKey := compEnc.EncodeKey(EAVT, d)
+	assert.Less(t, len(compKey), len(key),
+		"compressed key should be smaller than raw key for long strings")
+}
+
+// ---- Determinism ----
+
+func TestCompressedKey_Determinism(t *testing.T) {
+	enc := compressedEncoder()
+	longStr := strings.Repeat("determinism key test ", 30)
+	d := makeCompressDatom(longStr)
+
+	golden := enc.EncodeKey(EAVT, d)
+	for i := 0; i < 100; i++ {
+		key := enc.EncodeKey(EAVT, d)
+		assert.True(t, bytes.Equal(golden, key), "iteration %d: key differs", i)
+	}
+}

--- a/datalog/storage/compressed_key_test.go
+++ b/datalog/storage/compressed_key_test.go
@@ -43,7 +43,7 @@ func TestCompressedKey_RoundTrip_AllIndexes(t *testing.T) {
 			key := enc.EncodeKey(idx, d)
 			require.NotEmpty(t, key)
 
-			decoded, err := DatomFromKey(idx, key, enc)
+			decoded, err := DatomFromKey(idx, key, enc, nil)
 			require.NoError(t, err)
 
 			assert.Equal(t, longStr, decoded.V.(string),
@@ -65,7 +65,7 @@ func TestCompressedKey_RoundTrip_Bytes(t *testing.T) {
 	for _, idx := range []IndexType{EAVT, AEVT, AVET} {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
 			key := enc.EncodeKey(idx, d)
-			decoded, err := DatomFromKey(idx, key, enc)
+			decoded, err := DatomFromKey(idx, key, enc, nil)
 			require.NoError(t, err)
 			assert.True(t, bytes.Equal(longBytes, decoded.V.([]byte)))
 		})
@@ -99,7 +99,7 @@ func TestCompressedKey_SmallValueStaysRaw(t *testing.T) {
 		"short string should use TypeString, not compressed")
 
 	// Round-trip
-	decoded, err := DatomFromKey(EAVT, key, enc)
+	decoded, err := DatomFromKey(EAVT, key, enc, nil)
 	require.NoError(t, err)
 	assert.Equal(t, shortStr, decoded.V.(string))
 }
@@ -175,11 +175,11 @@ func TestCompressedKey_MixedTiers(t *testing.T) {
 	key1 := enc.EncodeKey(EAVT, d1)
 	key2 := enc.EncodeKey(EAVT, d2)
 
-	decoded1, err := DatomFromKey(EAVT, key1, enc)
+	decoded1, err := DatomFromKey(EAVT, key1, enc, nil)
 	require.NoError(t, err)
 	assert.Equal(t, shortStr, decoded1.V.(string))
 
-	decoded2, err := DatomFromKey(EAVT, key2, enc)
+	decoded2, err := DatomFromKey(EAVT, key2, enc, nil)
 	require.NoError(t, err)
 	assert.Equal(t, longStr, decoded2.V.(string))
 }
@@ -200,7 +200,7 @@ func TestCompressedKey_BackwardCompat(t *testing.T) {
 	assert.Equal(t, byte(datalog.TypeString), key[53], "raw encoder should use TypeString")
 
 	// Decode with compression-enabled encoder — should still work
-	decoded, err := DatomFromKey(EAVT, key, compEnc)
+	decoded, err := DatomFromKey(EAVT, key, compEnc, nil)
 	require.NoError(t, err)
 	assert.Equal(t, longStr, decoded.V.(string),
 		"compression-enabled decoder should read uncompressed keys")

--- a/datalog/storage/crdt_many_test.go
+++ b/datalog/storage/crdt_many_test.go
@@ -219,7 +219,7 @@ func TestResolveAddWinsSetDirect(t *testing.T) {
 
 	if len(result.Members) != 1 {
 		t.Errorf("Expected 1 member (add is newer), got %d: %v", len(result.Members), result.Members)
-	} else if !result.Members["warrior"] {
+	} else if _, ok := result.Members["warrior"]; !ok {
 		t.Errorf("Expected 'warrior' to be in set, got %v", result.Members)
 	}
 }
@@ -279,7 +279,7 @@ func TestResolveAddWinsSameLamport(t *testing.T) {
 	// At same Lamport, add should win
 	if len(result.Members) != 1 {
 		t.Errorf("Expected 1 member (add-wins at same Lamport), got %d: %v", len(result.Members), result.Members)
-	} else if !result.Members["warrior"] {
+	} else if _, ok := result.Members["warrior"]; !ok {
 		t.Errorf("Expected 'warrior' to be in set, got %v", result.Members)
 	}
 }
@@ -1168,7 +1168,10 @@ func TestCardinalityManyReplaceSet(t *testing.T) {
 	if len(result1.Members) != 3 {
 		t.Errorf("Expected 3 initial members, got %d", len(result1.Members))
 	}
-	if !result1.Members["warrior"] || !result1.Members["veteran"] || !result1.Members["leader"] {
+	_, hasW := result1.Members["warrior"]
+	_, hasV := result1.Members["veteran"]
+	_, hasL := result1.Members["leader"]
+	if !hasW || !hasV || !hasL {
 		t.Errorf("Initial members incorrect: %v", result1.Members)
 	}
 
@@ -1190,16 +1193,20 @@ func TestCardinalityManyReplaceSet(t *testing.T) {
 	if len(result2.Members) != 2 {
 		t.Errorf("Expected 2 members after Set, got %d: %v", len(result2.Members), result2.Members)
 	}
-	if !result2.Members["mage"] {
+	_, hasMage := result2.Members["mage"]
+	_, hasWarrior := result2.Members["warrior"]
+	_, hasVeteran := result2.Members["veteran"]
+	_, hasLeader := result2.Members["leader"]
+	if !hasMage {
 		t.Error("Expected 'mage' to be in set")
 	}
-	if !result2.Members["warrior"] {
+	if !hasWarrior {
 		t.Error("Expected 'warrior' to be in set")
 	}
-	if result2.Members["veteran"] {
+	if hasVeteran {
 		t.Error("'veteran' should have been removed")
 	}
-	if result2.Members["leader"] {
+	if hasLeader {
 		t.Error("'leader' should have been removed")
 	}
 }

--- a/datalog/storage/crdt_resolve.go
+++ b/datalog/storage/crdt_resolve.go
@@ -44,9 +44,9 @@ func ResolveLWWFromDatoms(datoms []datalog.Datom) (any, datalog.ElementID) {
 // - If add has higher Lamport: in set
 // - If remove has higher Lamport: not in set
 // - Same Lamport (concurrent): add wins
-func ResolveAddWinsFromDatoms(datoms []datalog.Datom) (map[any]bool, datalog.ElementID) {
+func ResolveAddWinsFromDatoms(datoms []datalog.Datom) (map[any]any, datalog.ElementID) {
 	if len(datoms) == 0 {
-		return make(map[any]bool), datalog.ElementID{}
+		return make(map[any]any), datalog.ElementID{}
 	}
 
 	var maxID datalog.ElementID
@@ -93,7 +93,7 @@ func ResolveAddWinsFromDatoms(datoms []datalog.Datom) (map[any]bool, datalog.Ele
 	}
 
 	// Resolve membership
-	result := make(map[any]bool)
+	result := make(map[any]any)
 	for _, state := range valueStates {
 		inSet := false
 		if state.hasAdd && !state.hasRemove {
@@ -107,7 +107,11 @@ func ResolveAddWinsFromDatoms(datoms []datalog.Datom) (map[any]bool, datalog.Ele
 			}
 		}
 		if inSet {
-			result[state.value] = true
+			key := state.value
+			if b, ok := key.([]byte); ok {
+				key = string(b)
+			}
+			result[key] = state.value
 		}
 	}
 

--- a/datalog/storage/crdt_resolve_test.go
+++ b/datalog/storage/crdt_resolve_test.go
@@ -92,8 +92,10 @@ func TestResolveAddWinsFromDatoms_OnlyAdds(t *testing.T) {
 	}
 
 	members, maxID := ResolveAddWinsFromDatoms(datoms)
-	assert.True(t, members["tag1"])
-	assert.True(t, members["tag2"])
+	_, hasTag1 := members["tag1"]
+	_, hasTag2 := members["tag2"]
+	assert.True(t, hasTag1)
+	assert.True(t, hasTag2)
 	assert.Equal(t, 2, len(members))
 	assert.Equal(t, elemID(101, 1), maxID)
 }
@@ -106,7 +108,8 @@ func TestResolveAddWinsFromDatoms_AddThenRemove_RemoveWins(t *testing.T) {
 	}
 
 	members, _ := ResolveAddWinsFromDatoms(datoms)
-	assert.False(t, members["tag1"])
+	_, hasTag1 := members["tag1"]
+	assert.False(t, hasTag1)
 	assert.Equal(t, 0, len(members))
 }
 
@@ -118,7 +121,8 @@ func TestResolveAddWinsFromDatoms_RemoveThenAdd_AddWins(t *testing.T) {
 	}
 
 	members, _ := ResolveAddWinsFromDatoms(datoms)
-	assert.True(t, members["tag1"])
+	_, hasTag1 := members["tag1"]
+	assert.True(t, hasTag1)
 }
 
 func TestResolveAddWinsFromDatoms_Concurrent_AddWins(t *testing.T) {
@@ -129,7 +133,8 @@ func TestResolveAddWinsFromDatoms_Concurrent_AddWins(t *testing.T) {
 	}
 
 	members, _ := ResolveAddWinsFromDatoms(datoms)
-	assert.True(t, members["tag1"]) // Add wins at same Lamport
+	_, hasTag1 := members["tag1"]
+	assert.True(t, hasTag1) // Add wins at same Lamport
 }
 
 func TestResolveAddWinsFromDatoms_MultipleValues(t *testing.T) {
@@ -146,9 +151,12 @@ func TestResolveAddWinsFromDatoms_MultipleValues(t *testing.T) {
 	}
 
 	members, maxID := ResolveAddWinsFromDatoms(datoms)
-	assert.False(t, members["tag1"]) // Removed
-	assert.True(t, members["tag2"])  // Only added
-	assert.True(t, members["tag3"])  // Re-added
+	_, hasTag1 := members["tag1"]
+	_, hasTag2 := members["tag2"]
+	_, hasTag3 := members["tag3"]
+	assert.False(t, hasTag1) // Removed
+	assert.True(t, hasTag2)  // Only added
+	assert.True(t, hasTag3)  // Re-added
 	assert.Equal(t, 2, len(members))
 	assert.Equal(t, elemID(300, 1), maxID)
 }

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -224,16 +224,22 @@ func (it *CRDTResolvingIterator) startNewGroup(datom *datalog.Datom) {
 // - REMOVE before ADD = remove has higher Tx = value is removed
 // - REMOVE after ADD = we already emitted = ignore remove
 func (it *CRDTResolvingIterator) processAddWins(datom *datalog.Datom) *datalog.Datom {
+	// Use a hashable key for map lookups. []byte is not hashable in Go,
+	// but the datom itself (returned to caller) preserves the original type.
 	v := datom.V
+	key := v
+	if b, ok := key.([]byte); ok {
+		key = string(b)
+	}
 
 	if datom.Op == datalog.OpCRDTAdd {
 		// Already emitted this value?
-		if it.emitted[v] {
+		if it.emitted[key] {
 			return nil
 		}
 
 		// Check if tombstoned
-		if tombstoneLamport, exists := it.tombstones[v]; exists {
+		if tombstoneLamport, exists := it.tombstones[key]; exists {
 			// Add wins at same Lamport, otherwise remove wins
 			if datom.Tx.Lamport < tombstoneLamport {
 				return nil // Remove wins
@@ -242,13 +248,13 @@ func (it *CRDTResolvingIterator) processAddWins(datom *datalog.Datom) *datalog.D
 		}
 
 		// Emit this add
-		it.emitted[v] = true
+		it.emitted[key] = true
 		return datom
 
 	} else if datom.Op == datalog.OpCRDTRemove {
 		// Record tombstone (first one we see = highest Tx)
-		if _, exists := it.tombstones[v]; !exists {
-			it.tombstones[v] = datom.Tx.Lamport
+		if _, exists := it.tombstones[key]; !exists {
+			it.tombstones[key] = datom.Tx.Lamport
 		}
 		return nil
 	}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -2398,7 +2398,7 @@ func entryToValue(entry *CacheEntry, valueType schema.ValueType) interface{} {
 			return nil
 		}
 		values := make([]interface{}, 0, len(set))
-		for v := range set {
+		for _, v := range set {
 			values = append(values, v)
 		}
 		return values
@@ -2490,7 +2490,7 @@ func (d *Database) ResolveAllAttributes(entity datalog.Identity) (map[datalog.Ke
 			set := entry.ManySet()
 			if len(set) > 0 {
 				values := make([]interface{}, 0, len(set))
-				for v := range set {
+				for _, v := range set {
 					values = append(values, v)
 				}
 				result[kw] = values

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -78,8 +78,9 @@ type DatabaseOptions struct {
 	Schema            schema.SchemaProvider   // Optional schema for validation
 	AnnotationHandler annotations.Handler     // Optional handler for query tracing
 	ReplicaID         uint64                  // For CRDT mode: 0 = auto-generate random; non-zero = use specified. Ignored for existing DBs.
-	DisableCache      bool                    // Disable EA cache; queries resolve directly from storage
-	PlannerOptions    *planner.PlannerOptions // Optional override for default planner options
+	DisableCache           bool                    // Disable EA cache; queries resolve directly from storage
+	PlannerOptions         *planner.PlannerOptions // Optional override for default planner options
+	CompressionThreshold   int                     // Compress string/[]byte values >= this size (0 = disabled)
 }
 
 // NewDatabaseWithOptions creates a database with the specified options.
@@ -101,7 +102,13 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 		return nil, fmt.Errorf("database path is required")
 	}
 
-	store, err := NewBadgerStore(opts.Path, NewKeyEncoder(BinaryStrategy))
+	encoder := NewKeyEncoder(BinaryStrategy)
+	if opts.CompressionThreshold > 0 {
+		if be, ok := encoder.(*BinaryKeyEncoder); ok {
+			be.CompressionThreshold = opts.CompressionThreshold
+		}
+	}
+	store, err := NewBadgerStore(opts.Path, encoder)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create store: %w", err)
 	}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -80,7 +80,7 @@ type DatabaseOptions struct {
 	ReplicaID         uint64                  // For CRDT mode: 0 = auto-generate random; non-zero = use specified. Ignored for existing DBs.
 	DisableCache           bool                    // Disable EA cache; queries resolve directly from storage
 	PlannerOptions         *planner.PlannerOptions // Optional override for default planner options
-	CompressionThreshold   int                     // Compress string/[]byte values >= this size (0 = disabled)
+	CompressionThreshold   int                     // Compress string/[]byte values >= this size (default 256; -1 to disable)
 }
 
 // NewDatabaseWithOptions creates a database with the specified options.
@@ -103,9 +103,14 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 	}
 
 	encoder := NewKeyEncoder(BinaryStrategy)
-	if opts.CompressionThreshold > 0 {
+	// Default compression threshold is 256 bytes. Use -1 to disable.
+	threshold := opts.CompressionThreshold
+	if threshold == 0 {
+		threshold = 256
+	}
+	if threshold > 0 {
 		if be, ok := encoder.(*BinaryKeyEncoder); ok {
-			be.CompressionThreshold = opts.CompressionThreshold
+			be.CompressionThreshold = threshold
 		}
 	}
 	store, err := NewBadgerStore(opts.Path, encoder)

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -103,10 +103,12 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 	}
 
 	encoder := NewKeyEncoder(BinaryStrategy)
-	// Default compression threshold is 256 bytes. Use -1 to disable.
+	// Default compression threshold is 512 bytes. Use -1 to disable.
+	// Values below ~500 bytes rarely compress due to ~300 bytes of
+	// FSE table + block header overhead in the compressed format.
 	threshold := opts.CompressionThreshold
 	if threshold == 0 {
-		threshold = 256
+		threshold = 512
 	}
 	if threshold > 0 {
 		if be, ok := encoder.(*BinaryKeyEncoder); ok {

--- a/datalog/storage/datom_decoder.go
+++ b/datalog/storage/datom_decoder.go
@@ -9,10 +9,10 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/codec"
 )
 
-// DatomFromKey reconstructs a datom from an index key
-// This allows us to avoid fetching values since the key contains all information
-// Returns by value to allow callers to reuse storage (no heap allocation per call)
-func DatomFromKey(index IndexType, key []byte, encoder KeyEncoder) (datalog.Datom, error) {
+// DatomFromKey reconstructs a datom from an index key.
+// For Tier 3 (hashed) values, db is required to fetch compressed data from the blob store.
+// Pass nil for db when Tier 3 values are not expected.
+func DatomFromKey(index IndexType, key []byte, encoder KeyEncoder, db *badger.DB) (datalog.Datom, error) {
 	// DecodeKey returns fixed-size arrays directly (no heap escape)
 	entity, attr, vBytes, tx, op, afterRef, err := encoder.DecodeKey(index, key)
 	if err != nil {
@@ -34,14 +34,43 @@ func DatomFromKey(index IndexType, key []byte, encoder KeyEncoder) (datalog.Dato
 		}
 	}
 
+	// Tier 3: hashed values need blob store lookup
+	if vType == datalog.TypeHashedString || vType == datalog.TypeHashedBytes {
+		if db == nil {
+			return datalog.Datom{}, fmt.Errorf("hashed value requires database for blob lookup")
+		}
+		if len(vData) != 20 {
+			return datalog.Datom{}, fmt.Errorf("hashed value hash must be 20 bytes, got %d", len(vData))
+		}
+		var hash [20]byte
+		copy(hash[:], vData)
+		compressed, err := getBlob(db, hash)
+		if err != nil {
+			return datalog.Datom{}, fmt.Errorf("failed to read blob: %w", err)
+		}
+		// Decompress and return as the original type
+		decompressed, err := datalog.ValueFromBytes(
+			datalog.ValueType(vType-2), // TypeHashedString→TypeCompressedString, etc.
+			compressed,
+		)
+		if err != nil {
+			return datalog.Datom{}, fmt.Errorf("failed to decompress blob: %w", err)
+		}
+		return datalog.Datom{
+			E:        datalog.InternIdentityFromHash(entity),
+			A:        datalog.InternKeywordFromBytes(attr),
+			V:        decompressed,
+			Tx:       Tx(tx).ToElementID(),
+			Op:       datalog.CRDTOp(op),
+			AfterRef: Tx(afterRef).ToElementID(),
+		}, nil
+	}
+
 	v, err := datalog.ValueFromBytes(vType, vData)
 	if err != nil {
 		return datalog.Datom{}, fmt.Errorf("failed to decode value: %w", err)
 	}
 
-	// Convert to user datom using direct array-based interning
-	// No intermediate copies needed - arrays go straight to intern cache lookup
-	// tx is [16]byte, convert to Tx type then to uint64
 	return datalog.Datom{
 		E:        datalog.InternIdentityFromHash(entity),
 		A:        datalog.InternKeywordFromBytes(attr),
@@ -53,10 +82,11 @@ func DatomFromKey(index IndexType, key []byte, encoder KeyEncoder) (datalog.Dato
 }
 
 // KeyOnlyIterator wraps a BadgerIterator to decode datoms from keys
-// This avoids fetching values entirely
+// This avoids fetching values entirely (except for Tier 3 blob lookups)
 type KeyOnlyIterator struct {
 	*BadgerIterator
 	encoder      KeyEncoder
+	db           *badger.DB
 	currentDatom datalog.Datom
 	hasDatom     bool
 	currentError error
@@ -83,6 +113,7 @@ func NewKeyOnlyIterator(store *BadgerStore, index IndexType, start, end []byte) 
 	return &KeyOnlyIterator{
 		BadgerIterator: bi,
 		encoder:        store.encoder,
+		db:             store.db,
 	}, nil
 }
 
@@ -101,7 +132,7 @@ func (i *KeyOnlyIterator) Next() bool {
 	// Decode datom from key - must copy since BadgerDB reuses the key buffer
 	key := i.it.Item().KeyCopy(nil)
 
-	i.currentDatom, i.currentError = DatomFromKey(i.index, key, i.encoder)
+	i.currentDatom, i.currentError = DatomFromKey(i.index, key, i.encoder, i.db)
 
 	if i.currentError != nil {
 		return false

--- a/datalog/storage/datom_decoder_test.go
+++ b/datalog/storage/datom_decoder_test.go
@@ -25,12 +25,12 @@ func TestDatomFromKeyValueSemantics(t *testing.T) {
 	key := encoder.EncodeKey(EAVT, originalDatom)
 
 	// Decode twice
-	d1, err1 := DatomFromKey(EAVT, key, encoder)
+	d1, err1 := DatomFromKey(EAVT, key, encoder, nil)
 	if err1 != nil {
 		t.Fatalf("DatomFromKey first call failed: %v", err1)
 	}
 
-	d2, err2 := DatomFromKey(EAVT, key, encoder)
+	d2, err2 := DatomFromKey(EAVT, key, encoder, nil)
 	if err2 != nil {
 		t.Fatalf("DatomFromKey second call failed: %v", err2)
 	}
@@ -78,7 +78,7 @@ func TestDatomFromKeyAllIndexTypes(t *testing.T) {
 		t.Run(indexNames[i], func(t *testing.T) {
 			key := encoder.EncodeKey(idx, originalDatom)
 
-			decoded, err := DatomFromKey(idx, key, encoder)
+			decoded, err := DatomFromKey(idx, key, encoder, nil)
 			if err != nil {
 				t.Fatalf("DatomFromKey(%s) failed: %v", indexNames[i], err)
 			}

--- a/datalog/storage/export.go
+++ b/datalog/storage/export.go
@@ -13,27 +13,31 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/edn"
 )
 
+// ExportOptions configures EDN export behavior.
+type ExportOptions struct {
+	Compressed bool // Use #lzj tagged literals for large string values
+}
+
 // Export writes all datoms in the database to EDN format.
-// Each line contains a single EDN vector: [#identity "L85" :attribute value tx-id]
-//
-// The format preserves all type information for round-trip fidelity:
-//   - Entities: #identity "L85hash" (always L85 encoded, 25 chars)
-//   - Attributes: keyword (e.g., :person/name)
-//   - Values: EDN representation with type tags where needed
-//   - Transaction IDs: integers
-//
-// Example output:
-//
-//	[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/name "Alice" 1]
-//	[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/age 30 1]
-//	[#identity "0$&1Jt:M;j(7P!6s0BvD4k!,!" :person/created #inst "2025-01-15T10:30:00Z" 1]
-//
-// The output is suitable for Import() to restore the database.
-func (d *Database) Export(w io.Writer) error {
-	// Scan all datoms from EAVT index only
-	// Keys are prefixed with index type byte, so we scan from EAVT prefix to EATV prefix
+// With no options, values are serialized as plain EDN strings.
+// With Compressed: true, large strings use #lzj tagged literals.
+func (d *Database) Export(w io.Writer, opts ...ExportOptions) error {
+	formatter := FormatDatomEDN
+	if len(opts) > 0 && opts[0].Compressed {
+		formatter = FormatDatomEDNCompressed
+	}
+	return d.export(w, formatter)
+}
+
+// ExportCompressed is a convenience alias for Export with Compressed: true.
+func (d *Database) ExportCompressed(w io.Writer) error {
+	return d.Export(w, ExportOptions{Compressed: true})
+}
+
+// export is the shared implementation for Export and ExportCompressed.
+func (d *Database) export(w io.Writer, formatDatom func(*datalog.Datom) string) error {
 	start := []byte{byte(EAVT)}
-	end := []byte{byte(EATV)} // EATV is the next index after EAVT
+	end := []byte{byte(EATV)}
 	iter, err := d.store.Scan(EAVT, start, end)
 	if err != nil {
 		return fmt.Errorf("failed to scan database: %w", err)
@@ -48,8 +52,7 @@ func (d *Database) Export(w io.Writer) error {
 			return fmt.Errorf("failed to read datom: %w", err)
 		}
 
-		// Format as EDN vector
-		line := FormatDatomEDN(datom)
+		line := formatDatom(datom)
 		if _, err := bw.WriteString(line); err != nil {
 			return fmt.Errorf("failed to write datom: %w", err)
 		}
@@ -63,6 +66,42 @@ func (d *Database) Export(w io.Writer) error {
 	}
 
 	return nil
+}
+
+// FormatDatomEDNCompressed formats a datom as EDN, using #lzj for compressible values.
+func FormatDatomEDNCompressed(d *datalog.Datom) string {
+	nodes := []edn.Node{
+		IdentityNode(d.E),
+		{Type: edn.NodeKeyword, Value: d.A.String()},
+		ValueNodeCompressed(d.V),
+		ElementIDNode(d.Tx),
+		{Type: edn.NodeKeyword, Value: FormatCRDTOpEDN(d.Op)},
+	}
+	if d.Op.HasAfterRef() {
+		nodes = append(nodes, ElementIDNode(d.AfterRef))
+	}
+	vec := edn.Node{Type: edn.NodeVector, Nodes: nodes}
+	return vec.String()
+}
+
+// ValueNodeCompressed builds an EDN node for a value, using #lzj for large
+// string values that compress well. []byte values use #bytes (uncompressed)
+// to avoid type ambiguity on import. Small strings use plain EDN.
+func ValueNodeCompressed(v interface{}) edn.Node {
+	if s, ok := v.(string); ok {
+		compressed := codec.Compress([]byte(s))
+		if compressed != nil {
+			return edn.Node{
+				Type: edn.NodeTagged,
+				Tag:  "lzj",
+				Tagged: &edn.Node{
+					Type:  edn.NodeString,
+					Value: codec.EncodeL85(compressed),
+				},
+			}
+		}
+	}
+	return ValueNode(v)
 }
 
 // Import reads datoms from EDN format and loads them into the database.
@@ -546,6 +585,24 @@ func parseTaggedValue(node *edn.Node) (interface{}, error) {
 		}
 
 		return datalog.ElementID{Lamport: lamport, ReplicaID: replicaID}, nil
+
+	case "lzj":
+		// LZJ compressed string: L85-decode, then decompress
+		if valueNode.Type != edn.NodeString {
+			return nil, fmt.Errorf("#lzj requires string value")
+		}
+		if valueNode.Value == "" {
+			return "", nil
+		}
+		compressed, err := codec.DecodeL85(valueNode.Value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid L85 in #lzj: %w", err)
+		}
+		decompressed, err := codec.Decompress(compressed)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decompress #lzj: %w", err)
+		}
+		return string(decompressed), nil
 
 	default:
 		return nil, fmt.Errorf("unknown tag: #%s", tag)

--- a/datalog/storage/export.go
+++ b/datalog/storage/export.go
@@ -16,6 +16,11 @@ import (
 // ExportOptions configures EDN export behavior.
 type ExportOptions struct {
 	Compressed bool // Use #lzj tagged literals for large string values
+	// SkipEntity, when non-nil, is called for each datom's entity Identity.
+	// If it returns true, the datom is omitted from the export.
+	// This enables filtering out entire entity classes (e.g., task metadata)
+	// without a separate pass over the database.
+	SkipEntity func(datalog.Identity) bool
 }
 
 // Export writes all datoms in the database to EDN format.
@@ -23,19 +28,24 @@ type ExportOptions struct {
 // With Compressed: true, large strings use #lzj tagged literals.
 func (d *Database) Export(w io.Writer, opts ...ExportOptions) error {
 	formatter := FormatDatomEDN
-	if len(opts) > 0 && opts[0].Compressed {
-		formatter = FormatDatomEDNCompressed
+	var skipEntity func(datalog.Identity) bool
+	if len(opts) > 0 {
+		if opts[0].Compressed {
+			formatter = FormatDatomEDNCompressed
+		}
+		skipEntity = opts[0].SkipEntity
 	}
-	return d.export(w, formatter)
+	return d.export(w, formatter, skipEntity)
 }
 
 // ExportCompressed is a convenience alias for Export with Compressed: true.
+// To filter entities during compressed export, use Export directly with ExportOptions.
 func (d *Database) ExportCompressed(w io.Writer) error {
 	return d.Export(w, ExportOptions{Compressed: true})
 }
 
 // export is the shared implementation for Export and ExportCompressed.
-func (d *Database) export(w io.Writer, formatDatom func(*datalog.Datom) string) error {
+func (d *Database) export(w io.Writer, formatDatom func(*datalog.Datom) string, skipEntity func(datalog.Identity) bool) error {
 	start := []byte{byte(EAVT)}
 	end := []byte{byte(EATV)}
 	iter, err := d.store.Scan(EAVT, start, end)
@@ -50,6 +60,10 @@ func (d *Database) export(w io.Writer, formatDatom func(*datalog.Datom) string) 
 		datom, err := iter.Datom()
 		if err != nil {
 			return fmt.Errorf("failed to read datom: %w", err)
+		}
+
+		if skipEntity != nil && skipEntity(datom.E) {
+			continue
 		}
 
 		line := formatDatom(datom)

--- a/datalog/storage/key_encoder_binary.go
+++ b/datalog/storage/key_encoder_binary.go
@@ -8,7 +8,9 @@ import (
 )
 
 // BinaryKeyEncoder implements KeyEncoder using raw binary for space efficiency
-type BinaryKeyEncoder struct{}
+type BinaryKeyEncoder struct {
+	CompressionThreshold int // 0 = disabled; values >= this size are compressed
+}
 
 // txToDescending applies bitwise NOT to Tx bytes for descending sort order.
 // This ensures highest ElementID sorts first in forward scans, enabling O(1)
@@ -55,8 +57,18 @@ func (e *BinaryKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 	prefix := []byte{byte(index)}
 
 	// Get value bytes with type prefix (1 byte type + variable length data)
-	vType := byte(datalog.Type(sd.V))
-	vData := datalog.ValueBytes(sd.V)
+	// When compression is enabled, EncodeValue handles tier routing.
+	var vType byte
+	var vData []byte
+	if e.CompressionThreshold > 0 {
+		vt, vd, _ := datalog.EncodeValue(sd.V, e.CompressionThreshold)
+		vType = byte(vt)
+		vData = vd
+		// Note: BlobData (Tier 3) is ignored here — assertDatom handles blob writes
+	} else {
+		vType = byte(datalog.Type(sd.V))
+		vData = datalog.ValueBytes(sd.V)
+	}
 	vBytes := append([]byte{vType}, vData...)
 
 	// Encode Tx with bitwise NOT for descending sort order

--- a/datalog/storage/key_encoder_binary.go
+++ b/datalog/storage/key_encoder_binary.go
@@ -49,27 +49,42 @@ func txFromDescending(encoded []byte) [16]byte {
 //	TAEV: [prefix][Tx↓][A][E][type][value][AfterRef?][Op]  - transaction log
 //
 // AfterRef? = 16 bytes present only if Op ∈ {OpRGAInsert(3), OpRGATombstone(4)}
-func (e *BinaryKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
-	// Convert to storage datom first
-	sd := ToStorageDatom(*d)
-
-	// Each index has a 1-byte prefix to separate namespaces
-	prefix := []byte{byte(index)}
-
-	// Get value bytes with type prefix (1 byte type + variable length data)
-	// When compression is enabled, EncodeValue handles tier routing.
+// EncodeValueBytes computes the type+data bytes for a value, applying
+// compression if enabled. Returns the bytes for the key and optional
+// BlobData for Tier 3 values. Call this once per datom, then pass the
+// result to EncodeKeyWithValueBytes for each index.
+func (e *BinaryKeyEncoder) EncodeValueBytes(v interface{}) (vBytes []byte, blobData *datalog.BlobData) {
 	var vType byte
 	var vData []byte
 	if e.CompressionThreshold > 0 {
-		vt, vd, _ := datalog.EncodeValue(sd.V, e.CompressionThreshold)
+		vt, vd, bd := datalog.EncodeValue(v, e.CompressionThreshold)
 		vType = byte(vt)
 		vData = vd
-		// Note: BlobData (Tier 3) is ignored here — assertDatom handles blob writes
+		blobData = bd
 	} else {
-		vType = byte(datalog.Type(sd.V))
-		vData = datalog.ValueBytes(sd.V)
+		vType = byte(datalog.Type(v))
+		vData = datalog.ValueBytes(v)
 	}
-	vBytes := append([]byte{vType}, vData...)
+	vBytes = append([]byte{vType}, vData...)
+	return
+}
+
+func (e *BinaryKeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
+	sd := ToStorageDatom(*d)
+	vBytes, _ := e.EncodeValueBytes(sd.V)
+	return e.encodeKeyWithParts(index, &sd, vBytes)
+}
+
+// EncodeKeyWithValueBytes builds an index key using pre-encoded value bytes.
+// Use this when encoding the same datom into multiple indexes to avoid
+// recomputing compression 7 times.
+func (e *BinaryKeyEncoder) EncodeKeyWithValueBytes(index IndexType, d *datalog.Datom, vBytes []byte) []byte {
+	sd := ToStorageDatom(*d)
+	return e.encodeKeyWithParts(index, &sd, vBytes)
+}
+
+func (e *BinaryKeyEncoder) encodeKeyWithParts(index IndexType, sd *StorageDatom, vBytes []byte) []byte {
+	prefix := []byte{byte(index)}
 
 	// Encode Tx with bitwise NOT for descending sort order
 	txDesc := txToDescending(sd.Tx)

--- a/datalog/storage/key_mask_iterator.go
+++ b/datalog/storage/key_mask_iterator.go
@@ -226,6 +226,7 @@ func NewKeyMaskIteratorFromStore(store *BadgerStore, index IndexType, start, end
 		mask:     mask,
 		encoder:  store.encoder,
 		index:    index,
+		db:       store.db,
 	}, nil
 }
 
@@ -235,6 +236,7 @@ type KeyMaskFilterWrapper struct {
 	mask         *KeyMaskConstraint
 	encoder      KeyEncoder
 	index        IndexType
+	db           *badger.DB
 	currentDatom datalog.Datom
 	hasDatom     bool
 	currentError error
@@ -276,7 +278,7 @@ func (w *KeyMaskFilterWrapper) Next() bool {
 			w.datomsDecoded++
 
 			// Decode the datom
-			w.currentDatom, w.currentError = DatomFromKey(w.index, key, w.encoder)
+			w.currentDatom, w.currentError = DatomFromKey(w.index, key, w.encoder, w.db)
 			if w.currentError != nil {
 				continue
 			}
@@ -354,7 +356,7 @@ func (i *KeyMaskIterator) Next() bool {
 
 		// Only decode if the mask matches
 		i.datomsDecoded++
-		i.currentDatom, i.currentError = DatomFromKey(i.index, key, i.encoder)
+		i.currentDatom, i.currentError = DatomFromKey(i.index, key, i.encoder, i.db)
 
 		if i.currentError != nil {
 			continue

--- a/datalog/storage/key_mask_test.go
+++ b/datalog/storage/key_mask_test.go
@@ -106,7 +106,7 @@ func BenchmarkRawOperations(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			decoded := 0
 			for _, key := range keys {
-				_, err := DatomFromKey(AEVT, key, encoder)
+				_, err := DatomFromKey(AEVT, key, encoder, nil)
 				if err == nil {
 					decoded++
 				}
@@ -132,7 +132,7 @@ func BenchmarkRawOperations(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			decoded := 0
 			for _, key := range matchingKeys {
-				_, err := DatomFromKey(AEVT, key, encoder)
+				_, err := DatomFromKey(AEVT, key, encoder, nil)
 				if err == nil {
 					decoded++
 				}
@@ -152,7 +152,7 @@ func BenchmarkRawOperations(b *testing.B) {
 			decoded := 0
 			for _, key := range keys {
 				if bytes.Equal(key[valueStart:valueEnd], targetValue) {
-					_, err := DatomFromKey(AEVT, key, encoder)
+					_, err := DatomFromKey(AEVT, key, encoder, nil)
 					if err == nil {
 						decoded++
 					}
@@ -209,7 +209,7 @@ func BenchmarkKeyMaskVsDecoding(b *testing.B) {
 			matches := 0
 			for _, key := range keys {
 				// Decode the full datom
-				datom, err := DatomFromKey(AEVT, key, encoder)
+				datom, err := DatomFromKey(AEVT, key, encoder, nil)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -26,6 +26,29 @@ type BadgerMatcher struct {
 	cache             *Cache                   // CRDT resolution cache for O(1) access to resolved views
 }
 
+// encodeValueForSearch encodes a value for use in index lookups, applying
+// compression if the encoder has it enabled. This ensures the search prefix
+// matches the stored key's value encoding.
+func encodeValueForSearch(v interface{}, encoder KeyEncoder) []byte {
+	// Check if the encoder has compression enabled
+	if be, ok := encoder.(*BinaryKeyEncoder); ok && be.CompressionThreshold > 0 {
+		vType, vData, _ := datalog.EncodeValue(v, be.CompressionThreshold)
+		return append([]byte{byte(vType)}, vData...)
+	}
+
+	// L85 reference handling
+	vType := byte(datalog.Type(v))
+	if _, isL85 := encoder.(*L85KeyEncoder); isL85 && vType == byte(datalog.TypeReference) {
+		var vArr [20]byte
+		copy(vArr[:], datalog.ValueBytes(v))
+		return append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
+	}
+
+	// Default: type + raw bytes
+	vData := datalog.ValueBytes(v)
+	return append([]byte{vType}, vData...)
+}
+
 // isHistoryMode returns true when raw (non-CRDT-resolved) datoms are requested.
 func (m *BadgerMatcher) isHistoryMode() bool {
 	return m.txID != nil && *m.txID == (datalog.ElementID{})
@@ -547,32 +570,13 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 					aStorage := ToStorageDatom(datalog.Datom{A: aPtr}).A
 					_ = aStorage // used below
 
-					// Create a dummy datom to use encoder
-					dummyDatom := &datalog.Datom{
-						E:  eId,
-						A:  aPtr,
-						V:  nil,
-						Tx: datalog.ElementID{},
-					}
-
 					if v != nil {
 						// E, A, and V are bound - use AEVT prefix range
 						// CRITICAL: Must use prefix range, not exact key!
 						// EncodeKey includes Tx=0, but actual datoms have real Tx values.
 						// The scan range [A+E+V+Tx(0), A+E+V+Tx(1)) would miss all real datoms.
 						// Instead, use EncodePrefixRange to scan all Tx values for (A, E, V) prefix.
-						sDatom := ToStorageDatom(*dummyDatom)
-						sDatom.V = v
-						vType := byte(datalog.Type(sDatom.V))
-						var valueBytes []byte
-						if _, isL85 := encoder.(*L85KeyEncoder); isL85 && vType == byte(datalog.TypeReference) {
-							var vArr [20]byte
-							copy(vArr[:], datalog.ValueBytes(sDatom.V))
-							valueBytes = append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
-						} else {
-							vData := datalog.ValueBytes(sDatom.V)
-							valueBytes = append([]byte{vType}, vData...)
-						}
+						valueBytes := encodeValueForSearch(v, encoder)
 						// AEVT order: A + E + V + Tx, so prefix with (A, E, V) to scan all Tx
 						start, end := encoder.EncodePrefixRange(AEVT, aStorage[:], eBytes[:], valueBytes)
 						return AEVT, start, end
@@ -614,31 +618,7 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 
 			if v != nil {
 				// A and V bound - use AVET index
-				// Create dummy datom for encoding
-				dummyDatom := &datalog.Datom{
-					E:  datalog.NewIdentity(""),
-					A:  aPtr,
-					V:  v,
-					Tx: datalog.ElementID{},
-				}
-				// Get value bytes with type prefix
-				// Must match how EncodeKey encodes values!
-				sDatom := ToStorageDatom(*dummyDatom)
-				vType := byte(datalog.Type(sDatom.V))
-				var valueBytes []byte
-
-				// Check if we're using L85 encoding and have a reference value
-				if _, isL85 := encoder.(*L85KeyEncoder); isL85 && vType == byte(datalog.TypeReference) {
-					// L85 encoder stores references as type + L85-encoded bytes
-					var vArr [20]byte
-					copy(vArr[:], datalog.ValueBytes(sDatom.V))
-					valueBytes = append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
-				} else {
-					// Binary encoder or non-reference values: type + raw bytes
-					vData := datalog.ValueBytes(sDatom.V)
-					valueBytes = append([]byte{vType}, vData...)
-				}
-
+				valueBytes := encodeValueForSearch(v, encoder)
 				start, end := encoder.EncodePrefixRange(AVET, aStorage[:], valueBytes)
 				return AVET, start, end
 			}
@@ -665,29 +645,7 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 	} else if v != nil {
 		// Only V bound - use VAET index with per-datom cardinality resolution
 		// VAET: V → A → E → Tx↓ - groups by A, enabling efficient cardinality lookup
-		// Create dummy datom for value encoding
-		dummyDatom := &datalog.Datom{
-			E:  datalog.NewIdentity(""),
-			A:  datalog.NewKeyword(""),
-			V:  v,
-			Tx: datalog.ElementID{},
-		}
-		sDatom := ToStorageDatom(*dummyDatom)
-		vType := byte(datalog.Type(sDatom.V))
-		var valueBytes []byte
-
-		// Check if we're using L85 encoding and have a reference value
-		if _, isL85 := encoder.(*L85KeyEncoder); isL85 && vType == byte(datalog.TypeReference) {
-			// L85 encoder stores references as type + L85-encoded bytes
-			var vArr [20]byte
-			copy(vArr[:], datalog.ValueBytes(sDatom.V))
-			valueBytes = append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
-		} else {
-			// Binary encoder or non-reference values: type + raw bytes
-			vData := datalog.ValueBytes(sDatom.V)
-			valueBytes = append([]byte{vType}, vData...)
-		}
-
+		valueBytes := encodeValueForSearch(v, encoder)
 		start, end := encoder.EncodePrefixRange(VAET, valueBytes)
 		return VAET, start, end
 	} else if tx != nil {

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -824,7 +824,7 @@ func (m *BadgerMatcher) LookupAttribute(entity datalog.Identity, attr datalog.Ke
 				if len(set) > 0 {
 					// Return all values as slice for consistency with cardinality-vector
 					result := make([]interface{}, 0, len(set))
-					for v := range set {
+					for _, v := range set {
 						result = append(result, v)
 					}
 					return result, true
@@ -1037,7 +1037,7 @@ func (m *BadgerMatcher) LookupAllAttributes(entity datalog.Identity, attr datalo
 			case schema.CardinalityMany:
 				set := entry.ManySet()
 				result := make([]interface{}, 0, len(set))
-				for v := range set {
+				for _, v := range set {
 					result = append(result, v)
 				}
 				return result, nil
@@ -1094,7 +1094,7 @@ func (m *BadgerMatcher) lookupAllAttributesFallback(eBytes, aBytes []byte) ([]in
 			return nil, fmt.Errorf("resolving add-wins set: %w", err)
 		}
 		values := make([]interface{}, 0, len(result.Members))
-		for v := range result.Members {
+		for _, v := range result.Members {
 			values = append(values, v)
 		}
 		return values, nil

--- a/datalog/storage/matcher_cache_test.go
+++ b/datalog/storage/matcher_cache_test.go
@@ -97,8 +97,10 @@ func TestMatcherCacheCardinalityMany(t *testing.T) {
 	entry := db.Cache().GetOrResolve(key, matcher)
 	require.NotNil(t, entry)
 	assert.Equal(t, schema.CardinalityMany, entry.Cardinality())
-	assert.True(t, entry.ManySet()["warrior"])
-	assert.True(t, entry.ManySet()["veteran"])
+	_, hasWarrior := entry.ManySet()["warrior"]
+	_, hasVeteran := entry.ManySet()["veteran"]
+	assert.True(t, hasWarrior)
+	assert.True(t, hasVeteran)
 }
 
 func TestMatcherCacheCardinalityVector(t *testing.T) {
@@ -339,7 +341,8 @@ func TestMatcherCacheAddWinsResolution(t *testing.T) {
 
 	entry := db.Cache().GetOrResolve(key, matcher)
 	require.NotNil(t, entry)
-	assert.True(t, entry.ManySet()["warrior"], "warrior should be in set after add-remove-add")
+	_, hasWarrior2 := entry.ManySet()["warrior"]
+	assert.True(t, hasWarrior2, "warrior should be in set after add-remove-add")
 }
 
 // =============================================================================

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -1108,7 +1108,12 @@ func (m *BadgerMatcher) matchFromCache(
 		}
 		if v != nil {
 			// V is bound - membership check
-			if set[v] {
+			// []byte keys are stored as string(bytes) for hashability
+			lookupKey := v
+			if b, ok := lookupKey.([]byte); ok {
+				lookupKey = string(b)
+			}
+			if _, exists := set[lookupKey]; exists {
 				tuple := buildTuple(v, entry.Version())
 				return executor.NewMaterializedRelationWithOptions(symbols, []executor.Tuple{tuple}, m.options), true
 			}
@@ -1116,7 +1121,7 @@ func (m *BadgerMatcher) matchFromCache(
 		}
 		// V is unbound - return all set members
 		tuples := make([]executor.Tuple, 0, len(set))
-		for val := range set {
+		for _, val := range set {
 			tuple := buildTuple(val, entry.Version())
 			tuples = append(tuples, tuple)
 		}
@@ -1329,12 +1334,16 @@ func (m *BadgerMatcher) matchWithBindingsFromCache(
 			}
 			if v != nil {
 				// Membership check
-				if set[v] {
+				lookupKey := v
+				if b, ok := lookupKey.([]byte); ok {
+					lookupKey = string(b)
+				}
+				if _, exists := set[lookupKey]; exists {
 					resultTuples = append(resultTuples, buildTuple(eIdent, v, entry.Version()))
 				}
 			} else {
 				// Return all set members
-				for val := range set {
+				for _, val := range set {
 					resultTuples = append(resultTuples, buildTuple(eIdent, val, entry.Version()))
 				}
 			}
@@ -1382,7 +1391,7 @@ func (m *BadgerMatcher) matchCardinalityManyAsRelation(
 	// We need to map the values to the correct symbol positions
 	tuples := make([]executor.Tuple, 0, len(result.Members))
 
-	for member := range result.Members {
+	for _, member := range result.Members {
 		tuple := make(executor.Tuple, len(symbols))
 		for i, sym := range symbols {
 			switch {
@@ -1720,7 +1729,7 @@ func (it *cardinalityManyScanAllEntitiesIterator) Next() bool {
 			if len(result.Members) > 0 {
 				it.currentEntity = datom.E
 				it.currentSetMembers = make([]interface{}, 0, len(result.Members))
-				for member := range result.Members {
+				for _, member := range result.Members {
 					it.currentSetMembers = append(it.currentSetMembers, member)
 				}
 				it.currentMaxElementID = result.MaxElementID

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -935,28 +935,7 @@ func (it *validatingVBoundIterator) openCRDTScan() (*CRDTResolvingIterator, Iter
 
 // encodeValue converts a value to bytes for index prefix
 func (it *validatingVBoundIterator) encodeValue(v any) []byte {
-	encoder := it.matcher.store.encoder
-
-	// Create dummy datom for encoding
-	dummyDatom := &datalog.Datom{
-		E:  datalog.NewIdentity(""),
-		A:  datalog.NewKeyword(":dummy"),
-		V:  v,
-		Tx: datalog.ElementID{},
-	}
-	sDatom := ToStorageDatom(*dummyDatom)
-	vType := byte(datalog.Type(sDatom.V))
-
-	// Check if we're using L85 encoding and have a reference value
-	if _, isL85 := encoder.(*L85KeyEncoder); isL85 && vType == byte(datalog.TypeReference) {
-		var vArr [20]byte
-		copy(vArr[:], datalog.ValueBytes(sDatom.V))
-		return append([]byte{vType}, []byte(codec.EncodeFixed20(vArr))...)
-	}
-
-	// Binary encoder or non-reference values: type + raw bytes
-	vData := datalog.ValueBytes(sDatom.V)
-	return append([]byte{vType}, vData...)
+	return encodeValueForSearch(v, it.matcher.store.encoder)
 }
 
 // buildTuple creates a result tuple from a validated datom

--- a/datalog/storage/perf_diagnostic_test.go
+++ b/datalog/storage/perf_diagnostic_test.go
@@ -49,7 +49,7 @@ func BenchmarkDatomDecoding(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := DatomFromKey(AVET, key, encoder)
+		_, err := DatomFromKey(AVET, key, encoder, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -195,7 +195,7 @@ func BenchmarkDatomFromKeyToTuple(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		// This is the hot path in iterator.Next()
-		d, err := DatomFromKey(EAVT, key, encoder)
+		d, err := DatomFromKey(EAVT, key, encoder, nil)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/datalog/storage/set_resolution.go
+++ b/datalog/storage/set_resolution.go
@@ -6,9 +6,12 @@ import (
 
 // SetResolutionResult contains the resolved set membership and metadata
 type SetResolutionResult struct {
-	// Members contains values currently in the set (after add-wins resolution)
-	// Uses map for O(1) membership lookup, as required by cache design.
-	Members map[interface{}]bool
+	// Members maps hashable keys to original Go values in the set.
+	// Keys are produced by setKey(). For most types the key equals the value.
+	// For []byte, the key is string(bytes) but the value is the original []byte.
+	// Point lookup: _, ok := Members[setKey(v)]
+	// Iteration: for _, v := range Members
+	Members map[interface{}]interface{}
 
 	// MaxElementID is the highest ElementID seen during resolution
 	// Used for cache freshness tracking
@@ -48,7 +51,7 @@ func (m *BadgerMatcher) resolveAddWinsSet(eBytes, aBytes []byte) (*SetResolution
 	defer iter.Close()
 
 	result := &SetResolutionResult{
-		Members: make(map[interface{}]bool),
+		Members: make(map[interface{}]interface{}),
 	}
 
 	// Track state per value: map[valueKey] -> {highestAddTx, highestRemoveTx, hasAdd, hasRemove, value}
@@ -120,7 +123,11 @@ func (m *BadgerMatcher) resolveAddWinsSet(eBytes, aBytes []byte) (*SetResolution
 		// If only removes (no adds), not in set
 
 		if inSet {
-			result.Members[state.value] = true
+			key := state.value
+			if b, ok := key.([]byte); ok {
+				key = string(b) // []byte is not hashable as a Go map key
+			}
+			result.Members[key] = state.value
 		}
 	}
 

--- a/datalog/storage/set_resolution_bytes_test.go
+++ b/datalog/storage/set_resolution_bytes_test.go
@@ -1,0 +1,133 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// TestCardinalityMany_ByteValues verifies that []byte values work correctly
+// with cardinality-many (add-wins set) CRDT semantics. This is a regression
+// test for a panic caused by using []byte as a map key in resolveAddWinsSet.
+func TestCardinalityMany_ByteValues(t *testing.T) {
+	dir, err := os.MkdirTemp("", "bytes-many-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":test/data"),
+		ValueType:   schema.TypeBytes,
+		Cardinality: schema.CardinalityMany,
+	})
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:   dir,
+		Schema: s,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	entity := datalog.NewIdentity("bytes-entity")
+	attr := datalog.NewKeyword(":test/data")
+	v1 := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	v2 := []byte{0xCA, 0xFE, 0xBA, 0xBE}
+
+	// Add both values
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, v1)
+	tx.Add(entity, attr, v2)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Query — should return both without panicking
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(s)
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	count := 0
+	iter := results.Iterator()
+	for iter.Next() {
+		count++
+	}
+	assert.Equal(t, 2, count, "should have both []byte values")
+}
+
+// TestCardinalityMany_ByteValues_Retract verifies retraction works for []byte
+// values in cardinality-many sets.
+func TestCardinalityMany_ByteValues_Retract(t *testing.T) {
+	dir, err := os.MkdirTemp("", "bytes-retract-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":test/data"),
+		ValueType:   schema.TypeBytes,
+		Cardinality: schema.CardinalityMany,
+	})
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:   dir,
+		Schema: s,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	entity := datalog.NewIdentity("bytes-retract")
+	attr := datalog.NewKeyword(":test/data")
+	v1 := []byte{0x01, 0x02, 0x03}
+	v2 := []byte{0x04, 0x05, 0x06}
+
+	// Add both
+	tx := db.NewTransaction()
+	tx.Add(entity, attr, v1)
+	tx.Add(entity, attr, v2)
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Retract v2
+	tx2 := db.NewTransaction()
+	tx2.Retract(entity, attr, v2)
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Only v1 should remain
+	matcher := NewBadgerMatcher(db.Store())
+	matcher.SetSchema(s)
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Constant{Value: entity},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Blank{},
+		},
+	}
+	results, err := matcher.Match(pattern, nil)
+	require.NoError(t, err)
+
+	var values [][]byte
+	iter := results.Iterator()
+	for iter.Next() {
+		values = append(values, iter.Tuple()[0].([]byte))
+	}
+	assert.Len(t, values, 1, "should have one value after retract")
+	if len(values) == 1 {
+		assert.Equal(t, v1, values[0])
+	}
+}

--- a/datalog/value_encoding.go
+++ b/datalog/value_encoding.go
@@ -1,10 +1,13 @@
 package datalog
 
 import (
+	"crypto/sha1"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"time"
+
+	"github.com/wbrown/janus-datalog/datalog/codec"
 )
 
 // ValueType represents the type of a value
@@ -20,8 +23,24 @@ const (
 	TypeReference
 	TypeKeyword
 	TypeSymbol
-	TypeElementID // 0x09 - CRDT ElementID for transaction ordering
+	TypeElementID        // 0x09 - CRDT ElementID for transaction ordering
+	TypeCompressedString // 0x0A - compressed string (LZ77+FSE, data in key)
+	TypeCompressedBytes  // 0x0B - compressed []byte (LZ77+FSE, data in key)
+	TypeHashedString     // 0x0C - content hash of compressed string (data in blob store)
+	TypeHashedBytes      // 0x0D - content hash of compressed []byte (data in blob store)
 )
+
+// BlobData holds the compressed bytes for a Tier 3 value (content hash in key,
+// compressed data stored separately in the blob store).
+type BlobData struct {
+	Hash            [20]byte // SHA1 of CompressedBytes
+	CompressedBytes []byte   // compressed payload including version header
+}
+
+// maxKeyValueSize is the maximum compressed value size that fits in a key.
+// Above this, the value is stored in the blob store (Tier 3).
+// Badger has a 64KB key limit; subtract overhead for E(20)+A(32)+Tx(16)+Op(1)=69 bytes.
+const maxKeyValueSize = 60000
 
 // Type returns the type of a value
 func Type(v Value) ValueType {
@@ -165,7 +184,78 @@ func ValueFromBytes(vType ValueType, data []byte) (Value, error) {
 			return nil, fmt.Errorf("ElementID value must be %d bytes, got %d", ElementIDSize, len(data))
 		}
 		return ElementIDFromBytes(data), nil
+	case TypeCompressedString:
+		decompressed, err := codec.Decompress(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decompress string: %w", err)
+		}
+		return string(decompressed), nil
+	case TypeCompressedBytes:
+		decompressed, err := codec.Decompress(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decompress bytes: %w", err)
+		}
+		return decompressed, nil
+	case TypeHashedString, TypeHashedBytes:
+		return nil, fmt.Errorf("hashed value type %d requires blob store lookup", vType)
 	default:
 		return nil, fmt.Errorf("unknown value type: %v", vType)
+	}
+}
+
+// EncodeValue encodes a value with compression awareness.
+// For string/[]byte values above the threshold, compresses and routes to the
+// appropriate tier:
+//   - Tier 1 (raw): below threshold → (TypeString/TypeBytes, rawBytes, nil)
+//   - Tier 2 (compressed in key): compressed fits in key → (TypeCompressedString/Bytes, compressed, nil)
+//   - Tier 3 (blob store): compressed too large → (TypeHashedString/Bytes, hash, &BlobData)
+//
+// For all other types, returns the standard encoding with nil BlobData.
+// threshold <= 0 disables compression (all values stored raw).
+func EncodeValue(v Value, threshold int) (ValueType, []byte, *BlobData) {
+	if threshold <= 0 {
+		return Type(v), ValueBytes(v), nil
+	}
+
+	switch val := v.(type) {
+	case string:
+		raw := []byte(val)
+		if len(raw) < threshold {
+			return TypeString, raw, nil
+		}
+		return compressAndRoute(raw, TypeCompressedString, TypeHashedString)
+
+	case []byte:
+		if len(val) < threshold {
+			return TypeBytes, val, nil
+		}
+		return compressAndRoute(val, TypeCompressedBytes, TypeHashedBytes)
+
+	default:
+		return Type(v), ValueBytes(v), nil
+	}
+}
+
+// compressAndRoute compresses data and routes to Tier 2 (key) or Tier 3 (blob).
+func compressAndRoute(raw []byte, compressedType, hashedType ValueType) (ValueType, []byte, *BlobData) {
+	compressed := codec.Compress(raw)
+	if compressed == nil {
+		// Safety net: compression didn't help, store raw
+		if compressedType == TypeCompressedString {
+			return TypeString, raw, nil
+		}
+		return TypeBytes, raw, nil
+	}
+
+	if len(compressed) <= maxKeyValueSize {
+		// Tier 2: compressed fits in key
+		return compressedType, compressed, nil
+	}
+
+	// Tier 3: too large for key, store hash in key and compressed in blob
+	hash := sha1.Sum(compressed)
+	return hashedType, hash[:], &BlobData{
+		Hash:            hash,
+		CompressedBytes: compressed,
 	}
 }

--- a/datalog/value_encoding_test.go
+++ b/datalog/value_encoding_test.go
@@ -1,7 +1,10 @@
 package datalog
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestSymbolValueEncoding_RoundTrip(t *testing.T) {
@@ -173,5 +176,230 @@ func TestElementIDValueBytes_NaturalOrder(t *testing.T) {
 	// Compare bytes - lower Lamport should produce smaller bytes (natural order)
 	if lowBytes[0] > highBytes[0] || (lowBytes[0] == highBytes[0] && lowBytes[7] > highBytes[7]) {
 		t.Errorf("Value encoding should use natural order: low(%v) should encode to smaller bytes than high(%v)", low, high)
+	}
+}
+
+// ---- EncodeValue Tests ----
+
+func TestEncodeValue_BelowThreshold(t *testing.T) {
+	threshold := 256
+	for _, size := range []int{0, 1, 10, 100, 255} {
+		input := strings.Repeat("x", size)
+		vType, vData, blobData := EncodeValue(input, threshold)
+		if vType != TypeString {
+			t.Errorf("size=%d: got type %d, want TypeString (%d)", size, vType, TypeString)
+		}
+		if !bytes.Equal(vData, []byte(input)) {
+			t.Errorf("size=%d: data mismatch", size)
+		}
+		if blobData != nil {
+			t.Errorf("size=%d: expected nil blobData", size)
+		}
+	}
+}
+
+func TestEncodeValue_BelowThreshold_Bytes(t *testing.T) {
+	threshold := 256
+	input := make([]byte, 100)
+	for i := range input {
+		input[i] = byte(i)
+	}
+	vType, vData, blobData := EncodeValue(input, threshold)
+	if vType != TypeBytes {
+		t.Errorf("got type %d, want TypeBytes (%d)", vType, TypeBytes)
+	}
+	if !bytes.Equal(vData, input) {
+		t.Error("data mismatch")
+	}
+	if blobData != nil {
+		t.Error("expected nil blobData")
+	}
+}
+
+func TestEncodeValue_CompressibleString(t *testing.T) {
+	threshold := 256
+	input := strings.Repeat("This is a compressible test string. ", 20) // ~720 bytes
+
+	vType, vData, blobData := EncodeValue(input, threshold)
+	if vType != TypeCompressedString {
+		t.Fatalf("got type %d, want TypeCompressedString (%d)", vType, TypeCompressedString)
+	}
+	if len(vData) >= len(input) {
+		t.Errorf("compressed (%d) should be smaller than original (%d)", len(vData), len(input))
+	}
+	if blobData != nil {
+		t.Error("expected nil blobData for Tier 2")
+	}
+
+	// Round-trip through ValueFromBytes
+	decoded, err := ValueFromBytes(TypeCompressedString, vData)
+	if err != nil {
+		t.Fatalf("ValueFromBytes: %v", err)
+	}
+	if decoded.(string) != input {
+		t.Error("round-trip failed: decoded string doesn't match original")
+	}
+}
+
+func TestEncodeValue_CompressibleBytes(t *testing.T) {
+	threshold := 256
+	input := []byte(strings.Repeat("binary compressible data ", 30))
+
+	vType, vData, blobData := EncodeValue(input, threshold)
+	if vType != TypeCompressedBytes {
+		t.Fatalf("got type %d, want TypeCompressedBytes (%d)", vType, TypeCompressedBytes)
+	}
+	if blobData != nil {
+		t.Error("expected nil blobData for Tier 2")
+	}
+
+	decoded, err := ValueFromBytes(TypeCompressedBytes, vData)
+	if err != nil {
+		t.Fatalf("ValueFromBytes: %v", err)
+	}
+	if !bytes.Equal(decoded.([]byte), input) {
+		t.Error("round-trip failed")
+	}
+}
+
+func TestEncodeValue_SafetyNet(t *testing.T) {
+	threshold := 256
+	// High-entropy data that won't compress
+	input := make([]byte, 300)
+	for i := range input {
+		input[i] = byte((i * 137 + 43) % 256) // pseudo-random, high entropy
+	}
+	str := string(input)
+
+	vType, vData, _ := EncodeValue(str, threshold)
+	if vType != TypeString {
+		t.Errorf("high-entropy string: got type %d, want TypeString (safety net)", vType)
+	}
+	if !bytes.Equal(vData, []byte(str)) {
+		t.Error("safety net: data should be raw bytes")
+	}
+}
+
+func TestEncodeValue_ThresholdDisabled(t *testing.T) {
+	input := strings.Repeat("compressible ", 100)
+
+	// threshold = 0 disables compression
+	vType, _, _ := EncodeValue(input, 0)
+	if vType != TypeString {
+		t.Errorf("threshold=0: got type %d, want TypeString", vType)
+	}
+
+	// threshold = -1 also disables
+	vType, _, _ = EncodeValue(input, -1)
+	if vType != TypeString {
+		t.Errorf("threshold=-1: got type %d, want TypeString", vType)
+	}
+}
+
+func TestEncodeValue_ThresholdHuge(t *testing.T) {
+	input := strings.Repeat("x", 10000)
+	vType, _, _ := EncodeValue(input, 1000000)
+	if vType != TypeString {
+		t.Errorf("threshold=1M: got type %d, want TypeString (below threshold)", vType)
+	}
+}
+
+func TestEncodeValue_ExistingTypes_NoRegression(t *testing.T) {
+	threshold := 256
+
+	// int64
+	vType, vData, blob := EncodeValue(int64(42), threshold)
+	if vType != TypeInt || len(vData) != 8 || blob != nil {
+		t.Errorf("int64: type=%d data_len=%d blob=%v", vType, len(vData), blob)
+	}
+
+	// float64
+	vType, vData, blob = EncodeValue(3.14, threshold)
+	if vType != TypeFloat || len(vData) != 8 || blob != nil {
+		t.Errorf("float64: type=%d data_len=%d blob=%v", vType, len(vData), blob)
+	}
+
+	// bool
+	vType, vData, blob = EncodeValue(true, threshold)
+	if vType != TypeBool || len(vData) != 1 || blob != nil {
+		t.Errorf("bool: type=%d data_len=%d blob=%v", vType, len(vData), blob)
+	}
+
+	// time
+	vType, vData, blob = EncodeValue(time.Now(), threshold)
+	if vType != TypeTime || len(vData) != 8 || blob != nil {
+		t.Errorf("time: type=%d data_len=%d blob=%v", vType, len(vData), blob)
+	}
+
+	// keyword
+	vType, _, blob = EncodeValue(NewKeyword(":test"), threshold)
+	if vType != TypeKeyword || blob != nil {
+		t.Errorf("keyword: type=%d blob=%v", vType, blob)
+	}
+
+	// identity/reference
+	vType, vData, blob = EncodeValue(NewIdentity("x"), threshold)
+	if vType != TypeReference || len(vData) != 20 || blob != nil {
+		t.Errorf("identity: type=%d data_len=%d blob=%v", vType, len(vData), blob)
+	}
+
+	// short string (below threshold)
+	vType, _, blob = EncodeValue("hello", threshold)
+	if vType != TypeString || blob != nil {
+		t.Errorf("short string: type=%d blob=%v", vType, blob)
+	}
+}
+
+func TestEncodeValue_Determinism(t *testing.T) {
+	input := strings.Repeat("determinism in value encoding ", 20)
+	vType1, vData1, _ := EncodeValue(input, 256)
+
+	for i := 0; i < 100; i++ {
+		vType, vData, _ := EncodeValue(input, 256)
+		if vType != vType1 {
+			t.Fatalf("iteration %d: type %d != %d", i, vType, vType1)
+		}
+		if !bytes.Equal(vData, vData1) {
+			t.Fatalf("iteration %d: data differs", i)
+		}
+	}
+}
+
+func TestEncodeValue_HashedString(t *testing.T) {
+	// Create a string large enough that even compressed it exceeds maxKeyValueSize.
+	// We need compressed > 60KB. At ~3-4x compression, need ~200-240KB of prose.
+	// Use repetitive-but-varied text to avoid extremely high compression ratios.
+	input := strings.Repeat(
+		"The quick brown fox jumped over the lazy dog on a fine summer morning. "+
+			"The birds were singing and the sun was shining brightly through the trees. "+
+			"A gentle breeze carried the scent of flowers across the meadow below. "+
+			"In the distance, mountains rose against the clear blue sky above. ", 800)
+
+	vType, vData, blobData := EncodeValue(input, 256)
+
+	if len(input) < 200000 {
+		t.Skipf("input only %d bytes, may not trigger Tier 3", len(input))
+	}
+
+	if vType == TypeHashedString {
+		// Tier 3: verify hash and blob data
+		if len(vData) != 20 {
+			t.Errorf("hash should be 20 bytes, got %d", len(vData))
+		}
+		if blobData == nil {
+			t.Fatal("expected non-nil blobData for Tier 3")
+		}
+		if len(blobData.CompressedBytes) == 0 {
+			t.Error("blobData.CompressedBytes should not be empty")
+		}
+		// Verify hash matches
+		if !bytes.Equal(vData, blobData.Hash[:]) {
+			t.Error("hash in vData doesn't match blobData.Hash")
+		}
+	} else if vType == TypeCompressedString {
+		// Tier 2: compressed fits in key (text was more compressible than expected)
+		t.Logf("input %d bytes compressed to %d (Tier 2, not Tier 3)", len(input), len(vData))
+	} else {
+		t.Errorf("expected TypeCompressedString or TypeHashedString, got %d", vType)
 	}
 }

--- a/docs/proposals/COMPRESSED_STRING_VALUES.md
+++ b/docs/proposals/COMPRESSED_STRING_VALUES.md
@@ -182,11 +182,11 @@ encoding for the compressed bytes (the same encoding used for entity IDs
 and transaction IDs throughout the codebase):
 
 ```clojure
-[#identity "abc123" :task/content #compressed "L85-encoded-compressed-data" [100 1] :op/none]
+[#identity "abc123" :task/content #lzj "L85-encoded-compressed-data" [100 1] :op/none]
 ```
 
 Both tiers serialize the same way in EDN — the compressed bytes with a
-`#compressed` tagged literal. The tier distinction (key vs value log) is a
+`#lzj` tagged literal. The tier distinction (key vs value log) is a
 storage detail that doesn't affect the logical datom.
 
 L85 has 25% encoding overhead (vs base64's 33%), is terminal/JSON/URL safe,
@@ -197,7 +197,7 @@ than offset by the compression ratio (~70-80% reduction).
 compatibility. A `--compressed` flag enables compressed tagged literals for
 size-sensitive use cases (backup, transfer).
 
-On import, the EDN parser recognizes `#compressed`, L85-decodes the
+On import, the EDN parser recognizes `#lzj`, L85-decodes the
 payload, and routes through the same compress-and-tier logic — no
 decompress-then-recompress round-trip for Tier 2 values. Tier 3 values
 derive the content hash from the compressed bytes at import time.
@@ -254,9 +254,9 @@ Existing databases have uncompressed strings. No migration needed:
 - Write path: new writes above the threshold are compressed and tiered.
   Old uncompressed values remain until overwritten.
 - Export: uncompressed values export as plain strings. Compressed values
-  export with `#compressed` tag (if `--compressed` flag is set) or
+  export with `#lzj` tag (if `--compressed` flag is set) or
   decompressed as plain strings (default).
-- Import: both plain and `#compressed` tagged values import correctly.
+- Import: both plain and `#lzj` tagged values import correctly.
 
 ## Trade-offs
 

--- a/docs/proposals/COMPRESSED_STRING_VALUES.md
+++ b/docs/proposals/COMPRESSED_STRING_VALUES.md
@@ -1,0 +1,362 @@
+# Proposal: Compressed String Values
+
+## Motivation
+
+Databases with large text values (multi-paragraph prose, source code, structured
+output) produce oversized storage files and EDN exports. A database with ~3000
+tasks storing text content can reach 200MB in EDN, where the text values account
+for a significant portion of the size. Natural language and structured text
+compress 3-5x with modern algorithms.
+
+Currently, strings are stored verbatim in badger and serialized verbatim in EDN.
+There is no mechanism to reduce the storage footprint of large text values.
+
+Additionally, badger has a **64KB key size limit**. Since janus-datalog stores
+the entire datom (E, A, V, Tx, Op) in the key, large strings approaching this
+limit fail to store. Downstream applications work around this by splitting
+multi-paragraph text into `[]string` (cardinality-vector), which increases
+datom count and CRDT metadata overhead. Compression addresses both the storage
+size problem and the key size limit.
+
+## Design
+
+### Three-Tier Storage
+
+Values are routed through three tiers based on size, with a single compression
+pass determining the tier:
+
+```
+write(value) →
+  if len(value) < threshold → Tier 1: store raw in key
+  else →
+    compressed = compress(value)
+    if len(compressed) fits in key → Tier 2: store compressed in key
+    else → Tier 3: hash(compressed) in key, compressed in badger value
+```
+
+**Tier 1: Raw** (below threshold, e.g. < 512 bytes)
+- String or bytes stored in key as-is. No overhead. No behavior change.
+- The vast majority of values: attribute names, codes, short notes.
+
+**Tier 2: Compressed in key** (above threshold, compressed fits in ~60KB)
+- Compressed bytes stored directly in the key across all indexes.
+- Stays entirely in the LSM tree — no value log touch.
+- This is the common case for large text: 3-5x compression means
+  original values up to ~200-300KB fit compressed in the key.
+
+**Tier 3: Content hash + value log** (compressed exceeds key limit)
+- Content hash of compressed bytes stored in the key.
+- Compressed bytes stored in badger's value field.
+- Requires a value log dereference on read — slower than Tier 2.
+- Strictly better than the status quo: these values currently cannot
+  be stored at all without the `[]string` split workaround.
+
+The tier boundaries are determined by the compressed size — a single
+compression pass produces the bytes, and the length determines routing.
+No double compression. Tier 2 and Tier 3 use the same compressed `[]byte`;
+the only difference is where it's stored.
+
+### Applies to Both Variable-Length Types
+
+The two variable-length value types in janus-datalog are `string` and `[]byte`.
+The compression and tiering logic is identical for both — the only difference
+is the type byte prefix in the key encoding. One code path, two type tags.
+
+### Transparent Compression at the Codec Layer
+
+The query engine sees normal strings and byte slices — compression is
+invisible to queries, predicates, and joins.
+
+```
+Write path:  value → compress → route by compressed size → store
+Read path:   key type tag → raw | decompress from key | fetch value + decompress
+Query path:  all comparisons operate on decompressed values (no change)
+```
+
+### Value Types
+
+Two new internal value types in the codec, one per tier:
+
+```go
+// Tier 2: compressed bytes stored directly in key
+type CompressedValue struct {
+    Data           []byte // compressed payload
+    OriginalLength int    // for pre-allocating decompression buffer
+    IsString       bool   // true = string, false = []byte
+}
+
+// Tier 3: content hash in key, compressed bytes in badger value
+type HashedValue struct {
+    Hash     [32]byte // content hash of compressed bytes
+    IsString bool     // true = string, false = []byte
+}
+```
+
+These types are internal to the storage layer — they never appear in query
+results, `:find` bindings, or user-facing APIs. The codec detects the type
+tag on read and returns a plain `string` or `[]byte` to the caller.
+
+### Compression Algorithm: Custom, Owned Implementation
+
+**The compression format must be deterministic forever.** Compressed bytes
+are embedded in badger keys, which are identity — if the same input ever
+produces different compressed bytes, AVET lookups return false negatives
+and uniqueness constraints silently break. This is silent data corruption.
+
+For this reason, the compression algorithm must be **owned by this project**,
+like L85. Depending on a third-party library (e.g., `klauspost/compress/zstd`)
+means a minor version bump could change compression output, breaking key
+identity across all indexes.
+
+The implementation targets zstd-like ratios (3-5x on text) using the core
+techniques that drive zstd's advantage over DEFLATE, without the format
+compatibility overhead:
+
+**Core techniques (from [COMPRESSION_RESEARCH.md](COMPRESSION_RESEARCH.md)):**
+- **LZ77 with large window** (1MB+, vs DEFLATE's 32KB) — ~40% of improvement
+- **Repeat offset tracking** (3 recent offsets) — ~20% of improvement
+- **FSE/tANS entropy coding** for sequences — ~20% of improvement
+- **Huffman coding** for literals
+- **Separated literal/sequence streams**
+
+**Implementation options** (in order of complexity):
+
+| Tier | Approach | Text ratio | Lines of Go |
+|------|----------|-----------|-------------|
+| 1 | LZ77 + large window + repeat offsets + Huffman everywhere | 3-4x | ~1000 |
+| 2 | Above + FSE for sequence streams, Huffman for literals | 3.5-5x | ~1750 |
+| 3 | Above but FSE everywhere (one entropy coder, not two) | 3.5-5x | ~1480 |
+
+**What we skip** from full zstd (RFC 8878):
+- Magic numbers, content checksums, dictionary support
+- Multiple block types, predefined FSE tables
+- Multiple Huffman table transmission formats
+- Repeat-table mode, skippable frames, multi-frame support
+
+A custom format needs only: LZ77 matches, entropy coding, repeat offsets,
+and a minimal block header. See [COMPRESSION_RESEARCH.md](COMPRESSION_RESEARCH.md)
+for detailed analysis of each component.
+
+### Threshold
+
+Only compress values above a minimum size. Short strings have poor compression
+ratios and the overhead is not worth it.
+
+Suggested default: **512 bytes**. Configurable via `DatabaseOptions`.
+
+Values below the threshold are stored raw (Tier 1, no behavior change).
+
+### All Indexes Stay Complete
+
+**Compression does not skip or alter any index.** Every datom is indexed in
+every applicable index (EAVT, AEVT, AVET, VAET), regardless of tier. This
+preserves the fundamental database invariant that indexes are complete.
+
+The key encoder uses the same encode path for both writes and lookups. For
+AVET exact-match queries like `[?e :attr "specific-string"]`:
+
+1. The search string is compressed using the same deterministic algorithm
+2. The compressed size determines the same tier as the stored value
+3. The key encoder produces the same bytes as the original write
+4. `EncodePrefixRange` creates the correct scan boundaries
+
+This works because compression is deterministic — same input always produces
+same output. The compressed bytes ARE the canonical representation.
+
+**Trade-off: `str/starts-with?` prefix range scans.** The AVET key structure
+currently supports latent prefix range scans on raw UTF-8 strings (the
+infrastructure exists via `EncodePrefixRange` + `incrementLastByte`, though
+`str/starts-with?` is not yet pushed to storage). Compressed bytes do not
+preserve UTF-8 sort order, so this optimization is foreclosed for compressed
+values. This is acceptable because:
+- `str/starts-with?` currently evaluates at the Relation layer (post-scan)
+- In typical queries, other patterns narrow the result set before the
+  string predicate applies — the filter operates on a small Relation
+- The storage savings (3-5x across all indexes) outweigh the foregone
+  optimization for one uncommon query pattern
+
+### EDN Serialization
+
+Compressed values serialize with a tagged literal in EDN, using L85
+encoding for the compressed bytes (the same encoding used for entity IDs
+and transaction IDs throughout the codebase):
+
+```clojure
+[#identity "abc123" :task/content #compressed "L85-encoded-compressed-data" [100 1] :op/none]
+```
+
+Both tiers serialize the same way in EDN — the compressed bytes with a
+`#compressed` tagged literal. The tier distinction (key vs value log) is a
+storage detail that doesn't affect the logical datom.
+
+L85 has 25% encoding overhead (vs base64's 33%), is terminal/JSON/URL safe,
+and is already implemented in `codec/l85.go`. The encoding overhead is more
+than offset by the compression ratio (~70-80% reduction).
+
+**Default export is uncompressed** for human readability and tooling
+compatibility. A `--compressed` flag enables compressed tagged literals for
+size-sensitive use cases (backup, transfer).
+
+On import, the EDN parser recognizes `#compressed`, L85-decodes the
+payload, and routes through the same compress-and-tier logic — no
+decompress-then-recompress round-trip for Tier 2 values. Tier 3 values
+derive the content hash from the compressed bytes at import time.
+
+### CRDT Compatibility
+
+Compression is applied per-datom, per-value. Each version of a cardinality-one
+attribute is independently compressed. CRDT resolution (LWW, add-wins, RGA)
+operates on datom identity (E, A, Tx), not on values — compression does not
+affect conflict resolution.
+
+For equality comparisons in CRDT set operations (cardinality-many), values
+must be decompressed before comparison. This is the same cost as a query
+predicate — acceptable since set operations on large text values are rare.
+
+### Interaction with Badger's Table Compression
+
+Badger itself supports optional table-level compression (zstd or snappy) on
+SST files. This operates on entire SST blocks, not individual values. The
+two layers are complementary:
+
+- **Per-value compression** (this proposal): Reduces the key size in all
+  indexes. Effective on individual large strings. The compressed form is
+  what badger sees as the "value" portion of the key.
+- **Table compression** (badger built-in): Compresses entire SST blocks
+  including all keys and metadata. Effective on bulk data patterns.
+
+With both: per-value compression shrinks the keys, then table compression
+further compresses the blocks. The double compression is not redundant —
+per-value targets individual large strings, table compression targets the
+surrounding structure and small values. In practice, enabling per-value
+compression may reduce table compression effectiveness slightly (compressed
+data doesn't compress well again), but the net effect is still a significant
+size reduction because the keys are smaller in ALL indexes, not just the SST
+files.
+
+### Schema Integration
+
+Global threshold via `DatabaseOptions`:
+
+```go
+db.Open(path, db.WithCompressionThreshold(512))
+```
+
+This applies automatically to any `string` or `[]byte` value above the
+threshold without schema changes. Per-attribute control is deferred unless
+a concrete need arises.
+
+### Migration
+
+Existing databases have uncompressed strings. No migration needed:
+- Read path: the type tag in the key distinguishes raw, compressed, and
+  hashed values. All three coexist.
+- Write path: new writes above the threshold are compressed and tiered.
+  Old uncompressed values remain until overwritten.
+- Export: uncompressed values export as plain strings. Compressed values
+  export with `#compressed` tag (if `--compressed` flag is set) or
+  decompressed as plain strings (default).
+- Import: both plain and `#compressed` tagged values import correctly.
+
+## Trade-offs
+
+| Aspect | Impact |
+|--------|--------|
+| Read latency (Tier 2) | +10-50μs per decompressed value |
+| Read latency (Tier 3) | +value log dereference + decompression |
+| Write latency | +20-100μs per compressed value (single pass) |
+| Storage size | 3-5x reduction for large text values (Tier 2) |
+| Key size limit | Effectively removed (Tier 3 handles overflow) |
+| EDN size | 2-3x reduction with `--compressed` flag |
+| Memory | Decompressed values are GC'd normally |
+| AVET lookups | Compress search term — determinism guarantees match |
+| AVET range scans | Foregone for compressed values (acceptable) |
+| Complexity | Three-tier routing, custom compression codec |
+| `[]string` workaround | No longer needed for most use cases |
+
+## Determinism: The Load-Bearing Requirement
+
+The entire design depends on compression determinism: the same input must
+always produce the same compressed bytes, forever. This is not a nice-to-have —
+it's a correctness requirement. Violations cause:
+
+- AVET lookups returning false negatives
+- Uniqueness constraints silently breaking
+- Duplicate logical datoms with different key bytes
+
+This is why the compression algorithm must be owned by this project (like
+L85), not delegated to a third-party library whose output could change
+between versions. The format must be frozen: fixed algorithm, fixed
+parameters, deterministic by construction.
+
+A comprehensive determinism test suite (known inputs → known outputs)
+must be maintained as a hard gate on any changes to the compression code.
+
+## Future Direction: Eliminating the []string Split Pattern
+
+With three-tier storage, the primary motivation for the `[]string` split
+pattern (the 64KB key limit) is eliminated. A single cardinality-one
+attribute can hold multi-paragraph text at lower storage cost than the
+split vector.
+
+The remaining reason for splitting is CRDT granularity — editing paragraph
+3 of 10 replaces the entire compressed blob. A more ambitious future design
+(compressed segments with per-segment CRDT resolution) could address this,
+building on the compression infrastructure established here.
+
+## Not In Scope
+
+- Compression of non-variable-length types (integers, keywords, refs, time)
+- Dictionary-based compression across values (would require shared state)
+- Streaming decompression for very large values
+- Compression of the badger WAL or SST files (badger has its own compression)
+- Per-attribute compression control (deferred; global threshold is sufficient)
+- Pushing `str/starts-with?` to storage (remains at Relation layer)
+
+## Phase 1 Results: FSE Entropy Coder Performance
+
+The FSE (Finite State Entropy) coder is implemented and benchmarked as the
+entropy coding foundation. Measured on Apple M5 Max:
+
+### Throughput
+
+| Operation | 256B | 1KB | 4KB | 16KB |
+|-----------|------|-----|-----|------|
+| Compress | 77 MB/s | 129 MB/s | 157 MB/s | 160 MB/s |
+| Decompress | — | 337 MB/s | 343 MB/s | 355 MB/s |
+
+### Per-Value Latency
+
+| Operation | 256B | 1KB | 4KB |
+|-----------|------|-----|-----|
+| Compress | 3.3μs | 7.9μs | 26μs |
+| Decompress | — | 3.0μs | 12μs |
+
+### Allocations
+
+| Operation | Allocs | Notes |
+|-----------|--------|-------|
+| Compress | 11 | Pooled pairs via sync.Pool, table build dominates |
+| Decompress | 2 | Output buffer + bit reader; decode table cached via sync.Map |
+
+### Compression Ratios (FSE alone, no LZ77)
+
+| Data type | Ratio |
+|-----------|-------|
+| Highly skewed (95/5) | 17.8x |
+| English text | 1.58x |
+
+FSE alone achieves modest ratios on natural text (~1.6x) because it only
+exploits byte frequency, not repeated patterns. LZ77 (Phase 2) handles
+pattern matching and is where the 3-5x target ratio will come from. The
+FSE coder's role is to optimally encode the LZ77 output streams.
+
+The decode table cache (`sync.Map`) eliminates table reconstruction on
+repeated decompressions with the same distribution — critical for the
+query read path where many values share similar byte distributions.
+
+## References
+
+- [COMPRESSION_RESEARCH.md](COMPRESSION_RESEARCH.md) — detailed analysis of
+  compression algorithms, order-preserving techniques, and how production
+  databases handle key compression

--- a/docs/proposals/COMPRESSION_RESEARCH.md
+++ b/docs/proposals/COMPRESSION_RESEARCH.md
@@ -1,0 +1,528 @@
+# Compression Research: Algorithms and Order-Preserving Techniques
+
+Reference material for the [Compressed String Values](COMPRESSED_STRING_VALUES.md) proposal.
+Research conducted 2026-03-28.
+
+---
+
+## Part 1: zstd Internals and Minimal Implementation
+
+### 1. Core Algorithmic Components of zstd
+
+zstd's compression pipeline has three main stages:
+
+#### Stage 1: LZ77-style Match Finding
+
+zstd uses LZ77 as its foundation, same as DEFLATE. It finds repeated byte sequences and encodes them as (literal-run, match-offset, match-length) triples. The key differences from DEFLATE's LZ77:
+
+- **Larger window sizes**: DEFLATE is limited to 32KB windows. zstd supports up to 128MB windows (and even larger with long-distance matching). This is the single biggest contributor to better compression on large files — matches that DEFLATE literally cannot see because they're too far back.
+
+- **Repeat offsets**: zstd maintains a buffer of the 3 most recently used offsets. When a match reuses a recent offset, it encodes as offset 1, 2, or 3 instead of the full offset value. This is extremely effective on structured data where the same field spacing recurs (JSON keys at regular intervals, struct fields, etc.). DEFLATE has no equivalent.
+
+- **Sequence encoding**: Rather than interleaving literals and matches in a single stream, zstd separates them into three parallel streams: literals lengths, match lengths, and offsets. Each stream can be compressed independently with its own entropy coder.
+
+#### Stage 2: Huffman Coding for Literals
+
+Raw literal bytes (the parts that didn't match anything) are compressed with Huffman coding. This is the same approach as DEFLATE, though zstd can optionally use multiple Huffman tables per block or skip Huffman entirely if literals are high-entropy.
+
+#### Stage 3: FSE (Finite State Entropy) for Sequences
+
+The three sequence streams (literal-lengths, match-lengths, offsets) are each encoded with FSE (Finite State Entropy), which is Yann Collet's implementation of tANS (table-based Asymmetric Numeral Systems).
+
+**This is the key innovation over DEFLATE's Huffman coding for sequences.** FSE achieves near-Shannon-entropy compression even for skewed distributions, while Huffman is limited to integer-bit codes (minimum 1 bit per symbol).
+
+#### The Sequence Encoding Pipeline in Detail
+
+A zstd compressed block contains:
+1. **Literals section**: Raw bytes compressed with Huffman (or stored raw/RLE)
+2. **Sequences section**: Three interleaved FSE-coded streams
+   - Literal lengths (how many raw bytes before each match)
+   - Offsets (where the match starts, relative to current position)
+   - Match lengths (how long the match is)
+3. **FSE tables**: Distribution tables for each stream (can be predefined, shared, or per-block)
+
+Each value in the sequence streams is encoded as a **baseline + extra bits** pair. For example, a match length of 35 might encode as code 25 (baseline 35, 0 extra bits). Larger values use more extra bits. This is similar to DEFLATE's approach but with finer granularity and FSE instead of Huffman for the code symbols.
+
+### 2. What Contributes Most to Compression Ratio Improvement Over DEFLATE
+
+Ranked by impact:
+
+#### (a) Larger match windows — HIGH impact on large files
+
+DEFLATE's 32KB window means it misses long-distance repetitions entirely. On files larger than ~64KB, zstd's larger window finds matches DEFLATE cannot. On small files (<32KB), this advantage vanishes.
+
+**Quantified**: On the Silesia benchmark corpus, increasing window from 32KB to 1MB alone accounts for roughly 5-15% better compression on text files. Going to 8MB+ adds another few percent on larger files.
+
+#### (b) FSE/tANS entropy coding — MODERATE impact
+
+FSE codes fractional bits. Huffman cannot code a symbol at less than 1 bit. For highly skewed distributions (e.g., offset-code distribution where offset 1 occurs 40% of the time), FSE saves 5-15% over Huffman on the sequence streams.
+
+On text data specifically, the sequence distributions tend to be moderately skewed (common match lengths, common small offsets), so FSE typically saves 3-8% over what Huffman would achieve for the same data.
+
+**However**: The sequences are a minority of the compressed output. Literals dominate on text. FSE's advantage applies mainly to the ~30-40% of output that encodes sequences. Net improvement on total output: roughly 2-5%.
+
+#### (c) Repeat offsets — MODERATE impact on structured data
+
+On JSON/EDN/structured text, repeat offsets are very effective. Field names recur at regular intervals. Encoding "same offset as last time" costs ~1 bit vs 15-25 bits for a full offset.
+
+**Quantified**: On JSON data, repeat offsets capture 20-40% of all matches. On natural language prose, it's more like 10-20%. Net compression improvement: 3-8% on structured data, 1-3% on prose.
+
+#### (d) Separated streams — LOW-MODERATE impact
+
+Separating literals, literal-lengths, match-lengths, and offsets into independent streams lets each have its own optimized entropy table. DEFLATE interleaves everything into one Huffman table shared between literals and length/distance codes.
+
+This helps because the statistical distributions are fundamentally different between these categories. Impact: ~1-3%.
+
+#### (e) Better match finder heuristics — LOW impact on ratio, HIGH on speed
+
+zstd's match finders (hash chains, binary trees, optimal parsing at high levels) are more sophisticated than typical DEFLATE implementations. At comparable speed, zstd finds slightly better matches. At high compression levels, zstd's optimal parser can explore much larger match-space.
+
+**Summary**: On text data, the rough breakdown of zstd's advantage over DEFLATE is:
+- Larger windows: ~40% of the improvement
+- FSE for sequences: ~20% of the improvement
+- Repeat offsets: ~20% of the improvement
+- Stream separation: ~10% of the improvement
+- Better match finding: ~10% of the improvement
+
+### 3. What's in the zstd Format That You Wouldn't Need in a Custom Format
+
+#### The zstd frame format includes:
+
+**Framing overhead (not needed for custom use):**
+- Magic number (4 bytes) — format identification
+- Frame header with flags for: window size, single-segment flag, content size, checksum flag, dictionary ID
+- Block headers (3 bytes each: last-block flag, block type, block size)
+- Optional content checksum (xxHash64, 4 bytes)
+- Skippable frames (for metadata embedding)
+
+**Dictionary support (not needed without pre-shared dictionaries):**
+- Dictionary ID field in frame header
+- Dictionary decoding tables (Huffman + 3 FSE tables)
+- Dictionary content (raw bytes for initial match window)
+- Dictionary is specifically for small data (<1KB) where there isn't enough data to build good statistics
+
+**Streaming/incremental features (not needed for single-shot compression):**
+- Multi-block support within a frame
+- Block-level types (raw, RLE, compressed, reserved)
+- The ability to reset statistics per-block vs reusing previous block's tables
+
+**Backward compatibility / generality:**
+- Multiple Huffman table transmission formats (direct, FSE-compressed weights)
+- Predefined FSE distribution tables (for when explicit tables would cost more than they save)
+- The "repeat" mode for FSE tables (reuse previous block's table)
+- RLE blocks (entire block is one repeated byte)
+- Raw blocks (store uncompressed when compression would expand)
+
+#### What you'd actually need for a minimal custom format:
+
+1. LZ77 match finding with configurable window
+2. Literal encoding (Huffman or raw)
+3. Sequence encoding: literal-lengths, offsets, match-lengths with FSE
+4. FSE table serialization (just one format, not three alternatives)
+5. Repeat offset tracking (3 recent offsets)
+6. A minimal block/stream header (just enough to know sizes)
+
+You could skip: magic numbers, checksums, dictionary support, multiple block types, skippable frames, predefined tables, the repeat-table mode, and the elaborate flag-based header.
+
+### 4. Complexity of FSE/tANS Implementation
+
+#### What FSE actually does
+
+FSE is a table-driven entropy coder. The core idea:
+
+**Encoding**: You have a state (an integer). For each symbol you encode, you look up (state, symbol) in a table to get a new state and some bits to output. The table is constructed so that symbols with higher probability cause fewer bits to be output.
+
+**Decoding**: You have a state. You look it up in a table to get the symbol, the number of bits to read, and the next state base. You read bits, compute the new state, and continue.
+
+#### Table construction (the hard part)
+
+Given a normalized distribution (symbol frequencies that sum to a power of 2, typically 2^accuracy_log where accuracy_log is 5-9):
+
+1. **Spread symbols across the state table** proportional to their frequency. zstd uses a specific deterministic spread function (not random, not optimal, but good and fast).
+2. **Build encoding tables**: For each symbol, compute the range of states that correspond to it, and for each state, compute the output bits and next state.
+3. **Build decoding tables**: Inverse of encoding — given a state, what symbol does it decode to, and how to compute the next state.
+
+#### Implementation complexity
+
+Based on examining reference implementations and simplified versions:
+
+**Minimal FSE decoder** (decompress only): ~200-300 lines of Go
+- Table reconstruction from normalized counts: ~80 lines
+- Bit reader: ~50 lines
+- Decode loop: ~40 lines
+- Table building: ~80 lines
+
+**Minimal FSE encoder** (compress only): ~300-400 lines of Go
+- Normalization (convert raw counts to power-of-2 sum): ~100 lines (this is the trickiest part)
+- Table construction: ~100 lines
+- Bit writer: ~50 lines
+- Encode loop: ~50 lines
+- Table serialization: ~50 lines
+
+**Both encoder and decoder**: ~500-700 lines of Go for a clean implementation.
+
+**The tricky parts:**
+- **Count normalization**: Converting arbitrary symbol frequencies to frequencies that sum to exactly 2^N, while preserving the relative proportions and ensuring every present symbol gets at least frequency 1. Yann Collet's normalization algorithm has subtle edge cases.
+- **Bit-level I/O**: FSE reads/writes variable numbers of bits, often straddling byte boundaries. Getting the bit buffer management right (especially flushing) is fiddly.
+- **State table spread**: The specific spread algorithm matters for interoperability but any valid spread works for a custom format.
+
+**Comparison**: A Huffman coder is ~200-400 lines total. FSE is roughly 1.5-2x the complexity of Huffman.
+
+#### Existing minimal/educational implementations worth studying:
+
+- **Yann Collet's original FSE repo** (`github.com/Cyan4973/FiniteStateEntropy`) — C reference, ~1500 lines total for the library, but includes multiple variants
+- **klauspost/compress** (`github.com/klauspost/compress/fse`) — Go implementation used in production, ~800 lines for FSE proper
+- **Jarek Duda's original ANS paper** — the mathematical foundation, explains why ANS achieves Shannon entropy
+- **Charles Bloom's blog posts** on ANS/tANS — excellent practical explanations of the algorithm
+- **Fabian Giesen's blog** ("Interleaved entropy coders", "A whirlwind tour of ANS") — the clearest explanation of how tANS works mechanically
+
+### 5. Minimum Subset to Match zstd Ratios on Text Data
+
+For natural language and structured text (JSON/EDN), here's the minimum you'd need:
+
+#### Essential components:
+
+1. **LZ77 with large window** (minimum 1MB, ideally 4-8MB for large files)
+   - Hash-chain or hash-table match finder (not binary tree — those are for high compression levels)
+   - Lazy matching (check if the next position has a better match before committing)
+   - Minimum match length of 3 (standard for text)
+
+2. **Repeat offset tracking** (3 recent offsets)
+   - Critical for structured text where field spacing repeats
+   - Cheap to implement: just a 3-element ring buffer
+   - Encode as special offset values 1, 2, 3
+
+3. **Huffman coding for literals**
+   - You don't need FSE for literals — zstd itself uses Huffman here
+   - Single Huffman table per block is fine
+   - On text, literals are the bulk of the data; Huffman is good enough
+
+4. **FSE for sequence streams** (literal-lengths, match-lengths, offsets)
+   - This is where FSE matters most — these distributions are highly skewed
+   - You could substitute Huffman here and lose ~2-4% compression
+   - If you want to truly match zstd ratios, FSE is needed
+
+5. **Baseline + extra bits encoding for sequences**
+   - The predefined tables mapping value ranges to (code, baseline, extra-bits) triples
+   - You can use zstd's own tables or design similar ones
+
+#### What you can skip and still get close:
+
+- **Dictionary support**: Not needed unless compressing many small documents
+- **Multiple block types**: Just use "compressed" blocks
+- **Predefined distribution tables**: Always transmit explicit tables
+- **Huffman-compressed FSE table headers**: Use a simpler table serialization
+- **Content checksums**: Skip for a custom format (add at application layer if needed)
+- **Multi-frame support**: Single frame per compression unit
+- **Long-distance matching**: Only helps on very large files (>16MB); skip for typical use
+
+#### Rough line count estimate for a minimal "zstd-like" compressor in Go:
+
+| Component | Lines (approx) |
+|-----------|----------------|
+| LZ77 match finder (hash chain) | 300-400 |
+| Repeat offset logic | 50-80 |
+| Huffman coder (literals) | 200-300 |
+| FSE coder (sequences) | 500-700 |
+| Sequence encoding (baseline+extra bits) | 150-200 |
+| Bit-level I/O | 100-150 |
+| Block framing (minimal) | 100-150 |
+| **Total** | **~1400-2000** |
+
+This would get you within 1-3% of zstd's compression ratio on text data at comparable speed. The main thing you'd sacrifice vs full zstd is the optimal parser (which only matters at compression levels 16+, and costs significant CPU).
+
+#### Alternative: FSE everywhere (skip Huffman)
+
+An interesting simplification: use FSE for both literals and sequences. This eliminates Huffman entirely and reduces the number of coding algorithms to implement from 2 to 1. The cost is ~0.5% worse compression on literals (FSE and Huffman are very close on byte-alphabet data) but simpler code. zstd uses Huffman for literals because it's slightly faster to decode, not because it compresses better.
+
+#### The "80% of zstd with 20% of the complexity" approach
+
+If you just want "much better than DEFLATE" without matching zstd exactly:
+
+1. LZ77 with 1MB+ window (~400 lines)
+2. Repeat offsets (~60 lines)
+3. Huffman for everything (literals + sequences) (~300 lines)
+4. Baseline+extra bits for sequences (~150 lines)
+5. Minimal framing (~100 lines)
+
+**Total: ~1000 lines.** This gets you the large-window advantage and repeat offsets (the two biggest wins), uses Huffman everywhere (simpler than FSE, gives up ~2-4%), and skips all the format complexity. On text data, this would compress 10-25% better than DEFLATE, vs zstd's 15-30% better than DEFLATE.
+
+### Key References
+
+- **RFC 8878** — the zstd format specification (authoritative but dense)
+- **Yann Collet, "Finite State Entropy"** — original FSE description and C implementation
+- **Jarek Duda, "Asymmetric numeral systems"** (2009) — the foundational ANS paper
+- **Fabian Giesen's blog** — practical tANS explainers, particularly "Interleaved entropy coders"
+- **Charles Bloom's blog** ("cbloom rants") — extensive ANS analysis and implementation notes
+- **klauspost/compress** — production Go implementation of zstd, FSE, Huffman; good code to study
+- **facebook/zstd** — the reference C implementation by Yann Collet
+
+---
+
+## Part 2: Content-Addressable and Order-Preserving Compression
+
+### 1. Order-Preserving Key Compression
+
+#### Foundational Work: Antoshenkov et al. (1996)
+
+The seminal paper is **"Order Preserving String Compression"** by Antoshenkov, Lomet, and Murray (ICDE 1996, IEEE). It introduced a parsing/tokenization technique for variable-length keys that produces compressed output preserving lexicographic order. The core idea: partition the string space into ranges, encode the common prefix of each range. This was implemented in DEC's Rdb relational database. The algorithm (ALM — Antoshenkov-Lomet-Murray) guarantees order preservation of encoded results.
+
+- Paper: [IEEE Xplore](https://ieeexplore.ieee.org/document/492216/)
+- Semantic Scholar: [PDF](https://www.semanticscholar.org/paper/Order-Preserving-Key-Compression-Antoshenkov-Lomet/a8df13fd41e53db57d34f453d352e6068d604e42)
+
+#### HOPE: High-speed Order-Preserving Encoder (Zhang et al., SIGMOD 2020)
+
+The most important modern work is **HOPE** from CMU (Zhang, Liu, Andersen, Kaminsky, Keeton, Pavlo). HOPE is a fast dictionary-based compressor that encodes arbitrary keys while preserving their order. It identifies common key patterns at fine granularity and exploits entropy for compression.
+
+Key results:
+- **Up to 40% lower query latency** and **up to 30% smaller memory** for in-memory search trees
+- Evaluated on 5 data structures: SuRF, ART, HOT, B+tree, Prefix B+tree
+- Implements **6 representative compression schemes** making different tradeoffs between compression rate and encoding speed
+- Uses a theoretical model for reasoning about order-preserving dictionary designs
+
+This is directly relevant to L85 encoding — HOPE shows that dictionary-based schemes can compress keys while preserving the exact sort order range scans depend on.
+
+- Paper: [CMU PDF](https://db.cs.cmu.edu/papers/2020/zhang-sigmod2020.pdf)
+- ArXiv: [2003.02391](https://arxiv.org/abs/2003.02391)
+
+#### Hu-Tucker Optimal Alphabetic Coding
+
+The **Hu-Tucker algorithm** constructs optimal alphabetic binary codes where codeword ordering matches the natural order of the source symbols. Unlike Huffman coding (which can reorder), Hu-Tucker guarantees the alphabetic/lexicographic constraint is preserved while minimizing total code length. This is the theoretical foundation for order-preserving variable-length codes.
+
+- MIT lecture notes: [Hu-Tucker](https://math.mit.edu/~djk/18.310/Lecture-Notes/PeterShor-hu-tucker.html)
+
+### 2. Searchable / Homomorphic Compression
+
+#### HOCO / HocoPG (Guan et al., SIGMOD 2023 / VLDB 2024)
+
+**Homomorphic Compression (HOCO)** is the most significant work here. It allows performing text operations directly on compressed data without decompression. Three compression schemes were implemented with homomorphism support:
+
+- **9.18x higher throughput** for random access and modification operations vs. state-of-the-art
+- **7.16x lower latency** for text analytics vs. uncompressed processing
+- Supports string matching, replacement, substring extraction, and full-text search on compressed form
+- **HocoPG** integrates this into PostgreSQL: data is automatically compressed on INSERT, all subsequent queries operate on compressed form
+
+This is the strongest example of "operate on compressed data" in the literature.
+
+- HOCO paper: [ACM DL](https://dl.acm.org/doi/10.1145/3626765)
+- HocoPG: [VLDB PDF](https://www.vldb.org/pvldb/vol17/p4477-guan.pdf)
+
+#### FSST: Fast Static Symbol Table (Boncz et al., VLDB 2020)
+
+**FSST** from CWI Amsterdam is a lightweight string compression scheme used in column stores. Its key property: **equality comparisons can be performed directly on compressed values** as long as both operands are compressed with the same symbol table. This means queries with equality-selection predicates work on compressed strings without decompression.
+
+Properties:
+- Maps 1-8 byte "symbols" to single-byte "codes"
+- Random access to individual compressed strings (not block-based)
+- Decompression speed comparable to or better than LZ4, with significantly better compression
+- Implemented in DuckDB and other column stores
+
+FSST supports equality but NOT order comparison on compressed form — the compression does not preserve sort order.
+
+- Paper: [VLDB PDF](https://www.vldb.org/pvldb/vol13/p2649-boncz.pdf)
+- Implementation: [GitHub cwida/fsst](https://github.com/cwida/fsst), [Go port](https://github.com/axiomhq/fsst)
+
+#### CompressDB (Zhang et al., SIGMOD 2022)
+
+**CompressDB** uses context-free grammar to compress data and supports both query and manipulation without decompression. It integrates at the filesystem level so databases (SQLite, MySQL, LevelDB, MongoDB, ClickHouse, Neo4j) can use it transparently.
+
+Results: 40% throughput improvement, 44% latency reduction, 1.75x compression ratio.
+
+- Paper: [ACM DL](https://dl.acm.org/doi/10.1145/3514221.3526130)
+
+#### Order-Preserving Run-Length Encoding (US Patent 5,619,199)
+
+IBM patented a scheme specifically for **comparing RLE-compressed keys without decompression**. When a mismatch occurs during comparison, the algorithm extracts codewords (compressed character + escape character + count) and compares them directly. This enables B-tree index traversal on compressed keys.
+
+- Patent: [US5619199](https://patents.google.com/patent/US5619199)
+
+### 3. Order-Preserving Encodings (Not Encryption)
+
+This category is highly relevant to janus-datalog's L85 encoding.
+
+#### Memcomparable Format (TiDB / RisingWave)
+
+TiDB uses a **Memcomparable** encoding where the comparison result of two objects before encoding is consistent with byte-array comparison after encoding. All row data is arranged in TiKV by RowID order, enabling efficient range scans on encoded keys.
+
+Key techniques:
+- **Integers**: Big-endian, sign-bit flipping (signed integers XOR with 0x80 in MSB)
+- **Strings**: Chunked encoding with padding and continuation bytes
+- **Floats**: IEEE 754 with conditional bit flipping
+
+- TiDB docs: [TiDB Computing](https://docs.pingcap.com/tidb/stable/tidb-computing/)
+- Rust implementation: [risingwavelabs/memcomparable](https://github.com/risingwavelabs/memcomparable)
+
+#### FoundationDB Tuple Layer
+
+FoundationDB's tuple layer is the gold standard for order-preserving multi-type encoding:
+
+- **Type code prefix** (single byte) identifies each element
+- **Integers**: Variable-length encoding with 17 typecodes (0x0c-0x1c). Negative numbers use big-endian one's complement. Zero is 0x14. Supports arbitrary precision via typecodes 0x0b/0x1d.
+- **Strings**: Null-terminated with null bytes escaped as 0x00 0xFF (order-preserving escape)
+- **Floats**: IEEE big-endian with conditional bit flipping: "if sign bit set, flip all bits; otherwise flip only sign bit"
+- **Nested tuples**: Recursive encoding with 0x05 typecode
+- **Key property**: Common tuple prefix serializes as common byte prefix
+
+This is architecturally very similar to what L85 does for janus-datalog, but more general.
+
+- Design doc: [GitHub](https://github.com/apple/foundationdb/blob/main/design/tuple.md)
+
+#### CockroachDB Key Encoding
+
+CockroachDB encodes SQL primary keys into KV keys such that `enc(x) <= enc(y) iff x <= y` for ascending columns (reversed for descending). Uses a prefix-free encoding where the first byte indicates field type. STRING and BYTES share an encoding. Collated strings appear twice: once as sort key, once as actual value.
+
+- Tech notes: [encoding.md](https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/encoding.md)
+- Encoding code: [encoding.go](https://github.com/cockroachdb/cockroach/blob/master/pkg/util/encoding/encoding.go)
+
+#### Other Notable Implementations
+
+- **[bytekey](https://github.com/danburkert/bytekey)** (Rust): Lexicographic sort-order preserving binary encoding for LevelDB-style stores
+- **[orderly](https://github.com/ndimiduk/orderly)** (Java): Schema and type system for creating sortable byte arrays (HBase)
+- **[StatelyDB](https://stately.cloud/blog/encoding-sortable-binary-database-keys)**: Uses a "sort byte" prefix encoding both length and sign for integers
+
+#### Sortable Base64/Base85
+
+Standard Base64 and Base85 do NOT preserve sort order because the alphabet ordering doesn't match byte value ordering. Solutions require custom alphabets where character ordering matches the underlying byte ordering. L85 already does this correctly — the L85 alphabet is specifically chosen to be in ASCII sort order, so lexicographic comparison of L85-encoded strings matches the byte comparison of the underlying binary data.
+
+### 4. How Real Database Systems Handle Key/Value Compression
+
+#### Approach A: Compress values, keep keys sortable (most common)
+
+Most LSM-tree and B-tree databases do NOT compress their keys with general-purpose compression. Instead they:
+
+1. **Use order-preserving encodings** for keys (memcomparable, tuple layer, etc.)
+2. **Apply prefix compression** within sorted blocks
+3. **Compress values** with general-purpose algorithms (LZ4, zstd, Snappy)
+
+#### LevelDB / RocksDB / Pebble: Block-level prefix compression
+
+Keys are delta-encoded within blocks:
+- Each entry stores `(shared_bytes, unshared_bytes, value_length, key_delta, value)`
+- **Restart points** every N keys (default 16) store the full key for binary search
+- This is NOT general compression — it's prefix deduplication of sorted keys
+- Range scans work because the block is decompressed in memory; within a block, binary search uses restart points
+
+RocksDB also supports **prefix bloom filters** for efficient prefix-based seeks, and **zstd dictionary compression** across blocks within an SSTable for better value compression.
+
+Pebble (CockroachDB's Go storage engine) uses the same block format. There is an [open issue for dictionary compression](https://github.com/cockroachdb/pebble/issues/3453) to improve cross-block compression.
+
+#### WiredTiger (MongoDB): Prefix compression for indexes
+
+- Default for all indexes: adjacent key prefix compression
+- First key per page stored in full, subsequent keys store only the suffix differing from predecessor
+- Also uses suffix truncation: when splitting nodes, shorter separator keys replace full keys
+- Block-level Snappy compression for collections
+
+#### InnoDB (MySQL): Page-level compression
+
+- B-tree pages compressed as whole units
+- Uncompressed "modification log" within compressed pages avoids recompression on small updates
+- Key prefix compression within pages
+
+#### ClickHouse: Column-level specialized encodings
+
+ClickHouse uses a two-layer approach:
+1. **Encodings** (Delta, DoubleDelta, Gorilla, T64) transform data by type to reduce entropy
+2. **Compression** (LZ4, ZSTD) compresses the encoded output
+
+These encodings do NOT preserve sort order — they're designed for columnar analytics where you decompress before comparing. Sort order is maintained by the MergeTree's primary key ordering, not by compression.
+
+#### DuckDB: Lightweight compression
+
+Seven algorithms (Constant, RLE, BitPacking, FOR, Dictionary, FSST, Chimp/Patas), selected per-column-segment. Dramatic compression ratios (e.g., 1.73GB to 0.21GB for On Time dataset). Operates in conjunction with late materialization and vectorized execution.
+
+#### Datomic: Fressian + zip
+
+Datomic segments (arrays of ~1000-20000 datoms) are serialized with **Fressian** (a byte-code-driven extensible binary format), then compressed with zip, producing ~50KB segments. Sort order is maintained at the segment/B-tree level (segment boundaries are sorted keys), but within a segment, data must be decompressed before querying. The B-tree has 1000+ branching factor and only ~3 levels deep.
+
+#### Apache Parquet: Dictionary encoding + min/max statistics
+
+Parquet uses dictionary encoding and RLE within column chunks. Range scans work through **predicate pushdown** using per-chunk min/max statistics — the query engine skips chunks whose range doesn't overlap the predicate. Dictionary-level predicate evaluation can provide up to 8x speedup.
+
+### 5. B-Tree Compression Survey (SIGMOD 2024)
+
+**"Revisiting B-tree Compression: An Experimental Study"** evaluated 7 compression techniques:
+- Prefix compression (used by WiredTiger, InnoDB)
+- Suffix truncation (used by WiredTiger)
+- Head+Tail compression (recommended — best search/insert performance with decent compression)
+- Partial-key approaches (SAP HANA's CPB-tree)
+- Front coding (MyISAM)
+
+Key finding: **Head+Tail Compression** achieves faster performance than uncompressed B-trees while maintaining decent compression ratio, because shorter keys mean more keys per node means fewer cache misses.
+
+- Paper: [Purdue PDF](https://www.cs.purdue.edu/homes/csjgwang/pubs/SIGMOD24_BtreeCompression.pdf)
+
+### 6. Dictionary-Based Order-Preserving String Compression (Binnig et al., SIGMOD 2009)
+
+Designed for SAP HANA-style column stores: replaces variable-length strings with fixed-length integer codes from an order-preserving dictionary. The dictionary maps string values to integer codes such that the code ordering matches the string ordering. Enables range queries on codes without decompression. Uses front coding internally (lexicographic ordering + prefix deduplication).
+
+- Paper: [CMU Course PDF](https://15721.courses.cs.cmu.edu/spring2016/papers/p283-binnig.pdf)
+
+### 7. The Fundamental Tension
+
+LZ77 replaces repeated substrings with (offset, length) back-references. The encoded form of "apple" depends on whether "apple" appeared earlier in the stream and where. Two different strings can compress to forms where the lexicographic relationship is reversed. There is no way to fix this without giving up the back-referencing that makes LZ77 effective.
+
+Order-preserving schemes are constrained to **per-symbol or per-pattern mappings** where code ordering matches input ordering. This rules out cross-reference between positions — which is exactly what gives LZ77 its power.
+
+**This tension is fundamental, not an implementation gap.** No future algorithm will achieve both LZ77-level ratios and sort-order preservation on general data.
+
+### 8. Summary and Relevance to L85
+
+L85 is already an **order-preserving encoding** (category 3 above). It maps 20-byte binary values to 25-character printable strings while preserving lexicographic sort order, using a carefully chosen 85-character alphabet in ASCII sort order with big-endian encoding.
+
+The research suggests several potential directions:
+
+**If the goal is to make keys shorter while preserving sort order:**
+- HOPE's dictionary-based approach could compress common key patterns while maintaining order. This is the most directly applicable academic work.
+- Hu-Tucker coding provides the theoretical optimum for order-preserving variable-length codes.
+
+**If the goal is to compress values while still supporting range scans:**
+- The standard approach (LevelDB/RocksDB/Pebble) is: keep keys in order-preserving encoding, use prefix deduplication within sorted blocks, compress values with LZ4/zstd. This is what BadgerDB already does.
+- Dictionary compression across blocks (as proposed for Pebble) would improve value compression for sorted index data.
+
+**If the goal is to support operations on compressed data:**
+- FSST for equality comparison on compressed strings
+- HOCO/HocoPG for text operations on compressed data
+- Order-preserving dictionary encoding (Binnig et al.) for range queries on compressed dictionary codes
+
+**The gap in the literature**: There is no system that does true general-purpose compression of keys while preserving arbitrary range scan capability on the compressed form. Every production database either (a) uses order-preserving *encoding* (not compression) for keys, or (b) compresses at the block/page level and decompresses for comparison. HOPE is the closest to bridging this gap, but it's dictionary-based encoding, not general compression.
+
+### All References
+
+- [HOPE paper — CMU SIGMOD 2020](https://db.cs.cmu.edu/papers/2020/zhang-sigmod2020.pdf)
+- [HOPE on ArXiv](https://arxiv.org/abs/2003.02391)
+- [Antoshenkov et al. — IEEE ICDE 1996](https://ieeexplore.ieee.org/document/492216/)
+- [HOCO — ACM SIGMOD 2023](https://dl.acm.org/doi/10.1145/3626765)
+- [HocoPG — VLDB 2024](https://www.vldb.org/pvldb/vol17/p4477-guan.pdf)
+- [FSST — VLDB 2020](https://www.vldb.org/pvldb/vol13/p2649-boncz.pdf)
+- [FSST GitHub](https://github.com/cwida/fsst)
+- [FSST Go port](https://github.com/axiomhq/fsst)
+- [CompressDB — SIGMOD 2022](https://dl.acm.org/doi/10.1145/3514221.3526130)
+- [Order-Preserving RLE Patent US5619199](https://patents.google.com/patent/US5619199)
+- [FoundationDB Tuple Design](https://github.com/apple/foundationdb/blob/main/design/tuple.md)
+- [CockroachDB Encoding](https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/encoding.md)
+- [TiDB Computing / Memcomparable](https://docs.pingcap.com/tidb/stable/tidb-computing/)
+- [risingwavelabs/memcomparable (Rust)](https://github.com/risingwavelabs/memcomparable)
+- [Memcmp-friendly encoding blog](https://yizhang82.dev/sorting-structured-data-1)
+- [StatelyDB key encoding](https://stately.cloud/blog/encoding-sortable-binary-database-keys)
+- [Lexicographic sort order blog](https://cornerwings.github.io/2019/10/lexical-sorting/)
+- [bytekey (Rust)](https://github.com/danburkert/bytekey)
+- [orderly (Java)](https://github.com/ndimiduk/orderly)
+- [B-tree Compression Survey — SIGMOD 2024](https://www.cs.purdue.edu/homes/csjgwang/pubs/SIGMOD24_BtreeCompression.pdf)
+- [Binnig et al. Dictionary Compression — SIGMOD 2009](https://dl.acm.org/doi/abs/10.1145/1559845.1559877)
+- [SuRF — SIGMOD 2018](https://www.pdl.cmu.edu/PDL-FTP/Storage/surf_sigmod18.pdf)
+- [Hu-Tucker Algorithm](https://math.mit.edu/~djk/18.310/Lecture-Notes/PeterShor-hu-tucker.html)
+- [DuckDB Lightweight Compression](https://duckdb.org/2022/10/28/lightweight-compression)
+- [RocksDB Prefix Seek](https://github.com/facebook/rocksdb/wiki/Prefix-Seek)
+- [Pebble dictionary compression issue](https://github.com/cockroachdb/pebble/issues/3453)
+- [WiredTiger compression](http://source.wiredtiger.com/2.3.0/file_formats.html)
+- [Datomic Internals](https://tonsky.me/blog/unofficial-guide-to-datomic-internals/)
+- [ClickHouse compression docs](https://clickhouse.com/docs/data-compression/compression-in-clickhouse)
+- [LevelDB prefix compression](https://medium.com/@xuezaigds/leveldb-explained-prefix-compression-and-restart-points-in-blockbuilder-5ebeb51c2b0d)
+- [Boldyreva et al. OPE — Crypto 2009](https://link.springer.com/chapter/10.1007/978-3-642-01001-9_13)
+- [Andy Pavlo CMU 15-721 Compression Lecture](https://15721.courses.cs.cmu.edu/spring2023/slides/05-compression.pdf)
+- [RFC 8878 — zstd format specification](https://www.rfc-editor.org/rfc/rfc8878)
+- [Yann Collet, FiniteStateEntropy (GitHub)](https://github.com/Cyan4973/FiniteStateEntropy)
+- [Jarek Duda, "Asymmetric numeral systems" (2009)](https://arxiv.org/abs/0902.0271)
+- [klauspost/compress (Go)](https://github.com/klauspost/compress)
+- [facebook/zstd (C reference)](https://github.com/facebook/zstd)

--- a/tests/compressed_values_e2e_test.go
+++ b/tests/compressed_values_e2e_test.go
@@ -1,0 +1,429 @@
+package tests
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// makeTier3Text creates a string that compresses but stays above 60KB compressed.
+// Uses pseudo-random printable ASCII so LZ77 finds few long matches.
+func makeTier3Text(size int) string {
+	data := make([]byte, size)
+	state := uint64(99)
+	printable := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,;:!?-_"
+	for i := range data {
+		state = state*6364136223846793005 + 1442695040888963407
+		data[i] = printable[int((state>>33))%len(printable)]
+	}
+	return string(data)
+}
+
+func openCompressedDB(t *testing.T, s schema.SchemaProvider) (*storage.Database, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "e2e-compress-*")
+	require.NoError(t, err)
+	db, err := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+		Path:                 dir,
+		Schema:               s,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	return db, func() { db.Close(); os.RemoveAll(dir) }
+}
+
+func longText(prefix string, size int) string {
+	base := prefix + " " + strings.Repeat("The quick brown fox jumps over the lazy dog. ", size/45+2)
+	if len(base) > size {
+		return base[:size]
+	}
+	return base
+}
+
+// TestE2E_CompressedQuery_FindByEntity runs a full Datalog query that reads
+// compressed values through the entire pipeline: parser → planner → executor → storage.
+func TestE2E_CompressedQuery_FindByEntity(t *testing.T) {
+	db, cleanup := openCompressedDB(t, nil)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("alice")
+	tx := db.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":person/name"), "Alice")
+	tx.Add(entity, datalog.NewKeyword(":person/bio"), longText("Alice's biography", 800))
+	tx.Add(entity, datalog.NewKeyword(":person/age"), int64(30))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Full Datalog query — find bio by entity
+	tuples, err := executor.CollectTuples(db.Query(
+		`[:find ?bio :in $ ?e :where [?e :person/bio ?bio]]`,
+		entity,
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples, 1)
+	assert.Equal(t, longText("Alice's biography", 800), tuples[0][0].(string))
+}
+
+// TestE2E_CompressedQuery_FindByValue runs an AVET-path query with a compressed
+// value as the search term.
+func TestE2E_CompressedQuery_FindByValue(t *testing.T) {
+	db, cleanup := openCompressedDB(t, nil)
+	defer cleanup()
+
+	bio := longText("unique biography content", 600)
+	entity := datalog.NewIdentity("bob")
+	tx := db.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":person/bio"), bio)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Query with value bound — triggers AVET lookup on compressed value
+	tuples, err := executor.CollectTuples(db.Query(
+		`[:find ?e :in $ ?bio :where [?e :person/bio ?bio]]`,
+		bio,
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples, 1)
+	assert.Equal(t, entity, tuples[0][0])
+}
+
+// TestE2E_CompressedQuery_Join runs a join query where one side has compressed values.
+func TestE2E_CompressedQuery_Join(t *testing.T) {
+	db, cleanup := openCompressedDB(t, nil)
+	defer cleanup()
+
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+
+	tx := db.NewTransaction()
+	tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":person/bio"), longText("Alice is a software engineer", 500))
+	tx.Add(bob, datalog.NewKeyword(":person/name"), "Bob")
+	tx.Add(bob, datalog.NewKeyword(":person/bio"), longText("Bob is a data scientist", 500))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Join: find names and bios
+	tuples, err := executor.CollectTuples(db.Query(
+		`[:find ?name ?bio :where [?e :person/name ?name] [?e :person/bio ?bio]]`,
+	))
+	require.NoError(t, err)
+	assert.Len(t, tuples, 2, "should find both people")
+
+	// Verify both names and bios are present
+	names := map[string]string{}
+	for _, tuple := range tuples {
+		name := tuple[0].(string)
+		bio := tuple[1].(string)
+		names[name] = bio
+	}
+	assert.Contains(t, names, "Alice")
+	assert.Contains(t, names, "Bob")
+	assert.True(t, strings.HasPrefix(names["Alice"], "Alice is a software engineer"))
+	assert.True(t, strings.HasPrefix(names["Bob"], "Bob is a data scientist"))
+}
+
+// TestE2E_CompressedQuery_CRDT_LWW verifies cardinality-one LWW through
+// the full query pipeline with compressed values.
+func TestE2E_CompressedQuery_CRDT_LWW(t *testing.T) {
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":doc/content"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+
+	db, cleanup := openCompressedDB(t, s)
+	defer cleanup()
+
+	entity := datalog.NewIdentity("doc1")
+
+	// Write version 1
+	tx1 := db.NewTransaction()
+	tx1.Set(entity, datalog.NewKeyword(":doc/content"), longText("first draft", 500))
+	_, err := tx1.Commit()
+	require.NoError(t, err)
+
+	// Write version 2
+	tx2 := db.NewTransaction()
+	tx2.Set(entity, datalog.NewKeyword(":doc/content"), longText("final version", 500))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	// Query should return only the latest
+	tuples, err := executor.CollectTuples(db.Query(
+		`[:find ?content :in $ ?e :where [?e :doc/content ?content]]`,
+		entity,
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples, 1)
+	assert.True(t, strings.HasPrefix(tuples[0][0].(string), "final version"))
+}
+
+// TestE2E_CompressedQuery_StrStartsWith verifies str/starts-with? predicate
+// works on compressed values (evaluates at Relation layer after decompression).
+func TestE2E_CompressedQuery_StrStartsWith(t *testing.T) {
+	db, cleanup := openCompressedDB(t, nil)
+	defer cleanup()
+
+	tx := db.NewTransaction()
+	for i := 0; i < 5; i++ {
+		e := datalog.NewIdentity(strings.Repeat("a", i+1))
+		tx.Add(e, datalog.NewKeyword(":doc/content"), longText("Chapter 1: Introduction", 400+i*10))
+	}
+	for i := 0; i < 5; i++ {
+		e := datalog.NewIdentity(strings.Repeat("b", i+1))
+		tx.Add(e, datalog.NewKeyword(":doc/content"), longText("Chapter 2: Methods", 400+i*10))
+	}
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Query with str/starts-with? on compressed values
+	tuples, err := executor.CollectTuples(db.Query(
+		`[:find ?e :where [?e :doc/content ?c] [(str/starts-with? ?c "Chapter 1")]]`,
+	))
+	require.NoError(t, err)
+	assert.Len(t, tuples, 5, "should find 5 entities with Chapter 1 content")
+}
+
+// TestE2E_CompressedExportImportQuery writes data, exports with #lzj,
+// imports into a fresh DB, and runs full Datalog queries on the imported data.
+func TestE2E_CompressedExportImportQuery(t *testing.T) {
+	db1, cleanup1 := openCompressedDB(t, nil)
+	defer cleanup1()
+
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+
+	tx := db1.NewTransaction()
+	tx.Add(alice, datalog.NewKeyword(":person/name"), "Alice")
+	tx.Add(alice, datalog.NewKeyword(":person/bio"), longText("Alice bio", 600))
+	tx.Add(bob, datalog.NewKeyword(":person/name"), "Bob")
+	tx.Add(bob, datalog.NewKeyword(":person/bio"), longText("Bob bio", 600))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Export compressed
+	var buf bytes.Buffer
+	err = db1.Export(&buf, storage.ExportOptions{Compressed: true})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "#lzj")
+
+	// Import into fresh DB
+	dir2, err := os.MkdirTemp("", "e2e-import-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir2)
+
+	db2, err := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+		Path:                 dir2,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	err = db2.Import(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+
+	// Full Datalog query on imported data
+	tuples, err := executor.CollectTuples(db2.Query(
+		`[:find ?name ?bio :where [?e :person/name ?name] [?e :person/bio ?bio]]`,
+	))
+	require.NoError(t, err)
+	assert.Len(t, tuples, 2)
+
+	names := map[string]bool{}
+	for _, tuple := range tuples {
+		name := tuple[0].(string)
+		bio := tuple[1].(string)
+		names[name] = true
+		if name == "Alice" {
+			assert.True(t, strings.HasPrefix(bio, "Alice bio"))
+		} else if name == "Bob" {
+			assert.True(t, strings.HasPrefix(bio, "Bob bio"))
+		}
+	}
+	assert.True(t, names["Alice"])
+	assert.True(t, names["Bob"])
+
+	// AVET lookup on imported compressed value
+	tuples2, err := executor.CollectTuples(db2.Query(
+		`[:find ?e :in $ ?bio :where [?e :person/bio ?bio]]`,
+		longText("Alice bio", 600),
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples2, 1, "AVET lookup on imported compressed value should work")
+}
+
+// TestE2E_Tier3_FullQuery writes a Tier 3 blob value and queries it through
+// the full db.Query() pipeline — parser, planner, executor, storage, blob store.
+func TestE2E_Tier3_FullQuery(t *testing.T) {
+	db, cleanup := openCompressedDB(t, nil)
+	defer cleanup()
+
+	bigValue := makeTier3Text(100000)
+
+	// Verify this actually reaches Tier 3
+	vType, _, _ := datalog.EncodeValue(bigValue, 256)
+	if vType != datalog.TypeHashedString {
+		t.Skipf("value reaches type 0x%02x not Tier 3 (len=%d)", vType, len(bigValue))
+	}
+
+	entity := datalog.NewIdentity("tier3-e2e")
+	tx := db.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":doc/content"), bigValue)
+	tx.Add(entity, datalog.NewKeyword(":doc/title"), "Big Document")
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Query 1: Find Tier 3 value by entity (E+A bound, V unbound)
+	tuples, err := executor.CollectTuples(db.Query(
+		`[:find ?content :in $ ?e :where [?e :doc/content ?content]]`,
+		entity,
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples, 1)
+	assert.Equal(t, bigValue, tuples[0][0].(string), "Tier 3 value should round-trip through db.Query()")
+
+	// Query 2: Join Tier 3 value with another attribute
+	tuples2, err := executor.CollectTuples(db.Query(
+		`[:find ?title ?content :in $ ?e :where [?e :doc/title ?title] [?e :doc/content ?content]]`,
+		entity,
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples2, 1)
+	assert.Equal(t, "Big Document", tuples2[0][0].(string))
+	assert.Equal(t, bigValue, tuples2[0][1].(string))
+
+	// Query 3: AVET lookup with Tier 3 value as input parameter
+	tuples3, err := executor.CollectTuples(db.Query(
+		`[:find ?e :in $ ?content :where [?e :doc/content ?content]]`,
+		bigValue,
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples3, 1, "AVET lookup on Tier 3 blob value should work")
+	assert.Equal(t, entity, tuples3[0][0])
+}
+
+// TestE2E_CompressedQuery_JoinOnValue joins on a compressed value — the variable
+// ?content appears in two patterns and the executor must match on the decompressed value.
+func TestE2E_CompressedQuery_JoinOnValue(t *testing.T) {
+	db, cleanup := openCompressedDB(t, nil)
+	defer cleanup()
+
+	sharedContent := longText("shared content for join test", 600)
+	differentContent := longText("different content not shared", 600)
+
+	alice := datalog.NewIdentity("alice-join")
+	bob := datalog.NewIdentity("bob-join")
+	carol := datalog.NewIdentity("carol-join")
+
+	tx := db.NewTransaction()
+	// Alice and Bob share the same content value
+	tx.Add(alice, datalog.NewKeyword(":doc/content"), sharedContent)
+	tx.Add(bob, datalog.NewKeyword(":doc/mirror"), sharedContent)
+	// Carol has different content
+	tx.Add(carol, datalog.NewKeyword(":doc/content"), differentContent)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Join on ?content — should find alice+bob pair, not carol
+	tuples, err := executor.CollectTuples(db.Query(
+		`[:find ?e1 ?e2 :where [?e1 :doc/content ?c] [?e2 :doc/mirror ?c]]`,
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples, 1, "join on compressed value should find exactly one pair")
+	assert.Equal(t, alice, tuples[0][0])
+	assert.Equal(t, bob, tuples[0][1])
+}
+
+// TestE2E_Tier3_JoinOnValue joins on a Tier 3 blob value through db.Query().
+func TestE2E_Tier3_JoinOnValue(t *testing.T) {
+	db, cleanup := openCompressedDB(t, nil)
+	defer cleanup()
+
+	bigValue := makeTier3Text(100000)
+	vType, _, _ := datalog.EncodeValue(bigValue, 256)
+	if vType != datalog.TypeHashedString {
+		t.Skipf("value doesn't reach Tier 3")
+	}
+
+	e1 := datalog.NewIdentity("tier3-join-1")
+	e2 := datalog.NewIdentity("tier3-join-2")
+
+	tx := db.NewTransaction()
+	tx.Add(e1, datalog.NewKeyword(":doc/content"), bigValue)
+	tx.Add(e2, datalog.NewKeyword(":doc/mirror"), bigValue)
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Join on the Tier 3 value
+	tuples, err := executor.CollectTuples(db.Query(
+		`[:find ?e1 ?e2 :where [?e1 :doc/content ?c] [?e2 :doc/mirror ?c]]`,
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples, 1, "join on Tier 3 blob value should find exactly one pair")
+	assert.Equal(t, e1, tuples[0][0])
+	assert.Equal(t, e2, tuples[0][1])
+}
+
+// TestE2E_Tier3_ExportImportQuery writes a Tier 3 value, exports with #lzj
+// (inline in EDN), imports into a fresh DB, and runs full queries.
+func TestE2E_Tier3_ExportImportQuery(t *testing.T) {
+	db1, cleanup1 := openCompressedDB(t, nil)
+	defer cleanup1()
+
+	bigValue := makeTier3Text(100000)
+
+	vType, _, _ := datalog.EncodeValue(bigValue, 256)
+	if vType != datalog.TypeHashedString {
+		t.Skipf("value doesn't reach Tier 3")
+	}
+
+	entity := datalog.NewIdentity("tier3-export-e2e")
+	tx := db1.NewTransaction()
+	tx.Add(entity, datalog.NewKeyword(":doc/content"), bigValue)
+	tx.Add(entity, datalog.NewKeyword(":doc/title"), "Exported Blob")
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Export compressed — Tier 3 value should be inline #lzj
+	var buf bytes.Buffer
+	err = db1.Export(&buf, storage.ExportOptions{Compressed: true})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "#lzj")
+
+	// Import into fresh DB
+	dir2, err := os.MkdirTemp("", "tier3-e2e-import-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir2)
+
+	db2, err := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+		Path:                 dir2,
+		CompressionThreshold: 256,
+	})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	err = db2.Import(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+
+	// Full query on imported Tier 3 data
+	tuples, err := executor.CollectTuples(db2.Query(
+		`[:find ?title ?content :in $ ?e :where [?e :doc/title ?title] [?e :doc/content ?content]]`,
+		entity,
+	))
+	require.NoError(t, err)
+	require.Len(t, tuples, 1)
+	assert.Equal(t, "Exported Blob", tuples[0][0].(string))
+	assert.Equal(t, bigValue, tuples[0][1].(string),
+		"Tier 3 value should survive export→import→query round-trip")
+}


### PR DESCRIPTION
## Problem

Large text values (multi-paragraph prose, source code, structured output) produce oversized storage and EDN exports. A production database with ~3000 tasks reaches 189MB in EDN. Badger's 64KB key size limit prevents storing multi-paragraph text without splitting into `[]string` vectors, which increases datom count and CRDT metadata overhead.

## Solution

Transparent LZJ compression in the value codec layer. Values above a configurable threshold (default 256 bytes) are compressed before storage and decompressed on read. The query engine sees normal strings — compression is invisible to queries, predicates, and joins.

### Three-tier storage

- **Tier 1 (raw)**: Values below threshold stored as-is. No overhead.
- **Tier 2 (compressed in key)**: Compressed bytes stored directly in the badger key across all 7 indexes. Stays in the LSM tree — no value log touch.
- **Tier 3 (content hash + blob)**: For values whose compressed form exceeds 60KB, a SHA1 hash is stored in the key and the compressed bytes go in a content-addressed blob store (`[0xFF][hash:20]` in the same BadgerDB). Strictly better than the status quo where these values cannot be stored at all.

### Custom owned compression codec (LZJ)

The compression format must be deterministic forever — same input always produces same compressed bytes. This is a correctness requirement because compressed bytes are embedded in badger keys, which are identity. A third-party library could change output between versions, silently breaking AVET lookups and uniqueness constraints.

LZJ is a custom LZ77+FSE codec targeting zstd-like ratios:

| Data Type | Ratio |
|-----------|-------|
| English prose 1KB | 3.6x |
| EDN structured | 12.9x |
| Source code | 10.6x |
| Repetitive binary | 12.7x |

| Operation | 1KB | 4KB | 16KB |
|-----------|-----|-----|------|
| Compress | 43 MB/s | 112 MB/s | 284 MB/s |
| **Decompress** | **2.1 GB/s** | **2.3 GB/s** | **2.4 GB/s** |

Decompression (the read-path hot side) is 2+ GB/s with 7 allocations. Per-value latency: 477ns for 1KB.

### EDN `#lzj` tagged literal

Compressed export uses `#lzj "L85-encoded-compressed-data"`. Default export is uncompressed for human readability. Import recognizes both formats.

### API

```go
d, err := db.Open(path, db.WithCompressionThreshold(256))
```

### Bug fix: `[]byte` CRDT set resolution panic

Discovered during Tier 3 testing: `[]byte` values in cardinality-many attributes panicked because Go maps cannot key on `[]byte`. Fixed `SetResolutionResult.Members` from `map[any]bool` to `map[any]any` (hashable key + original typed value), with `[]byte` → `string` conversion only at the map key insertion point. Zero extra allocations for string/int/keyword values. Original `[]byte` type preserved for consumers.

## Test plan

- [x] 185 codec tests: golden determinism (frozen hex), round-trip fuzz (500 random + 200 text + 100 structured), concurrent determinism
- [x] 10 value encoding tests: type routing, safety net, threshold, existing types regression
- [x] 10 compressed key tests: all 7 indexes, AVET lookup, mixed tiers, backward compat
- [x] 16 storage integration tests: write/read, AVET, CRDT LWW/add-wins/retract, mixed values, cross-boundary equality
- [x] 12 blob store + Tier 3 tests: put/get, content dedup, AVET lookup, LWW, add-wins retract, entity scan, nil-DB error
- [x] 10 EDN export/import tests: default/compressed export, #lzj import, round-trip, AVET after import, Tier 3 inline, malformed input
- [x] 10 E2E tests through `db.Query()`: find by entity/value, join, join-on-compressed-value, CRDT LWW, str/starts-with?, Tier 3 full query + join + AVET, export-import-query for both tiers
- [x] 2 `[]byte` CRDT reproduction tests
- [x] 5 frozen golden tests (byte-level determinism proof)
- [x] Zero regressions across all 15 packages