### PR TITLE
Fix or-join outer binding propagation, silent subquery failures, and UTC time decoding

### DIFF
--- a/datalog/executor/decorrelation_executor.go
+++ b/datalog/executor/decorrelation_executor.go
@@ -449,7 +449,10 @@ func (e *DefaultQueryExecutor) executeBatchedGroup(
 	combinedRel := combineGroups(groups)
 
 	// Get unique combinations of input values
-	inputCombinations := getUniqueInputCombinations(combinedRel, inputSymbols)
+	inputCombinations, err := getUniqueInputCombinations(combinedRel, inputSymbols)
+	if err != nil {
+		return nil, fmt.Errorf("subquery input extraction failed: %w", err)
+	}
 
 	if len(inputCombinations) == 0 {
 		// No input combinations - return empty results for all subqueries

--- a/datalog/executor/product_test.go
+++ b/datalog/executor/product_test.go
@@ -1,0 +1,45 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestProductPreservesDisjointSymbols verifies that Product() of disjoint
+// relations produces a combined relation with all symbols, and that
+// getUniqueInputCombinations can find symbols from any constituent relation.
+func TestProductPreservesDisjointSymbols(t *testing.T) {
+	rel1 := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?person"), datalog.NewSymbol("?a"), datalog.NewSymbol("?v")},
+		[]Tuple{{"alice", ":name", "Alice"}, {"bob", ":name", "Bob"}},
+	)
+	rel2 := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?config")},
+		[]Tuple{{"config-1"}},
+	)
+
+	product := Relations{rel1, rel2}.Product()
+	require.NotNil(t, product)
+
+	syms := product.Symbols()
+	symNames := make([]string, len(syms))
+	for i, s := range syms {
+		symNames[i] = s.String()
+	}
+
+	assert.Contains(t, symNames, "?person")
+	assert.Contains(t, symNames, "?a")
+	assert.Contains(t, symNames, "?v")
+	assert.Contains(t, symNames, "?config")
+
+	mat := product.Materialize()
+	assert.Equal(t, 2, mat.Size())
+
+	combos, err := getUniqueInputCombinations(mat, []query.Symbol{datalog.NewSymbol("?config")})
+	require.NoError(t, err)
+	assert.Len(t, combos, 1, "should find 1 unique ?config value")
+}

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -159,9 +159,7 @@ func (e *DefaultQueryExecutor) Execute(ctx Context, q *query.Query, inputs []Rel
 			}))
 
 		case *query.OrJoinClause:
-			// OR-JOIN has the same union semantics as OR. Join vars are planner
-			// metadata for scheduling; the executor uses the same path for both.
-			newRel, err := e.executeOrClause(ctx, &query.OrClause{Branches: c.Branches}, groups)
+			newRel, err := e.executeOrJoinClause(ctx, c, groups)
 			if err != nil {
 				return nil, fmt.Errorf("clause %d (or-join) failed: %w", i, err)
 			}
@@ -835,7 +833,10 @@ func (e *DefaultQueryExecutor) executeSubquery(ctx Context, subq *query.Subquery
 	combinedRel = combinedRel.Materialize()
 
 	// Get unique combinations of input values
-	inputCombinations := getUniqueInputCombinations(combinedRel, inputSymbols)
+	inputCombinations, err := getUniqueInputCombinations(combinedRel, inputSymbols)
+	if err != nil {
+		return nil, fmt.Errorf("subquery input extraction failed: %w", err)
+	}
 
 	// Execute subquery for each combination
 	var allResults []Relation
@@ -865,15 +866,16 @@ func (e *DefaultQueryExecutor) executeSubquery(ctx Context, subq *query.Subquery
 		}
 
 		// For subqueries, we expect a single result group (aggregations should have collapsed)
+		var nestedResult Relation
 		if len(nestedGroups) == 0 {
-			// Empty result - skip this combination
-			continue
-		}
-		if len(nestedGroups) > 1 {
+			// No result groups — create empty relation with the subquery's output symbols
+			// so applyBindingForm can produce a properly-typed empty result.
+			nestedResult = NewMaterializedRelation(extractBindingSymbols(subq.Binding), []Tuple{})
+		} else if len(nestedGroups) > 1 {
 			return nil, fmt.Errorf("subquery returned %d disjoint groups - expected 1", len(nestedGroups))
+		} else {
+			nestedResult = nestedGroups[0]
 		}
-
-		nestedResult := nestedGroups[0]
 
 		// Apply binding form to join results with outer query values
 		boundResult, err := applyBindingForm(nestedResult, subq.Binding, inputValues, inputSymbols)
@@ -961,7 +963,10 @@ func (e *DefaultQueryExecutor) executeSubqueryComponentized(ctx Context, subq *q
 	inputSymbols := batcher.ExtractInputSymbols(subq.Query.In)
 
 	// Get unique input combinations
-	inputCombinations := getUniqueInputCombinations(combinedRel, inputSymbols)
+	inputCombinations, err := getUniqueInputCombinations(combinedRel, inputSymbols)
+	if err != nil {
+		return nil, fmt.Errorf("subquery input extraction failed: %w", err)
+	}
 
 	// Select execution strategy
 	strategy := selector.SelectStrategy(subq.Query, len(inputCombinations), e.options)
@@ -1627,34 +1632,13 @@ func (e *DefaultQueryExecutor) executeOrJoinClause(ctx Context, clause *query.Or
 		return NewMaterializedRelationWithOptions(nil, nil, e.options), nil
 	}
 
-	joinVars := clause.JoinVars
-	if len(joinVars) == 0 {
+	if len(clause.JoinVars) == 0 {
 		return nil, fmt.Errorf("OR-JOIN clause has no join variables")
 	}
 
-	if branchesNeedCorrelatedExecution(clause.Branches) {
-		return e.executeOrJoinClauseCorrelatedUnion(ctx, clause, groups)
-	}
-
-	var branchResults []Relation
-
-	for i, branch := range clause.Branches {
-		branchResult, err := e.executeInnerClauses(ctx, branch, nil)
-		if err != nil {
-			return nil, fmt.Errorf("OR-JOIN branch %d execution failed: %w", i+1, err)
-		}
-
-		if branchResult != nil {
-			branchResults = append(branchResults, branchResult)
-		}
-	}
-
-	if len(branchResults) == 0 {
-		return NewMaterializedRelationWithOptions(joinVars, nil, e.options), nil
-	}
-
-	// Union all branch results, projecting to join vars
-	return unionRelations(branchResults, joinVars, e.options), nil
+	// Or-join always uses correlated execution. Its purpose is to vary
+	// which clause matches while preserving outer-bound join variables.
+	return e.executeOrJoinClauseCorrelatedUnion(ctx, clause, groups)
 }
 
 // executeOrJoinClauseCorrelatedUnion evaluates all branches per outer tuple
@@ -2084,7 +2068,7 @@ func (e *DefaultQueryExecutor) executeInnerClauses(ctx Context, clauses []query.
 			groups = groups.Collapse(ctx)
 
 		case *query.OrJoinClause:
-			newRel, err := e.executeOrClause(ctx, &query.OrClause{Branches: c.Branches}, groups)
+			newRel, err := e.executeOrJoinClause(ctx, c, groups)
 			if err != nil {
 				return nil, err
 			}

--- a/datalog/executor/subquery.go
+++ b/datalog/executor/subquery.go
@@ -35,7 +35,10 @@ func (e *Executor) executeSubquery(ctx Context, subqPlan planner.SubqueryPlan, i
 func ExecuteSubquery(ctx Context, parentExec *Executor, subqPlan planner.SubqueryPlan, inputRelation Relation) (Relation, error) {
 	// CRITICAL: Extract input combinations ONCE before trying batched vs sequential paths
 	// Both paths need the combinations, and calling Iterator() twice on a StreamingRelation will panic
-	inputCombinations := getUniqueInputCombinations(inputRelation, subqPlan.Inputs)
+	inputCombinations, err := getUniqueInputCombinations(inputRelation, subqPlan.Inputs)
+	if err != nil {
+		return nil, fmt.Errorf("subquery input extraction failed: %w", err)
+	}
 
 	// Check if we can batch execute with RelationInput
 	if canBatchSubquery(subqPlan.Subquery.Query) {
@@ -417,7 +420,7 @@ func executePhasesWithInputs(ctx Context, parentExec *Executor, plan *planner.Qu
 
 // getUniqueInputCombinations extracts unique combinations of input values.
 // This is a pure function that performs data transformation.
-func getUniqueInputCombinations(rel Relation, inputSymbols []query.Symbol) []map[query.Symbol]interface{} {
+func getUniqueInputCombinations(rel Relation, inputSymbols []query.Symbol) ([]map[query.Symbol]interface{}, error) {
 	// Find symbol indices for input symbols
 	indices := make([]int, len(inputSymbols))
 	for i, sym := range inputSymbols {
@@ -427,8 +430,7 @@ func getUniqueInputCombinations(rel Relation, inputSymbols []query.Symbol) []map
 		} else {
 			indices[i] = SymbolIndex(rel, sym)
 			if indices[i] < 0 {
-				// Symbol not found - should not happen if planner is correct
-				return nil
+				return nil, fmt.Errorf("subquery input symbol %s not found in outer relation (available: %v)", sym, rel.Symbols())
 			}
 		}
 	}
@@ -469,7 +471,7 @@ func getUniqueInputCombinations(rel Relation, inputSymbols []query.Symbol) []map
 		}
 	}
 
-	return combinations
+	return combinations, nil
 }
 
 // createInputRelationsFromPattern creates relations from a subquery pattern's inputs.

--- a/datalog/executor/subquery_input_error_test.go
+++ b/datalog/executor/subquery_input_error_test.go
@@ -1,0 +1,54 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestGetUniqueInputCombinations_MissingSymbolReturnsError verifies that
+// getUniqueInputCombinations returns an error when an input symbol is
+// not found in the relation, instead of silently returning nil.
+func TestGetUniqueInputCombinations_MissingSymbolReturnsError(t *testing.T) {
+	// Create a relation with symbols [?a, ?b]
+	rel := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?a"), datalog.NewSymbol("?b")},
+		[]Tuple{{"x", int64(1)}, {"y", int64(2)}},
+	)
+
+	t.Run("present_symbol_succeeds", func(t *testing.T) {
+		combos, err := getUniqueInputCombinations(rel, []query.Symbol{datalog.NewSymbol("?a")})
+		require.NoError(t, err)
+		assert.Len(t, combos, 2)
+	})
+
+	t.Run("missing_symbol_returns_error", func(t *testing.T) {
+		combos, err := getUniqueInputCombinations(rel, []query.Symbol{datalog.NewSymbol("?missing")})
+		assert.Error(t, err, "should error when input symbol is not in relation")
+		assert.Nil(t, combos)
+		assert.Contains(t, err.Error(), "?missing")
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("one_present_one_missing_returns_error", func(t *testing.T) {
+		combos, err := getUniqueInputCombinations(rel, []query.Symbol{
+			datalog.NewSymbol("?a"),
+			datalog.NewSymbol("?missing"),
+		})
+		assert.Error(t, err)
+		assert.Nil(t, combos)
+	})
+
+	t.Run("source_symbol_skipped", func(t *testing.T) {
+		// Source symbols (like $) use index -1 and should not trigger the error.
+		combos, err := getUniqueInputCombinations(rel, []query.Symbol{
+			datalog.NewSymbol("$"),
+			datalog.NewSymbol("?a"),
+		})
+		require.NoError(t, err)
+		assert.Len(t, combos, 2)
+	})
+}

--- a/datalog/planner/clause_utils.go
+++ b/datalog/planner/clause_utils.go
@@ -38,11 +38,7 @@ func extractClauseSymbols(clause query.Clause) ClauseSymbols {
 	case *query.OrClause:
 		return extractOrClauseSymbols(c)
 	case *query.OrJoinClause:
-		// Same symbol extraction as OrClause — join vars are planner scheduling
-		// metadata, not additional requirements. The algebra bridge infers join
-		// vars that may include branch-produced symbols; treating those as
-		// Requires would break phasing.
-		return extractOrClauseSymbols(&query.OrClause{Branches: c.Branches})
+		return extractOrJoinClauseSymbols(c)
 	case *query.OrDefaultClause:
 		return extractOrDefaultClauseSymbols(c)
 	case *query.OrDefaultJoinClause:
@@ -698,14 +694,46 @@ func findConstantBindableScalars(scalarInputs []query.Symbol, clauses []query.Cl
 	patternSyms := make(map[query.Symbol]bool)
 	collectDataPatternSymbols(clauses, patternSyms)
 
-	// Return scalar inputs not found in any data pattern
+	// Also collect symbols used as subquery inputs — these must remain in the
+	// relation so executeSubquery can extract them via getUniqueInputCombinations.
+	subqueryInputSyms := make(map[query.Symbol]bool)
+	collectSubqueryInputSymbols(clauses, subqueryInputSyms)
+
+	// Return scalar inputs not found in any data pattern or subquery input
 	var result []query.Symbol
 	for _, sym := range scalarInputs {
-		if !patternSyms[sym] {
+		if !patternSyms[sym] && !subqueryInputSyms[sym] {
 			result = append(result, sym)
 		}
 	}
 	return result
+}
+
+// collectSubqueryInputSymbols recursively walks clauses and collects all variable
+// symbols that appear as subquery inputs (the arguments passed to nested queries).
+func collectSubqueryInputSymbols(clauses []query.Clause, out map[query.Symbol]bool) {
+	for _, clause := range clauses {
+		switch c := clause.(type) {
+		case *query.SubqueryPattern:
+			for _, input := range c.Inputs {
+				if v, ok := input.(query.Variable); ok {
+					out[v.Name] = true
+				}
+			}
+		case *query.NotClause:
+			collectSubqueryInputSymbols(c.Clauses, out)
+		case *query.NotJoinClause:
+			collectSubqueryInputSymbols(c.Clauses, out)
+		case *query.OrClause:
+			for _, branch := range c.Branches {
+				collectSubqueryInputSymbols(branch, out)
+			}
+		case *query.OrJoinClause:
+			for _, branch := range c.Branches {
+				collectSubqueryInputSymbols(branch, out)
+			}
+		}
+	}
 }
 
 // collectDataPatternSymbols recursively walks clauses and collects all variable

--- a/datalog/storage/batch_scan_debug_test.go
+++ b/datalog/storage/batch_scan_debug_test.go
@@ -23,11 +23,10 @@ func TestBatchScanDebug(t *testing.T) {
 	tx := db.NewTransaction()
 
 	priceTime := datalog.NewKeyword(":price/time")
-	loc, _ := time.LoadLocation("America/New_York")
 
 	for i := 1; i <= 5; i++ {
 		entity := datalog.NewIdentity(fmt.Sprintf("e%d", i))
-		tm := time.Date(2025, 6, 2, 10+i, 0, 0, 0, loc) // All on day 2
+		tm := time.Date(2025, 6, 2, 10+i, 0, 0, 0, time.UTC) // All on day 2 UTC
 		tx.Add(entity, priceTime, tm)
 		t.Logf("Added: %s -> day %d", entity.String(), tm.Day())
 	}

--- a/datalog/storage/batch_scan_trace_test.go
+++ b/datalog/storage/batch_scan_trace_test.go
@@ -27,14 +27,12 @@ func TestBatchScanTrace(t *testing.T) {
 	priceSymbol := datalog.NewKeyword(":price/symbol")
 	priceTime := datalog.NewKeyword(":price/time")
 
-	loc, _ := time.LoadLocation("America/New_York")
-
-	// Create 200 bars - 100 on day 1, 100 on day 2
+	// Create 200 bars - 100 on day 1, 100 on day 2 (UTC)
 	tx = db.NewTransaction()
 	for day := 1; day <= 2; day++ {
 		for i := 0; i < 100; i++ {
 			barEntity := datalog.NewIdentity(fmt.Sprintf("bar-%d-%d", day, i))
-			barTime := time.Date(2025, 6, day, 9, 30+i, 0, 0, loc)
+			barTime := time.Date(2025, 6, day, 9, 30+i, 0, 0, time.UTC)
 			tx.Add(barEntity, priceSymbol, symbolEntity)
 			tx.Add(barEntity, priceTime, barTime)
 		}

--- a/datalog/storage/ohlc_realistic_test.go
+++ b/datalog/storage/ohlc_realistic_test.go
@@ -41,8 +41,6 @@ func TestOHLCRealisticQueries(t *testing.T) {
 	priceClose := datalog.NewKeyword(":price/close")
 	priceVolume := datalog.NewKeyword(":price/volume")
 
-	loc, _ := time.LoadLocation("America/New_York")
-
 	// Create CRWV symbol entity
 	tx := db.NewTransaction()
 	crwvEntity := datalog.NewIdentity("CRWV")
@@ -57,7 +55,7 @@ func TestOHLCRealisticQueries(t *testing.T) {
 	// Market hours: 9:30 AM (570 minutes) to 4:00 PM (960 minutes)
 	// 5-minute bars: 78 bars per day
 	tx = db.NewTransaction()
-	baseTime := time.Date(2025, 8, 22, 9, 30, 0, 0, loc)
+	baseTime := time.Date(2025, 8, 22, 9, 30, 0, 0, time.UTC)
 	basePrice := 100.0
 
 	for i := 0; i < 78; i++ {

--- a/datalog/storage/orjoin_cardinality_test.go
+++ b/datalog/storage/orjoin_cardinality_test.go
@@ -1,0 +1,67 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// TestOrJoinContainerItemCardinality verifies that the or-join test's
+// data model requires cardinality-many for :container/item.
+// Without schema, LWW keeps only the last write, losing item1.
+func TestOrJoinContainerItemCardinality(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cardinality-check-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	containerA := datalog.NewIdentity("container:A")
+	item1 := datalog.NewIdentity("item:1")
+	item2 := datalog.NewIdentity("item:2")
+	kw := datalog.NewKeyword
+
+	t.Run("without_schema_lww_loses_item1", func(t *testing.T) {
+		db, err := NewDatabase(t.TempDir())
+		require.NoError(t, err)
+		defer db.Close()
+
+		tx := db.NewTransaction()
+		tx.Add(containerA, kw(":container/item"), item1)
+		tx.Add(containerA, kw(":container/item"), item2)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+
+		results, err := executor.CollectTuples(db.Query(
+			`[:find ?item :where [?c :container/item ?item]]`))
+		require.NoError(t, err)
+		t.Logf("Without schema: %v", results)
+		// LWW: only the last write survives
+		assert.Len(t, results, 1, "without schema, LWW keeps only last write")
+	})
+
+	t.Run("with_schema_both_items_kept", func(t *testing.T) {
+		s := schema.NewBuilder().
+			Attribute(":container/item").Type(schema.TypeRef).Many().Add().
+			MustBuild()
+
+		db, err := NewDatabaseWithSchema(t.TempDir(), s)
+		require.NoError(t, err)
+		defer db.Close()
+
+		tx := db.NewTransaction()
+		tx.Add(containerA, kw(":container/item"), item1)
+		tx.Add(containerA, kw(":container/item"), item2)
+		_, err = tx.Commit()
+		require.NoError(t, err)
+
+		results, err := executor.CollectTuples(db.Query(
+			`[:find ?item :where [?c :container/item ?item]]`))
+		require.NoError(t, err)
+		t.Logf("With schema: %v", results)
+		assert.Len(t, results, 2, "with schema, cardinality-many keeps both")
+	})
+}

--- a/datalog/storage/orjoin_projection_regression_test.go
+++ b/datalog/storage/orjoin_projection_regression_test.go
@@ -1,0 +1,175 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/qb"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// TestOrJoinProjectionInheritsOuterBindings reproduces the bug documented in
+// docs/bugs/active/ORJOIN_PROJECTION_REQUIRES_REBINDING.md
+//
+// When or-join projection variables are already bound by outer clauses,
+// Datomic makes those bindings available inside each branch. Janus Datalog
+// currently does not: it converts or-join to plain or, discarding the
+// JoinVars, so branches execute without outer context.
+//
+// Data model: containers have an owner, location, and items.
+// Items or containers can be flagged. Containers can be archived or deleted.
+//
+// The query: find items in containers matching an owner+location, where
+// either the item OR its container is flagged, excluding archived/deleted
+// containers.
+func TestOrJoinProjectionInheritsOuterBindings(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "orjoin-projection-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Schema: :container/item is cardinality-many (a container has multiple items)
+	s := schema.NewBuilder().
+		Attribute(":container/item").Type(schema.TypeRef).Many().Add().
+		MustBuild()
+
+	db, err := NewDatabaseWithSchema(tmpDir, s)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Set up data
+	containerA := datalog.NewIdentity("container:A")
+	containerB := datalog.NewIdentity("container:B")
+	containerC := datalog.NewIdentity("container:C")
+	item1 := datalog.NewIdentity("item:1")
+	item2 := datalog.NewIdentity("item:2")
+	item3 := datalog.NewIdentity("item:3")
+	item4 := datalog.NewIdentity("item:4")
+	owner := datalog.NewIdentity("owner:alice")
+
+	kw := datalog.NewKeyword
+
+	tx := db.NewTransaction()
+	// Container A: owned by alice, in warehouse-1, has items 1 and 2
+	tx.Add(containerA, kw(":container/owner"), owner)
+	tx.Add(containerA, kw(":container/location"), "warehouse-1")
+	tx.Add(containerA, kw(":container/item"), item1)
+	tx.Add(containerA, kw(":container/item"), item2)
+
+	// Container B: owned by alice, in warehouse-1, has item 3, is archived
+	tx.Add(containerB, kw(":container/owner"), owner)
+	tx.Add(containerB, kw(":container/location"), "warehouse-1")
+	tx.Add(containerB, kw(":container/item"), item3)
+	tx.Add(containerB, kw(":container/archived"), true)
+
+	// Container C: owned by alice, in warehouse-2, has item 4
+	tx.Add(containerC, kw(":container/owner"), owner)
+	tx.Add(containerC, kw(":container/location"), "warehouse-2")
+	tx.Add(containerC, kw(":container/item"), item4)
+
+	// Item 1: flagged (item-level flag)
+	tx.Add(item1, kw(":item/flagged"), true)
+	// Item 2: not flagged, but container A is flagged (container-level flag)
+	tx.Add(containerA, kw(":item/flagged"), true)
+	// Item 3: flagged, but container B is archived (should be excluded)
+	tx.Add(item3, kw(":item/flagged"), true)
+	// Item 4: flagged, but in warehouse-2 (should be excluded by location filter)
+	tx.Add(item4, kw(":item/flagged"), true)
+
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	t.Run("idiomatic_or_join_with_outer_bindings", func(t *testing.T) {
+		// This is the idiomatic Datomic pattern from the bug doc.
+		// ?container and ?item are bound by outer clauses; the or-join
+		// varies which entity carries :item/flagged.
+		//
+		// Expected: items 1 and 2 from container A (warehouse-1, not archived)
+		// Item 1 matches because it is directly flagged.
+		// Item 2 matches because its container (A) is flagged.
+		// Item 3 excluded: container B is archived.
+		// Item 4 excluded: container C is in warehouse-2.
+		result, err := executor.CollectTuples(db.Query(
+			`[:find ?item
+			  :in $ ?owner ?location
+			  :where
+			  [?container :container/owner ?owner]
+			  [?container :container/location ?location]
+			  [?container :container/item ?item]
+			  (or-join [?container ?item]
+			    [?item :item/flagged true]
+			    [?container :item/flagged true])
+			  (not [?container :container/archived true])]`,
+			owner, "warehouse-1"))
+		require.NoError(t, err, "or-join with outer-bound projection variables should not error")
+		assert.Len(t, result, 2, "should find 2 flagged items in warehouse-1")
+	})
+
+	t.Run("workaround_repeated_bindings", func(t *testing.T) {
+		// The documented workaround: duplicate binding clauses inside each branch.
+		result, err := executor.CollectTuples(db.Query(
+			`[:find ?item
+			  :in $ ?owner ?location
+			  :where
+			  (or-join [?container ?item]
+			    (and [?container :container/owner ?owner]
+			         [?container :container/location ?location]
+			         [?container :container/item ?item]
+			         [?item :item/flagged true])
+			    (and [?container :container/owner ?owner]
+			         [?container :container/location ?location]
+			         [?container :container/item ?item]
+			         [?container :item/flagged true]))
+			  (not [?container :container/archived true])]`,
+			owner, "warehouse-1"))
+		require.NoError(t, err)
+		assert.Len(t, result, 2, "workaround should find 2 flagged items")
+	})
+
+	t.Run("qb_or_join_with_outer_bindings", func(t *testing.T) {
+		// Same query via the qb builder.
+		container := qb.NewVar("container")
+		item := qb.NewVar("item")
+		ownerVar := qb.NewVar("owner")
+		locationVar := qb.NewVar("location")
+
+		q := qb.Query().
+			Find(item).
+			In(qb.DB, qb.Scalar(ownerVar), qb.Scalar(locationVar)).
+			Where(
+				qb.Pat(container, qb.Kw(":container/owner"), ownerVar),
+				qb.Pat(container, qb.Kw(":container/location"), locationVar),
+				qb.Pat(container, qb.Kw(":container/item"), item),
+				qb.OrJoin(container, item).
+					Branch(qb.Pat(item, qb.Kw(":item/flagged"), qb.V(true))).
+					Branch(qb.Pat(container, qb.Kw(":item/flagged"), qb.V(true))),
+				qb.Not(qb.Pat(container, qb.Kw(":container/archived"), qb.V(true))),
+			).
+			MustBuild()
+
+		result, err := executor.CollectTuples(db.Query(q, owner, "warehouse-1"))
+		require.NoError(t, err, "qb or-join with outer-bound projection variables should not error")
+		assert.Len(t, result, 2, "should find 2 flagged items in warehouse-1")
+	})
+
+	t.Run("simple_or_join_projects_outer_variable", func(t *testing.T) {
+		// Minimal reproduction: or-join lists a variable in its projection
+		// that is only bound by an outer clause, not by any branch.
+		// The or-join should carry the outer binding through.
+		result, err := executor.CollectTuples(db.Query(
+			`[:find ?container ?item
+			  :where
+			  [?container :container/item ?item]
+			  (or-join [?container ?item]
+			    [?item :item/flagged true]
+			    [?container :item/flagged true])]`))
+		require.NoError(t, err, "or-join should inherit outer binding for ?container")
+		// Items 1 (item flagged), 2 (container A flagged), 3 (item flagged), 4 (item flagged)
+		// Container A is flagged, so all its items (1, 2) match via either branch.
+		assert.GreaterOrEqual(t, len(result), 3,
+			"should find items where either the item or container is flagged")
+	})
+}

--- a/datalog/value_encoding.go
+++ b/datalog/value_encoding.go
@@ -164,7 +164,7 @@ func ValueFromBytes(vType ValueType, data []byte) (Value, error) {
 			return nil, fmt.Errorf("time value must be 8 bytes, got %d", len(data))
 		}
 		nanos := int64(binary.BigEndian.Uint64(data))
-		return time.Unix(0, nanos), nil
+		return time.Unix(0, nanos).UTC(), nil
 	case TypeBytes:
 		return data, nil
 	case TypeReference:

--- a/docs/bugs/resolved/ORJOIN_PROJECTION_REQUIRES_REBINDING.md
+++ b/docs/bugs/resolved/ORJOIN_PROJECTION_REQUIRES_REBINDING.md
@@ -1,0 +1,104 @@
+# or-join projection variables must be independently bound in each branch
+
+## Trigger
+
+A query uses `or-join` to check a condition on two different entities, with shared bindings established in outer clauses:
+
+```clojure
+[:find ?item
+ :in $ ?owner ?location
+ :where
+ [?container :container/owner ?owner]
+ [?container :container/location ?location]
+ [?container :container/item ?item]
+ (or-join [?container ?item]
+   [?item :item/flagged true]
+   [?container :item/flagged true])
+ (not [?container :container/archived true])
+ (not [?container :entity/deleted true])]
+```
+
+The intent: `?container` and `?item` are bound by the outer clauses; the `or-join` just varies which entity carries the `:item/flagged` attribute. This is the idiomatic Datomic pattern for "check a property on either of two related entities."
+
+## Error
+
+```
+NOT-JOIN variable ?container not found in input relation
+```
+
+The trailing `(not ...)` clause fails because the planner does not propagate the outer bindings of `?container` and `?item` through the `or-join`.
+
+## Workaround
+
+Repeat all binding clauses inside each `or-join` branch so every projection variable is independently bound:
+
+```clojure
+[:find ?item
+ :in $ ?owner ?location
+ :where
+ (or-join [?container ?item]
+   (and [?container :container/owner ?owner]
+        [?container :container/location ?location]
+        [?container :container/item ?item]
+        [?item :item/flagged true])
+   (and [?container :container/owner ?owner]
+        [?container :container/location ?location]
+        [?container :container/item ?item]
+        [?container :item/flagged true]))
+ (not [?container :container/archived true])
+ (not [?container :entity/deleted true])]
+```
+
+This works but duplicates the binding clauses across every branch, making queries verbose and fragile.
+
+## Root cause
+
+The planner treats `or-join` branches as independent subqueries. Each branch must produce a complete relation for the projection variables listed in the `or-join` head. When a branch contains only `[?item :item/flagged true]`, the planner sees `?container` as unbound within that branch and either drops it from the output relation or errors when a downstream clause (like `not-join`) references it.
+
+In Datomic, `or-join` inherits bindings from the enclosing `where` context. Variables bound before the `or-join` are available inside each branch without re-binding. The janus-datalog planner does not implement this outer-binding inheritance for `or-join` projection variables.
+
+## Impact
+
+Any `or-join` that varies a condition while depending on shared bindings from outer clauses requires duplicating those outer clauses inside every branch. For queries with many shared predicates and multiple `or-join` branches, this can triple or quadruple the query size.
+
+## Expected behavior
+
+Variables named in `or-join`'s projection list that are already bound in the enclosing `where` context should be available inside each branch. Branches should only need to bind variables that are new to the branch. The `or-join` result should be the union of branch results, with outer-bound variables carried through.
+
+## Discovered
+
+2026-04-14. A query needed to check a boolean flag on either of two related entities joined by a reference attribute. The idiomatic single-clause-per-branch form produced the NOT-JOIN error; the workaround required duplicating three binding clauses into each branch.
+
+## Root cause (resolved 2026-04-15)
+
+Three independent bugs, all in the "silent failure" family:
+
+### 1. Planner: `extractOrJoinClauseSymbols` was dead code
+
+`extractClauseSymbols` in `clause_utils.go` had a correct `extractOrJoinClauseSymbols` function (line 414) that properly tracked join vars as Requires when not produced by all branches. But the switch case at line 40 bypassed it, converting OrJoinClause to OrClause and discarding JoinVars with the comment "join vars are planner scheduling metadata." This meant the planner never knew that or-join needed outer-bound variables.
+
+**Fix**: Changed the switch case to call `extractOrJoinClauseSymbols`.
+
+### 2. Executor: `executeOrJoinClause` was dead code
+
+Both call sites (lines 164 and 2087 in `query_executor.go`) converted `OrJoinClause` to `OrClause` before executing, discarding JoinVars. A correct `executeOrJoinClause` function existed at line 1625 with correlated union logic but was never called.
+
+**Fix**: Changed both call sites to call `executeOrJoinClause`. Simplified the function to always use correlated execution, since or-join's purpose is to vary which clause matches while preserving outer-bound join variables — the uncorrelated path is semantically wrong for or-join.
+
+### 3. `findConstantBindableScalars` removed subquery inputs from relations
+
+Scalar inputs that only appeared as subquery arguments (not in data patterns) were classified as "constant-bindable" and projected out of the input relation. The subquery executor then couldn't find them. This was a separate silent failure: `getUniqueInputCombinations` returned `nil` (no error) when an input symbol was missing.
+
+**Fix**: `findConstantBindableScalars` now also checks `collectSubqueryInputSymbols` before classifying a scalar as constant-bindable. `getUniqueInputCombinations` now returns an error instead of silent nil.
+
+### Additional fixes found during investigation
+
+- **Empty subquery results silently skipped**: `executeSubquery` had a `continue` that skipped input combinations when the nested query returned zero groups. Replaced with explicit empty relation creation so the code path is transparent.
+- **Time values decoded in local timezone**: `value_encoding.go` used `time.Unix(0, nanos)` which returns local time, not UTC. On machines in non-UTC zones, `day`/`month`/`year` extraction returned wrong values. Fixed to `time.Unix(0, nanos).UTC()`.
+
+## Regression tests
+
+- `datalog/storage/orjoin_projection_regression_test.go` — 4 subtests covering the idiomatic pattern, the workaround, the qb builder variant, and the simple case
+- `datalog/storage/orjoin_cardinality_test.go` — verifies that multi-valued attributes require cardinality-many schema
+- `datalog/executor/subquery_input_error_test.go` — verifies `getUniqueInputCombinations` returns errors for missing symbols
+- `datalog/executor/product_test.go` — verifies `Product()` preserves disjoint symbols


### PR DESCRIPTION
## Summary

Fixes three classes of bugs found while investigating the or-join projection issue documented in `docs/bugs/active/ORJOIN_PROJECTION_REQUIRES_REBINDING.md`.

**Or-join outer bindings**: The planner and executor both converted `OrJoinClause` to plain `OrClause`, discarding JoinVars. Correct implementations existed as dead code. Wired them up; `executeOrJoinClause` now always uses correlated execution (the correct semantics for or-join).

**Silent subquery failures**: `getUniqueInputCombinations` returned nil instead of an error when input symbols were missing. `findConstantBindableScalars` incorrectly projected subquery input variables out of the input relation. Empty nested query results were silently skipped via `continue`. All three now surface errors or produce explicit empty relations.

**UTC time decoding**: `value_encoding.go` used `time.Unix(0, nanos)` which returns local time, not UTC. Day/month/year extraction produced wrong results on non-UTC machines. Fixed to `time.Unix(0, nanos).UTC()`.

## Test plan

- [x] `TestOrJoinProjectionInheritsOuterBindings` — 4 subtests for or-join with outer-bound projection variables
- [x] `TestOrJoinContainerItemCardinality` — verifies LWW vs cardinality-many behavior
- [x] `TestGetUniqueInputCombinations_MissingSymbolReturnsError` — verifies error on missing input symbols
- [x] `TestProductPreservesDisjointSymbols` — verifies Product preserves symbols from all groups
- [x] `TestCacheMatrix_ABoundViaSubquery` — was silently returning wrong results, now passes
- [x] `TestBatchScanDebug`, `TestBatchScanTrace`, `TestOHLCRealisticQueries` — timezone fixes, all pass
- [x] Full test suite: `go test -count=1 ./...` — all green