### PR TITLE
Fix byte-value panics and attribute-length truncation/collision

### DIFF
--- a/datalog/intern.go
+++ b/datalog/intern.go
@@ -9,44 +9,46 @@ import (
 
 // keywordInternCache provides keyword interning to avoid repeated allocations
 // Uses sync.Map for lock-free concurrent reads
-// Cache key is [32]byte (null-padded) to match storage format
+// Cache key is the full keyword string so distinct keywords never collide,
+// regardless of length. (The 32-byte storage form is a separate concern,
+// enforced by length validation on the write/schema paths.)
 type keywordInternCache struct {
-	cache sync.Map // map[[32]byte]Keyword
+	cache sync.Map // map[string]Keyword
 }
 
 // Global keyword intern instance
 var keywordIntern = &keywordInternCache{}
 
 // InternKeyword returns an interned keyword instance.
-// Pads the string to 32 bytes for cache key lookup.
+// Keyed by the full string, so two distinct keywords never share a pointer
+// even if their first 32 bytes match.
 func InternKeyword(s string) Keyword {
-	// Pad to 32 bytes for cache key (matches storage format)
-	var key [32]byte
-	copy(key[:], s)
-
 	// Fast path: load existing (lock-free)
-	if val, ok := keywordIntern.cache.Load(key); ok {
+	if val, ok := keywordIntern.cache.Load(s); ok {
 		return val.(Keyword)
 	}
 
 	// Slow path: create and store
 	kw := &keyword{value: s}
-	actual, _ := keywordIntern.cache.LoadOrStore(key, kw)
+	actual, _ := keywordIntern.cache.LoadOrStore(s, kw)
 	return actual.(Keyword)
 }
 
 // InternKeywordFromBytes returns an interned keyword from storage bytes.
-// Uses the 32-byte key directly without conversion.
+// The null padding is trimmed to recover the keyword string, which is the
+// cache key — so a keyword decoded from storage shares the same interned
+// pointer as one created via InternKeyword.
 func InternKeywordFromBytes(key [32]byte) Keyword {
+	str := strings.TrimRight(string(key[:]), "\x00")
+
 	// Fast path: load existing (lock-free)
-	if val, ok := keywordIntern.cache.Load(key); ok {
+	if val, ok := keywordIntern.cache.Load(str); ok {
 		return val.(Keyword)
 	}
 
-	// Slow path: trim null padding to get string, create and store
-	str := strings.TrimRight(string(key[:]), "\x00")
+	// Slow path: create and store
 	kw := &keyword{value: str}
-	actual, _ := keywordIntern.cache.LoadOrStore(key, kw)
+	actual, _ := keywordIntern.cache.LoadOrStore(str, kw)
 	return actual.(Keyword)
 }
 

--- a/datalog/keyword_intern_collision_test.go
+++ b/datalog/keyword_intern_collision_test.go
@@ -1,0 +1,33 @@
+package datalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// Reproduction for docs/bugs/BUG_ATTRIBUTE_KEY_TRUNCATION_COLLISION.md
+//
+// InternKeyword keys the intern cache by a [32]byte buffer filled with
+// copy(key[:], s), which silently truncates strings longer than 32 bytes.
+// Two distinct keyword strings that share their first 32 bytes therefore
+// intern to the same *keyword pointer.
+func TestKeywordInterning_LongNamesDoNotCollide(t *testing.T) {
+	// 42 bytes of shared prefix — well past the 32-byte intern key — so the
+	// distinguishing suffix lives entirely beyond the truncation boundary.
+	shared := ":collintern/" + strings.Repeat("x", 30)
+	n1 := shared + "-one"
+	n2 := shared + "-two"
+
+	a1 := NewKeyword(n1)
+	a2 := NewKeyword(n2)
+
+	if a1 == a2 {
+		t.Fatalf("distinct keywords interned to the same pointer: %q and %q share their first 32 bytes and were truncated", n1, n2)
+	}
+	if got := a1.String(); got != n1 {
+		t.Errorf("a1.String() = %q, want %q", got, n1)
+	}
+	if got := a2.String(); got != n2 {
+		t.Errorf("a2.String() = %q, want %q", got, n2)
+	}
+}

--- a/datalog/reflect/ordered_set_test.go
+++ b/datalog/reflect/ordered_set_test.go
@@ -165,15 +165,15 @@ func (m *mockTransaction) LookupAllAttributes(entity datalog.Identity, attr data
 	return nil, nil
 }
 
-// CharacterWithPreferences tests OrderedSet[string] fields
-type CharacterWithPreferences struct {
+// CharacterPrefs tests OrderedSet[string] fields
+type CharacterPrefs struct {
 	ID    datalog.Identity           `datalog:"-,id"`
 	Name  string                     `datalog:"name"`
 	Prefs datalog.OrderedSet[string] `datalog:"prefs"`
 }
 
-// EntityWithOrderedRefs tests OrderedSet[datalog.Identity] fields
-type EntityWithOrderedRefs struct {
+// EntityOrderedRefs tests OrderedSet[datalog.Identity] fields
+type EntityOrderedRefs struct {
 	ID      datalog.Identity                     `datalog:"-,id"`
 	Name    string                               `datalog:"name"`
 	Follows datalog.OrderedSet[datalog.Identity] `datalog:"follows"`
@@ -182,24 +182,24 @@ type EntityWithOrderedRefs struct {
 // TestSchemaFromStruct_OrderedSet verifies that SchemaFromStruct correctly infers
 // CardinalityVector with UniqueElements for OrderedSet fields.
 func TestSchemaFromStruct_OrderedSet(t *testing.T) {
-	sch, err := dlreflect.SchemaFromStruct(CharacterWithPreferences{})
+	sch, err := dlreflect.SchemaFromStruct(CharacterPrefs{})
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
 
 	// Check name attribute (regular string)
-	nameAttr := sch.GetAttribute(datalog.NewKeyword(":character-with-preferences/name"))
+	nameAttr := sch.GetAttribute(datalog.NewKeyword(":character-prefs/name"))
 	if nameAttr == nil {
-		t.Fatal("expected :character-with-preferences/name attribute")
+		t.Fatal("expected :character-prefs/name attribute")
 	}
 	if nameAttr.Cardinality != schema.CardinalityOne {
 		t.Errorf("expected name cardinality=one, got %s", nameAttr.Cardinality)
 	}
 
 	// Check prefs attribute (OrderedSet)
-	prefsAttr := sch.GetAttribute(datalog.NewKeyword(":character-with-preferences/prefs"))
+	prefsAttr := sch.GetAttribute(datalog.NewKeyword(":character-prefs/prefs"))
 	if prefsAttr == nil {
-		t.Fatal("expected :character-with-preferences/prefs attribute")
+		t.Fatal("expected :character-prefs/prefs attribute")
 	}
 
 	t.Logf("Prefs attribute: cardinality=%s, uniqueElements=%v, type=%s",
@@ -218,14 +218,14 @@ func TestSchemaFromStruct_OrderedSet(t *testing.T) {
 
 // TestSchemaFromStruct_OrderedSetRef verifies ref types in OrderedSet
 func TestSchemaFromStruct_OrderedSetRef(t *testing.T) {
-	sch, err := dlreflect.SchemaFromStruct(EntityWithOrderedRefs{})
+	sch, err := dlreflect.SchemaFromStruct(EntityOrderedRefs{})
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
 
-	followsAttr := sch.GetAttribute(datalog.NewKeyword(":entity-with-ordered-refs/follows"))
+	followsAttr := sch.GetAttribute(datalog.NewKeyword(":entity-ordered-refs/follows"))
 	if followsAttr == nil {
-		t.Fatal("expected :entity-with-ordered-refs/follows attribute")
+		t.Fatal("expected :entity-ordered-refs/follows attribute")
 	}
 
 	t.Logf("Follows attribute: cardinality=%s, uniqueElements=%v, type=%s",
@@ -251,13 +251,13 @@ func TestSaveStruct_OrderedSet_SchemaVerify(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create schema from struct
-	sch, err := dlreflect.SchemaFromStruct(CharacterWithPreferences{})
+	sch, err := dlreflect.SchemaFromStruct(CharacterPrefs{})
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
 
 	// Verify attribute exists in schema
-	prefsKw := datalog.NewKeyword(":character-with-preferences/prefs")
+	prefsKw := datalog.NewKeyword(":character-prefs/prefs")
 	prefsAttr := sch.GetAttribute(prefsKw)
 	if prefsAttr == nil {
 		t.Fatalf("prefs attribute not found in schema")
@@ -301,7 +301,7 @@ func TestSaveStruct_OrderedSet_SchemaVerify(t *testing.T) {
 	// Note: Vectors return the entire ordered list as a single value (array)
 	// This is different from sets where each element is a separate tuple
 	tuples, err := executor.CollectTuples(db.Query(
-		`[:find ?v :in $ ?e :where [?e :character-with-preferences/prefs ?v]]`,
+		`[:find ?v :in $ ?e :where [?e :character-prefs/prefs ?v]]`,
 		entityID,
 	))
 	if err != nil {
@@ -333,7 +333,7 @@ func TestSaveStruct_OrderedSet(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create schema from struct
-	sch, err := dlreflect.SchemaFromStruct(CharacterWithPreferences{})
+	sch, err := dlreflect.SchemaFromStruct(CharacterPrefs{})
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
@@ -350,7 +350,7 @@ func TestSaveStruct_OrderedSet(t *testing.T) {
 	prefs.Append("compact-view")
 	prefs.Append("notifications")
 
-	character := CharacterWithPreferences{
+	character := CharacterPrefs{
 		Name:  "Alice",
 		Prefs: *prefs,
 	}
@@ -369,7 +369,7 @@ func TestSaveStruct_OrderedSet(t *testing.T) {
 	// Query to verify values are stored
 	// Note: Vectors return entire ordered list as single array value
 	tuples, err := executor.CollectTuples(db.Query(
-		`[:find ?v :in $ ?e :where [?e :character-with-preferences/prefs ?v]]`,
+		`[:find ?v :in $ ?e :where [?e :character-prefs/prefs ?v]]`,
 		charID,
 	))
 	if err != nil {
@@ -399,7 +399,7 @@ func TestSaveStruct_OrderedSetDuplicates(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	sch, err := dlreflect.SchemaFromStruct(CharacterWithPreferences{})
+	sch, err := dlreflect.SchemaFromStruct(CharacterPrefs{})
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
@@ -415,7 +415,7 @@ func TestSaveStruct_OrderedSetDuplicates(t *testing.T) {
 	prefs.Append("a")
 	prefs.Append("b")
 
-	character := CharacterWithPreferences{
+	character := CharacterPrefs{
 		Name:  "Bob",
 		Prefs: *prefs,
 	}
@@ -431,7 +431,7 @@ func TestSaveStruct_OrderedSetDuplicates(t *testing.T) {
 
 	// Try to add a duplicate via direct transaction
 	tx2 := db.NewTransaction()
-	kw := datalog.NewKeyword(":character-with-preferences/prefs")
+	kw := datalog.NewKeyword(":character-prefs/prefs")
 	// Adding "a" again should be a no-op due to UniqueElements enforcement
 	if err := tx2.Add(charID, kw, "a"); err != nil {
 		t.Fatalf("Add failed: %v", err)
@@ -442,7 +442,7 @@ func TestSaveStruct_OrderedSetDuplicates(t *testing.T) {
 
 	// Query to verify - vectors return as single array value
 	tuples, err := executor.CollectTuples(db.Query(
-		`[:find ?v :in $ ?e :where [?e :character-with-preferences/prefs ?v]]`,
+		`[:find ?v :in $ ?e :where [?e :character-prefs/prefs ?v]]`,
 		charID,
 	))
 	if err != nil {
@@ -473,7 +473,7 @@ func TestPullInto_OrderedSet(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	sch, err := dlreflect.SchemaFromStruct(CharacterWithPreferences{})
+	sch, err := dlreflect.SchemaFromStruct(CharacterPrefs{})
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
@@ -490,7 +490,7 @@ func TestPullInto_OrderedSet(t *testing.T) {
 	prefs.Append("compact-view")
 	prefs.Append("notifications")
 
-	character := CharacterWithPreferences{
+	character := CharacterPrefs{
 		Name:  "Alice",
 		Prefs: *prefs,
 	}
@@ -505,7 +505,7 @@ func TestPullInto_OrderedSet(t *testing.T) {
 	}
 
 	// Pull back into new struct
-	var loaded CharacterWithPreferences
+	var loaded CharacterPrefs
 	if err := db.PullInto(charID, &loaded); err != nil {
 		t.Fatalf("PullInto failed: %v", err)
 	}
@@ -541,7 +541,7 @@ func TestSaveStruct_OrderedSetUpdate(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	sch, err := dlreflect.SchemaFromStruct(CharacterWithPreferences{})
+	sch, err := dlreflect.SchemaFromStruct(CharacterPrefs{})
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
@@ -558,7 +558,7 @@ func TestSaveStruct_OrderedSetUpdate(t *testing.T) {
 	prefs.Append("b")
 	prefs.Append("c")
 
-	character := CharacterWithPreferences{
+	character := CharacterPrefs{
 		Name:  "Carol",
 		Prefs: *prefs,
 	}
@@ -589,7 +589,7 @@ func TestSaveStruct_OrderedSetUpdate(t *testing.T) {
 	}
 
 	// Pull back and verify
-	var loaded CharacterWithPreferences
+	var loaded CharacterPrefs
 	if err := db.PullInto(charID, &loaded); err != nil {
 		t.Fatalf("PullInto failed: %v", err)
 	}
@@ -677,7 +677,7 @@ func TestSaveStruct_OrderedSetEmpty(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	sch, err := dlreflect.SchemaFromStruct(CharacterWithPreferences{})
+	sch, err := dlreflect.SchemaFromStruct(CharacterPrefs{})
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
@@ -689,7 +689,7 @@ func TestSaveStruct_OrderedSetEmpty(t *testing.T) {
 	defer db.Close()
 
 	// Create character with empty OrderedSet
-	character := CharacterWithPreferences{
+	character := CharacterPrefs{
 		Name:  "Eve",
 		Prefs: datalog.OrderedSet[string]{}, // zero value
 	}
@@ -704,7 +704,7 @@ func TestSaveStruct_OrderedSetEmpty(t *testing.T) {
 	}
 
 	// Pull back
-	var loaded CharacterWithPreferences
+	var loaded CharacterPrefs
 	if err := db.PullInto(charID, &loaded); err != nil {
 		t.Fatalf("PullInto failed: %v", err)
 	}
@@ -727,7 +727,7 @@ func TestSaveStruct_OrderedSetRefs(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	sch, err := dlreflect.SchemaFromStruct(EntityWithOrderedRefs{})
+	sch, err := dlreflect.SchemaFromStruct(EntityOrderedRefs{})
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
@@ -749,7 +749,7 @@ func TestSaveStruct_OrderedSetRefs(t *testing.T) {
 	follows.Append(id2)
 	follows.Append(id3)
 
-	entity := EntityWithOrderedRefs{
+	entity := EntityOrderedRefs{
 		Name:    "Dave",
 		Follows: *follows,
 	}
@@ -766,7 +766,7 @@ func TestSaveStruct_OrderedSetRefs(t *testing.T) {
 	// Query to verify refs are stored
 	// Note: Vectors return entire ordered list as single array value
 	tuples, err := executor.CollectTuples(db.Query(
-		`[:find ?f :in $ ?e :where [?e :entity-with-ordered-refs/follows ?f]]`,
+		`[:find ?f :in $ ?e :where [?e :entity-ordered-refs/follows ?f]]`,
 		entityID,
 	))
 	if err != nil {
@@ -788,7 +788,7 @@ func TestSaveStruct_OrderedSetRefs(t *testing.T) {
 	}
 
 	// Pull back and verify
-	var loaded EntityWithOrderedRefs
+	var loaded EntityOrderedRefs
 	if err := db.PullInto(entityID, &loaded); err != nil {
 		t.Fatalf("PullInto failed: %v", err)
 	}

--- a/datalog/schema/builder.go
+++ b/datalog/schema/builder.go
@@ -124,6 +124,12 @@ func (ab *AttributeBuilder) Add() *Builder {
 		return ab.parent
 	}
 
+	// Reject attribute names too long to store without truncation/aliasing.
+	if n := len(ab.def.Ident.String()); n > datalog.MaxAttributeBytes {
+		ab.parent.errors = append(ab.parent.errors, fmt.Errorf("attribute %q is %d bytes, exceeds the %d-byte storage limit", ab.def.Ident.String(), n, datalog.MaxAttributeBytes))
+		return ab.parent
+	}
+
 	ab.parent.schema.Add(ab.def)
 	return ab.parent
 }

--- a/datalog/storage/attribute_truncation_collision_test.go
+++ b/datalog/storage/attribute_truncation_collision_test.go
@@ -1,0 +1,76 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// Tests for docs/bugs/BUG_ATTRIBUTE_KEY_TRUNCATION_COLLISION.md (storage side).
+//
+// Policy: reject. The storage Attribute is a fixed [32]byte; rather than
+// truncating (and silently aliasing) longer names, writes and schema
+// definitions of over-length attributes fail with a clear error.
+// (The interning half is covered by datalog.TestKeywordInterning_LongNamesDoNotCollide.)
+
+// longAttrName is well past the 32-byte storage limit.
+func longAttrName() string {
+	return ":collision/" + strings.Repeat("x", 30) // 41 bytes
+}
+
+// TestStorage_LongAttributeNameRejectedOnWrite: every write entry point rejects
+// an over-length attribute instead of truncating it.
+func TestStorage_LongAttributeNameRejectedOnWrite(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	e := datalog.NewIdentity("entity-1")
+	a := datalog.NewKeyword(longAttrName())
+	require.Greater(t, len(a.String()), datalog.MaxAttributeBytes)
+
+	tx := db.NewTransaction()
+	require.Error(t, tx.Set(e, a, "v"), "Set must reject over-length attribute")
+	require.Error(t, tx.Add(e, a, "v"), "Add must reject over-length attribute")
+	require.Error(t, tx.Remove(e, a, "v"), "Remove must reject over-length attribute")
+	require.Error(t, tx.Retract(e, a, "v"), "Retract must reject over-length attribute")
+}
+
+// TestSchema_LongAttributeDefinitionRejected: schema construction rejects an
+// over-length attribute ident.
+func TestSchema_LongAttributeDefinitionRejected(t *testing.T) {
+	_, err := schema.NewBuilder().
+		Attribute(longAttrName()).Type(schema.TypeString).One().Add().
+		Build()
+	require.Error(t, err, "Build must reject over-length attribute definition")
+}
+
+// TestStorage_MaxLengthAttributeNameAccepted: a name exactly at the limit is
+// accepted and round-trips (guards against an off-by-one that would reject
+// valid names).
+func TestStorage_MaxLengthAttributeNameAccepted(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// ":boundary/" is 10 bytes; pad to exactly MaxAttributeBytes.
+	name := ":boundary/" + strings.Repeat("a", datalog.MaxAttributeBytes-len(":boundary/"))
+	require.Len(t, name, datalog.MaxAttributeBytes)
+
+	e := datalog.NewIdentity("entity-boundary")
+	a := datalog.NewKeyword(name)
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, "value-at-limit"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	full, err := db.Pull(e, `[*]`)
+	require.NoError(t, err)
+	require.Equal(t, "value-at-limit", full[strings.TrimPrefix(name, ":")])
+}

--- a/datalog/storage/cardinality_many_set_bytes_test.go
+++ b/datalog/storage/cardinality_many_set_bytes_test.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// Reproductions for docs/bugs/BUG_CARDINALITY_MANY_SET_BYTES_PANIC.md
+//
+// Transaction.Set for cardinality-many builds map[interface{}]bool keyed
+// directly by set members (newSet[val], pendingAdds[v], pendingRemoves[v]).
+// []byte is a valid TypeBytes value but is not a valid Go map key, so Set
+// panics with "hash of unhashable type []uint8".
+
+func newBytesManyDB(t *testing.T) (*Database, datalog.Identity, datalog.Keyword) {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := schema.NewBuilder().
+		Attribute(":file/chunks").Type(schema.TypeBytes).Many().Add().
+		Build()
+	require.NoError(t, err)
+	db, err := NewDatabaseWithSchema(dir, s)
+	require.NoError(t, err)
+	return db, datalog.NewIdentity("file-1"), datalog.NewKeyword(":file/chunks")
+}
+
+func collectByteSet(t *testing.T, db *Database, e datalog.Identity) [][]byte {
+	t.Helper()
+	rows, err := executor.CollectTuples(db.Query(`[:find ?v :in $ ?e :where [?e :file/chunks ?v]]`, e))
+	require.NoError(t, err)
+	out := make([][]byte, 0, len(rows))
+	for _, row := range rows {
+		b, ok := row[0].([]byte)
+		require.Truef(t, ok, "expected []byte member, got %T", row[0])
+		out = append(out, b)
+	}
+	return out
+}
+
+// TestCardinalityManySet_ByteValues_NoPanic: a plain Set of byte members must
+// not panic and must persist the set.
+func TestCardinalityManySet_ByteValues_NoPanic(t *testing.T) {
+	db, e, a := newBytesManyDB(t)
+	defer db.Close()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Set on cardinality-many []byte panicked (bug reproduced): %v", r)
+		}
+	}()
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, [][]byte{[]byte("chunk-a"), []byte("chunk-b")}))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, [][]byte{[]byte("chunk-a"), []byte("chunk-b")}, collectByteSet(t, db, e))
+}
+
+// TestCardinalityManySet_ByteValues_ReplacesExistingSet: a second Set replaces
+// the committed set (add-wins diff against current membership of []byte values).
+func TestCardinalityManySet_ByteValues_ReplacesExistingSet(t *testing.T) {
+	db, e, a := newBytesManyDB(t)
+	defer db.Close()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Set replacement on cardinality-many []byte panicked (bug reproduced): %v", r)
+		}
+	}()
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, [][]byte{[]byte("a"), []byte("b")}))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	tx = db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, [][]byte{[]byte("b"), []byte("c")}))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, [][]byte{[]byte("b"), []byte("c")}, collectByteSet(t, db, e))
+}
+
+// TestCardinalityManySet_ByteValues_PendingOpsInSameTransaction: Set must see
+// earlier Add ops in the same transaction. This exercises the pendingAdds /
+// pendingRemoves maps, which use the same direct-[]byte-key pattern as newSet,
+// so a fix that only repairs newSet would still panic here.
+func TestCardinalityManySet_ByteValues_PendingOpsInSameTransaction(t *testing.T) {
+	db, e, a := newBytesManyDB(t)
+	defer db.Close()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Set after pending Add on []byte panicked (bug reproduced): %v", r)
+		}
+	}()
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, a, []byte("a")))
+	require.NoError(t, tx.Add(e, a, []byte("b")))
+	require.NoError(t, tx.Set(e, a, [][]byte{[]byte("b"), []byte("c")}))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, [][]byte{[]byte("b"), []byte("c")}, collectByteSet(t, db, e))
+}
+
+// TestCardinalityManySet_ByteValues_DuplicateMembersDedupByContent: two byte
+// slices with equal content are the same set member.
+func TestCardinalityManySet_ByteValues_DuplicateMembersDedupByContent(t *testing.T) {
+	db, e, a := newBytesManyDB(t)
+	defer db.Close()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Set with duplicate []byte members panicked (bug reproduced): %v", r)
+		}
+	}()
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, [][]byte{[]byte("dup"), []byte("dup")}))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, [][]byte{[]byte("dup")}, collectByteSet(t, db, e))
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -1304,6 +1304,10 @@ func (t *Transaction) Add(e datalog.Identity, a datalog.Keyword, v interface{}) 
 		return fmt.Errorf("transaction is closed")
 	}
 
+	if err := validateAttributeStorable(a); err != nil {
+		return err
+	}
+
 	// Nil values are not allowed in relational algebra - absence of fact represents "no value"
 	if v == nil {
 		return fmt.Errorf("nil value not allowed for attribute %s: use absence of fact to represent no value", a.String())
@@ -1428,6 +1432,10 @@ func (t *Transaction) Remove(e datalog.Identity, a datalog.Keyword, v interface{
 
 	if t.closed {
 		return fmt.Errorf("transaction is closed")
+	}
+
+	if err := validateAttributeStorable(a); err != nil {
+		return err
 	}
 
 	// Nil values are not allowed
@@ -1567,6 +1575,33 @@ func (t *Transaction) Remove(e datalog.Identity, a datalog.Keyword, v interface{
 // toAnySlice converts a typed slice (e.g. []string, []int64) to []interface{}
 // using reflection. Returns the converted slice and true, or nil and false if
 // the value is not a slice.
+// validateAttributeStorable rejects attribute keywords whose UTF-8 form is too
+// long to store. The storage Attribute is a fixed [32]byte; a longer name would
+// be silently truncated and alias other attributes sharing its first 32 bytes
+// (see datalog.MaxAttributeBytes). Rejecting at write/schema time turns that
+// silent corruption into a clear error.
+func validateAttributeStorable(a datalog.Keyword) error {
+	if a == nil {
+		return fmt.Errorf("nil attribute")
+	}
+	if n := len(a.String()); n > datalog.MaxAttributeBytes {
+		return fmt.Errorf("attribute %q is %d bytes, exceeds the %d-byte storage limit", a.String(), n, datalog.MaxAttributeBytes)
+	}
+	return nil
+}
+
+// memberKey derives a hashable map key for a cardinality-many set member:
+// a type tag plus the value's encoded bytes. []byte (and other non-comparable
+// values) cannot be used as Go map keys directly, so membership maps key by
+// this string and carry the original value separately. It is byte-for-byte the
+// same key resolveAddWinsSet uses internally, so the Set diff lines up with
+// stored membership. Note: this keys floats by raw bits, which differs from
+// datalog.ValuesEqual at float corner cases (±0.0, NaN) but matches the read
+// path — the property that matters here.
+func memberKey(v interface{}) string {
+	return string(append([]byte{byte(datalog.Type(v))}, datalog.ValueBytes(v)...))
+}
+
 func toAnySlice(v interface{}) ([]interface{}, bool) {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Slice {
@@ -1593,6 +1628,10 @@ func (t *Transaction) Set(e datalog.Identity, a datalog.Keyword, v interface{}) 
 
 	if t.closed {
 		return fmt.Errorf("transaction is closed")
+	}
+
+	if err := validateAttributeStorable(a); err != nil {
+		return err
 	}
 
 	// Nil values are not allowed in relational algebra - absence of fact represents "no value"
@@ -1647,10 +1686,13 @@ func (t *Transaction) Set(e datalog.Identity, a datalog.Keyword, v interface{}) 
 			}
 		}
 
-		// Build set of new values for O(1) lookup
-		newSet := make(map[interface{}]bool, len(newSlice))
+		// Build set of new values for O(1) lookup, keyed by memberKey so
+		// non-comparable members like []byte can be map keys; the stored value
+		// is the original so emitted datoms keep their real type. Keying by
+		// content also dedups duplicate slice members.
+		newSet := make(map[string]interface{}, len(newSlice))
 		for _, val := range newSlice {
-			newSet[val] = true
+			newSet[memberKey(val)] = val
 		}
 
 		// Get current set membership from committed state
@@ -1663,61 +1705,57 @@ func (t *Transaction) Set(e datalog.Identity, a datalog.Keyword, v interface{}) 
 			return fmt.Errorf("failed to read current set membership: %w", err)
 		}
 
-		// Apply pending transaction operations to get effective current set
-		// This ensures Set() sees Add/Remove ops from earlier in the same transaction
-		effectiveSet := make(map[interface{}]bool)
-		for member := range currentResult.Members {
-			effectiveSet[member] = true
+		// Apply pending transaction operations to get effective current set.
+		// This ensures Set() sees Add/Remove ops from earlier in the same
+		// transaction. Keyed by memberKey; values are the original members.
+		effectiveSet := make(map[string]interface{})
+		for _, member := range currentResult.Members {
+			effectiveSet[memberKey(member)] = member
 		}
 
 		// Scan pending datoms for this (E, A) pair
-		pendingAdds := make(map[interface{}]datalog.ElementID)
-		pendingRemoves := make(map[interface{}]datalog.ElementID)
+		pendingAdds := make(map[string]datalog.ElementID)
+		pendingRemoves := make(map[string]datalog.ElementID)
+		pendingValues := make(map[string]interface{})
 		for _, datom := range t.datoms {
 			if datom.E.Hash() != eBytes || datom.A.String() != a.String() {
 				continue
 			}
+			k := memberKey(datom.V)
+			pendingValues[k] = datom.V
 			// NEW FORMAT: Op is a field on Datom, V is the raw value
 			if datom.Op == datalog.OpCRDTAdd {
-				pendingAdds[datom.V] = datom.Tx
+				pendingAdds[k] = datom.Tx
 			} else if datom.Op == datalog.OpCRDTRemove {
-				pendingRemoves[datom.V] = datom.Tx
+				pendingRemoves[k] = datom.Tx
 			}
 		}
 
-		// Apply pending ops using add-wins semantics
-		// For each value, compare highest pending add Lamport vs highest pending remove Lamport
-		allPendingValues := make(map[interface{}]bool)
-		for v := range pendingAdds {
-			allPendingValues[v] = true
-		}
-		for v := range pendingRemoves {
-			allPendingValues[v] = true
-		}
-
-		for val := range allPendingValues {
-			addTx, hasAdd := pendingAdds[val]
-			removeTx, hasRemove := pendingRemoves[val]
+		// Apply pending ops using add-wins semantics. For each value, compare
+		// highest pending add Lamport vs highest pending remove Lamport.
+		for k, val := range pendingValues {
+			addTx, hasAdd := pendingAdds[k]
+			removeTx, hasRemove := pendingRemoves[k]
 
 			if hasAdd && !hasRemove {
 				// Only add pending
-				effectiveSet[val] = true
+				effectiveSet[k] = val
 			} else if !hasAdd && hasRemove {
 				// Only remove pending
-				delete(effectiveSet, val)
+				delete(effectiveSet, k)
 			} else {
 				// Both add and remove pending - compare Lamport (add-wins at same Lamport)
 				if addTx.Lamport >= removeTx.Lamport {
-					effectiveSet[val] = true
+					effectiveSet[k] = val
 				} else {
-					delete(effectiveSet, val)
+					delete(effectiveSet, k)
 				}
 			}
 		}
 
 		// Remove members that are in effective set but not in new set
-		for member := range effectiveSet {
-			if !newSet[member] {
+		for k, member := range effectiveSet {
+			if _, ok := newSet[k]; !ok {
 				elemID := t.db.clock.Next()
 				// NEW FORMAT: Op is a field on Datom, V is the raw value
 				t.datoms = append(t.datoms, datalog.Datom{
@@ -1730,10 +1768,10 @@ func (t *Transaction) Set(e datalog.Identity, a datalog.Keyword, v interface{}) 
 			}
 		}
 
-		// Add members that are in new set but not in effective set
-		// Iterate newSet (deduplicated) to avoid duplicate writes for duplicate slice values
-		for val := range newSet {
-			if !effectiveSet[val] {
+		// Add members that are in new set but not in effective set.
+		// newSet is deduplicated by content, avoiding duplicate writes.
+		for k, val := range newSet {
+			if _, ok := effectiveSet[k]; !ok {
 				elemID := t.db.clock.Next()
 				// NEW FORMAT: Op is a field on Datom, V is the raw value
 				t.datoms = append(t.datoms, datalog.Datom{
@@ -1902,6 +1940,10 @@ func (t *Transaction) Retract(e datalog.Identity, a datalog.Keyword, v interface
 
 	if t.closed {
 		return fmt.Errorf("transaction is closed")
+	}
+
+	if err := validateAttributeStorable(a); err != nil {
+		return err
 	}
 
 	// Nil values are not allowed - must specify exact value to retract

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -818,8 +818,10 @@ func (it *validatingVBoundIterator) validateCandidate(e datalog.Identity, a data
 		return false
 	}
 
-	// Check if winner's V matches our bound V
-	matches := winner.V == it.currentBoundV
+	// Check if winner's V matches our bound V. Use ValuesEqual (not raw ==)
+	// so byte-slice values compare by content instead of panicking on the
+	// uncomparable []byte dynamic type.
+	matches := datalog.ValuesEqual(winner.V, it.currentBoundV)
 
 	if it.matcher.handler != nil {
 		it.matcher.handler(annotations.Event{

--- a/datalog/storage/types.go
+++ b/datalog/storage/types.go
@@ -13,8 +13,15 @@ import (
 // Entity represents a unique identifier for an entity (20-byte SHA1 hash)
 type Entity [20]byte
 
-// Attribute represents an attribute name (stored directly if ≤32 bytes, SHA256 if longer)
+// Attribute represents an attribute name, stored directly as the keyword's
+// UTF-8 bytes. Names longer than the array are rejected at write and schema
+// time (see datalog.MaxAttributeBytes); they are never truncated.
 type Attribute [32]byte
+
+// Compile-time guarantee that the Attribute storage form matches the advertised
+// maximum attribute length. If Attribute is resized, datalog.MaxAttributeBytes
+// must change to match (or this assignment stops compiling).
+var _ [datalog.MaxAttributeBytes]byte = Attribute{}
 
 // Tx represents a transaction/CRDT identifier (16 bytes = ElementID)
 // Layout: Lamport (8 bytes big-endian) + ReplicaID (8 bytes big-endian)

--- a/datalog/storage/vbound_bytes_validation_test.go
+++ b/datalog/storage/vbound_bytes_validation_test.go
@@ -1,0 +1,182 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// Reproductions for docs/bugs/BUG_VBOUND_BYTES_VALIDATION_PANIC.md
+//
+// V-bound queries on a cardinality-one attribute route through
+// validatingVBoundIterator.validateCandidate, which compares the EATV winner
+// to the bound value with raw interface ==:
+//
+//	matches := winner.V == it.currentBoundV
+//
+// For []byte both sides are dynamic type []uint8, which is not comparable, so
+// the comparison panics with "comparing uncomparable type []uint8". The fix is
+// to use datalog.ValuesEqual / m.valuesEqual.
+
+func newBytesOneDB(t *testing.T) (*Database, datalog.Identity, datalog.Keyword) {
+	t.Helper()
+	dir := t.TempDir()
+	// Cardinality-one, NOT unique: forces the candidate+validate path
+	// (validateCandidate), not the unique (A,V)-LWW short-circuit.
+	s, err := schema.NewBuilder().
+		Attribute(":doc/hash").Type(schema.TypeBytes).One().Add().
+		Build()
+	require.NoError(t, err)
+	db, err := NewDatabaseWithSchema(dir, s)
+	require.NoError(t, err)
+	return db, datalog.NewIdentity("doc-1"), datalog.NewKeyword(":doc/hash")
+}
+
+func queryByHash(t *testing.T, db *Database, v []byte) []datalog.Identity {
+	t.Helper()
+	rows, err := executor.CollectTuples(db.Query(`[:find ?e :in $ ?v :where [?e :doc/hash ?v]]`, v))
+	require.NoError(t, err)
+	out := make([]datalog.Identity, 0, len(rows))
+	for _, row := range rows {
+		id, ok := row[0].(datalog.Identity)
+		require.Truef(t, ok, "expected Identity, got %T", row[0])
+		out = append(out, id)
+	}
+	return out
+}
+
+// TestVBoundCardinalityOneBytes_NoPanic: a V-bound query on a byte attribute
+// must not panic and must return the matching entity.
+func TestVBoundCardinalityOneBytes_NoPanic(t *testing.T) {
+	db, e, a := newBytesOneDB(t)
+	defer db.Close()
+
+	v := []byte{0xde, 0xad, 0xbe, 0xef}
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, v))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("V-bound []byte query panicked (bug reproduced): %v", r)
+		}
+	}()
+
+	got := queryByHash(t, db, v)
+	require.Len(t, got, 1)
+	require.True(t, got[0].Equal(e))
+}
+
+// TestVBoundCardinalityOneBytes_MatchesByContent: a different slice instance
+// with identical content must still match (byte-content equality).
+func TestVBoundCardinalityOneBytes_MatchesByContent(t *testing.T) {
+	db, e, a := newBytesOneDB(t)
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, []byte{0xca, 0xfe, 0xba, 0xbe}))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("V-bound []byte content match panicked (bug reproduced): %v", r)
+		}
+	}()
+
+	// Distinct slice, same content as stored.
+	got := queryByHash(t, db, []byte{0xca, 0xfe, 0xba, 0xbe})
+	require.Len(t, got, 1)
+	require.True(t, got[0].Equal(e))
+}
+
+// TestVBoundCardinalityOneBytes_RejectsStaleCandidate: after overwrite, the old
+// value still has an AVET candidate row, but the EATV winner differs. The
+// candidate must be rejected (and rejection must compare by content, not panic).
+func TestVBoundCardinalityOneBytes_RejectsStaleCandidate(t *testing.T) {
+	db, e, a := newBytesOneDB(t)
+	defer db.Close()
+
+	v1 := []byte{0x01, 0x01}
+	v2 := []byte{0x02, 0x02}
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, v1))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	tx = db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, v2)) // LWW overwrite; v1 row remains in AVET
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("V-bound stale-candidate validation panicked (bug reproduced): %v", r)
+		}
+	}()
+
+	require.Empty(t, queryByHash(t, db, v1), "stale value must not match the current winner")
+}
+
+// TestVBoundCardinalityOneBytes_AfterOverwrite: querying the current value after
+// an overwrite returns the entity.
+func TestVBoundCardinalityOneBytes_AfterOverwrite(t *testing.T) {
+	db, e, a := newBytesOneDB(t)
+	defer db.Close()
+
+	v1 := []byte{0x0a}
+	v2 := []byte{0x0b}
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, v1))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	tx = db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, v2))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("V-bound post-overwrite query panicked (bug reproduced): %v", r)
+		}
+	}()
+
+	got := queryByHash(t, db, v2)
+	require.Len(t, got, 1)
+	require.True(t, got[0].Equal(e))
+}
+
+// TestVBoundCardinalityOneBytes_AfterRemove: after a tombstone the value must
+// not match. (The Op==Remove check precedes the == comparison, so this is a
+// contract test that complements the panic reproductions above.)
+func TestVBoundCardinalityOneBytes_AfterRemove(t *testing.T) {
+	db, e, a := newBytesOneDB(t)
+	defer db.Close()
+
+	v := []byte{0xfe, 0xed}
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, v))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	tx = db.NewTransaction()
+	require.NoError(t, tx.Remove(e, a, v))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("V-bound post-remove query panicked (bug reproduced): %v", r)
+		}
+	}()
+
+	require.Empty(t, queryByHash(t, db, v), "removed value must not match")
+}

--- a/datalog/types.go
+++ b/datalog/types.go
@@ -51,6 +51,14 @@ type keyword struct {
 // Keyword is the exported pointer type, always interned.
 type Keyword = *keyword
 
+// MaxAttributeBytes is the maximum length, in bytes, of an attribute keyword's
+// string form that can be stored. The storage layer encodes an attribute into a
+// fixed-size key component (storage.Attribute, a [32]byte); longer names would
+// be silently truncated and alias each other, so writes and schema definitions
+// of longer attributes are rejected. Keep this in sync with len(storage.Attribute{})
+// (storage enforces the match with a compile-time assertion).
+const MaxAttributeBytes = 32
+
 // NewKeyword creates an interned keyword.
 // Accepts both ":foo/bar" and "foo/bar" formats (auto-prefixes colon).
 func NewKeyword(s string) Keyword {

--- a/docs/bugs/resolved/BUG_ATTRIBUTE_KEY_TRUNCATION_COLLISION.md
+++ b/docs/bugs/resolved/BUG_ATTRIBUTE_KEY_TRUNCATION_COLLISION.md
@@ -1,0 +1,194 @@
+# BUG: Attribute Keywords Collide After 32 Bytes
+
+**Date**: 2026-05-22
+**Severity**: Correctness (High)
+**Status**: Resolved (2026-05-22)
+**Affected**: Keyword interning, storage attribute encoding, schema lookup, all query/write paths using attributes longer than 32 bytes
+
+## Summary
+
+Attribute keywords are keyed by a fixed `[32]byte` value in both the global keyword intern cache and the storage representation. The code copies the keyword string into that buffer without rejecting or hashing strings longer than 32 bytes.
+
+As a result, two distinct attributes with the same first 32 bytes become the same interned keyword and the same storage attribute. Writes, schema definitions, queries, and CRDT resolution can silently alias unrelated attributes.
+
+## Root Cause
+
+`InternKeyword` uses the 32-byte storage key as the intern key and truncates longer strings via `copy`:
+
+```go
+func InternKeyword(s string) Keyword {
+    var key [32]byte
+    copy(key[:], s)
+
+    if val, ok := keywordIntern.cache.Load(key); ok {
+        return val.(Keyword)
+    }
+
+    kw := &keyword{value: s}
+    actual, _ := keywordIntern.cache.LoadOrStore(key, kw)
+    return actual.(Keyword)
+}
+```
+
+Storage does the same thing when converting a datom:
+
+```go
+var a Attribute
+copy(a[:], d.A.String())
+```
+
+The comment on `Attribute` says "stored directly if <=32 bytes, SHA256 if longer", but no SHA256 path exists here. The implementation is "stored directly, truncated if longer."
+
+## Collision Example
+
+These are distinct keywords:
+
+```go
+a1 := datalog.NewKeyword(":very-long-prefix-0123456789-A")
+a2 := datalog.NewKeyword(":very-long-prefix-0123456789-B")
+```
+
+If the differing suffix is beyond byte 32, both copy to the same `[32]byte` key. The second call to `NewKeyword` returns the first interned keyword pointer. From that point on, `a1 == a2` even though the source strings differ.
+
+## Expected Behavior
+
+Distinct keyword strings should remain distinct regardless of length, or the system should reject unsupported long attribute names with a clear error before writes/schema construction.
+
+## Actual Behavior
+
+Long attribute names can silently collide:
+
+- Schema definitions for distinct attributes can overwrite or alias each other.
+- Writes to one attribute can be returned by queries for another.
+- CRDT resolution groups unrelated datoms under the same `(E, A)` pair.
+- Pull and Query APIs inherit the same incorrect attribute identity.
+
+## Why This Is Subtle
+
+- Most test and example attributes are shorter than 32 bytes.
+- The code comments imply a hash fallback exists, so reviewers may assume long names are handled.
+- Once interning returns the same pointer, downstream equality checks look correct because they are comparing the same object.
+- The bug can present as a schema, cache, CRDT, or query issue depending on which API observes the aliasing first.
+
+## Reproduction Sketch
+
+```go
+prefix := ":attribute/name-with-shared-prefix-"
+a1 := datalog.NewKeyword(prefix + "one")
+a2 := datalog.NewKeyword(prefix + "two")
+
+if a1 == a2 {
+    panic("distinct attributes collided")
+}
+
+tx := db.NewTransaction()
+tx.Set(entity, a1, "value-one")
+tx.Set(entity, a2, "value-two")
+tx.Commit()
+
+// Querying a1 and a2 should return different values, but can alias.
+```
+
+The exact strings should be chosen so the first 32 bytes are identical and the first differing byte is after byte 32.
+
+## Fix Direction
+
+Pick one explicit attribute identity policy and enforce it everywhere:
+
+- Hash long attributes as the `Attribute` comment claims, with a reverse mapping if full keyword strings must round-trip from storage, or
+- Reject keyword strings whose encoded storage form exceeds 32 bytes, returning a clear schema/write/query construction error, or
+- Store attribute IDs in a separate intern table instead of truncating the keyword string into the index key.
+
+The fix must address both `InternKeyword` and `ToStorageDatom`. Fixing only storage leaves keyword pointer identity broken; fixing only interning leaves storage aliasing broken.
+
+## Verification Plan
+
+Add regression tests that fail before the fix:
+
+- `TestKeywordInterning_LongNamesDoNotCollide`
+- `TestStorage_LongAttributeNamesDoNotAlias`
+- `TestQuery_LongAttributeNamesRemainDistinct`
+- `TestSchema_LongAttributeDefinitionsRemainDistinct`
+
+Also add a negative/contract test for the chosen policy:
+
+- If hashing is chosen, verify full long keywords round-trip through query results and pull.
+- If rejection is chosen, verify long attributes fail at construction or write time with a clear error.
+
+## Resolution (2026-05-22)
+
+**Chosen policy: reject (hard failure).** Attribute names whose UTF-8 form
+exceeds the 32-byte storage cap are refused with a clear error rather than
+silently truncated. The cap stays at 32; hashing and raising the cap were
+considered and declined (see "Decision" below).
+
+Two independent defects, two independent fixes:
+
+### 1. Interning collision (`datalog/intern.go`)
+
+`InternKeyword` keyed its intern cache by a truncated `[32]byte`, so distinct
+keywords sharing their first 32 bytes interned to the same `*keyword` pointer.
+It now keys by the full string, so distinct names always get distinct pointers,
+at any length. `InternKeywordFromBytes` (the storage-decode path) was changed in
+lockstep — it trims the null padding to recover the string and keys by that —
+so a keyword decoded from storage stays pointer-identical to one created via
+`InternKeyword`. (This matters because keyword equality is pointer equality
+throughout the engine.)
+
+This fix is independent of the storage cap: interning is now correct for names
+of any length, even ones that can never be stored.
+
+### 2. Storage truncation (`copy(a[:], d.A.String())` into `[32]byte`)
+
+A single source-of-truth constant, `datalog.MaxAttributeBytes = 32`, with a
+compile-time assertion in `datalog/storage/types.go` that the storage
+`Attribute` array stays the same size (`var _ [datalog.MaxAttributeBytes]byte =
+Attribute{}`). Over-length attributes are rejected at every write/definition
+boundary:
+
+- `Transaction.Set`, `Add`, `Remove`, `Retract` call `validateAttributeStorable`
+  and return an error before building any datom. (`AddEntity`/`AddMap`/
+  `SaveStruct` funnel through these.)
+- `schema.Builder.Add()` records an error so `Build()` fails for an over-length
+  ident.
+
+Because `reflect.SchemaFromStruct` routes through the schema `Builder`, and
+`SaveStruct` routes through `tx.Add`/`Set`, reflect usage hard-fails cleanly too.
+
+### Decision: why reject, and a reflect caveat
+
+The cap was kept at 32 deliberately. During implementation, the reflect
+`OrderedSet` tests surfaced that `reflect` derives attribute names from Go struct
+names (`CharacterWithPreferences` → `:character-with-preferences/prefs`, 33
+bytes), so an ordinary struct name can exceed the cap. The decision was that
+this *should* be a straight-up failure rather than be accommodated by a larger
+key or a hash dictionary. Consequence: reflect users must keep
+`struct-name + field` within 32 bytes. The two offending test fixtures were
+renamed to valid names (`CharacterPrefs`, `EntityOrderedRefs`); they test
+`OrderedSet`, not the cap, which has its own dedicated rejection tests.
+
+### Tests
+
+- `datalog/keyword_intern_collision_test.go`:
+  `TestKeywordInterning_LongNamesDoNotCollide` — distinct 42-byte names intern
+  to distinct pointers and round-trip their strings.
+- `datalog/storage/attribute_truncation_collision_test.go` (rewritten for the
+  reject policy):
+  - `TestStorage_LongAttributeNameRejectedOnWrite` — Set/Add/Remove/Retract all
+    return an error for an over-length attribute.
+  - `TestSchema_LongAttributeDefinitionRejected` — `Build()` errors on an
+    over-length ident.
+  - `TestStorage_MaxLengthAttributeNameAccepted` — a name exactly at 32 bytes is
+    accepted and round-trips (guards against off-by-one).
+
+The original plan's `TestStorage_LongAttributeNamesDoNotAlias` /
+`TestQuery_LongAttributeNamesRemainDistinct` were written for the "make distinct
+and storable" semantics; under the reject policy they were replaced by the
+rejection/boundary tests above. Full suite green: 15 packages, 0 failures.
+
+### Files changed
+
+`datalog/intern.go`, `datalog/types.go`, `datalog/storage/types.go`,
+`datalog/storage/database.go`, `datalog/schema/builder.go`,
+`datalog/reflect/ordered_set_test.go` (fixture renames), plus the two new test
+files.

--- a/docs/bugs/resolved/BUG_CARDINALITY_MANY_SET_BYTES_PANIC.md
+++ b/docs/bugs/resolved/BUG_CARDINALITY_MANY_SET_BYTES_PANIC.md
@@ -1,0 +1,164 @@
+# BUG: Cardinality-Many `Set` Panics on Byte Slice Members
+
+**Date**: 2026-05-22
+**Severity**: Stability / Correctness (High)
+**Status**: Resolved (2026-05-22)
+**Affected**: `Transaction.Set` for `CardinalityMany` attributes whose values are `[]byte` or other non-comparable slice types
+
+## Summary
+
+`Transaction.Set` for cardinality-many attributes builds Go maps keyed directly by set members. This works for comparable values like strings, ints, keywords, and identities, but panics for `[]byte` members because slices are not valid Go map keys.
+
+`[]byte` is a documented supported value type and `schema.TypeBytes` can be used with `CardinalityMany`, so this is a valid user input that can crash the process.
+
+## Root Cause
+
+The cardinality-many `Set` path converts the input slice to `[]interface{}` and then uses each member directly as a `map[interface{}]bool` key:
+
+```go
+newSet := make(map[interface{}]bool, len(newSlice))
+for _, val := range newSlice {
+    newSet[val] = true
+}
+```
+
+Later pending-operation maps use the same direct-key pattern:
+
+```go
+pendingAdds[datom.V] = datom.Tx
+pendingRemoves[datom.V] = datom.Tx
+```
+
+This is inconsistent with other CRDT set paths, which already special-case `[]byte` by deriving a hashable key while preserving the original value in results.
+
+## Reproduction Sketch
+
+```go
+s := schema.NewSchema()
+s.Add(&schema.AttributeDefinition{
+    Ident:       datalog.NewKeyword(":file/chunks"),
+    ValueType:   schema.TypeBytes,
+    Cardinality: schema.CardinalityMany,
+})
+
+db, _ := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+    Path:   dir,
+    Schema: s,
+})
+
+e := datalog.NewIdentity("file-1")
+a := datalog.NewKeyword(":file/chunks")
+
+tx := db.NewTransaction()
+err := tx.Set(e, a, [][]byte{
+    []byte("chunk-a"),
+    []byte("chunk-b"),
+})
+```
+
+Expected: `Set` writes an add-wins replacement set.
+
+Actual: panic similar to:
+
+```text
+panic: runtime error: hash of unhashable type []uint8
+```
+
+## Expected Behavior
+
+`Set` should accept byte-valued cardinality-many attributes just like `Add`, `Retract`, direct matcher resolution, and query paths do.
+
+At minimum, if a value type cannot be supported as a set member, `Set` should return a normal error during validation instead of panicking.
+
+## Actual Behavior
+
+The write path can panic before returning an error. This can crash applications even though the value type is valid according to the project type system.
+
+## Why This Is Subtle
+
+- Existing byte-value tests cover `Add`/`Retract` and resolution, not `Set` replacement.
+- Most cardinality-many examples use strings or refs, which are comparable and do not expose the panic.
+- The input is converted through `[]interface{}`, hiding the original typed slice until the map insertion.
+- Similar code elsewhere already has `[]byte` handling, making the overall feature appear supported.
+
+## Impact
+
+- Applications storing sets of blobs, hashes, compressed fragments, or binary IDs can crash on a normal `Set`.
+- The panic can occur after transaction construction begins, making it harder for callers to recover consistently.
+- The replacement-set API is less reliable than incremental `Add`/`Retract` for the same declared schema type.
+
+## Fix Direction
+
+Use a canonical, hashable value key for set membership maps in the cardinality-many `Set` path.
+
+The key should preserve type distinctions and value boundaries. Existing patterns include:
+
+- type byte + `datalog.ValueBytes(value)` as a string key, or
+- an existing tuple/value key primitive if one is already canonical for storage values.
+
+The map should store original values alongside the canonical key so query results and datoms preserve the original `[]byte` type.
+
+All pending-operation maps in this path must use the same keying scheme, not just `newSet`.
+
+## Verification Plan
+
+Add regression tests that currently fail:
+
+- `TestCardinalityManySet_ByteValues_NoPanic`
+- `TestCardinalityManySet_ByteValues_ReplacesExistingSet`
+- `TestCardinalityManySet_ByteValues_PendingOpsInSameTransaction`
+- `TestCardinalityManySet_ByteValues_DuplicateMembersDedupByContent`
+
+Run each relevant test with cache enabled and disabled where readback uses query or pull paths, to ensure the write fix integrates with both CRDT resolution modes.
+
+## Resolution (2026-05-22)
+
+The cardinality-many `Set` path in `datalog/storage/database.go` keyed five
+membership maps directly by the set member, which panics for `[]byte`. It was
+also internally inconsistent — it read `currentResult.Members` (already keyed by
+a derived hashable key) while building `newSet` from raw values, mixing two
+keying schemes.
+
+Fix: introduced `memberKey(v)`, a hashable map key built from a type tag plus
+`datalog.ValueBytes(v)`:
+
+```go
+func memberKey(v interface{}) string {
+    return string(append([]byte{byte(datalog.Type(v))}, datalog.ValueBytes(v)...))
+}
+```
+
+This is byte-for-byte the same key `resolveAddWinsSet` already uses internally,
+so the Set diff lines up with stored membership. (It is *not* canonical in the
+strict sense — it keys floats by raw bits, which differs from
+`datalog.ValuesEqual` at `±0.0`/`NaN` — but it matches the read path, which is
+the property that matters. The old raw-value keying actually disagreed with
+storage on floats; this change makes write and read agree.)
+
+All five maps in the path now key by `memberKey` and carry the original value
+for emission: `newSet`, `effectiveSet`, `pendingAdds`, `pendingRemoves`, and the
+merged `pendingValues` (replacing the old `allPendingValues`). The Remove/Add
+emission loops range `(key, originalValue)` and write `V: originalValue`, so
+datoms keep their real `[]byte` type. Keying by content also dedups duplicate
+slice members.
+
+### Tests
+
+`datalog/storage/cardinality_many_set_bytes_test.go` — all four from the plan,
+reading back through the public `db.Query` API:
+
+- `NoPanic`, `ReplacesExistingSet`, `DuplicateMembersDedupByContent`
+- `PendingOpsInSameTransaction` specifically exercises the pending-op maps
+  (the second panic site), guarding against a fix that only repairs `newSet`.
+
+All reproduced the panic before the fix and pass after it. Full suite green:
+15 packages, 0 failures.
+
+### Not covered
+
+The cardinality-**vector** `Set` path (RGA prefix-diff) has a similar
+value-comparison shape and was not audited here — flagged as a follow-up.
+
+### Files changed
+
+`datalog/storage/database.go`, plus the new test file.

--- a/docs/bugs/resolved/BUG_VBOUND_BYTES_VALIDATION_PANIC.md
+++ b/docs/bugs/resolved/BUG_VBOUND_BYTES_VALIDATION_PANIC.md
@@ -1,0 +1,142 @@
+# BUG: V-Bound Cardinality-One Validation Panics on Byte Values
+
+**Date**: 2026-05-22
+**Severity**: Stability / Correctness (Medium)
+**Status**: Resolved (2026-05-22)
+**Affected**: V-bound queries on cardinality-one `TypeBytes` attributes, especially candidate + validate paths using AVET/VAET
+
+## Summary
+
+The V-bound cardinality-one validation path compares the current winner value with the bound query value using Go's `==` operator on `interface{}` values. This panics when either side is a slice, including the supported `[]byte` value type.
+
+The codebase already has `datalog.ValuesEqual` for exactly this kind of comparison, but this path bypasses it.
+
+## Root Cause
+
+`validatingVBoundIterator.validateCandidate` point-lookups the current `(E, A)` winner via EATV and then compares the winner's value to the bound value directly:
+
+```go
+// Check if winner's V matches our bound V
+matches := winner.V == it.currentBoundV
+```
+
+For `[]byte`, both `winner.V` and `it.currentBoundV` are interface values whose dynamic type is `[]uint8`. Comparing them with `==` causes:
+
+```text
+panic: runtime error: comparing uncomparable type []uint8
+```
+
+Other matcher paths use `m.valuesEqual(...)`, which delegates to `datalog.ValuesEqual(...)` and handles byte slices with `bytes.Equal`.
+
+## Reproduction Sketch
+
+```go
+s := schema.NewSchema()
+s.Add(&schema.AttributeDefinition{
+    Ident:       datalog.NewKeyword(":doc/hash"),
+    ValueType:   schema.TypeBytes,
+    Cardinality: schema.CardinalityOne,
+})
+
+db, _ := storage.NewDatabaseWithOptions(storage.DatabaseOptions{
+    Path:   dir,
+    Schema: s,
+})
+
+e := datalog.NewIdentity("doc-1")
+a := datalog.NewKeyword(":doc/hash")
+v := []byte{0xde, 0xad, 0xbe, 0xef}
+
+tx := db.NewTransaction()
+tx.Set(e, a, v)
+tx.Commit()
+
+results, err := executor.CollectTuples(db.Query(
+    `[:find ?e :in $ ?v :where [?e :doc/hash ?v]]`,
+    v,
+))
+```
+
+Expected: one result containing `doc-1`.
+
+Actual: the V-validation path can panic when it compares the EATV winner to the bound byte slice.
+
+## Expected Behavior
+
+V-bound queries should support all valid value types. For `[]byte`, equality should be byte-content equality.
+
+## Actual Behavior
+
+The candidate validation path can panic for byte slices and any other non-comparable slice value that reaches this comparison.
+
+## Why This Is Subtle
+
+- The bug only appears in a specific V-bound validation path, not every bytes query.
+- Direct unbound reads and E/A-bound reads can work, giving confidence that byte values are supported.
+- Existing comparison utilities already handle byte slices, so this is a one-line semantic bypass rather than a missing primitive.
+- Many V-bound tests use strings, numbers, keywords, or refs, all of which are comparable.
+
+## Impact
+
+- Valid user queries can crash the process.
+- Applications using content hashes, blobs, or binary IDs as query values are exposed.
+- The same logical query may work or panic depending on planner/matcher strategy and whether validation is needed.
+
+## Fix Direction
+
+Replace direct interface equality with the canonical value comparison:
+
+```go
+matches := datalog.ValuesEqual(winner.V, it.currentBoundV)
+```
+
+or:
+
+```go
+matches := it.matcher.valuesEqual(winner.V, it.currentBoundV)
+```
+
+Use the same comparison policy consistently in all V-bound validation and vector/cache comparison paths.
+
+## Verification Plan
+
+Add regression tests that currently fail:
+
+- `TestVBoundCardinalityOneBytes_NoPanic`
+- `TestVBoundCardinalityOneBytes_MatchesByContent`
+- `TestVBoundCardinalityOneBytes_RejectsStaleCandidate`
+- `TestVBoundCardinalityOneBytes_AfterOverwrite`
+- `TestVBoundCardinalityOneBytes_AfterRemove`
+
+Run the tests through the public `db.Query` API, not only direct matcher calls, so the planner and candidate-validation strategy are exercised end to end.
+
+## Resolution (2026-05-22)
+
+One-line fix: `validatingVBoundIterator.validateCandidate` in
+`datalog/storage/matcher_relations.go` now compares the EATV winner to the
+bound value with `datalog.ValuesEqual` instead of raw `==`:
+
+```go
+matches := datalog.ValuesEqual(winner.V, it.currentBoundV)
+```
+
+`ValuesEqual` compares `[]byte` by content (`bytes.Equal`), so the comparison
+no longer panics on the uncomparable `[]uint8` dynamic type. This was the only
+offending site — the other `==` uses in that file are `== nil` and a comment.
+
+The `Op == OpCRDTRemove` check (line 817) precedes the comparison, so a
+tombstoned winner returns `false` before reaching `ValuesEqual`; the
+`AfterRemove` test confirms this branch is unaffected.
+
+### Tests
+
+`datalog/storage/vbound_bytes_validation_test.go` — all five from the plan,
+through the public `db.Query` API. `NoPanic`, `MatchesByContent`,
+`RejectsStaleCandidate`, and `AfterOverwrite` reproduced the panic before the
+fix and pass after it; `AfterRemove` passes throughout (it exercises the
+tombstone branch that never reaches the comparison). Full suite green:
+15 packages, 0 failures.
+
+### Files changed
+
+`datalog/storage/matcher_relations.go`, plus the new test file.


### PR DESCRIPTION
Resolves three correctness bugs documented in `docs/bugs/resolved/`. Each comes with reproductions written first (red), then the fix (green). Full suite: 15 packages, 0 failures.

## 1. V-bound []byte validation panic
`BUG_VBOUND_BYTES_VALIDATION_PANIC.md`

A V-bound query on a cardinality-one `TypeBytes` attribute (e.g. `[:find ?e :in $ ?v :where [?e :doc/hash ?v]]`) panicked with `comparing uncomparable type []uint8`. `validatingVBoundIterator.validateCandidate` compared the EATV winner to the bound value with raw `==`. Fixed to use `datalog.ValuesEqual` (byte-content equality). It was the only offending site; the `Op == OpCRDTRemove` check still precedes the comparison, so tombstones are unaffected.

## 2. Cardinality-many `Set` []byte panic
`BUG_CARDINALITY_MANY_SET_BYTES_PANIC.md`

`tx.Set` on a cardinality-many `TypeBytes` attribute panicked with `hash of unhashable type []uint8` — the path keyed five membership maps directly by the member (which `[]byte` can't be), and mixed two keying schemes. Introduced `memberKey(v)` (type tag + `ValueBytes`, byte-for-byte the key `resolveAddWinsSet` already uses internally) and re-keyed `newSet`/`effectiveSet`/`pendingAdds`/`pendingRemoves`/`pendingValues`, carrying the original value for emission so datoms keep their real type. Dedups duplicate members by content.

Note: this keys floats by raw bits (matching the read path), so it's not strictly canonical — it differs from `ValuesEqual` at `±0.0`/`NaN`, but it makes the write path agree with storage where it previously didn't. The cardinality-vector `Set` path has a similar value-comparison shape and is flagged as a follow-up audit (not addressed here).

## 3. Attribute truncation/collision
`BUG_ATTRIBUTE_KEY_TRUNCATION_COLLISION.md`

Attribute names longer than 32 bytes were truncated into both the keyword intern key and the storage `Attribute [32]byte`, silently aliasing distinct attributes across writes, queries, schema, and CRDT resolution. Two independent fixes:

- **Interning**: `InternKeyword`/`InternKeywordFromBytes` now key the intern cache by the full string (in lockstep, so storage-decoded and user-created keywords stay pointer-identical). Distinct names get distinct pointers at any length.
- **Storage cap — policy: reject (hard failure).** New `datalog.MaxAttributeBytes = 32` with a compile-time assertion that `storage.Attribute` stays that size. `Set`/`Add`/`Remove`/`Retract` and `schema.Builder.Add()` reject over-length attributes with a clear error instead of truncating. Hashing and raising the cap were considered and declined.

Because `reflect` derives attribute names from Go struct names, an ordinary struct name can exceed 32 bytes (`CharacterWithPreferences` → `:character-with-preferences/prefs`, 33 bytes). Two `OrderedSet` test fixtures hit this and were renamed (`CharacterPrefs`, `EntityOrderedRefs`); they test `OrderedSet`, not the cap, which has its own rejection/boundary tests. This does mean reflect users must keep `struct-name + field` within 32 bytes.

## Tests
- 13 reproductions across the three bugs, plus rejection/boundary tests for the attribute cap.
- Panic repros use `recover → t.Fatalf` so they fail cleanly (don't abort the binary) before the fix and pass after.
- Read-back goes through the public `db.Query`/`db.Pull` APIs so the planner and candidate-validation strategy are exercised end to end.