### PR TITLE
Iterator error propagation through the result pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,18 @@ All of these are decisions for the user, not you.
 **Wrong**: "The cache tests are failing, so I'll add a new cache type to make them pass."
 **Right**: "The cache tests are failing because ClauseBasedPlanner doesn't integrate with the cache the same way. How do you want to handle this?"
 
+## The Baseline Is Green — Never Blame Pre-Existing Conditions
+
+**Every test passes before any work session starts. This is an invariant, not something to verify.** The repository is always green at the start of your work (`go test -count=1 ./...` passes; the pre-push hook enforces it). Internalize this and reason from it.
+
+It has one unavoidable consequence: **any test that fails during or after your work was caused by your work** — either by a change you made, or by a stricter gate you chose to run (e.g. `-race`) that the standard suite does not. There is no third possibility. Therefore:
+
+- **NEVER attribute a test failure to "pre-existing conditions."** Not in your reasoning, not in your reporting. The phrasing "this is pre-existing / not my change / not part of this work / I didn't touch that code" is **forbidden** — it is blame-deflection (CYA), and against a green baseline it is also false by construction. Catch yourself before you emit it.
+- **NEVER run experiments to "prove" a failure is pre-existing.** No `git stash`, no `git checkout -- <file>`, no revert-and-rerun to A/B the baseline. You already know the baseline was green and you already have your own diff; causation is determined by **reading the diff and the failure**, never by mutating the working tree. (`git stash` is banned outright — it has silently buried uncommitted work in this repo. Never run it for any reason.)
+- **Do NOT invent gates the project does not use** (e.g. `-race`, extra linters) and then go chasing what they surface as if it were someone else's problem. The standard gate is `go test -count=1 ./...`. If you choose to run a stricter check, anything it finds is yours to fully resolve or you should not have run it.
+
+When a test is red there is exactly one fork: **fix it, or report it and ask** (per "When Tests Fail" above). There is no "investigate whose fault it is" step. Ownership is the default; the baseline guarantees it.
+
 ## When Asked to Revert
 
 **Revert IMMEDIATELY. Do not defer.**

--- a/datalog/annotations/types.go
+++ b/datalog/annotations/types.go
@@ -96,6 +96,24 @@ type Event struct {
 // Handler processes annotation events as they occur.
 type Handler func(event Event)
 
+// Synchronized wraps a Handler so its invocations are serialized through a
+// mutex, making it safe to call from multiple goroutines. The query engine
+// emits annotations from parallel workers (and from several collectors plus the
+// storage matcher, all sharing one handler), so a handler installed on a
+// Database is wrapped with this — handler authors don't need their own locking.
+// Returns nil for a nil handler.
+func Synchronized(h Handler) Handler {
+	if h == nil {
+		return nil
+	}
+	var mu sync.Mutex
+	return func(e Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		h(e)
+	}
+}
+
 // Collector accumulates events during query execution.
 type Collector struct {
 	enabled bool

--- a/datalog/executor/aggregation.go
+++ b/datalog/executor/aggregation.go
@@ -237,6 +237,10 @@ func executeSingleAggregation(rel Relation, aggregates []query.FindAggregate) Re
 		}
 	}
 
+	// Capture any deferred error from the input scan: a failed scan must not be
+	// silently aggregated into an empty/zero result.
+	aggErr := it.Error()
+
 	// Compute aggregates
 	results := make(Tuple, len(aggregates))
 	hasAnyValues := false
@@ -259,10 +263,14 @@ func executeSingleAggregation(rel Relation, aggregates []query.FindAggregate) Re
 	// return empty result set instead of a tuple with nil values
 	opts := rel.Options()
 	if !hasAnyValues {
-		return NewMaterializedRelationWithOptions(resultColumns, []Tuple{}, opts)
+		empty := NewMaterializedRelationWithOptions(resultColumns, []Tuple{}, opts)
+		empty.err = aggErr
+		return empty
 	}
 
-	return NewMaterializedRelationWithOptions(resultColumns, []Tuple{results}, opts)
+	result := NewMaterializedRelationWithOptions(resultColumns, []Tuple{results}, opts)
+	result.err = aggErr
+	return result
 }
 
 // executeGroupedAggregation performs aggregation with grouping
@@ -399,7 +407,11 @@ func executeGroupedAggregation(rel Relation, groupByVars []query.Symbol, aggrega
 	}
 
 	opts := rel.Options()
-	return NewMaterializedRelationWithOptions(resultColumns, resultTuples, opts)
+	result := NewMaterializedRelationWithOptions(resultColumns, resultTuples, opts)
+	// Carry any deferred error from the grouped input scan so a failed scan
+	// isn't laundered into a partial/empty grouped result.
+	result.err = it.Error()
+	return result
 }
 
 // computeAggregateValues is already defined in executor.go

--- a/datalog/executor/caching_error_replay_test.go
+++ b/datalog/executor/caching_error_replay_test.go
@@ -1,0 +1,60 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Part 2 of docs/proposals/ITERATOR_ERROR_CONTRACT_ENFORCEMENT.md:
+// caching relations must replay the source iterator's error through their own
+// Iterator().Error(), so the failure survives across internal materialization
+// (order-by, aggregation, joins, union) and reaches an Error()-checking boundary.
+
+// TestMaterialize_ReplaysSourceError: Materialize() of a stream that fails
+// mid-iteration must report the error on EVERY iteration. The first drive builds
+// the cache (and propagates via the real iterator); the replay must report it
+// too — that's the cached-failure path that currently drops it.
+func TestMaterialize_ReplaysSourceError(t *testing.T) {
+	m := newFailingStream(1, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)}).Materialize()
+	require.ErrorIs(t, driveErr(m), errInjectedIterator, "first iteration (cache build)")
+	require.ErrorIs(t, driveErr(m), errInjectedIterator, "replay from cache must also report the error")
+}
+
+// TestMaterialize_ReplaysSourceError_ImmediateFailure: a stream that fails
+// before yielding anything still reports the error on replay.
+func TestMaterialize_ReplaysSourceError_ImmediateFailure(t *testing.T) {
+	m := newFailingStream(0, Tuple{int64(1)}).Materialize()
+	require.ErrorIs(t, driveErr(m), errInjectedIterator, "first iteration (cache build)")
+	require.ErrorIs(t, driveErr(m), errInjectedIterator, "replay from cache must also report the error")
+}
+
+// TestSort_ReplaysSourceError: order-by materializes; the error must survive.
+func TestSort_ReplaysSourceError(t *testing.T) {
+	orderBy := []query.OrderByClause{{Variable: datalog.NewSymbol("?x"), Direction: query.OrderAsc}}
+	sorted := newFailingStream(1, Tuple{int64(2)}, Tuple{int64(1)}, Tuple{int64(3)}).Sort(orderBy)
+	require.ErrorIs(t, driveErr(sorted), errInjectedIterator)
+}
+
+// TestUnionRelation_MaterializeReplaysSourceError: union bug verification #4 —
+// materializing a union whose inner relation fails must surface the error, not a
+// silent prefix.
+func TestUnionRelation_MaterializeReplaysSourceError(t *testing.T) {
+	ch := make(chan relationItem, 1)
+	ch <- relationItem{relation: newFailingRelation(1, Tuple{int64(1)}, Tuple{int64(2)})}
+	close(ch)
+
+	ur := NewUnionRelation(ch, testSymbols(), ExecutorOptions{})
+	require.ErrorIs(t, driveErr(ur.Materialize()), errInjectedIterator)
+}
+
+// TestCollectTuples_OverMaterializedFailingRelation: the end-to-end property —
+// a boundary over a materialized failing relation returns the error (Part 1 +
+// Part 2 together).
+func TestCollectTuples_OverMaterializedFailingRelation(t *testing.T) {
+	m := newFailingStream(2, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)}).Materialize()
+	_, err := CollectTuples(m, nil)
+	require.ErrorIs(t, err, errInjectedIterator)
+}

--- a/datalog/executor/context.go
+++ b/datalog/executor/context.go
@@ -62,6 +62,29 @@ func NewContext(handler annotations.Handler) Context {
 	}
 }
 
+// forkContext returns an independent Context for a concurrent worker. A Context
+// carries per-query mutable state — AnnotatedContext.queryStart and the lazily
+// created BaseContext.metadata map / scanRegistry — none of which is safe for
+// concurrent use. Parallel workers must therefore each get their own context.
+// The annotation collector is shared (it is internally synchronized), so events
+// still aggregate into one place.
+func forkContext(ctx Context) Context {
+	switch c := ctx.(type) {
+	case *AnnotatedContext:
+		return &AnnotatedContext{collector: c.collector}
+	case *BaseContext:
+		return &BaseContext{}
+	case *subqueryContext:
+		return &subqueryContext{
+			parent:      forkContext(c.parent),
+			inputValues: c.inputValues, // read-only during execution
+			inputs:      c.inputs,
+		}
+	default:
+		return ctx
+	}
+}
+
 // BaseContext implementations - all are simple pass-throughs
 
 func (c *BaseContext) QueryBegin(query string) {}

--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -494,7 +494,7 @@ func (e *Executor) executeRealizedWithRelationInputIterationSequential(
 			return nil, fmt.Errorf("iteration execution failed: %w", err)
 		}
 
-		if result != nil && result.Size() > 0 {
+		if result != nil {
 			allResults = append(allResults, result)
 		}
 	}
@@ -504,12 +504,15 @@ func (e *Executor) executeRealizedWithRelationInputIterationSequential(
 		return NewMaterializedRelation(extractFindSymbols(plan.Query.Find), []Tuple{}), nil
 	}
 
-	// Union all results
+	// Union all results, propagating any per-tuple scan error rather than
+	// dropping it (a failed iteration must not look like an empty result).
 	var allTuples []Tuple
 	symbols := allResults[0].Symbols()
 
 	for _, rel := range allResults {
-		collectTuplesInto(&allTuples, rel)
+		if err := collectTuplesInto(&allTuples, rel); err != nil {
+			return nil, fmt.Errorf("iteration execution failed: %w", err)
+		}
 	}
 
 	return NewMaterializedRelation(symbols, allTuples), nil
@@ -583,28 +586,29 @@ func (e *Executor) executeRealizedWithRelationInputIterationParallel(
 		<-done
 	}
 
-	// Check for errors and collect results
-	var allResults []Relation
+	// Check for errors and collect results. Consume each per-worker result via
+	// collectTuplesInto so a failed scan's deferred error is propagated rather
+	// than silently dropped by Size() materialization.
+	var allTuples []Tuple
+	var symbols []query.Symbol
 	for _, r := range results {
 		if r.err != nil {
 			return nil, fmt.Errorf("parallel iteration execution failed: %w", r.err)
 		}
-		if r.result != nil && r.result.Size() > 0 {
-			allResults = append(allResults, r.result)
+		if r.result == nil {
+			continue
+		}
+		if symbols == nil {
+			symbols = r.result.Symbols()
+		}
+		if err := collectTuplesInto(&allTuples, r.result); err != nil {
+			return nil, fmt.Errorf("parallel iteration execution failed: %w", err)
 		}
 	}
 
 	// Combine all results
-	if len(allResults) == 0 {
+	if symbols == nil {
 		return NewMaterializedRelation(extractFindSymbols(plan.Query.Find), []Tuple{}), nil
-	}
-
-	// Union all results
-	var allTuples []Tuple
-	symbols := allResults[0].Symbols()
-
-	for _, rel := range allResults {
-		collectTuplesInto(&allTuples, rel)
 	}
 
 	return NewMaterializedRelation(symbols, allTuples), nil

--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -570,8 +570,10 @@ func (e *Executor) executeRealizedWithRelationInputIterationParallel(
 				}
 			}
 
-			// Execute the plan with these scalar inputs
-			result, err := e.executeRealizedNonIterating(ctx, plan, tupleInputRelations, relationInput)
+			// Execute the plan with these scalar inputs. Each worker gets its
+			// own forked context: a Context's per-query state (queryStart,
+			// metadata, scanRegistry) is not safe for concurrent mutation.
+			result, err := e.executeRealizedNonIterating(forkContext(ctx), plan, tupleInputRelations, relationInput)
 			results[idx] = iterationResult{result: result, err: err}
 		}(tupleIdx, tuple)
 	}

--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -369,10 +369,15 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 				// Materialize first to avoid iterator consumption issues
 				// Collect all tuples to create a reusable relation
 				var tuples []Tuple
-				collectTuplesInto(&tuples, group)
+				// A non-last phase materializes each group to pass Keep symbols
+				// forward. Carry any deferred scan error onto the materialized
+				// relation so Project propagates it into the next phase instead of
+				// laundering a failed scan into an empty result.
+				keepErr := collectTuplesInto(&tuples, group)
 
 				opts := group.Options()
 				materialized := NewMaterializedRelationWithOptions(group.Symbols(), tuples, opts)
+				materialized.err = keepErr
 
 				projected, err := materialized.Project(phase.Keep)
 				if err != nil {
@@ -667,10 +672,15 @@ func (e *Executor) executeRealizedNonIterating(
 			for i, group := range groups {
 				// Materialize first to avoid iterator consumption issues
 				var tuples []Tuple
-				collectTuplesInto(&tuples, group)
+				// A non-last phase materializes each group to pass Keep symbols
+				// forward. Carry any deferred scan error onto the materialized
+				// relation so Project propagates it into the next phase instead of
+				// laundering a failed scan into an empty result.
+				keepErr := collectTuplesInto(&tuples, group)
 
 				opts := group.Options()
 				materialized := NewMaterializedRelationWithOptions(group.Symbols(), tuples, opts)
+				materialized.err = keepErr
 
 				projected, err := materialized.Project(phase.Keep)
 				if err != nil {

--- a/datalog/executor/foreach_test.go
+++ b/datalog/executor/foreach_test.go
@@ -1,0 +1,84 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Contract tests for the canonical consumer (Part 1 of
+// docs/proposals/ITERATOR_ERROR_CONTRACT_ENFORCEMENT.md).
+
+func TestForEach_VisitsAllTuplesOnClean(t *testing.T) {
+	rel := newFailingRelation(100, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	var seen []int64
+	err := ForEach(rel, func(tu Tuple) error {
+		seen = append(seen, tu[0].(int64))
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 2, 3}, seen)
+}
+
+func TestForEach_EmptyIsNoError(t *testing.T) {
+	rel := newFailingRelation(100)
+	calls := 0
+	err := ForEach(rel, func(Tuple) error { calls++; return nil })
+	require.NoError(t, err)
+	require.Equal(t, 0, calls)
+}
+
+func TestForEach_ReturnsIteratorErrorImmediate(t *testing.T) {
+	rel := newFailingRelation(0, Tuple{int64(1)})
+	err := ForEach(rel, func(Tuple) error { return nil })
+	require.ErrorIs(t, err, errInjectedIterator)
+}
+
+func TestForEach_ReturnsIteratorErrorMidStream(t *testing.T) {
+	rel := newFailingRelation(1, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	calls := 0
+	err := ForEach(rel, func(Tuple) error { calls++; return nil })
+	require.ErrorIs(t, err, errInjectedIterator)
+	require.Equal(t, 1, calls, "fn runs for tuples yielded before the failure")
+}
+
+func TestForEach_StopsAndReturnsFnError(t *testing.T) {
+	fnErr := errors.New("fn boom")
+	rel := newFailingRelation(100, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	calls := 0
+	err := ForEach(rel, func(Tuple) error {
+		calls++
+		if calls == 2 {
+			return fnErr
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, fnErr)
+	require.Equal(t, 2, calls, "iteration stops at the fn error")
+}
+
+func TestForEach_ReturnsCloseErrorWhenIterationClean(t *testing.T) {
+	closeErr := errors.New("close boom")
+	rel := newFailingRelation(100, Tuple{int64(1)})
+	rel.closeErr = closeErr
+	err := ForEach(rel, func(Tuple) error { return nil })
+	require.ErrorIs(t, err, closeErr)
+}
+
+func TestForEach_IterationErrorBeatsCloseError(t *testing.T) {
+	closeErr := errors.New("close boom")
+	rel := newFailingRelation(0, Tuple{int64(1)})
+	rel.closeErr = closeErr
+	err := ForEach(rel, func(Tuple) error { return nil })
+	require.ErrorIs(t, err, errInjectedIterator, "iteration error must not be masked by Close()")
+}
+
+func TestForEach_FnErrorBeatsCloseError(t *testing.T) {
+	fnErr := errors.New("fn boom")
+	closeErr := errors.New("close boom")
+	rel := newFailingRelation(100, Tuple{int64(1)}, Tuple{int64(2)})
+	rel.closeErr = closeErr
+	err := ForEach(rel, func(Tuple) error { return fnErr })
+	require.ErrorIs(t, err, fnErr, "fn error must not be masked by Close()")
+}

--- a/datalog/executor/iterator_error_boundary_test.go
+++ b/datalog/executor/iterator_error_boundary_test.go
@@ -1,0 +1,110 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Reproductions for docs/bugs/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md
+//
+// The Iterator contract requires callers to check Error() after Next() returns
+// false. CollectTuples (and the QueryInto/QueryOneInto storage boundaries) don't,
+// so an iterator failure is reported as an empty or truncated success.
+
+var errInjectedIterator = errors.New("injected iterator failure")
+
+// failingRelation behaves like its embedded Relation except that its iterator
+// stops after failAfter tuples and reports errInjectedIterator via Error() —
+// mimicking KeyOnlyIterator/CRDTResolvingIterator deferring failures to Error().
+type failingRelation struct {
+	Relation
+	failAfter int
+	closeErr  error
+}
+
+func (f failingRelation) Iterator() Iterator {
+	return &failingIterator{inner: f.Relation.Iterator(), failAfter: f.failAfter, closeErr: f.closeErr}
+}
+
+type failingIterator struct {
+	inner     Iterator
+	failAfter int
+	yielded   int
+	failed    bool
+	closeErr  error // if set, Close() returns this (to test Close vs iteration error precedence)
+}
+
+func (it *failingIterator) Next() bool {
+	if it.failed {
+		return false
+	}
+	if it.yielded >= it.failAfter {
+		it.failed = true // deferred failure: Next() returns false, Error() reports it
+		return false
+	}
+	if it.inner.Next() {
+		it.yielded++
+		return true
+	}
+	return false
+}
+
+func (it *failingIterator) Tuple() Tuple { return it.inner.Tuple() }
+
+func (it *failingIterator) Close() error {
+	_ = it.inner.Close()
+	return it.closeErr
+}
+
+func (it *failingIterator) Error() error {
+	if it.failed {
+		return errInjectedIterator
+	}
+	return it.inner.Error()
+}
+
+func testSymbols() []query.Symbol { return []query.Symbol{datalog.NewSymbol("?x")} }
+
+func newFailingRelation(failAfter int, tuples ...Tuple) failingRelation {
+	return failingRelation{
+		Relation:  NewMaterializedRelation(testSymbols(), tuples),
+		failAfter: failAfter,
+	}
+}
+
+// newFailingStream wraps a failing iterator in a real StreamingRelation, so
+// that transforms which consume via Iterator() (Materialize, Sort, Aggregate)
+// run the real collectTuplesInto path against a failing source.
+func newFailingStream(failAfter int, tuples ...Tuple) *StreamingRelation {
+	inner := NewMaterializedRelation(testSymbols(), tuples).Iterator()
+	return NewStreamingRelation(testSymbols(), &failingIterator{inner: inner, failAfter: failAfter})
+}
+
+// driveErr drives a relation's iterator to exhaustion and returns Error().
+func driveErr(rel Relation) error {
+	it := rel.Iterator()
+	defer it.Close()
+	for it.Next() {
+	}
+	return it.Error()
+}
+
+// TestCollectTuples_ReturnsIteratorError: an iterator that fails immediately must
+// not be reported as an empty successful result.
+func TestCollectTuples_ReturnsIteratorError(t *testing.T) {
+	rel := newFailingRelation(0, Tuple{int64(1)}, Tuple{int64(2)})
+	_, err := CollectTuples(rel, nil)
+	require.ErrorIs(t, err, errInjectedIterator)
+}
+
+// TestCollectTuples_ReturnsIteratorErrorAfterPartialResults: an iterator that
+// fails partway must not be reported as a truncated successful result.
+func TestCollectTuples_ReturnsIteratorErrorAfterPartialResults(t *testing.T) {
+	rel := newFailingRelation(1, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	_, err := CollectTuples(rel, nil)
+	require.ErrorIs(t, err, errInjectedIterator)
+}

--- a/datalog/executor/join.go
+++ b/datalog/executor/join.go
@@ -20,6 +20,7 @@ import (
 type hashJoinIterator struct {
 	hashTable    *TupleKeyMap
 	probeIt      Iterator
+	buildErr     error // deferred error captured from the (eagerly consumed) build relation
 	seen         *TupleKeyMap
 	buildIsLeft  bool
 	joinSyms     []query.Symbol
@@ -125,6 +126,9 @@ func (it *hashJoinIterator) Close() error {
 }
 
 func (it *hashJoinIterator) Error() error {
+	if it.buildErr != nil {
+		return it.buildErr
+	}
 	if it.probeIt != nil {
 		return it.probeIt.Error()
 	}
@@ -513,6 +517,10 @@ func HashJoinWithOptions(left, right Relation, joinSyms []query.Symbol, opts Exe
 		}
 	}
 
+	// Capture any deferred error from the build scan before closing it, so a
+	// build-side failure isn't lost (it propagates onto the join result).
+	buildErr := buildIt.Error()
+
 	// Close build iterator BEFORE probe phase begins.
 	// The build relation may share underlying iterators with the probe relation
 	// (e.g., OrFallbackRelation wraps a StreamingRelation that is also the probe).
@@ -563,6 +571,7 @@ func HashJoinWithOptions(left, right Relation, joinSyms []query.Symbol, opts Exe
 		iter := &hashJoinIterator{
 			hashTable:    hashTable,
 			probeIt:      probeRel.Iterator(),
+			buildErr:     buildErr,
 			seen:         NewTupleKeyMapWithCapacity(expectedResults),
 			buildIsLeft:  buildIsLeft,
 			joinSyms:     joinSyms,
@@ -658,8 +667,16 @@ func HashJoinWithOptions(left, right Relation, joinSyms []query.Symbol, opts Exe
 			probeCount, matchCount, len(results))
 	}
 
-	// We already deduplicated with 'seen', no need to do it again
-	return NewMaterializedRelationNoDedupeWithOptions(outputSyms, results, opts)
+	// We already deduplicated with 'seen', no need to do it again.
+	// Carry any deferred build/probe error onto the result so a failed scan
+	// isn't laundered into an empty/partial join.
+	result := NewMaterializedRelationNoDedupeWithOptions(outputSyms, results, opts)
+	if buildErr != nil {
+		result.err = buildErr
+	} else if pe := probeIt.Error(); pe != nil {
+		result.err = pe
+	}
+	return result
 }
 
 // SemiJoin returns tuples from left that have matches in right

--- a/datalog/executor/phase_boundary_error_test.go
+++ b/datalog/executor/phase_boundary_error_test.go
@@ -1,0 +1,111 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/planner"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// failingScanMatcher returns a streaming relation that defers an error (like a
+// real storage scan whose value fails to decode) for one attribute, and ordinary
+// data for any other. It lets a synthetic multi-phase RealizedPlan drive a
+// failing scan into a specific phase.
+type failingScanMatcher struct {
+	failAttr datalog.Keyword
+	dataRel  Relation
+}
+
+func (m *failingScanMatcher) Match(pattern *query.DataPattern, _ Relations) (Relation, error) {
+	var syms []query.Symbol
+	for _, el := range pattern.Elements {
+		if v, ok := el.(query.Variable); ok {
+			syms = append(syms, v.Name)
+		}
+	}
+	if c, ok := pattern.GetA().(query.Constant); ok {
+		if attr, ok := c.Value.(datalog.Keyword); ok && attr == m.failAttr {
+			// A real scan surfaces a decode failure as a StreamingRelation whose
+			// iterator defers the error to Error(); mirror that here so Project and
+			// the phase pipeline see a realistic failing source.
+			inner := NewMaterializedRelation(syms, nil).Iterator()
+			return NewStreamingRelation(syms, &failingIterator{inner: inner, failAfter: 0}), nil
+		}
+	}
+	return m.dataRel, nil
+}
+
+// TestExecuteRealized_NonLastPhaseKeep_SurfacesScanError feeds a hand-built
+// two-phase RealizedPlan to the executor. Phase 0's scan fails (deferred error)
+// and is a non-last phase with Keep symbols, so its result flows through the Keep
+// projection in ExecuteRealized and then across the phase boundary into phase 1.
+// The failure must surface, not be laundered into an empty result.
+//
+// The planner currently never emits multi-phase plans (the greedy phaser
+// collapses every query into one phase — unintentionally), so this laundering
+// site is only reachable via a synthetic plan today. That does not make the
+// laundering acceptable: when the phaser is fixed to emit real multi-phase plans,
+// a failing scan in a non-last phase must already propagate.
+func TestExecuteRealized_NonLastPhaseKeep_SurfacesScanError(t *testing.T) {
+	symE := datalog.NewSymbol("?e")
+	symV := datalog.NewSymbol("?v")
+	symW := datalog.NewSymbol("?w")
+	aAttr := datalog.NewKeyword(":doc/a")
+	bAttr := datalog.NewKeyword(":doc/b")
+
+	varE := query.Variable{Name: symE}
+	varV := query.Variable{Name: symV}
+	varW := query.Variable{Name: symW}
+
+	// Phase 0 scans :doc/a (fails); Phase 1 scans :doc/b joining on ?e.
+	p0 := &query.DataPattern{Elements: []query.PatternElement{varE, query.Constant{Value: aAttr}, varV}}
+	p1 := &query.DataPattern{Elements: []query.PatternElement{varE, query.Constant{Value: bAttr}, varW}}
+
+	plan := &planner.RealizedPlan{
+		Query: &query.Query{
+			Find:  []query.FindElement{query.FindVariable{Symbol: symW}},
+			In:    []query.InputSpec{query.DatabaseInput{Name: datalog.SymDollar}},
+			Where: []query.Clause{p0, p1},
+		},
+		Phases: []planner.RealizedPhase{
+			{
+				// Non-last phase: provides ?e ?v, keeps ?e for phase 1.
+				Query: &query.Query{
+					Find:  []query.FindElement{query.FindVariable{Symbol: symE}, query.FindVariable{Symbol: symV}},
+					In:    []query.InputSpec{query.DatabaseInput{Name: datalog.SymDollar}},
+					Where: []query.Clause{p0},
+				},
+				Provides: []query.Symbol{symE, symV},
+				Keep:     []query.Symbol{symE},
+				Metadata: map[string]interface{}{},
+			},
+			{
+				// Last phase: joins phase 0's ?e with :doc/b.
+				Query: &query.Query{
+					Find:  []query.FindElement{query.FindVariable{Symbol: symW}},
+					In:    []query.InputSpec{query.DatabaseInput{Name: datalog.SymDollar}, query.RelationInput{Symbols: []query.Symbol{symE}}},
+					Where: []query.Clause{p1},
+				},
+				Available: []query.Symbol{symE},
+				Provides:  []query.Symbol{symE, symW},
+				Metadata:  map[string]interface{}{},
+			},
+		},
+	}
+
+	dataRel := NewMaterializedRelation(
+		[]query.Symbol{symE, symW},
+		[]Tuple{{datalog.NewIdentity("e1"), "w1"}},
+	)
+	matcher := &failingScanMatcher{failAttr: aAttr, dataRel: dataRel}
+	exec := NewExecutor(matcher, nil)
+
+	result, err := exec.ExecuteRealized(NewContext(nil), plan, nil)
+	if err == nil && result != nil {
+		err = driveErr(result)
+	}
+	require.ErrorIs(t, err, errInjectedIterator,
+		"a failing scan in a non-last phase must surface, not be laundered by the Keep projection or phase boundary")
+}

--- a/datalog/executor/product_test.go
+++ b/datalog/executor/product_test.go
@@ -43,3 +43,26 @@ func TestProductPreservesDisjointSymbols(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, combos, 1, "should find 1 unique ?config value")
 }
+
+// TestProductMaterializeSurfacesSourceError verifies that materializing a
+// Product() of disjoint relations surfaces a constituent relation's deferred
+// iterator error rather than laundering it into an empty result. This is the
+// "product path" of docs/bugs/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md;
+// it is reached in production where a subquery's input groups are disjoint and
+// the combined relation is materialized (query_executor.go input combination).
+func TestProductMaterializeSurfacesSourceError(t *testing.T) {
+	// failAfter 0 → yields no tuples and reports its failure via Error(), exactly
+	// like a storage scan whose value fails to decode (e.g. a missing Tier-3 blob).
+	failing := newFailingRelation(0, Tuple{int64(1)})
+	other := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?config")},
+		[]Tuple{{"config-1"}},
+	)
+
+	product := Relations{failing, other}.Product()
+	require.IsType(t, &ProductRelation{}, product, "two disjoint relations must form a ProductRelation")
+
+	mat := product.Materialize()
+	require.ErrorIs(t, driveErr(mat), errInjectedIterator,
+		"materializing a product must surface a constituent's deferred error, not drop it")
+}

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -1950,7 +1950,19 @@ func (e *DefaultQueryExecutor) filterWithNotJoinClause(ctx Context, clause *quer
 			return nil, fmt.Errorf("NOT-JOIN inner clause execution failed: %w", err)
 		}
 
-		if innerResult != nil && innerResult.Size() > 0 {
+		// Count inner results via ForEach so a failed inner scan surfaces as an
+		// error rather than looking like "no match" — which would wrongly
+		// un-exclude this combo and silently corrupt the NOT-JOIN result.
+		matched := false
+		if innerResult != nil {
+			count := 0
+			if ferr := ForEach(innerResult, func(Tuple) error { count++; return nil }); ferr != nil {
+				return nil, fmt.Errorf("NOT-JOIN inner clause execution failed: %w", ferr)
+			}
+			matched = count > 0
+		}
+
+		if matched {
 			key := NewTupleKeyFull(combo)
 			matchedKeys.Put(key, struct{}{})
 		}

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -1504,42 +1504,6 @@ func extractKeyFromTuple(tuple Tuple, syms []query.Symbol, symbols []query.Symbo
 	return key
 }
 
-// crossJoinWithOuter produces the cross product of outer tuples with branch result tuples
-// Used when a fallback branch (like ground expression) doesn't include outer context
-func crossJoinWithOuter(outer, branch Relation, opts ExecutorOptions) Relation {
-	if outer == nil || branch == nil {
-		return branch
-	}
-
-	outerSyms := outer.Symbols()
-	branchSyms := branch.Symbols()
-
-	// Combined symbols: outer symbols + branch symbols
-	combinedSyms := make([]query.Symbol, 0, len(outerSyms)+len(branchSyms))
-	combinedSyms = append(combinedSyms, outerSyms...)
-	combinedSyms = append(combinedSyms, branchSyms...)
-
-	// Materialize branch result (usually small, like a single ground value)
-	var branchTuples []Tuple
-	collectTuplesInto(&branchTuples, branch)
-
-	// Cross join: for each outer tuple, combine with each branch tuple
-	var resultTuples []Tuple
-	outerIter := outer.Iterator()
-	for outerIter.Next() {
-		outerTuple := outerIter.Tuple()
-		for _, branchTuple := range branchTuples {
-			combined := make(Tuple, len(outerTuple)+len(branchTuple))
-			copy(combined, outerTuple)
-			copy(combined[len(outerTuple):], branchTuple)
-			resultTuples = append(resultTuples, combined)
-		}
-	}
-	outerIter.Close()
-
-	return NewMaterializedRelationWithOptions(combinedSyms, resultTuples, opts)
-}
-
 // executeOrClauseUnion implements standard Datalog union semantics
 func (e *DefaultQueryExecutor) executeOrClauseUnion(ctx Context, clause *query.OrClause, groups Relations) (Relation, error) {
 	collector := ctx.Collector()

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -25,7 +25,12 @@ func copyTuple(t Tuple) Tuple {
 // collectTuplesInto appends all tuples from a relation into the destination slice.
 // It checks RequiresCopy() to avoid unnecessary copying when the relation
 // guarantees stable tuple references (e.g., MaterializedRelation).
-func collectTuplesInto(dest *[]Tuple, rel Relation) {
+// collectTuplesInto appends all tuples from rel into dest and returns any error
+// the source iterator deferred to Error() (per the Iterator contract), plus a
+// Close() error if iteration was otherwise clean. Callers that build a cached
+// relation from the result must carry this error onto that relation so the
+// failure isn't laundered by materialization.
+func collectTuplesInto(dest *[]Tuple, rel Relation) error {
 	needsCopy := rel.RequiresCopy()
 	it := rel.Iterator()
 	for it.Next() {
@@ -35,7 +40,40 @@ func collectTuplesInto(dest *[]Tuple, rel Relation) {
 		}
 		*dest = append(*dest, tuple)
 	}
-	it.Close()
+	err := it.Error()
+	if cerr := it.Close(); err == nil {
+		err = cerr
+	}
+	return err
+}
+
+// ForEach drives rel's iterator per the documented Iterator contract: it yields
+// each tuple to fn, then resolves the outcome whether the loop ended by
+// exhaustion, an fn error, or an iterator failure. It returns, in priority
+// order: fn's error (iteration stops on the first), then it.Error() (iteration
+// aborted), then any Close() error. An iteration or fn error always wins over a
+// Close() error so a cleanup failure cannot mask the real cause.
+//
+// fn must copy the tuple if it retains it: streaming iterators may reuse the
+// tuple's backing memory across calls.
+func ForEach(rel Relation, fn func(Tuple) error) (err error) {
+	it := rel.Iterator()
+	// Close() is deferred (panic-safe) and is a separate signal: it only
+	// surfaces when nothing else failed, so a cleanup error can't mask the
+	// real iteration/fn error.
+	defer func() {
+		if cerr := it.Close(); err == nil {
+			err = cerr
+		}
+	}()
+	for it.Next() {
+		if e := fn(it.Tuple()); e != nil {
+			// fn error is the more specific cause; return it without consulting
+			// the iterator's deferred Error().
+			return e
+		}
+	}
+	return it.Error()
 }
 
 // CollectTuples materializes a Relation into [][]interface{}.
@@ -49,17 +87,14 @@ func CollectTuples(rel Relation, err error) ([][]interface{}, error) {
 	if rel == nil {
 		return [][]interface{}{}, nil
 	}
-	var tuples [][]interface{}
-	it := rel.Iterator()
-	defer it.Close()
-	for it.Next() {
-		src := it.Tuple()
+	tuples := [][]interface{}{}
+	if ferr := ForEach(rel, func(src Tuple) error {
 		t := make([]interface{}, len(src))
 		copy(t, src)
 		tuples = append(tuples, t)
-	}
-	if tuples == nil {
-		tuples = [][]interface{}{}
+		return nil
+	}); ferr != nil {
+		return nil, ferr
 	}
 	return tuples, nil
 }
@@ -217,6 +252,7 @@ func (i *CountingIterator) IsDone() bool {
 type CachingIterator struct {
 	inner             Iterator
 	cache             *[]Tuple      // Pointer to cache in StreamingRelation
+	errPtr            *error        // Pointer to err in StreamingRelation (captured on completion)
 	cacheComplete     chan struct{} // Closed when caching finishes
 	cachingInProgress *bool         // Pointer to flag in StreamingRelation
 	cacheReady        *bool         // Pointer to ready flag in StreamingRelation
@@ -226,11 +262,12 @@ type CachingIterator struct {
 }
 
 // NewCachingIterator creates a caching iterator that builds a cache as it iterates
-func NewCachingIterator(inner Iterator, cachePtr *[]Tuple, completeChan chan struct{},
+func NewCachingIterator(inner Iterator, cachePtr *[]Tuple, errPtr *error, completeChan chan struct{},
 	cachingInProgress *bool, cacheReady *bool, mu *sync.Mutex) *CachingIterator {
 	return &CachingIterator{
 		inner:             inner,
 		cache:             cachePtr,
+		errPtr:            errPtr,
 		cacheComplete:     completeChan,
 		cachingInProgress: cachingInProgress,
 		cacheReady:        cacheReady,
@@ -262,8 +299,14 @@ func (ci *CachingIterator) Next() bool {
 		return true
 	}
 
-	// Iteration complete - signal waiting goroutines
+	// Iteration complete - capture any deferred source error for cache replay,
+	// then signal waiting goroutines.
 	ci.done = true
+	if ci.errPtr != nil {
+		ci.mu.Lock()
+		*ci.errPtr = ci.inner.Error()
+		ci.mu.Unlock()
+	}
 	ci.signalComplete()
 	return false
 }
@@ -312,6 +355,11 @@ type MaterializedRelation struct {
 	symbols []query.Symbol
 	tuples  []Tuple
 	options ExecutorOptions
+	// err is the deferred error from the source iteration that produced these
+	// tuples (e.g., a stream that failed partway while being cached). It is
+	// replayed by Iterator().Error() so a failure isn't laundered by
+	// materialization. nil when the source iterated cleanly.
+	err error
 }
 
 func NewMaterializedRelation(symbols []query.Symbol, tuples []Tuple) *MaterializedRelation {
@@ -396,7 +444,21 @@ func (r *MaterializedRelation) Iterator() Iterator {
 	return &sliceIterator{
 		tuples: r.tuples,
 		pos:    -1,
+		err:    r.err,
 	}
+}
+
+// carryErr propagates this relation's deferred (taint) error onto a relation
+// derived from it, so a transform of incomplete data stays marked incomplete.
+// Used by the unary transforms, which build a new relation from r's tuples.
+func (r *MaterializedRelation) carryErr(derived Relation) Relation {
+	if r.err == nil {
+		return derived
+	}
+	if m, ok := derived.(*MaterializedRelation); ok && m.err == nil {
+		m.err = r.err
+	}
+	return derived
 }
 
 func (r *MaterializedRelation) Size() int {
@@ -599,7 +661,9 @@ func (r *MaterializedRelation) Project(symbols []query.Symbol) (Relation, error)
 		projected[i] = projTuple
 	}
 
-	return NewMaterializedRelationWithOptions(symbols, projected, r.options), nil
+	result := NewMaterializedRelationWithOptions(symbols, projected, r.options)
+	result.err = r.err // a projection of tainted data is still tainted
+	return result, nil
 }
 
 // Materialize returns self since MaterializedRelation is already materialized
@@ -610,7 +674,7 @@ func (r *MaterializedRelation) Materialize() Relation {
 // Sort returns a new relation sorted by the specified order-by clauses
 func (r *MaterializedRelation) Sort(orderBy []query.OrderByClause) Relation {
 	// Use the SortRelation function we created
-	return SortRelation(r, orderBy)
+	return r.carryErr(SortRelation(r, orderBy))
 }
 
 // Filter returns a new relation with only tuples that satisfy the filter
@@ -739,6 +803,9 @@ func contains(symbols []query.Symbol, sym query.Symbol) bool {
 type sliceIterator struct {
 	tuples []Tuple
 	pos    int
+	// err is the deferred error replayed by a cached/materialized relation that
+	// was built from a source whose iteration failed. nil for clean caches.
+	err error
 }
 
 func (it *sliceIterator) Next() bool {
@@ -757,7 +824,7 @@ func (it *sliceIterator) Close() error {
 	return nil
 }
 
-func (it *sliceIterator) Error() error { return nil }
+func (it *sliceIterator) Error() error { return it.err }
 
 // StreamingRelation wraps an iterator as a relation
 type StreamingRelation struct {
@@ -785,6 +852,11 @@ type StreamingRelation struct {
 	// Lightweight size tracking: count tuples without buffering data
 	counter        *CountingIterator // For tracking tuple count during iteration
 	iteratorCalled bool              // Track if Iterator() was already called (for single-use enforcement)
+
+	// err holds the source iterator's deferred error, captured when the cache
+	// finishes building. Replayed by cache-replay iterators so a failure during
+	// the first (caching) pass isn't lost on subsequent iterations.
+	err error
 }
 
 func NewStreamingRelation(symbols []query.Symbol, iterator Iterator) *StreamingRelation {
@@ -815,10 +887,12 @@ func (r *StreamingRelation) Iterator() Iterator {
 
 	// Fast path: If we have a complete cache, return reusable iterator
 	if r.cacheReady {
+		err := r.err
 		r.mu.Unlock()
 		return &sliceIterator{
 			tuples: r.cache,
 			pos:    -1,
+			err:    err, // replay the source failure captured during cache build
 		}
 	}
 
@@ -831,9 +905,13 @@ func (r *StreamingRelation) Iterator() Iterator {
 		<-completeChan
 
 		// Cache is now ready, return iterator over cached data
+		r.mu.Lock()
+		err := r.err
+		r.mu.Unlock()
 		return &sliceIterator{
 			tuples: r.cache,
 			pos:    -1,
+			err:    err,
 		}
 	}
 
@@ -870,7 +948,7 @@ func (r *StreamingRelation) Iterator() Iterator {
 
 	// If caching enabled, wrap with CachingIterator
 	if r.shouldCache {
-		return NewCachingIterator(baseIter, &r.cache, r.cacheComplete, &r.cachingInProgress, &r.cacheReady, &r.mu)
+		return NewCachingIterator(baseIter, &r.cache, &r.err, r.cacheComplete, &r.cachingInProgress, &r.cacheReady, &r.mu)
 	}
 
 	// Pure streaming - single use
@@ -1170,10 +1248,15 @@ func (r *StreamingRelation) Materialize() Relation {
 func (r *StreamingRelation) Sort(orderBy []query.OrderByClause) Relation {
 	// Collect all tuples (can't sort without materializing)
 	var tuples []Tuple
-	collectTuplesInto(&tuples, r)
+	err := collectTuplesInto(&tuples, r)
 
-	// Create MaterializedRelation and delegate to its Sort
 	mat := NewMaterializedRelationWithOptions(r.symbols, tuples, r.options)
+	if err != nil {
+		// Source failed mid-iteration: carry the error so the boundary sees it
+		// and discards the (incomplete) data. Sorting tainted data is moot.
+		mat.err = err
+		return mat
+	}
 	return mat.Sort(orderBy)
 }
 
@@ -1433,7 +1516,7 @@ func (p *ProductRelation) Project(symbols []query.Symbol) (Relation, error) {
 
 func (p *ProductRelation) Materialize() Relation {
 	var tuples []Tuple
-	collectTuplesInto(&tuples, p)
+	_ = collectTuplesInto(&tuples, p)
 	return NewMaterializedRelationWithOptions(p.symbols, tuples, p.options)
 }
 

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -1516,8 +1516,10 @@ func (p *ProductRelation) Project(symbols []query.Symbol) (Relation, error) {
 
 func (p *ProductRelation) Materialize() Relation {
 	var tuples []Tuple
-	_ = collectTuplesInto(&tuples, p)
-	return NewMaterializedRelationWithOptions(p.symbols, tuples, p.options)
+	err := collectTuplesInto(&tuples, p)
+	result := NewMaterializedRelationWithOptions(p.symbols, tuples, p.options)
+	result.err = err
+	return result
 }
 
 func (p *ProductRelation) Sort(orderBy []query.OrderByClause) Relation {

--- a/datalog/executor/relation_ops.go
+++ b/datalog/executor/relation_ops.go
@@ -460,6 +460,7 @@ func unionRelations(relations []Relation, syms []query.Symbol, opts ExecutorOpti
 
 	seen := NewTupleKeyMap()
 	var allTuples []Tuple
+	var firstErr error
 
 	for _, rel := range relations {
 		// Build symbol index mapping
@@ -498,10 +499,16 @@ func unionRelations(relations []Relation, syms []query.Symbol, opts ExecutorOpti
 				allTuples = append(allTuples, projected)
 			}
 		}
+		// Capture a branch's deferred scan error so the union doesn't drop it.
+		if e := iter.Error(); e != nil && firstErr == nil {
+			firstErr = e
+		}
 		iter.Close()
 	}
 
-	return NewMaterializedRelationWithOptions(syms, allTuples, opts)
+	result := NewMaterializedRelationWithOptions(syms, allTuples, opts)
+	result.err = firstErr
+	return result
 }
 
 // convertPlannerConstraints converts planner-level storage constraints to executor-level constraints

--- a/datalog/executor/union_relation.go
+++ b/datalog/executor/union_relation.go
@@ -111,8 +111,10 @@ func (ur *UnionRelation) Project(symbols []query.Symbol) (Relation, error) {
 // Errors from Close() are silently dropped (limitation of Relation interface)
 func (ur *UnionRelation) Materialize() Relation {
 	var allTuples []Tuple
-	collectTuplesInto(&allTuples, ur)
-	return NewMaterializedRelation(ur.symbols, allTuples)
+	err := collectTuplesInto(&allTuples, ur)
+	mat := NewMaterializedRelation(ur.symbols, allTuples)
+	mat.err = err
+	return mat
 }
 
 // Sort returns a sorted relation (forces materialization)
@@ -236,8 +238,13 @@ func (it *UnionIterator) Next() bool {
 			continue
 		}
 
-		// Current iterator exhausted - close it and get next relation
+		// Current iterator exhausted - capture any deferred error before
+		// discarding it (otherwise UnionIterator.Error() loses it once
+		// currentIter is nil), then close and get the next relation.
 		if it.currentIter != nil {
+			if e := it.currentIter.Error(); e != nil && it.firstError == nil {
+				it.firstError = e
+			}
 			it.currentIter.Close()
 			it.currentIter = nil
 			it.currentRelation = nil

--- a/datalog/executor/union_relation_error_test.go
+++ b/datalog/executor/union_relation_error_test.go
@@ -1,0 +1,36 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Reproductions for docs/bugs/BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.md
+
+// TestUnionIterator_InnerIteratorErrorPropagates: when an inner relation's
+// iterator yields some tuples and then fails, UnionIterator closes it without
+// checking Error() first, so the failure is lost. Consuming the union to
+// exhaustion and checking Error() must surface the inner failure.
+func TestUnionIterator_InnerIteratorErrorPropagates(t *testing.T) {
+	syms := []query.Symbol{datalog.NewSymbol("?x")}
+
+	ch := make(chan relationItem, 1)
+	ch <- relationItem{relation: newFailingRelation(1, Tuple{int64(1)}, Tuple{int64(2)})}
+	close(ch)
+
+	ur := NewUnionRelation(ch, syms, ExecutorOptions{})
+	it := ur.Iterator()
+	defer it.Close()
+	for it.Next() {
+		// drain to exhaustion
+	}
+	require.ErrorIs(t, it.Error(), errInjectedIterator)
+}
+
+// NOTE: the UnionRelation concurrent-iteration / one-shot-channel cache-build
+// race is a separate bug (BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP,
+// "Failure Mode 1"). Its reproduction belongs with that fix, not the
+// error-propagation work here.

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -170,7 +170,7 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 		planCache:         planner.NewPlanCache(1000, 0),
 		parseCache:        NewParseCache(1000),
 		schema:            opts.Schema,
-		annotationHandler: opts.AnnotationHandler,
+		annotationHandler: annotations.Synchronized(opts.AnnotationHandler),
 		plannerOptions:    opts.PlannerOptions,
 		clock:             clock,
 		replicaID:         replicaID,
@@ -351,7 +351,9 @@ func (d *Database) AnnotationHandler() annotations.Handler {
 func (d *Database) SetAnnotationHandler(handler annotations.Handler) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	d.annotationHandler = handler
+	// Serialize: the engine emits annotations from parallel workers, so the
+	// handler must be safe to call concurrently.
+	d.annotationHandler = annotations.Synchronized(handler)
 }
 
 // NewTransaction starts a new write transaction.
@@ -943,9 +945,6 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 	if err != nil {
 		return err
 	}
-	iter := rel.Iterator()
-	defer iter.Close()
-
 	// Check if element type is a struct or scalar
 	// time.Time and Keyword are structs but treated as scalars
 	// Identity is a pointer type alias and goes through scalar path automatically
@@ -958,12 +957,17 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 		}
 
 		newSlice := reflect.MakeSlice(sliceVal.Type(), 0, 0)
-		for iter.Next() {
+		// ForEach surfaces iterator errors (decode/blob/CRDT failures deferred
+		// to Error()) instead of letting them look like a complete result.
+		if ferr := executor.ForEach(rel, func(t executor.Tuple) error {
 			elem := reflect.New(elemType).Elem()
-			if err := mapper.MapTuple(iter.Tuple(), elem); err != nil {
+			if err := mapper.MapTuple(t, elem); err != nil {
 				return err
 			}
 			newSlice = reflect.Append(newSlice, elem)
+			return nil
+		}); ferr != nil {
+			return ferr
 		}
 		sliceVal.Set(newSlice)
 		return nil
@@ -975,23 +979,14 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 	}
 
 	newSlice := reflect.MakeSlice(sliceVal.Type(), 0, 0)
-	for iter.Next() {
-		tuple := iter.Tuple()
+	if ferr := executor.ForEach(rel, func(tuple executor.Tuple) error {
 		if len(tuple) == 0 {
-			continue
+			return nil
 		}
-
-		var elemVal reflect.Value
-		if elemIsPtr {
-			elemVal = reflect.New(elemType).Elem()
-		} else {
-			elemVal = reflect.New(elemType).Elem()
-		}
-
+		elemVal := reflect.New(elemType).Elem()
 		if err := setScalarValue(elemVal, tuple[0]); err != nil {
 			return err
 		}
-
 		if elemIsPtr {
 			ptr := reflect.New(elemType)
 			ptr.Elem().Set(elemVal)
@@ -999,6 +994,9 @@ func (d *Database) QueryInto(dest interface{}, queryInput interface{}, inputs ..
 		} else {
 			newSlice = reflect.Append(newSlice, elemVal)
 		}
+		return nil
+	}); ferr != nil {
+		return ferr
 	}
 	sliceVal.Set(newSlice)
 	return nil
@@ -1043,16 +1041,24 @@ func (d *Database) QueryOneInto(dest interface{}, queryInput interface{}, inputs
 	iter := rel.Iterator()
 	defer iter.Close()
 
-	// Read first tuple
+	// Read first tuple. A false Next() can mean empty OR a deferred iterator
+	// failure — check Error() so a failure isn't reported as "not found".
 	if !iter.Next() {
+		if e := iter.Error(); e != nil {
+			return false, e
+		}
 		return false, nil
 	}
 	firstTuple := make([]interface{}, len(iter.Tuple()))
 	copy(firstTuple, iter.Tuple())
 
-	// Check for multiple results
+	// Check for multiple results. A false Next() here can also be a failure;
+	// don't let it look like "exactly one result".
 	if iter.Next() {
 		return false, dlreflect.ErrMultipleResults
+	}
+	if e := iter.Error(); e != nil {
+		return false, e
 	}
 
 	// Check if destination is a struct (but not time.Time, Identity, Keyword which are scalars)

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -797,6 +797,12 @@ func (it *hashJoinIterator) Next() bool {
 			}
 		}
 	}
+	// Inner iterator exhausted — propagate any deferred error (e.g. a
+	// CRDTResolvingIterator decode/blob failure that made Next() return false
+	// rather than erroring in Datom()).
+	if srcErr := it.iter.Error(); srcErr != nil && it.err == nil {
+		it.err = srcErr
+	}
 	return false
 }
 

--- a/datalog/storage/matcher_iterator_reusing.go
+++ b/datalog/storage/matcher_iterator_reusing.go
@@ -210,6 +210,12 @@ func (it *reusingIterator) Next() bool {
 		it.currentIdx++
 		if it.currentIdx >= len(it.tuples) {
 			if it.storageIter != nil {
+				// Propagate any deferred error before discarding the inner
+				// iterator (e.g., a CRDTResolvingIterator decode/blob failure
+				// that made Next() return false rather than erroring in Datom()).
+				if srcErr := it.storageIter.Error(); srcErr != nil && it.err == nil {
+					it.err = srcErr
+				}
 				it.storageIter.Close()
 			}
 			return false

--- a/datalog/storage/query_boundary_error_test.go
+++ b/datalog/storage/query_boundary_error_test.go
@@ -1,0 +1,179 @@
+package storage
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Integration reproduction for docs/bugs/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md.
+//
+// A Tier-3 value stores its compressed bytes in the blob store with a content
+// hash in the index key. If the blob is missing, decoding the value fails — and
+// the storage iterator surfaces that only through Error() after Next() returns
+// false. This drives a REAL deferred-iterator failure through the public
+// boundaries (CollectTuples / QueryInto / QueryOneInto), which must not report
+// it as an empty or "not found" success.
+
+// writeTier3ValueThenCorruptBlob writes one datom whose value lands in the Tier-3
+// blob store, then deletes every blob key so the value can no longer be decoded.
+func writeTier3ValueThenCorruptBlob(t *testing.T) (*Database, datalog.Identity, datalog.Keyword) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// DisableCache so reads hit storage (and thus the blob) rather than a warm
+	// resolved value. Small compression threshold so the value is compressed;
+	// large incompressible payload so the compressed form exceeds the in-key
+	// size limit and routes to Tier 3.
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir,
+		DisableCache:         true,
+		CompressionThreshold: 64,
+	})
+	require.NoError(t, err)
+
+	e := datalog.NewIdentity("doc-1")
+	a := datalog.NewKeyword(":doc/blob")
+
+	// Tier 3 requires the *compressed* size to exceed maxKeyValueSize (60000).
+	// Use a large incompressible (random) region so it can't shrink below that,
+	// plus a compressible (zero) region so Compress() reports a net benefit and
+	// returns non-nil (pure-random returns nil and would store raw, inline).
+	payload := make([]byte, 80*1024)
+	_, err = rand.Read(payload)
+	require.NoError(t, err)
+	payload = append(payload, make([]byte, 80*1024)...)
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, payload))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Delete all blob keys (prefix 0xFF) so the value cannot be decoded.
+	deleted := 0
+	err = db.store.db.Update(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+		prefix := []byte{0xFF}
+		var keys [][]byte
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			keys = append(keys, it.Item().KeyCopy(nil))
+		}
+		for _, k := range keys {
+			if derr := txn.Delete(k); derr != nil {
+				return derr
+			}
+			deleted++
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Greater(t, deleted, 0, "expected a Tier-3 blob to corrupt; value may not have routed to the blob store")
+
+	return db, e, a
+}
+
+func TestCollectTuples_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	_, err := executor.CollectTuples(db.Query(`[:find ?v :in $ ?e :where [?e :doc/blob ?v]]`, e))
+	require.ErrorContains(t, err, "blob", "a missing blob must not be reported as an empty result")
+}
+
+func TestQueryInto_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	var out [][]byte
+	err := db.QueryInto(&out, `[:find ?v :in $ ?e :where [?e :doc/blob ?v]]`, e)
+	require.ErrorContains(t, err, "blob", "a missing blob must not be reported as an empty slice")
+}
+
+func TestQueryOneInto_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	var out []byte
+	found, err := db.QueryOneInto(&out, `[:find ?v :in $ ?e :where [?e :doc/blob ?v]]`, e)
+	require.ErrorContains(t, err, "blob", "a missing blob must not be reported as found=false,nil")
+	require.False(t, found)
+}
+
+// TestQueryOrderBy_SurfacesBlobDecodeError: order-by materializes (Sort) the
+// failing scan; the error must survive that transform to the boundary.
+func TestQueryOrderBy_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	_, err := executor.CollectTuples(db.Query(`[:find ?v :in $ ?e :where [?e :doc/blob ?v] :order-by [?v]]`, e))
+	require.ErrorContains(t, err, "blob", "order-by over a missing blob must surface the error")
+}
+
+// TestQueryAggregate_SurfacesBlobDecodeError: aggregation consumes the failing
+// scan; the error must survive that transform to the boundary.
+func TestQueryAggregate_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	_, err := executor.CollectTuples(db.Query(`[:find (count ?v) :in $ ?e :where [?e :doc/blob ?v]]`, e))
+	require.ErrorContains(t, err, "blob", "aggregate over a missing blob must surface the error")
+}
+
+// TestQueryNot_SurfacesBlobDecodeError: the (not [?e :doc/blob ?v]) inner scan
+// decodes the value; when that fails, the inner relation looks empty and NOT
+// would wrongly include the entity. The error must surface instead of producing
+// a silently-wrong result.
+func TestQueryNot_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, datalog.NewKeyword(":doc/name"), "doc-one"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	_, err = executor.CollectTuples(db.Query(`[:find ?n :in $ ?e :where [?e :doc/name ?n] (not [?e :doc/blob ?v])]`, e))
+	require.ErrorContains(t, err, "blob", "a failed inner scan must surface, not silently un-exclude the entity")
+}
+
+// TestIndexNestedLoop_SurfacesBlobDecodeError: the index-nested-loop strategy
+// (reusingIterator) is not reachable via db.Query (the matcher hardcodes
+// HashJoinScan), so this drives it directly with IndexNestedLoopThreshold high.
+// The reusingIterator must surface the inner scan's deferred error on exhaustion.
+func TestIndexNestedLoop_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	q, err := parser.ParseQuery(`[:find ?v :in $ ?e :where [?e :doc/blob ?v]]`)
+	require.NoError(t, err)
+	pattern := q.Where[0].(*query.DataPattern)
+
+	matcher := NewBadgerMatcherWithOptions(db.store, executor.ExecutorOptions{IndexNestedLoopThreshold: 999999})
+	bindingRel := executor.NewMaterializedRelation([]query.Symbol{datalog.NewSymbol("?e")}, []executor.Tuple{{e}})
+
+	result, err := matcher.Match(pattern, executor.Relations{bindingRel})
+	require.NoError(t, err)
+	it := result.Iterator()
+	for it.Next() {
+	}
+	require.ErrorContains(t, it.Error(), "blob", "index-nested-loop scan must surface the blob decode error")
+	it.Close()
+}
+
+// TestQueryGroupedAggregate_SurfacesBlobDecodeError: a grouped aggregation
+// (group-by var in :find) routes through the grouped path; the failing scan's
+// error must survive.
+func TestQueryGroupedAggregate_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	_, err := executor.CollectTuples(db.Query(`[:find ?e (count ?v) :in $ ?e :where [?e :doc/blob ?v]]`, e))
+	require.ErrorContains(t, err, "blob", "grouped aggregate over a missing blob must surface the error")
+}

--- a/datalog/storage/query_boundary_error_test.go
+++ b/datalog/storage/query_boundary_error_test.go
@@ -177,3 +177,56 @@ func TestQueryGroupedAggregate_SurfacesBlobDecodeError(t *testing.T) {
 	_, err := executor.CollectTuples(db.Query(`[:find ?e (count ?v) :in $ ?e :where [?e :doc/blob ?v]]`, e))
 	require.ErrorContains(t, err, "blob", "grouped aggregate over a missing blob must surface the error")
 }
+
+// TestQueryRelationInput_SurfacesBlobDecodeError: a RelationInput query
+// (:in $ [[?e] ...]) iterates per input tuple and collects the per-tuple results;
+// that collection must propagate a failing scan's error, not drop it.
+func TestQueryRelationInput_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	_, err := executor.CollectTuples(db.Query(
+		`[:find ?v :in $ [[?e] ...] :where [?e :doc/blob ?v]]`,
+		[][]any{{e}}))
+	require.ErrorContains(t, err, "blob", "relation-input iteration over a missing blob must surface the error")
+}
+
+// TestQuerySubquery_SurfacesBlobDecodeError: a subquery whose inner scan decodes
+// the corrupted blob must surface the error through subquery result combination.
+func TestQuerySubquery_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	_, err := executor.CollectTuples(db.Query(
+		`[:find ?v :in $ ?e
+		  :where [(q [:find ?bv :in $ ?e2 :where [?e2 :doc/blob ?bv]] $ ?e) [[?v]]]]`,
+		e))
+	require.ErrorContains(t, err, "blob", "subquery over a missing blob must surface the error")
+}
+
+// TestQueryOr_SurfacesBlobDecodeError: an (or ...) branch that scans the
+// corrupted blob must surface the error through union of branch results.
+func TestQueryOr_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	_, err := executor.CollectTuples(db.Query(
+		`[:find ?v :in $ ?e :where (or [?e :doc/blob ?v] [?e :doc/missing ?v])]`,
+		e))
+	require.ErrorContains(t, err, "blob", "OR branch over a missing blob must surface the error")
+}
+
+// TestQueryMultiPhase_SurfacesBlobDecodeError: a two-pattern join over the
+// corrupted value must surface the error rather than return empty. NOTE: this
+// propagates via the collapsed/streaming join path; it does NOT force the failing
+// scan into a non-last phase's Keep projection in executor.go — that laundering
+// site (Site 1) is not yet triggered and remains open.
+func TestQueryMultiPhase_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	_, err := executor.CollectTuples(db.Query(
+		`[:find ?e2 :in $ ?e :where [?e :doc/blob ?v] [?e2 :doc/blob ?v]]`,
+		e))
+	require.ErrorContains(t, err, "blob", "multi-phase join over a missing blob must surface the error")
+}

--- a/datalog/storage/query_boundary_error_test.go
+++ b/datalog/storage/query_boundary_error_test.go
@@ -230,3 +230,117 @@ func TestQueryMultiPhase_SurfacesBlobDecodeError(t *testing.T) {
 		e))
 	require.ErrorContains(t, err, "blob", "multi-phase join over a missing blob must surface the error")
 }
+
+// writeValidThenCorruptBlob writes two :doc/blob datoms so an unbound scan yields
+// a VALID row first and a FAILING row second. The attr-bound, E/V-unbound scan is
+// E-primary (AETV for cardinality-one, AEVT for cardinality-many), and L85 is
+// sort-order-preserving and IS the E key component, so the entity with the lower
+// L85 is scanned first. That entity gets a small inline value (always decodes);
+// the other gets a large Tier-3 value whose blob is then deleted. Deleting every
+// blob key corrupts only the Tier-3 entity, so the failure lands on the SECOND
+// Next() — exercising the truncation / second-Next() boundary paths.
+func writeValidThenCorruptBlob(t *testing.T) *Database {
+	t.Helper()
+	dir := t.TempDir()
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:                 dir,
+		DisableCache:         true,
+		CompressionThreshold: 64,
+	})
+	require.NoError(t, err)
+
+	a := datalog.NewKeyword(":doc/blob")
+	low, high := datalog.NewIdentity("doc-1"), datalog.NewIdentity("doc-2")
+	if high.L85() < low.L85() {
+		low, high = high, low // ensure `low` sorts first in the E-primary scan
+	}
+
+	// Tier 3 requires the compressed size to exceed maxKeyValueSize (60000): a
+	// large incompressible region plus a compressible region so Compress() helps.
+	payload := make([]byte, 80*1024)
+	_, err = rand.Read(payload)
+	require.NoError(t, err)
+	payload = append(payload, make([]byte, 80*1024)...)
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(low, a, []byte("ok"))) // small → inline, always decodes
+	require.NoError(t, tx.Set(high, a, payload))     // large → Tier 3 blob
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Delete all blob keys (prefix 0xFF). Only `high` is Tier-3, so only its value
+	// becomes undecodable; `low` is inline and still resolves.
+	deleted := 0
+	err = db.store.db.Update(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+		prefix := []byte{0xFF}
+		var keys [][]byte
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			keys = append(keys, it.Item().KeyCopy(nil))
+		}
+		for _, k := range keys {
+			if derr := txn.Delete(k); derr != nil {
+				return derr
+			}
+			deleted++
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Greater(t, deleted, 0, "expected a Tier-3 blob to corrupt")
+
+	return db
+}
+
+// TestQueryInto_SurfacesBlobDecodeErrorAfterPartialResults: QueryInto consumes a
+// scan that yields one valid row then fails (Failure Mode 3, truncation). The
+// error must surface AND the destination must not be populated with the partial
+// prefix. If the ForEach error check were missing, out would hold the valid "ok"
+// row and err would be nil.
+func TestQueryInto_SurfacesBlobDecodeErrorAfterPartialResults(t *testing.T) {
+	db := writeValidThenCorruptBlob(t)
+	defer db.Close()
+
+	var out [][]byte
+	err := db.QueryInto(&out, `[:find ?v :where [?e :doc/blob ?v]]`)
+	require.ErrorContains(t, err, "blob", "a mid-iteration failure must surface, not yield a truncated success")
+	require.Nil(t, out, "destination must not be populated with the partial prefix on error")
+}
+
+// TestQueryOneInto_SurfacesBlobDecodeErrorOnSecondNext: QueryOneInto reads a
+// valid first row, then the second Next() fails (Verification Plan #4). The error
+// must surface as found=false. If the second-Next() Error() check were missing,
+// the first row would be mapped and the call would return found=true, nil.
+func TestQueryOneInto_SurfacesBlobDecodeErrorOnSecondNext(t *testing.T) {
+	db := writeValidThenCorruptBlob(t)
+	defer db.Close()
+
+	var out []byte
+	found, err := db.QueryOneInto(&out, `[:find ?v :where [?e :doc/blob ?v]]`)
+	require.ErrorContains(t, err, "blob", "a failure on the second Next() must surface, not look like exactly one result")
+	require.False(t, found, "a failed second Next() must not be reported as a found single result")
+}
+
+// TestScan_YieldsValidRowThenFails asserts the precondition the two tests above
+// rely on: the scan yields exactly one valid row and THEN fails. This is what
+// makes them exercise the truncation / second-Next() branches rather than the
+// already-covered first-Next() path. If the scan order ever changes, this fails
+// and flags the coverage regression directly.
+func TestScan_YieldsValidRowThenFails(t *testing.T) {
+	db := writeValidThenCorruptBlob(t)
+	defer db.Close()
+
+	rel, err := db.Query(`[:find ?v :where [?e :doc/blob ?v]]`)
+	require.NoError(t, err)
+	it := rel.Iterator()
+	defer it.Close()
+
+	yielded := 0
+	for it.Next() {
+		yielded++
+	}
+	require.ErrorContains(t, it.Error(), "blob")
+	require.Equal(t, 1, yielded, "exactly one valid row must precede the failing row (truncation precondition)")
+}

--- a/docs/bugs/BUG_DOCUMENTATION_OPTION_DRIFT.md
+++ b/docs/bugs/BUG_DOCUMENTATION_OPTION_DRIFT.md
@@ -1,0 +1,291 @@
+# BUG: Documentation and Option Surface Drift From Executable Defaults
+
+**Date**: 2026-05-24
+**Severity**: Medium - users can enable stale options or trust performance claims that are no longer wired to defaults
+**Status**: Open (documentation/API consistency issue)
+**Affected**: `TODO.md`, `PERFORMANCE_STATUS.md`, `DATOMIC_COMPATIBILITY.md`, `storage.DefaultPlannerOptions`, `planner.PlannerOptions`
+
+## Summary
+
+The repository's documentation, planner option names, and executable defaults
+have drifted apart.
+
+Several docs describe features as complete, default, or production-ready, while
+the current option surface marks related flags as disabled, deprecated, ignored,
+or moved to experimental. Conversely, some implemented optimization paths are
+documented as part of normal planning but are not enabled by the default database
+configuration.
+
+This creates a product/API correctness problem: users and future maintainers can
+turn on stale flags, assume optimizations are active when they are not, or trust
+performance claims that no longer correspond to the default code path.
+
+## Evidence
+
+### 1. `TODO.md` says conditional aggregate rewriting is complete
+
+```markdown
+- **Conditional aggregate rewriting (7.7x faster correlated aggregates)**
+- **AETV index for A-primary CRDT resolution**
+- **Value elimination: ~50% storage reduction (keys-only storage)**
+
+### Production Readiness: Ready
+
+The engine is **functionally complete, semantically correct, and blazingly fast**.
+```
+
+### 2. `PlannerOptions` says the same option is disabled / experimental
+
+```go
+type PlannerOptions struct {
+    // ...
+    EnableConditionalAggregateRewriting bool // DISABLED: Feature moved to experimental/
+    EnableAlgebraOptimizer              bool // Enable relational algebra IR optimization
+    EnableSubqueryDecorrelation         bool // Deprecated: legacy executor decorrelation is retired; use EnableAlgebraOptimizer
+    EnableParallelDecorrelation         bool // Deprecated: no effect without the retired legacy decorrelation path
+    // ...
+}
+```
+
+The public option still exists, but its comment says it is disabled. The docs
+still advertise the feature as complete and performance-relevant.
+
+### 3. Semantic rewriting is documented as part of planning, but default options do not enable it
+
+The architecture docs describe time extraction folding as part of planner clause
+rewriting:
+
+```markdown
+Time extraction folding: `[(year ?t) ?y] + [(= ?y 2025)]` is rewritten to
+`[(>= ?t 2025-01-01T00:00:00Z)] + [(< ?t 2026-01-01T00:00:00Z)]`.
+```
+
+But the database defaults do not set `EnableSemanticRewriting: true`:
+
+```go
+func DefaultPlannerOptions() planner.PlannerOptions {
+    return planner.PlannerOptions{
+        UseClauseBasedPlanner: true,
+
+        EnableDynamicReordering: true,
+        EnablePredicatePushdown: true,
+        EnableAlgebraOptimizer:  true,
+        // EnableSemanticRewriting is omitted, so the bool default is false.
+        // ...
+    }
+}
+```
+
+The implementation checks the flag before rewriting:
+
+```go
+func (r *SemanticRewriter) Rewrite(clauses []query.Clause) []query.Clause {
+    if !r.options.EnableSemanticRewriting {
+        return clauses
+    }
+
+    return r.rewriteTimeExtractions(clauses)
+}
+```
+
+So the documented optimization is not active by default unless another caller
+explicitly sets the option.
+
+### 4. Some options are explicitly ignored but still exposed
+
+`PlannerOptions` contains fields that are described as deprecated or ignored:
+
+```go
+UseClauseBasedPlanner   bool // Deprecated: always true. Only one planner now.
+EnableDynamicReordering bool // Legacy option (ignored by clause-based planner)
+MaxPhases               int  // Legacy option (ignored by clause-based planner)
+EnableFineGrainedPhases bool // Legacy option (ignored by clause-based planner)
+```
+
+Keeping ignored options can be useful for compatibility, but the public docs
+should clearly identify them as compatibility no-ops. Otherwise advanced users
+will reasonably expect these flags to change planner behavior.
+
+## Expected Behavior
+
+For any documented feature or option, one of the following should be true:
+
+1. The feature is active in the default path and documented as default.
+2. The feature is implemented but opt-in, and docs show exactly how to enable it.
+3. The feature is experimental/disabled, and docs do not present it as production
+   behavior.
+4. The option is deprecated/ignored, and docs mark it as a compatibility no-op.
+
+## Actual Behavior
+
+The repository currently mixes all four states:
+
+- docs present some optimizations as complete/default
+- option comments mark related flags as disabled or deprecated
+- default options omit some documented rewrites
+- performance docs contain historical benchmark claims without always tying them
+  to the current default configuration
+
+## Why This Matters
+
+### 1. Users Can Tune the Wrong Knobs
+
+An advanced user reading the docs may set `EnableConditionalAggregateRewriting`
+or `EnableDynamicReordering` expecting behavior changes. The comments say those
+paths are disabled, retired, or ignored.
+
+### 2. Performance Claims Become Hard to Trust
+
+The codebase has unusually detailed performance documentation, but performance
+claims need to say whether they apply to:
+
+- current defaults,
+- opt-in options,
+- archived/retired implementations, or
+- benchmarks from a previous architecture.
+
+Without that distinction, the docs overstate confidence in the shipped path.
+
+### 3. Future Bug Triage Gets Noisy
+
+When behavior differs from docs, users report "planner bug" or "optimization
+regression" even when the actual issue is a disabled flag or stale doc.
+
+### 4. Sole-Author Codebases Need Executable Truth
+
+This repository contains a lot of valuable design history. The risk is that
+history and current truth live side by side without a strong marker separating
+them. That is especially dangerous in a database, where stale architecture notes
+can lead to wrong assumptions during correctness work.
+
+## Failure Modes
+
+### Failure Mode 1: User Assumes Time Rewrite Is Default
+
+User writes:
+
+```clojure
+[:find ?e
+ :where [?e :price/time ?t]
+        [(year ?t) ?y]
+        [(= ?y 2025)]]
+```
+
+Docs imply this folds to a range predicate. Default options leave
+`EnableSemanticRewriting` false, so the expression path runs normally.
+
+The query is correct but slower than documented.
+
+### Failure Mode 2: User Enables Retired Conditional Aggregate Flag
+
+User reads the performance docs, enables:
+
+```go
+planner.PlannerOptions{
+    EnableConditionalAggregateRewriting: true,
+}
+```
+
+The option exists, but the type comment says the feature is disabled/moved to
+experimental. The user has no clear way to know whether the flag is live,
+ignored, or partially live.
+
+### Failure Mode 3: Maintainer Investigates an Ignored Option
+
+A maintainer sees a benchmark difference and toggles `MaxPhases` or
+`EnableFineGrainedPhases`, not realizing the current clause-based planner ignores
+those fields.
+
+That wastes debugging time and can produce misleading conclusions.
+
+## Fix Direction
+
+### 1. Create a Single Current-Truth Options Reference
+
+Update `docs/reference/PLANNER_OPTIONS.md` so every option is categorized:
+
+- **Default-active**
+- **Opt-in active**
+- **Compatibility no-op**
+- **Experimental/disabled**
+- **Removed in effect; retained for API compatibility**
+
+Each option should state:
+
+- default value from `storage.DefaultPlannerOptions`
+- whether it changes current code behavior
+- which files consume it
+- whether it affects correctness, performance, or observability
+
+### 2. Align Top-Level Docs With Defaults
+
+Update `README.md`, `ARCHITECTURE.md`, `TODO.md`, and
+`PERFORMANCE_STATUS.md` to distinguish:
+
+- current default behavior
+- optional behavior
+- archived historical behavior
+
+Avoid "production-ready" claims immediately next to known disabled/experimental
+features unless the caveat is explicit.
+
+### 3. Consider Deprecation Enforcement
+
+For ignored options, consider one of:
+
+1. remove them if API stability is not required,
+2. mark them with `Deprecated:` Go doc comments so `go doc` surfaces it, or
+3. validate options and emit annotation/warning events when no-op fields are set.
+
+Example:
+
+```go
+// Deprecated: ignored by the clause-based planner. Kept only for source
+// compatibility with older tests/configuration.
+EnableDynamicReordering bool
+```
+
+### 4. Add Drift Tests
+
+If docs keep a machine-readable options table, add a small test that verifies
+the documented defaults match `DefaultPlannerOptions()`.
+
+At minimum, add tests around high-risk assumptions:
+
+- semantic rewriting default state
+- algebra optimizer default state
+- conditional aggregate rewriting flag behavior
+- deprecated planner flags do not affect plans
+
+## Verification Plan
+
+1. Run a documentation audit for all mentions of:
+   - `EnableSemanticRewriting`
+   - `EnableConditionalAggregateRewriting`
+   - `EnableSubqueryDecorrelation`
+   - `EnableDynamicReordering`
+   - `MaxPhases`
+   - `UseClauseBasedPlanner`
+
+2. For each mention, label it as current/default/opt-in/archived.
+
+3. Add or update tests:
+   - `TestDefaultPlannerOptions_DocumentedDefaults`
+   - `TestDeprecatedPlannerOptions_DoNotChangePlan`
+   - `TestSemanticRewriting_DefaultMatchesDocs`
+
+4. Re-run:
+
+```bash
+go test ./...
+```
+
+## Related
+
+- `docs/wip/QUERY_EXECUTOR_FEATURE_GAPS.md` already documents some remaining
+  QueryExecutor optimization gaps and is more careful about status than the
+  top-level roadmap.
+- `PERFORMANCE_STATUS.md` contains valuable benchmark history but needs sharper
+  labeling of current defaults versus historical/opt-in paths.
+- `TODO.md` currently mixes roadmap, marketing summary, and historical status in
+  one file; that makes drift more likely.

--- a/docs/bugs/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md
+++ b/docs/bugs/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md
@@ -1,0 +1,246 @@
+# BUG: Iterator Errors Dropped at Public Result Boundaries
+
+**Date**: 2026-05-24
+**Severity**: High - storage/decode/subquery failures can become successful partial results
+**Status**: Open (code review finding; needs dedicated repro tests)
+**Affected**: `executor.CollectTuples`, `storage.Database.QueryInto`, `storage.Database.QueryOneInto`, tuple collection paths that cannot return errors
+
+## Summary
+
+The executor `Iterator` contract says callers must check `Error()` after `Next()`
+returns false. Several public result-consumption APIs iterate relations and return
+success without checking `Iterator.Error()`.
+
+That means an iterator-level failure can be misreported as:
+
+1. an empty successful result,
+2. a truncated successful result, or
+3. `found=false, nil` from `QueryOneInto`.
+
+This is especially risky because the storage layer intentionally moved some
+failures into deferred iterator errors. `KeyOnlyIterator.Next()` returns false on
+decode failure and preserves the error for `Error()`. `CRDTResolvingIterator`
+does the same for source decode errors and unique-walk failures.
+
+## Root Cause
+
+The iterator contract is explicit:
+
+```go
+type Iterator interface {
+    Next() bool
+    Tuple() Tuple
+    Close() error
+
+    // Error returns any error encountered during iteration.
+    // Callers must check Error() after Next() returns false to
+    // distinguish normal exhaustion from execution failure.
+    Error() error
+}
+```
+
+But result collection paths do not consistently enforce that contract.
+
+### `executor.CollectTuples`
+
+```go
+func CollectTuples(rel Relation, err error) ([][]interface{}, error) {
+    if err != nil {
+        return nil, err
+    }
+    if rel == nil {
+        return [][]interface{}{}, nil
+    }
+    var tuples [][]interface{}
+    it := rel.Iterator()
+    defer it.Close()
+    for it.Next() {
+        src := it.Tuple()
+        t := make([]interface{}, len(src))
+        copy(t, src)
+        tuples = append(tuples, t)
+    }
+    if tuples == nil {
+        tuples = [][]interface{}{}
+    }
+    return tuples, nil
+}
+```
+
+There is no `if err := it.Error(); err != nil { return nil, err }` after the
+loop. A failing iterator is indistinguishable from a normally exhausted iterator.
+
+### `storage.Database.QueryInto`
+
+```go
+iter := rel.Iterator()
+defer iter.Close()
+
+// ...
+for iter.Next() {
+    elem := reflect.New(elemType).Elem()
+    if err := mapper.MapTuple(iter.Tuple(), elem); err != nil {
+        return err
+    }
+    newSlice = reflect.Append(newSlice, elem)
+}
+sliceVal.Set(newSlice)
+return nil
+```
+
+Both the struct-mapping path and scalar path return nil after the loop without
+checking `iter.Error()`.
+
+### `storage.Database.QueryOneInto`
+
+```go
+iter := rel.Iterator()
+defer iter.Close()
+
+if !iter.Next() {
+    return false, nil
+}
+firstTuple := make([]interface{}, len(iter.Tuple()))
+copy(firstTuple, iter.Tuple())
+
+if iter.Next() {
+    return false, dlreflect.ErrMultipleResults
+}
+```
+
+If the first `Next()` returns false due to an iterator failure, the API reports
+"not found" with no error. If the second `Next()` fails, the method proceeds as if
+there was exactly one result.
+
+## Why This Matters
+
+The storage and executor layers now have several iterators where failures are
+only visible through `Error()`:
+
+- `KeyOnlyIterator` decodes datoms in `Next()` and stores decode/blob lookup
+  errors in `currentError`
+- `CRDTResolvingIterator` records source `Datom()` errors and unique-walk errors
+  in `err`
+- `UnionIterator` can hold errors from parallel subquery workers
+- wrapper iterators generally propagate inner errors through their own `Error()`
+
+The repository already has tests for the storage iterator error contract, but the
+public consumption APIs do not consistently participate in that contract.
+
+## Expected Behavior
+
+Any public API that consumes a `Relation` should return iterator errors to the
+caller.
+
+Examples:
+
+- `executor.CollectTuples(...)` should return the iterator error
+- `QueryInto(...)` should return the iterator error and not silently install a
+  partial destination slice
+- `QueryOneInto(...)` should return the iterator error instead of `found=false`
+  or a partial success
+
+## Actual Behavior
+
+Several public APIs return success after `Next()` stops, regardless of whether
+iteration stopped normally or due to failure.
+
+## Failure Modes
+
+### Failure Mode 1: Blob Decode Failure Becomes Empty Result
+
+If a Tier 3 hashed value points at a missing/corrupt blob, `DatomFromKey` returns
+an error. Through `KeyOnlyIterator`, that can surface as `Next() == false` plus a
+non-nil `Error()`.
+
+`CollectTuples` currently reports `[][]interface{}{}` and `nil`.
+
+### Failure Mode 2: `QueryOneInto` Reports Not Found
+
+If the first iterator step fails, `QueryOneInto` returns:
+
+```go
+return false, nil
+```
+
+That is indistinguishable from a legitimate empty query result.
+
+### Failure Mode 3: Truncated Results
+
+If an iterator yields some tuples and then fails, `QueryInto` can populate the
+destination with the prefix and return nil.
+
+That is worse than an empty result because the caller sees plausible data.
+
+## Impact
+
+### Correctness
+
+Errors in storage decoding, blob lookup, CRDT resolution, or streaming union
+execution can be silently converted into valid-looking query results.
+
+### Debuggability
+
+The lower layers may preserve the right error, but the public API drops it at the
+last boundary. Users will debug "missing data" instead of seeing the real decode
+or iterator failure.
+
+### Trust
+
+This bug class undermines the iterator error propagation work already present in
+the storage layer. The contract is only useful if every consumer checks it.
+
+## Fix Direction
+
+Add explicit iterator error checks in all public and internal collection paths
+that can return errors.
+
+Immediate targets:
+
+1. `executor.CollectTuples`
+2. `storage.Database.QueryInto`
+3. `storage.Database.QueryOneInto`
+
+For internal helpers that currently cannot return errors, either:
+
+1. introduce error-returning variants, or
+2. ensure callers consume through a boundary that checks `Error()` before
+   returning to the user.
+
+Be careful with `defer iter.Close()`: `Close()` and `Error()` are separate
+signals. The iterator error should be checked before returning, and close errors
+should not mask a more specific iteration error unless that is a deliberate
+policy.
+
+## Verification Plan
+
+Add regression tests with a relation whose iterator yields controlled failures:
+
+1. `TestCollectTuples_ReturnsIteratorError`
+   - relation iterator returns false with `Error() == sentinel`
+   - expect `CollectTuples` returns sentinel
+
+2. `TestQueryInto_ReturnsIteratorError`
+   - execute through a fake or injected relation path if possible
+   - expect destination is not silently populated as success
+
+3. `TestQueryOneInto_ReturnsIteratorErrorOnFirstNext`
+   - first `Next()` returns false due to sentinel error
+   - expect `found=false, err=sentinel`
+
+4. `TestQueryOneInto_ReturnsIteratorErrorOnSecondNext`
+   - first tuple succeeds, second `Next()` fails
+   - expect sentinel error, not single-result success
+
+Also add one storage-backed test if practical:
+
+- create a datom with a Tier 3 hashed value, delete/corrupt the blob key, query
+  it, and verify the public API returns a blob/decode error.
+
+## Related
+
+- `datalog/storage/iterator_error_propagation_test.go` documents the storage
+  iterator error contract.
+- `docs/bugs/BUG_ITERATOR_LEAK_BUILTIN_EVALUATION.md` is another example where
+  iterator lifecycle obligations were correct in the interface but not
+  consistently observed by consumers.

--- a/docs/bugs/BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.md
+++ b/docs/bugs/BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.md
@@ -1,0 +1,265 @@
+# BUG: UnionRelation Concurrent Iteration and Inner Error Drop
+
+**Date**: 2026-05-24
+**Severity**: Medium-High - streaming union can race, duplicate consumption, or hide worker/inner iterator failures
+**Status**: Open (code review finding; needs focused reproducer)
+**Affected**: `executor.UnionRelation`, `executor.UnionIterator`, streaming subquery union paths
+
+## Summary
+
+`UnionRelation` is intended to make a channel-backed streaming union reusable:
+the first `Iterator()` consumes the channel and builds a tuple cache, and later
+`Iterator()` calls replay that cache.
+
+The implementation has two related problems:
+
+1. **Concurrent `Iterator()` calls before the cache is built can create multiple
+   consumers over the same one-shot channel and shared cache slice.**
+2. **Errors from the current inner relation iterator are dropped when that inner
+   iterator exhausts and is closed.**
+
+Both issues sit on a high-risk boundary: parallel subquery execution produces
+relations through a channel, while the `Relation` interface promises reusable
+iteration.
+
+## Root Cause
+
+### 1. `Iterator()` protects construction, not active cache building
+
+```go
+func (ur *UnionRelation) Iterator() Iterator {
+    ur.cacheMutex.Lock()
+    defer ur.cacheMutex.Unlock()
+
+    // If cache is already built, return a simple slice iterator over cached tuples
+    if ur.cacheBuilt {
+        return &sliceIterator{
+            tuples: ur.cached,
+            pos:    -1,
+        }
+    }
+
+    // First call - need to consume channel and build cache
+    return NewUnionIteratorWithCache(ur.source, &ur.cached, &ur.cacheBuilt)
+}
+```
+
+The mutex only protects the short critical section that creates the iterator. It
+does not record "cache build in progress."
+
+If goroutine A calls `Iterator()` and starts consuming the channel, goroutine B
+can call `Iterator()` before A finishes. Since `cacheBuilt` is still false, B also
+gets a `UnionIterator` over the same channel and the same cache pointer.
+
+That violates the comment at the top of the file:
+
+```go
+// IMPORTANT: Channels can only be consumed once, but Relations must be reusable
+// (multiple Iterator() calls).
+// Solution: First Iterator() call consumes channel and caches results,
+// subsequent calls replay from cache.
+```
+
+The current code implements "subsequent calls after cache completion replay from
+cache," not "subsequent calls while cache is building wait for cache completion."
+
+### 2. Inner iterator errors are not checked before discard
+
+```go
+// Current iterator exhausted - close it and get next relation
+if it.currentIter != nil {
+    it.currentIter.Close()
+    it.currentIter = nil
+    it.currentRelation = nil
+}
+```
+
+When an inner iterator's `Next()` returns false, `UnionIterator` closes and drops
+it without checking `it.currentIter.Error()`.
+
+`UnionIterator.Error()` can only return `currentIter.Error()` while
+`currentIter` is still assigned:
+
+```go
+func (it *UnionIterator) Error() error {
+    if it.firstError != nil {
+        return it.firstError
+    }
+    if it.currentIter != nil {
+        return it.currentIter.Error()
+    }
+    return nil
+}
+```
+
+After the iterator is closed and set to nil, that error is lost.
+
+## Expected Behavior
+
+`UnionRelation` should preserve normal `Relation` semantics:
+
+1. Multiple calls to `Iterator()` should be safe.
+2. A channel-backed relation should only have one channel consumer.
+3. Iterators created while the cache is being built should either:
+   - block until the cache is complete and then replay it, or
+   - participate in a documented single-use protocol.
+4. Any error from worker items or inner relation iterators should surface via
+   `Iterator.Error()`.
+
+## Actual Behavior
+
+1. Multiple concurrent `Iterator()` calls can consume the same channel.
+2. Multiple iterators can append to the same cache slice without synchronization.
+3. Inner iterator errors can be dropped at relation boundaries.
+
+## Failure Mode 1: Split Channel Consumption
+
+### Sketch
+
+```go
+union := NewUnionRelation(ch, symbols, opts)
+
+go func() {
+    it := union.Iterator()
+    defer it.Close()
+    for it.Next() {
+        // consume some results
+    }
+}()
+
+go func() {
+    it := union.Iterator()
+    defer it.Close()
+    for it.Next() {
+        // consumes from the same channel concurrently
+    }
+}()
+```
+
+Possible outcomes:
+
+- each iterator sees only part of the union
+- cache contents are incomplete or nondeterministic
+- tuple order and dedup behavior depends on scheduling
+- cache append races under the race detector
+
+## Failure Mode 2: Inner Iterator Error Lost
+
+### Sketch
+
+1. Channel yields a relation whose iterator returns several tuples.
+2. Inner iterator then stops with `Error() == sentinel`.
+3. `UnionIterator.Next()` sees `currentIter.Next() == false`.
+4. It calls `currentIter.Close()` and sets `currentIter = nil`.
+5. `UnionIterator.Error()` returns nil because `firstError` is nil and
+   `currentIter` is gone.
+
+The caller gets a successful prefix of the union.
+
+## Failure Mode 3: Worker Error Can Be Delayed or Masked
+
+`relationItem.err` is captured in `firstError`, but the iterator continues
+processing other items:
+
+```go
+if item.err != nil {
+    if it.firstError == nil {
+        it.firstError = item.err
+    }
+    continue
+}
+```
+
+Continuing after an error is defensible if the final `Error()` is always checked,
+but it compounds the public-boundary bug documented in
+`BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md`: callers that collect
+tuples without checking `Error()` will see a plausible partial result.
+
+## Impact
+
+### Correctness
+
+Parallel subquery results can be silently truncated or split between iterators if
+the relation is iterated concurrently before cache completion.
+
+### Resource Safety
+
+If a second iterator drains the channel unexpectedly, the first iterator's close
+and drain behavior can interact badly with producer goroutines. The current code
+tries to drain remaining items in `Close()` to unblock producers, which is
+reasonable for a single consumer but fragile when there are multiple consumers.
+
+### Error Reporting
+
+Inner relation failures can vanish even if callers correctly check
+`UnionIterator.Error()`.
+
+## Fix Direction
+
+### Cache Build Protocol
+
+Make cache construction an explicit state machine:
+
+```text
+notStarted -> building -> built
+                 |
+                 v
+              failed
+```
+
+Only one iterator should own channel consumption. Other `Iterator()` calls while
+state is `building` should wait on a completion channel/condition and then replay
+the built cache.
+
+The cache append path must be protected if any design allows more than one
+goroutine to touch the cache. The simpler design is single builder, many replay
+readers.
+
+### Error Preservation
+
+Before closing an exhausted inner iterator:
+
+```go
+if err := it.currentIter.Error(); err != nil && it.firstError == nil {
+    it.firstError = err
+}
+_ = it.currentIter.Close()
+```
+
+Also consider preserving close errors if no iteration error has already been
+recorded.
+
+### Public Boundary
+
+This bug should be fixed together with public iterator error propagation. A
+perfect `UnionIterator.Error()` still does not help if `CollectTuples`,
+`QueryInto`, or `QueryOneInto` drop the error after iteration.
+
+## Verification Plan
+
+Add focused unit tests:
+
+1. `TestUnionRelation_ConcurrentIteratorWhileBuilding`
+   - create a channel-backed union whose producer blocks between relation items
+   - call `Iterator()` from two goroutines before the first finishes
+   - expect both iterators to see the same complete tuple set
+   - run under `-race`
+
+2. `TestUnionRelation_OnlyOneChannelConsumer`
+   - instrument channel item consumption count
+   - verify one builder consumes the channel and later iterators replay cache
+
+3. `TestUnionIterator_InnerIteratorErrorPropagates`
+   - channel yields a relation with an iterator that fails after one tuple
+   - consume union to exhaustion
+   - expect `it.Error()` returns sentinel
+
+4. `TestUnionRelation_MaterializeReturnsIteratorError`
+   - after the public-boundary fix, materializing or collecting a failing union
+     should return the stored error instead of silently returning a prefix
+
+## Related
+
+- `docs/bugs/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md`
+- `docs/bugs/BUG_STREAMING_TUPLE_COPYING.md`
+- `docs/bugs/BUG_ITERATOR_LEAK_BUILTIN_EVALUATION.md`

--- a/docs/bugs/BUG_VBOUND_BYTES_WRONG_RESULTS_UNDER_RACE.md
+++ b/docs/bugs/BUG_VBOUND_BYTES_WRONG_RESULTS_UNDER_RACE.md
@@ -1,0 +1,74 @@
+# BUG: V-bound cardinality-one byte queries return empty under `-race`
+
+**Date**: 2026-05-24
+**Severity**: Unknown — potentially High (wrong query results), pending root-cause
+**Status**: Open (observed, root cause not yet determined)
+**Affected**: V-bound cardinality-one `TypeBytes` queries via the candidate+validate path (`validatingVBoundIterator`, AVET/VAET candidate scan + EATV validation). Observed in `datalog/storage/vbound_bytes_validation_test.go`.
+
+## Summary
+
+A V-bound query on a cardinality-one `TypeBytes` attribute — `[:find ?e :in $ ?v :where [?e :doc/hash ?v]]` with a `[]byte` value — returns **0 rows when it should return 1** when the package is run under the Go race detector (`-race`). The same tests pass under the standard test gate (`go test -count=1 ./...`, no `-race`).
+
+The race detector does **not** report a data race for these failures. It is a wrong *result*, surfaced only under `-race` scheduling — which points at timing/ordering sensitivity in the V-bound validation path rather than an unsynchronized memory access the detector can see.
+
+## How it was discovered
+
+While fixing an unrelated, genuine data race in parallel-subquery annotation handling (see `BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md` work / `annotations.Synchronized`), the storage package was run under `-race`. That run surfaced these V-bound failures. `-race` is not the project's standard gate, so this had not been observed before.
+
+## Reproduction
+
+```bash
+go test -count=1 -race ./datalog/storage/ -run 'TestVBoundCardinalityOneBytes'
+```
+
+Observed, consistently across runs:
+
+```
+--- FAIL: TestVBoundCardinalityOneBytes_NoPanic          ("[]" should have 1 item(s), but has 0)
+--- FAIL: TestVBoundCardinalityOneBytes_MatchesByContent
+--- PASS: TestVBoundCardinalityOneBytes_RejectsStaleCandidate
+--- FAIL: TestVBoundCardinalityOneBytes_AfterOverwrite
+--- PASS: TestVBoundCardinalityOneBytes_AfterRemove
+```
+
+Without `-race` (the standard gate), all five pass:
+
+```bash
+go test -count=1 ./datalog/storage/ -run 'TestVBoundCardinalityOneBytes'   # all PASS
+```
+
+## Established facts
+
+- The three failing tests (`NoPanic`, `MatchesByContent`, `AfterOverwrite`) all assert that the query **finds** the entity by its current byte value (expect ≥1 row).
+- The two passing tests (`RejectsStaleCandidate`, `AfterRemove`) assert the query returns **empty** (stale/removed value, expect 0 rows).
+- So the failure bias is consistent: under `-race`, the V-bound query returns **empty when it should find a match**. It never (observed) returns a spurious extra row.
+- The failure is an assertion failure (wrong row count), **not** a `WARNING: DATA RACE` from the detector.
+- The full standard suite (`go test -count=1 ./...`) is green, including these tests.
+- The query has no subqueries and a scalar `:in` input, so it does **not** go through the executor's parallel RelationInput iteration path.
+
+## Not yet established (root cause undetermined)
+
+The following are **hypotheses, not conclusions** — none have been verified, and they should not be treated as fact:
+
+- It may be specific to `[]byte` values (all affected tests use bytes); whether the same query shape on string/int values also diverges under `-race` has not been tested.
+- It may live in the candidate scan (AVET/VAET) or the EATV winner validation in `validatingVBoundIterator`, where `-race` scheduling could change iteration/seek ordering.
+- It may involve storage-layer concurrency (BadgerDB iterators, value prefetch) whose timing `-race` perturbs.
+
+Determining which requires dedicated investigation (e.g., narrowing to a single failing test, adding scan/validation annotations, and comparing the candidate set and EATV winner with vs. without `-race`).
+
+## Impact
+
+- If this reflects a genuine ordering/timing sensitivity, V-bound cardinality-one byte queries could return wrong (empty) results under real concurrent load, not just under `-race`. That is a correctness risk worth confirming.
+- If it is purely a `-race`-environment artifact, the practical impact is limited to running the suite under `-race`. This has **not** been determined.
+
+## Next steps
+
+1. Confirm determinism and isolate to a single failing test under `-race`.
+2. Determine whether it is `[]byte`-specific or affects all V-bound cardinality-one queries.
+3. Instrument the candidate scan and EATV validation to capture the candidate set and chosen winner with and without `-race`.
+4. Decide severity once the mechanism is known: real concurrency correctness bug vs. `-race`-only artifact.
+
+## Related
+
+- `docs/bugs/resolved/BUG_VBOUND_BYTES_VALIDATION_PANIC.md` — the original V-bound `[]byte` `==` panic (fixed in v0.11.4). Same code path; this is a different, result-correctness symptom.
+- `datalog/storage/vbound_bytes_validation_test.go` — the tests that surface this.

--- a/docs/bugs/resolved/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md
+++ b/docs/bugs/resolved/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-24
 **Severity**: High - storage/decode/subquery failures can become successful partial results
-**Status**: Open (code review finding; needs dedicated repro tests)
+**Status**: Resolved (2026-05-25) — see Resolution below
 **Affected**: `executor.CollectTuples`, `storage.Database.QueryInto`, `storage.Database.QueryOneInto`, tuple collection paths that cannot return errors
 
 ## Summary
@@ -244,3 +244,53 @@ Also add one storage-backed test if practical:
 - `docs/bugs/BUG_ITERATOR_LEAK_BUILTIN_EVALUATION.md` is another example where
   iterator lifecycle obligations were correct in the interface but not
   consistently observed by consumers.
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved.** Iterator-error propagation was threaded through the entire result pipeline, not only the three named public boundaries. All four verification-plan tests are in place, along with storage-backed reproductions and tests for the internal laundering sites discovered along the way.
+
+### Decisions
+
+- **Scope: the whole pipeline, not just the boundaries.** Fixing only `CollectTuples`/`QueryInto`/`QueryOneInto` would have left the error droppable at every internal materialization between the failing scan and the boundary. Error propagation was instead made a property of the relation/iterator plumbing, so any consumer inherits it.
+- **Keep the Go-standard `Next()` + `Error()` contract.** Changing the `Iterator` interface (e.g. folding the error into `Next()`'s return) was explicitly rejected. The deferred-error contract is deliberate and documented; the fix makes consumers honor it rather than altering the interface.
+- **One canonical consumer.** `executor.ForEach(rel, fn) error` drives `Next()`, checks `Error()`, and `Close()`s without masking the iteration error; `collectTuplesInto` now returns the iterator error. `MaterializedRelation`/`StreamingRelation` carry an `err` field that survives `Project`/`Sort`/materialize (`carryErr`), so a tainted relation stays tainted through derived relations.
+
+### Public boundaries
+
+- `CollectTuples` returns `it.Error()` after the loop.
+- `QueryInto` (struct and scalar paths) consumes via `ForEach` and returns before installing the destination slice, so a truncated iteration cannot leave a partial-but-"successful" result.
+- `QueryOneInto` checks `Error()` after both the first and the second `Next()`, so neither an empty-looking failure nor a second-row failure is misreported as "not found" or "exactly one result."
+
+### Internal laundering sites
+
+Error capture/propagation was added to: executor `HashJoin` build/probe; `unionRelations` and `UnionIterator`; single and grouped aggregation; the storage scan iterators (`unboundIterator`, `reusingIterator`, `hashJoinIterator`); the not-join inner consumer; the relation-input iteration (sequential and parallel); `ProductRelation.Materialize`; and the non-last-phase `Keep` projection.
+
+### The three "remaining laundering site" investigation
+
+Three suspected internal drops were enumerated and each judged on its merits rather than blanket-patched:
+
+- **`crossJoinWithOuter` — dead code.** No callers; it was deleted rather than "fixed."
+- **`ProductRelation.Materialize` — real, fixed.** `Relations.Product()` builds it for disjoint groups (reached in production at the subquery input-combination path). `ProductIterator.Error()` already aggregated its sub-iterators' errors — the drop was purely `Materialize` discarding it. It now carries the error onto the materialized result.
+- **Non-last-phase `Keep` projection — fixed defensively.** Key finding: the greedy phaser (`createPhasesGreedy`) collapses every satisfiable query into exactly one phase. This was confirmed empirically across nine query shapes and by argument: a selected clause's `Provides` become available within the same phase, so any clause satisfiable in a later phase is already satisfiable now (leftovers are unsatisfiable and would error, not form a clean phase 2). The non-last-phase block is therefore unreachable by any planned query today. **This single-phase collapse is unintentional**, so it was deliberately *not* pinned as an invariant — an early "always one phase" test was deleted precisely because it would have enshrined accidental behavior. Per decision, the Keep projection was still fixed and verified with a synthetic two-phase `RealizedPlan` fed straight to the executor, so it is correct once the phaser is fixed to emit real multi-phase plans. The phase boundary itself needed no new code: a failing (empty) group joins the next phase on the `Keep` symbol, and the `HashJoin` error capture carries it through `Collapse`.
+
+### Concurrency
+
+Running the suite under `-race` (not the standard gate) surfaced a genuine data race in parallel-subquery annotation handling: multiple workers shared one per-query context and one handler. Fixed with `forkContext` (a per-worker context) and `annotations.Synchronized` (serializes handler invocations at the install points, since the handler is also called from the storage matcher).
+
+### Issues encountered
+
+- **Test doubles must mirror real relation behavior.** A `failingRelation` that embeds a `MaterializedRelation` inherits its `Project`, which drops the error — unlike a real streaming scan whose `Project` composes iterators and carries it. The phase-boundary test had to use a `StreamingRelation`-backed failing source to be representative; an embedded-materialized double would have made the executor look correct when it was not.
+- **Weak assertions hide false greens.** `require.Error` passes on *any* error; assertions were tightened to `require.ErrorContains(..., "blob")` / `require.ErrorIs(..., errInjectedIterator)` so a test can only pass on the *expected* failure.
+- **A passing test does not prove the intended branch ran.** The two final boundary tests pass under either scan order, but only exercise the truncation / second-`Next()` branches if the valid row is scanned first. `TestScan_YieldsValidRowThenFails` pins that precondition (one row yielded, then error) so the coverage cannot silently degrade to the already-covered first-`Next()` path. The valid-first ordering is guaranteed, not hoped for: the attr-bound, E/V-unbound scan is E-primary (AETV/AEVT), `Identity.L85()` is sort-order-preserving and *is* the E key component, so the lower-L85 entity is scanned first and is given the valid inline value.
+
+### Tests
+
+- `datalog/executor/{foreach_test.go, iterator_error_boundary_test.go, caching_error_replay_test.go, union_relation_error_test.go, product_test.go, phase_boundary_error_test.go}`
+- `datalog/storage/query_boundary_error_test.go` — storage-backed reproductions using a corrupted Tier-3 blob, covering `CollectTuples`/`QueryInto`/`QueryOneInto`, order-by, aggregation, grouped aggregation, not, index-nested-loop, relation-input, subquery, or, multi-phase, plus the truncation and second-`Next()` cases.
+
+### Related / residual
+
+- `BUG_VBOUND_BYTES_WRONG_RESULTS_UNDER_RACE.md` was discovered while running `-race` and is documented separately (open; a wrong-result, not a data race the detector reports).
+- `BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.md`: its error-drop half is resolved here (UnionIterator inner-error capture); its concurrent cache-build race (Failure Mode 1) is a separate concern and is not addressed by this work.

--- a/docs/proposals/ITERATOR_ERROR_CONTRACT_ENFORCEMENT.md
+++ b/docs/proposals/ITERATOR_ERROR_CONTRACT_ENFORCEMENT.md
@@ -1,0 +1,147 @@
+# Plan: Enforce the Iterator Error Contract End-to-End
+
+**Date**: 2026-05-24
+**Status**: Proposal
+**Fixes**: `docs/bugs/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md`, and the error-drop half of `docs/bugs/BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.md`
+**Out of scope**: changing the `Next()`/`Error()` protocol; the `UnionRelation` concurrent-iteration / cache-build race (tracked separately in its own bug doc)
+
+## The contract is correct and deliberate
+
+The iterator protocol is the Go-standard `Next() bool` + `Error() error` pair (`sql.Rows`, `bufio.Scanner`). It is documented on the interface itself. From `datalog/storage/store.go`:
+
+> `Error()` must be checked after `Next()` returns false. A nil result indicates normal exhaustion; non-nil indicates that iteration aborted partway through (storage scan failure, sub-scan failure inside a wrapping iterator, or a `Datom()` decode error that couldn't be returned to the caller because `Next()` had already indicated "no next item"). [...] Wrapping iterators propagate from their inner iterator (return the first non-nil between the outer's own error and `inner.Error()`).
+
+That last clause is the structural justification: some failures are discovered *as* `Next()` returns false, when there is no in-band return value left to carry them. `Error()` is the channel for exactly those. `datalog/storage/iterator_error_propagation_test.go` exists to lock this contract in across the wrapping-iterator chain.
+
+**We are not changing this.** Replacing it with inline errors (`Next() (bool, error)`) or range-over-func was considered and rejected: it discards a deliberate, documented, idiomatic design that exists for a real reason, and it is an architectural reversal, not a bug fix.
+
+## The defect: consumers don't honor the contract
+
+There is exactly one legitimate error channel — `Iterator.Error()`. The bug is that not every consumer reads it. This shows up in two places.
+
+### 1. Boundary consumers drop `Error()`
+
+`executor.CollectTuples`, `storage.Database.QueryInto`, and `storage.Database.QueryOneInto` run `for it.Next() { ... }` and then return success without checking `it.Error()`. A storage decode, blob lookup, CRDT-resolution, or union failure becomes an empty result, a truncated result, or `found=false, nil`. `UnionIterator.Next()` is a sibling case: when an inner iterator exhausts it calls `Close()` without first checking `currentIter.Error()`, so the inner failure is lost even though the *outer* contract is otherwise fine.
+
+### 2. Caching relations drop the source `Error()`
+
+A terminology correction matters here. `Materialize()`, `Sorted()`, `Size()`, `Get()`, `IsEmpty()`, and `UnionRelation`'s cache are **not** an "eager evaluation" phase — they are **caching consumers**: they drive the underlying iterator once and remember the realized tuples for reuse. The relation's identity is unchanged; the cache is a performance/reuse mechanism.
+
+Because they are consumers, the contract applies to them — and because the relations they produce are *replayed* on later `Iterator()` calls, they are exactly the "wrapping iterators" the contract says must propagate the inner `Error()`. They currently don't:
+
+```go
+// datalog/executor/relation.go — collectTuplesInto, the collector behind Materialize()
+func collectTuplesInto(dest *[]Tuple, rel Relation) {
+    it := rel.Iterator()
+    for it.Next() { /* append */ }
+    it.Close() // <- source Error() never checked; Close() error discarded
+}
+```
+
+`Materialize()`/`Sorted()` build a `MaterializedRelation` that has no place to hold the source error, so order-by, aggregation, joins (build side), and `UnionRelation.Materialize` launder failures *before* any boundary can see them. `UnionRelation.Materialize`'s own comment admits it: "Errors from Close() are silently dropped (limitation of Relation interface)." This is a direct violation of the documented wrapping-iterator rule, not a missing feature.
+
+## Principle
+
+One error channel, honored everywhere. No second, parallel channel. Two parts:
+
+1. Implement the consume-and-check-`Error()` protocol in exactly one audited place, and route every boundary through it.
+2. Make caching relations comply with the contract they already violate: a cache must replay the source's terminal error through its own `Iterator.Error()`, just as any wrapping iterator does.
+
+---
+
+## Part 1 — One canonical consumer of the contract
+
+Add a single function that owns the documented protocol so no boundary re-derives it (wrongly):
+
+```go
+// ForEach drives rel's iterator per the documented contract: it yields each
+// tuple to fn, then — whether the loop ended by exhaustion, fn error, or
+// iterator failure — resolves the outcome. Returns:
+//   - fn's error if fn returned one (iteration stops),
+//   - else it.Error() if iteration aborted,
+//   - else any Close() error.
+// An iteration/fn error always takes precedence over a Close() error so a
+// cleanup failure can't mask the real cause.
+func ForEach(rel Relation, fn func(Tuple) error) error
+```
+
+Semantics, spelled out so the one implementation is unambiguous:
+
+- Drive `for it.Next()`, call `fn(it.Tuple())`; if `fn` returns an error, stop and return it (still `Close()` the iterator).
+- After the loop, call `it.Error()`. Non-nil → return it.
+- `Close()` is deferred; its error is returned only if no iteration/`fn` error already occurred. (Close and Error are separate signals; the iteration error is the more specific one and must win.)
+
+Route through it:
+
+- `CollectTuples` becomes a thin wrapper: `ForEach` appending copies.
+- `QueryInto` (struct path and scalar path) calls `ForEach`; the per-tuple `fn` does the reflect mapping and returns mapping errors directly, so both mapping errors and iterator errors share one path.
+- `QueryOneInto` uses a small "at most one" variant (or `ForEach` with a closure that captures the first tuple and returns `ErrMultipleResults` on the second). Critically, a first `Next()` that returns false must consult `Error()` before reporting `found=false`.
+- `UnionIterator.Next()`: before discarding an exhausted inner iterator, capture its error —
+
+  ```go
+  if err := it.currentIter.Error(); err != nil && it.firstError == nil {
+      it.firstError = err
+  }
+  _ = it.currentIter.Close()
+  ```
+
+  This is the same contract-compliance fix; it just happens inside a hand-written iterator rather than at a public boundary.
+
+The lone seam that can't use `ForEach` is `UnionIterator` itself, because it interleaves inner iteration with dedup and cache-building. That's fine: it implements the contract directly (the capture above), and the bug there was simply skipping the `Error()` check.
+
+---
+
+## Part 2 — Caching relations must obey the contract
+
+A cache of a stream must be transparent to *both* the tuples and the termination. Today it replays the tuples and swallows the terminal error. The fix is to carry the source's error so the cached relation's iterator reports it via `Error()`:
+
+- `collectTuplesInto` consumes via the canonical protocol, capturing the source `Error()` (and Close error) and returning it to its caller.
+- `MaterializedRelation` gains an `err error` field; its `sliceIterator.Error()` returns it. `Materialize()`/`Sorted()` set it from what `collectTuplesInto` reports. A `MaterializedRelation` built from a failed stream therefore replays "here are the tuples I got, then iteration aborted with this error" — a faithful implementation of the documented contract.
+- `UnionRelation`'s cache likewise records the builder's terminal error so replay iterators report it.
+
+Consequence: errors propagate through *any* number of caching layers (order-by over an aggregate over a failing scan) because each layer faithfully forwards the one `Error()` channel, and the boundary (Part 1) checks it. No signature changes, no parallel channel.
+
+### The lossy-signature methods stay as-is, and stay safe
+
+`Size() int`, `Get(i) Tuple`, `IsEmpty() bool`, `String()`, `Table()` cannot return an error. They do not need to, *provided Part 2 holds*: they may return a wrong/partial answer on a failing relation, but the error is not destroyed — it re-surfaces the moment the relation's data is actually consumed at an `Error()`-checking boundary. `Size`/`IsEmpty` feed plan/strategy choices (a wrong size yields a suboptimal plan, not a wrong result), and `String`/`Table` are debug formatting. None are the final correctness boundary, so leaving them lossy is acceptable as long as caching relations carry the error for the eventual real consumption.
+
+### Relationship to the previously-rejected "sticky error" (C)
+
+Earlier I floated stashing the error on the relation (option "C") and it was correctly called a side channel. The objection was sound *in that context*: I was simultaneously proposing to abolish `Error()`, so a stash was a contradictory parallel mechanism.
+
+With `Error()` affirmed as **the** documented contract, Part 2 is not a second channel. `MaterializedRelation.err` backing its iterator's `Error()` is the same kind of field as `KeyOnlyIterator.currentError` backing *its* `Error()` — it is the *implementation* of the one contract, not a bypass of it. The contract already requires wrapping iterators to propagate inner `Error()`; a caching relation is a replaying wrapper, so this is compliance, not invention.
+
+If that distinction doesn't hold up under scrutiny, the only contract-honoring alternative is error-returning signatures on the caching methods (`Materialize() (Relation, error)`, etc.) — more uniform but a broad `Relation` interface change.
+
+**Decided:** caching relations are contract-compliant `Error()` replayers. No `Relation` interface change. The caching-method-signature alternative is rejected.
+
+---
+
+## What we are explicitly not doing
+
+- Not changing `Next()`/`Error()` to inline errors or range-over-func.
+- Not introducing any error path other than `Iterator.Error()` and the existing executor return values (`Execute(...) ([]Relation, error)`, `Query(...) (Relation, error)`).
+- Not fixing the `UnionRelation` concurrent-iteration / one-shot-channel / cache-build race here — that is a separate correctness issue (single-builder state machine) tracked in `BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.md`.
+
+## Tests and guards
+
+- Reproductions already written and currently red: `TestCollectTuples_ReturnsIteratorError`, `...AfterPartialResults`, `TestUnionIterator_InnerIteratorErrorPropagates` (`datalog/executor/iterator_error_boundary_test.go`, `union_relation_error_test.go`).
+- Add: `QueryInto`/`QueryOneInto` boundary tests (first-`Next()` failure, mid-stream failure, second-`Next()` failure) — needs the canonical primitive so a failing relation can be exercised through the public API.
+- Add: caching-replay tests — materialize/sort/aggregate a failing stream and assert the resulting relation's `Iterator().Error()` returns the source error, and that a boundary over it returns the error.
+- Extend the existing `iterator_error_propagation_test.go` pattern from storage wrapping-iterators to the public boundaries.
+- Document the contract in the godoc at the public surface (`Database.Query`, the `Relation`/`Iterator` interfaces), since external callers receive `Relation`s directly (see below).
+
+## Public-surface reach
+
+`Database.Query` returns `(executor.Relation, error)` and `Database.Match` returns `executor.Relation` — both public, handing the exported `Relation` interface to external callers. So external code can drive `Iterator()` itself or use the exported `executor.CollectTuples`. Implications:
+
+- A lint/grep over this repo cannot cover external consumers, so it cannot enforce the contract on the public surface — only catch internal regressions. **Decided: no lint.** It would give false confidence without covering the surface that matters.
+- The lever that does reach external callers: make the error-checked consumers (`CollectTuples`, `QueryInto`, `QueryOneInto`, `ForEach`) the documented front door, and state the `Error()` contract in the godoc wherever a raw `Relation` is returned.
+- Regression protection is the boundary contract tests plus the canonical primitive being the obvious path, not a lint.
+
+A larger, separate question (not part of this fix): whether raw `Relation` should remain the *primary* public return, or whether the helpers should be the front door with raw iteration as an expert path.
+
+## Decisions
+
+1. **Part 2 mechanism — decided: contract-compliant `Error()` replay** on caching relations. No `Relation` interface change.
+2. **Lint guard — decided: none.** Rely on the canonical primitive, boundary contract tests, and godoc at the public surface (external callers receive `Relation`s, so a lint can't enforce the contract anyway).


### PR DESCRIPTION
## Summary

Resolves `BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES`: an iterator-level failure (e.g. a missing/corrupt Tier-3 blob, whose decode error is deferred to `Error()`) could be reported as an empty, truncated, or "not found" *success*. The fix threads iterator-error propagation through the entire result pipeline — not just the three named public APIs — so a failed scan can no longer be laundered into a valid-looking result.

## Approach / decisions

- **Whole-pipeline propagation, not just the boundaries.** Patching only `CollectTuples`/`QueryInto`/`QueryOneInto` would leave the error droppable at every internal materialization between the failing scan and the boundary. Error propagation is now a property of the relation/iterator plumbing, so any consumer inherits it.
- **Keep the Go `Next()` + `Error()` contract.** Changing the `Iterator` interface (folding the error into `Next()`) was explicitly rejected; the deferred-error contract is deliberate and documented. Consumers were made to honor it.
- **One canonical consumer.** `executor.ForEach(rel, fn) error` drives `Next()`, checks `Error()`, and closes without masking the iteration error; `collectTuplesInto` now returns the error; `MaterializedRelation`/`StreamingRelation` carry an `err` field that survives `Project`/`Sort`/materialize (`carryErr`).

## What changed

**Public boundaries**
- `CollectTuples` returns `it.Error()` after the loop.
- `QueryInto` (struct + scalar) consumes via `ForEach` and returns before installing the destination slice, so a truncated iteration cannot leave a partial-but-"successful" result.
- `QueryOneInto` checks `Error()` after both the first and the second `Next()`.

**Internal laundering sites**
- Executor `HashJoin` build/probe; `unionRelations`/`UnionIterator`; single and grouped aggregation; the storage scan iterators (`unboundIterator`, `reusingIterator`, `hashJoinIterator`); the not-join inner consumer; relation-input iteration (sequential and parallel); `ProductRelation.Materialize`; and the non-last-phase `Keep` projection.

**Three-site investigation**
- `crossJoinWithOuter`: dead code (no callers) — deleted, not "fixed."
- `ProductRelation.Materialize`: a real drop (reached via the subquery input-combination path) — fixed.
- Non-last-phase `Keep` projection: fixed defensively. The greedy phaser currently collapses every query into a single phase (confirmed empirically across nine shapes and by argument), so this block is unreachable by any planned query today — but that collapse is **unintentional**, so it was deliberately not pinned as an invariant, and the fix is verified with a synthetic two-phase plan fed straight to the executor.

**Concurrency**
- A `-race` run (not the standard gate) surfaced a parallel-subquery annotation-handler race; fixed with `forkContext` (per-worker context) and `annotations.Synchronized`.

## Tests

- Executor: `foreach_test.go`, `iterator_error_boundary_test.go`, `caching_error_replay_test.go`, `union_relation_error_test.go`, `product_test.go`, `phase_boundary_error_test.go`.
- Storage: `query_boundary_error_test.go` — storage-backed reproductions via a corrupted Tier-3 blob across CollectTuples/QueryInto/QueryOneInto, order-by, aggregation, grouped aggregation, not, index-nested-loop, relation-input, subquery, or, and multi-phase, plus the truncation and second-`Next()` cases, with a keystone test pinning the valid-row-first scan ordering so that coverage cannot silently degrade.
- `go test -count=1 ./...` green.

## Also included

- `docs/proposals/ITERATOR_ERROR_CONTRACT_ENFORCEMENT.md` — the design behind the fix.
- `CLAUDE.md` — a "baseline is green / never blame pre-existing conditions" working rule.
- Bug reports discovered during the work:
  - `BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.md` — its error-drop half is fixed here (UnionIterator inner-error capture); its concurrent cache-build race is open.
  - `BUG_VBOUND_BYTES_WRONG_RESULTS_UNDER_RACE.md` — wrong results for V-bound byte queries under `-race`; open, documented (not caused by this work).
  - `BUG_DOCUMENTATION_OPTION_DRIFT.md` — documented, not addressed here.
