### PR TITLE
Fix UnionRelation concurrent iteration splitting the one-shot channel

### DIFF
--- a/datalog/executor/union_relation.go
+++ b/datalog/executor/union_relation.go
@@ -19,9 +19,12 @@ type UnionRelation struct {
 	source     <-chan relationItem
 	symbols    []query.Symbol
 	opts       ExecutorOptions
-	cached     []Tuple    // Cache for reuse after first iteration
-	cacheBuilt bool       // Has cache been built?
-	cacheMutex sync.Mutex // Protect cache building
+	cached     []Tuple       // Final cache, published once cacheBuilt; immutable after
+	cacheBuilt bool          // Build complete: cached is final
+	building   bool          // A build is in progress (one builder owns the channel)
+	buildDone  chan struct{} // Closed when the build completes; created when building starts
+	buildErr   error         // First error from the build, surfaced to replay iterators
+	cacheMutex sync.Mutex    // Guards building/cacheBuilt/cached/buildErr transitions
 }
 
 // relationItem holds either a relation or an error from subquery execution
@@ -49,18 +52,40 @@ func (ur *UnionRelation) Iterator() Iterator {
 	ur.cacheMutex.Lock()
 	defer ur.cacheMutex.Unlock()
 
-	// If cache is already built, return a simple slice iterator over cached tuples
+	// Build complete: replay the final cache. The slice iterator carries any
+	// build error so Error() surfaces it on every replay.
 	if ur.cacheBuilt {
-		return &sliceIterator{
-			tuples: ur.cached,
-			pos:    -1,
-		}
+		return &sliceIterator{tuples: ur.cached, pos: -1, err: ur.buildErr}
 	}
 
-	// First call - need to consume channel and build cache
+	// A build is already in progress: this is a concurrent caller. It must NOT
+	// touch the one-shot channel — only the sole builder consumes it. Return a
+	// replay iterator that blocks until the build completes, then replays the
+	// complete cache.
+	if ur.building {
+		return &unionReplayWaitIterator{done: ur.buildDone, ur: ur}
+	}
 
-	// Create iterator that will build cache as a side effect
-	return NewUnionIteratorWithCache(ur.source, &ur.cached, &ur.cacheBuilt)
+	// First caller becomes the sole builder: it streams the channel, dedups, and
+	// builds the cache, then publishes it via finishBuild.
+	ur.building = true
+	ur.buildDone = make(chan struct{})
+	return newUnionBuildIterator(ur.source, ur)
+}
+
+// finishBuild publishes the completed cache and wakes any waiting replay
+// iterators. Idempotent: only the first call (builder exhaustion or Close)
+// publishes the cache and closes buildDone.
+func (ur *UnionRelation) finishBuild(cache []Tuple, buildErr error) {
+	ur.cacheMutex.Lock()
+	if !ur.cacheBuilt {
+		ur.cached = cache
+		ur.buildErr = buildErr
+		ur.cacheBuilt = true
+		ur.building = false
+		close(ur.buildDone)
+	}
+	ur.cacheMutex.Unlock()
 }
 
 // Size forces materialization to count tuples (expensive!)
@@ -188,19 +213,19 @@ type UnionIterator struct {
 	seen            *TupleKeyMap // Deduplication without materialization
 	currentTuple    Tuple
 	exhausted       bool
-	firstError      error    // Track first error encountered
-	cache           *[]Tuple // Pointer to cache to build
-	cacheBuilt      *bool    // Pointer to flag
+	firstError      error          // Track first error encountered
+	ur              *UnionRelation // Owner; receives the published cache on completion
+	cache           []Tuple        // Cache built locally; published via ur.finishBuild
 }
 
-// NewUnionIteratorWithCache creates a new union iterator that builds cache as it iterates
-func NewUnionIteratorWithCache(source <-chan relationItem, cache *[]Tuple, cacheBuilt *bool) *UnionIterator {
+// newUnionBuildIterator creates the sole builder iterator: it consumes the
+// channel, dedups, builds the cache locally, and publishes it to ur on
+// completion (channel exhaustion or Close).
+func newUnionBuildIterator(source <-chan relationItem, ur *UnionRelation) *UnionIterator {
 	return &UnionIterator{
-		source:     source,
-		seen:       NewTupleKeyMap(),
-		exhausted:  false,
-		cache:      cache,
-		cacheBuilt: cacheBuilt,
+		source: source,
+		seen:   NewTupleKeyMap(),
+		ur:     ur,
 	}
 }
 
@@ -227,10 +252,8 @@ func (it *UnionIterator) Next() bool {
 				it.seen.Put(key, true)
 				it.currentTuple = tuple
 
-				// Add to cache if we're building it
-				if it.cache != nil {
-					*it.cache = append(*it.cache, tuple)
-				}
+				// Accumulate into the local cache; published on completion.
+				it.cache = append(it.cache, tuple)
 
 				return true
 			}
@@ -253,14 +276,10 @@ func (it *UnionIterator) Next() bool {
 		// Read next relation from channel
 		item, ok := <-it.source
 		if !ok {
-			// Channel closed - all relations consumed
+			// Channel closed - all relations consumed. Publish the cache and
+			// wake any replay iterators waiting on the build.
 			it.exhausted = true
-
-			// Mark cache as built
-			if it.cacheBuilt != nil {
-				*it.cacheBuilt = true
-			}
-
+			it.ur.finishBuild(it.cache, it.firstError)
 			return false
 		}
 
@@ -292,14 +311,20 @@ func (it *UnionIterator) Tuple() Tuple {
 	return it.currentTuple
 }
 
-// Close releases resources
+// Close releases resources. If the builder is abandoned before the channel is
+// exhausted, it drains the remainder INTO the cache (by running Next to
+// completion) so the published cache is complete for replay/reuse and any
+// waiting replay iterators do not block forever. Draining also unblocks
+// producers still sending on the channel.
 func (it *UnionIterator) Close() error {
+	if !it.exhausted {
+		for it.Next() {
+			// Finish building the cache; the exhaustion path publishes it.
+		}
+	}
 	if it.currentIter != nil {
 		it.currentIter.Close()
-	}
-	// Drain remaining items from channel to unblock producers
-	for range it.source {
-		// Discard remaining items
+		it.currentIter = nil
 	}
 	return it.firstError
 }
@@ -310,6 +335,48 @@ func (it *UnionIterator) Error() error {
 	}
 	if it.currentIter != nil {
 		return it.currentIter.Error()
+	}
+	return nil
+}
+
+// unionReplayWaitIterator is returned to a concurrent caller that arrives while
+// the sole builder is still streaming the channel. On first use it blocks until
+// the build completes, then replays the complete published cache. It never
+// touches the channel, so the channel has exactly one consumer (the builder).
+type unionReplayWaitIterator struct {
+	done <-chan struct{}
+	ur   *UnionRelation
+	iter *sliceIterator // set once the build completes
+}
+
+func (it *unionReplayWaitIterator) ensure() {
+	if it.iter == nil {
+		<-it.done // wait for the builder to publish the cache
+		it.ur.cacheMutex.Lock()
+		it.iter = &sliceIterator{tuples: it.ur.cached, pos: -1, err: it.ur.buildErr}
+		it.ur.cacheMutex.Unlock()
+	}
+}
+
+func (it *unionReplayWaitIterator) Next() bool {
+	it.ensure()
+	return it.iter.Next()
+}
+
+func (it *unionReplayWaitIterator) Tuple() Tuple {
+	return it.iter.Tuple()
+}
+
+func (it *unionReplayWaitIterator) Close() error {
+	if it.iter != nil {
+		return it.iter.Close()
+	}
+	return nil
+}
+
+func (it *unionReplayWaitIterator) Error() error {
+	if it.iter != nil {
+		return it.iter.Error()
 	}
 	return nil
 }

--- a/datalog/executor/union_relation_concurrent_test.go
+++ b/datalog/executor/union_relation_concurrent_test.go
@@ -1,0 +1,103 @@
+package executor
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestUnionRelation_ConcurrentIteratorWhileBuilding reproduces Failure Mode 1 of
+// BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.
+//
+// UnionRelation is supposed to be a reusable Relation: every Iterator() call must
+// see the complete union. But Iterator() only holds the mutex while constructing
+// the iterator, not while the cache is being built. Two Iterator() calls that
+// race before cacheBuilt both receive a UnionIterator over the SAME one-shot
+// channel and the SAME cache slice. They therefore:
+//   - split the channel's items (neither sees the complete union), and
+//   - append to the shared cache concurrently (a data race under -race).
+//
+// Each concurrent Iterator() must instead see all n tuples.
+func TestUnionRelation_ConcurrentIteratorWhileBuilding(t *testing.T) {
+	const n = 500
+	syms := []query.Symbol{datalog.NewSymbol("?x")}
+
+	ch := make(chan relationItem, n)
+	for i := 0; i < n; i++ {
+		ch <- relationItem{relation: NewMaterializedRelation(syms, []Tuple{{int64(i)}})}
+	}
+	close(ch)
+
+	ur := NewUnionRelation(ch, syms, ExecutorOptions{})
+
+	collect := func() int {
+		it := ur.Iterator()
+		defer it.Close()
+		count := 0
+		for it.Next() {
+			count++
+		}
+		return count
+	}
+
+	var wg sync.WaitGroup
+	var c1, c2 int
+	wg.Add(2)
+	go func() { defer wg.Done(); c1 = collect() }()
+	go func() { defer wg.Done(); c2 = collect() }()
+	wg.Wait()
+
+	require.Equal(t, n, c1, "first concurrent Iterator() must see the complete union, not a split of the channel")
+	require.Equal(t, n, c2, "second concurrent Iterator() must see the complete union, not a split of the channel")
+}
+
+// countingRelation records how many times Iterator() is called on it.
+type countingRelation struct {
+	Relation
+	calls *int64
+}
+
+func (c countingRelation) Iterator() Iterator {
+	atomic.AddInt64(c.calls, 1)
+	return c.Relation.Iterator()
+}
+
+// TestUnionRelation_OnlyOneChannelConsumer verifies the one-shot channel is
+// consumed exactly once (by the sole builder), and that a later Iterator() call
+// replays from the cache without re-iterating the source relations.
+func TestUnionRelation_OnlyOneChannelConsumer(t *testing.T) {
+	const n = 50
+	syms := []query.Symbol{datalog.NewSymbol("?x")}
+
+	var calls int64
+	ch := make(chan relationItem, n)
+	for i := 0; i < n; i++ {
+		base := NewMaterializedRelation(syms, []Tuple{{int64(i)}})
+		ch <- relationItem{relation: countingRelation{Relation: base, calls: &calls}}
+	}
+	close(ch)
+
+	ur := NewUnionRelation(ch, syms, ExecutorOptions{})
+
+	drain := func() int {
+		it := ur.Iterator()
+		defer it.Close()
+		c := 0
+		for it.Next() {
+			c++
+		}
+		return c
+	}
+
+	// First Iterator(): the sole builder consumes every source relation once.
+	require.Equal(t, n, drain(), "builder must see all tuples")
+	require.Equal(t, int64(n), atomic.LoadInt64(&calls), "builder must iterate each source relation exactly once")
+
+	// Second Iterator(): replays from cache; it must not re-iterate the sources.
+	require.Equal(t, n, drain(), "replay must see all tuples")
+	require.Equal(t, int64(n), atomic.LoadInt64(&calls), "replay must not re-consume source relations")
+}

--- a/docs/bugs/resolved/BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.md
+++ b/docs/bugs/resolved/BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-24
 **Severity**: Medium-High - streaming union can race, duplicate consumption, or hide worker/inner iterator failures
-**Status**: Open (code review finding; needs focused reproducer)
+**Status**: Resolved (2026-05-25) — see Resolution below
 **Affected**: `executor.UnionRelation`, `executor.UnionIterator`, streaming subquery union paths
 
 ## Summary
@@ -263,3 +263,29 @@ Add focused unit tests:
 - `docs/bugs/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md`
 - `docs/bugs/BUG_STREAMING_TUPLE_COPYING.md`
 - `docs/bugs/BUG_ITERATOR_LEAK_BUILTIN_EVALUATION.md`
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved.** All three failure modes are addressed.
+
+### Failure Mode 1 — split channel consumption / cache race (fixed in this change)
+
+`UnionRelation.Iterator()` is now a three-way state machine under `cacheMutex`:
+
+- **built**: replay the final cache via a slice iterator that carries any build error.
+- **building**: a concurrent caller gets a `unionReplayWaitIterator` that blocks on a completion channel (`buildDone`) and then replays the complete cache. It never touches the source channel.
+- **not started**: the first caller becomes the sole builder. It streams the channel, dedups, and builds the cache locally, then publishes it via `finishBuild` (sets the cache, records the first error, closes `buildDone`). `Close()` on an abandoned builder drains the remainder into the cache so the published cache is always complete.
+
+This guarantees exactly one channel consumer and that every `Iterator()` sees the complete union. Verified by `TestUnionRelation_ConcurrentIteratorWhileBuilding` (previously a 277/500 channel split plus a data race on the cache append; now both iterators see all 500 and `-race` is clean) and `TestUnionRelation_OnlyOneChannelConsumer` (the builder iterates each source relation exactly once; the replay call re-consumes nothing).
+
+The blocking-replay design has one internal-only hazard: a single goroutine that holds both the builder and a replay iterator and drives the replay one *before* completing the builder would self-deadlock. The executor never does this — it drives one iterator to completion before obtaining another (the later call then sees `built` and replays without blocking), and genuine concurrent callers are on separate goroutines — so it cannot arise in current usage.
+
+### Failure Mode 2 — inner iterator error dropped (fixed earlier this session)
+
+`UnionIterator.Next()` now captures an exhausted inner iterator's `Error()` into `firstError` before closing and discarding it. Covered by `TestUnionIterator_InnerIteratorErrorPropagates`.
+
+### Failure Mode 3 — worker error masked at the public boundary
+
+`UnionIterator` still continues past a worker `item.err` (recording the first one), which is correct only if the final `Error()` is checked. The public boundaries now do check it — `CollectTuples`, `QueryInto`, and `QueryOneInto` all surface iterator errors (see `resolved/BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md`) — so a worker error can no longer be silently swallowed into a plausible partial result.


### PR DESCRIPTION
## Summary

Resolves `BUG_UNION_RELATION_CONCURRENT_ITERATION_AND_ERROR_DROP` (Failure Mode 1). `UnionRelation` wraps a one-shot worker channel and is supposed to be a reusable `Relation`, but two `Iterator()` calls that raced before the cache was built each received a `UnionIterator` over the **same channel** and the **same cache slice**. They split the union between consumers (neither saw the complete result) and appended to the shared cache without synchronization (a data race).

## Reproduction

`TestUnionRelation_ConcurrentIteratorWhileBuilding` — two goroutines call `Iterator()` on a 500-relation union and drain. Before the fix: a 277/500 split (one consumer saw 277, the other 223), and `-race` flagged a write/write race at the cache append (`union_relation.go` `*it.cache = append(...)`).

## Fix

`Iterator()` is now a single-builder state machine under `cacheMutex`:

- **built** → replay the final cache (slice iterator carries any build error).
- **building** → a concurrent caller gets a `unionReplayWaitIterator` that blocks on a completion channel (`buildDone`), then replays the complete cache. It never touches the source channel.
- **not started** → the first caller becomes the sole builder: it streams the channel, dedups, and builds the cache locally, then publishes it via `finishBuild` (sets the cache, records the first error, closes `buildDone`). `Close()` on an abandoned builder drains the remainder into the cache so the published cache is always complete.

This guarantees exactly one channel consumer and that every `Iterator()` sees the complete union — preserving the streaming pipeline for the common (sequential) case.

The blocking-replay design has one internal-only hazard: a single goroutine that holds both the builder and a replay iterator and drives the replay one *before* completing the builder would self-deadlock. The executor never does this (it drives one iterator to completion before obtaining another; the later call sees `built` and replays without blocking), and genuine concurrent callers are on separate goroutines — so it cannot arise in current usage.

## Failure Modes 2 and 3

These were already addressed earlier this session and are noted in the doc for completeness:
- **FM2** (inner iterator error dropped): `UnionIterator.Next()` captures an exhausted inner iterator's `Error()` before closing it — `TestUnionIterator_InnerIteratorErrorPropagates`.
- **FM3** (worker error masked): continuing past a worker error is safe now that the public boundaries (`CollectTuples`/`QueryInto`/`QueryOneInto`) all check `Error()`.

## Tests

- `TestUnionRelation_ConcurrentIteratorWhileBuilding` — both iterators now see all 500; `-race` clean.
- `TestUnionRelation_OnlyOneChannelConsumer` — the builder iterates each source relation exactly once; the replay call re-consumes nothing.
- Full `go test -count=1 ./...` green; union/subquery/decorrelation paths `-race` clean.
