### PR TITLE
Fix byte-valued hash keys (hashValue lacked a []byte case)

### DIFF
--- a/datalog/executor/tuple_key.go
+++ b/datalog/executor/tuple_key.go
@@ -110,6 +110,13 @@ func hashValue(v interface{}) uint64 {
 	case string:
 		return hashString(val)
 
+	case []byte:
+		// Hash by content. Without this case, []byte falls through to the
+		// default pointer-address hash below, so two equal byte slices get
+		// different (nondeterministic) hashes and never collide in a
+		// TupleKeyMap — breaking joins and dedup on byte-valued attributes.
+		return hashBytes(val)
+
 	case int:
 		return uint64(val)
 

--- a/datalog/executor/tuple_key_collision_test.go
+++ b/datalog/executor/tuple_key_collision_test.go
@@ -133,16 +133,19 @@ func TestTupleKeyMap_DistinguishesAdversarialPairs(t *testing.T) {
 	}
 }
 
-// TestTupleKeyMap_BytesAreDistinguishedByContent verifies that []byte values
-// are correctly distinguished by content (via the ValuesEqual fallback in
-// TupleKeyMap), even though hashValue's default case may put each []byte
-// instance into a different hash bucket. This is a correctness baseline,
-// not a performance assertion.
+// TestTupleKeyMap_BytesAreDistinguishedByContent verifies that []byte values are
+// keyed by content in a TupleKeyMap: equal content hashes equally (so it lands in
+// the same bucket and is found), and different content does not match. hashValue
+// has a dedicated []byte case that hashes by content (hashBytes). Without it,
+// []byte fell through to a pointer-address hash, so equal slices landed in
+// DIFFERENT buckets and the ValuesEqual fallback — which only resolves collisions
+// WITHIN a bucket — never ran. That made byte-valued joins/dedup miss; it surfaced
+// as resolved/BUG_VBOUND_BYTES_WRONG_RESULTS_UNDER_RACE (a join on a byte key
+// dropped rows, only reliably under -race because the bogus address hash happened
+// to collide otherwise).
 //
-// Exercises: tuple_key.go TupleKey, TupleKeyMap with []byte values
+// Exercises: tuple_key.go hashValue/TupleKey/TupleKeyMap with []byte values
 func TestTupleKeyMap_BytesAreDistinguishedByContent(t *testing.T) {
-	m := NewTupleKeyMap()
-
 	a := []byte{1, 2, 3}
 	bSameContent := []byte{1, 2, 3} // distinct slice, equal content
 	cDifferent := []byte{1, 2, 4}
@@ -151,13 +154,19 @@ func TestTupleKeyMap_BytesAreDistinguishedByContent(t *testing.T) {
 	kb := NewTupleKeyFull(Tuple{bSameContent})
 	kc := NewTupleKeyFull(Tuple{cDifferent})
 
-	m.Put(ka, struct{}{})
+	// Equal content must hash equally — landing in the same bucket by design,
+	// not by an accidental pointer-address collision.
+	if ka.hash != kb.hash {
+		t.Fatalf("equal []byte content must hash equally: got %d != %d", ka.hash, kb.hash)
+	}
 
+	m := NewTupleKeyMap()
+	m.Put(ka, struct{}{})
 	if !m.Exists(kb) {
-		t.Error("equal-content []byte should be found via ValuesEqual fallback")
+		t.Error("equal-content []byte must be found")
 	}
 	if m.Exists(kc) {
-		t.Error("different-content []byte should not match")
+		t.Error("different-content []byte must not match")
 	}
 }
 

--- a/datalog/storage/vbound_bytes_validation_test.go
+++ b/datalog/storage/vbound_bytes_validation_test.go
@@ -1,11 +1,17 @@
 package storage
 
 import (
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
 	"github.com/wbrown/janus-datalog/datalog/schema"
 )
 
@@ -179,4 +185,78 @@ func TestVBoundCardinalityOneBytes_AfterRemove(t *testing.T) {
 	}()
 
 	require.Empty(t, queryByHash(t, db, v), "removed value must not match")
+}
+
+// TestVBoundCardinalityOneBytes_ValidationTrail captures the v-validation
+// annotation trail so the failure under -race can be diagnosed: it shows whether
+// the candidate scan found a candidate and what the EATV winner comparison saw.
+func TestVBoundCardinalityOneBytes_ValidationTrail(t *testing.T) {
+	db, e, a := newBytesOneDB(t)
+	defer db.Close()
+
+	var mu sync.Mutex
+	var trail []string
+	db.SetAnnotationHandler(func(ev annotations.Event) {
+		if strings.HasPrefix(ev.Name, "v-validation/") ||
+			strings.Contains(ev.Name, "join") ||
+			strings.Contains(ev.Name, "collapse") ||
+			strings.Contains(ev.Name, "phase") ||
+			strings.Contains(ev.Name, "pattern") {
+			mu.Lock()
+			trail = append(trail, fmt.Sprintf("%s %v", ev.Name, ev.Data))
+			mu.Unlock()
+		}
+	})
+
+	v := []byte{0xde, 0xad, 0xbe, 0xef}
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, v))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	rows, err := executor.CollectTuples(db.Query(`[:find ?e :in $ ?v :where [?e :doc/hash ?v]]`, v))
+	require.NoError(t, err)
+
+	mu.Lock()
+	for _, s := range trail {
+		t.Log(s)
+	}
+	mu.Unlock()
+
+	require.Len(t, rows, 1)
+}
+
+// TestVBoundCardinalityOneBytes_DirectMatcher drives the matcher directly with
+// ?v bound, bypassing the executor's join of the pattern result with the :in
+// input. This isolates matcher behaviour from the join: if this returns the
+// entity under -race but the full query does not, the join is the culprit.
+func TestVBoundCardinalityOneBytes_DirectMatcher(t *testing.T) {
+	db, e, a := newBytesOneDB(t)
+	defer db.Close()
+
+	v := []byte{0xde, 0xad, 0xbe, 0xef}
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, v))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	q, err := parser.ParseQuery(`[:find ?e :in $ ?v :where [?e :doc/hash ?v]]`)
+	require.NoError(t, err)
+	pattern := q.Where[0].(*query.DataPattern)
+
+	bindingRel := executor.NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?v")},
+		[]executor.Tuple{{v}},
+	)
+	result, err := db.Matcher().Match(pattern, executor.Relations{bindingRel})
+	require.NoError(t, err)
+
+	it := result.Iterator()
+	count := 0
+	for it.Next() {
+		count++
+	}
+	require.NoError(t, it.Error())
+	it.Close()
+	require.Equal(t, 1, count, "matcher must return the matching entity (independent of the executor join)")
 }

--- a/docs/bugs/resolved/BUG_VBOUND_BYTES_WRONG_RESULTS_UNDER_RACE.md
+++ b/docs/bugs/resolved/BUG_VBOUND_BYTES_WRONG_RESULTS_UNDER_RACE.md
@@ -1,8 +1,8 @@
 # BUG: V-bound cardinality-one byte queries return empty under `-race`
 
 **Date**: 2026-05-24
-**Severity**: Unknown — potentially High (wrong query results), pending root-cause
-**Status**: Open (observed, root cause not yet determined)
+**Severity**: High — silent wrong results for hash joins / dedup on byte-valued keys
+**Status**: Resolved (2026-05-25) — see Resolution below
 **Affected**: V-bound cardinality-one `TypeBytes` queries via the candidate+validate path (`validatingVBoundIterator`, AVET/VAET candidate scan + EATV validation). Observed in `datalog/storage/vbound_bytes_validation_test.go`.
 
 ## Summary
@@ -72,3 +72,44 @@ Determining which requires dedicated investigation (e.g., narrowing to a single 
 
 - `docs/bugs/resolved/BUG_VBOUND_BYTES_VALIDATION_PANIC.md` — the original V-bound `[]byte` `==` panic (fixed in v0.11.4). Same code path; this is a different, result-correctness symptom.
 - `datalog/storage/vbound_bytes_validation_test.go` — the tests that surface this.
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved.** The hypotheses in this report (candidate scan / EATV validation timing) were wrong — that path is correct. The actual cause is a missing type case in the join/dedup hash function.
+
+### Corrected root cause
+
+`hashValue` in `datalog/executor/tuple_key.go` had cases for `string`, `int`, `Identity`, `Keyword`, etc., but **no case for `[]byte`**. A byte slice fell through to the default:
+
+```go
+default:
+    return uint64(uintptr(unsafe.Pointer(&v))) // address of a local — not the content
+```
+
+That hashes the address of a local interface variable, not the byte content, so two equal `[]byte` values produce different, nondeterministic hashes. In a `TupleKeyMap` (the hash table behind joins and dedup) they land in different buckets and never meet — the `datalog.ValuesEqual` fallback only resolves collisions *within* a bucket, so it never runs across buckets.
+
+The V-bound byte query joins the pattern result against the `:in ?v` input on `?v` (`[]byte`). The probe key hashes to a different bucket than the build key, the lookup misses, and the row is dropped → empty result. Without `-race`, the bogus addresses happened to collide (so the join accidentally matched); `-race` perturbs stack/heap layout so they differ → reliable miss. That is exactly the observed signature: `[]byte`-specific, `-race`-only, **no** data race reported (it is a single-goroutine logic bug, not a memory race), and biased toward returning empty (a missed lookup never produces a spurious extra row).
+
+The matcher itself is correct: driving `Match` directly (bypassing the executor join) returns the entity under `-race`. The drop is purely in the join's hash bucketing.
+
+### Scope
+
+Broader than V-bound queries: this fixes correctness for **any hash join or dedup keyed on a byte-valued attribute**. V-bound byte queries were just the most visible and reliably reproducible path.
+
+### Fix
+
+One missing case in `hashValue`, so byte values hash by content like every other type (`hashBytes` already existed):
+
+```go
+case []byte:
+    return hashBytes(val)
+```
+
+### Tests
+
+- `datalog/storage/vbound_bytes_validation_test.go` — the five original repro tests now pass under `-race`; added `TestVBoundCardinalityOneBytes_DirectMatcher` (matcher in isolation, no join) and `TestVBoundCardinalityOneBytes_ValidationTrail` (asserts the match and captures the validation/join annotation trail).
+- `datalog/executor/tuple_key_collision_test.go` — strengthened `TestTupleKeyMap_BytesAreDistinguishedByContent` to assert equal byte content hashes equally; its prior comment had rationalized the buggy address-hash behavior.
+
+Full `go test -count=1 ./...` is green, and the byte-valued tests pass under `-race`.


### PR DESCRIPTION
## Summary

Resolves `BUG_VBOUND_BYTES_WRONG_RESULTS_UNDER_RACE`, and more broadly fixes correctness for **any hash join or dedup keyed on a byte-valued attribute**.

`hashValue` in `datalog/executor/tuple_key.go` (the hash behind `TupleKeyMap`, used for joins and dedup) had cases for `string`, `int`, `Identity`, `Keyword`, etc. — but **no case for `[]byte`**. A byte slice fell through to the default:

```go
default:
    return uint64(uintptr(unsafe.Pointer(&v))) // address of a local, not the content
```

So two equal `[]byte` values get different, nondeterministic hashes. In a `TupleKeyMap` they land in different buckets and never meet — the `ValuesEqual` fallback only resolves collisions *within* a bucket. Any hash join / dedup keyed on a byte value silently misses.

## How it surfaced

A V-bound byte query (`[:find ?e :in $ ?v :where [?e :doc/hash ?v]]`) joins the pattern result against the `:in ?v` input on `?v` (`[]byte`). The probe key hashes to a different bucket than the build key → lookup misses → row dropped → empty result.

- **Reliable only under `-race`**: without it, the bogus addresses happened to collide (so the join accidentally matched); `-race` perturbs stack/heap layout so they differ.
- **No data race reported**: it's a single-goroutine logic bug, not a memory race.
- **Biased toward empty**: a missed lookup never yields a spurious extra row.

The original report blamed the candidate scan / EATV validation. Those are correct — driving `Match` directly (bypassing the executor join) returns the entity under `-race`. The drop is purely in the join's hash bucketing.

## Fix

One missing case, so byte values hash by content like every other type (`hashBytes` already existed):

```go
case []byte:
    return hashBytes(val)
```

## Tests

- `datalog/storage/vbound_bytes_validation_test.go` — the five original repro tests now pass under `-race`; added `TestVBoundCardinalityOneBytes_DirectMatcher` (matcher in isolation, no join) and `TestVBoundCardinalityOneBytes_ValidationTrail` (asserts the match and captures the validation/join annotation trail).
- `datalog/executor/tuple_key_collision_test.go` — strengthened `TestTupleKeyMap_BytesAreDistinguishedByContent` to assert that equal byte content hashes equally; its prior comment had rationalized the buggy address-hash behavior.

Full `go test -count=1 ./...` is green; the byte-valued tests pass under `-race`.
