### PR TITLE
Remove name-based transaction dedup from HashJoin

### DIFF
--- a/datalog/executor/join.go
+++ b/datalog/executor/join.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/annotations"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
@@ -271,8 +270,10 @@ func HashJoinWithOptions(left, right Relation, joinSyms []query.Symbol, opts Exe
 		}
 	}
 
-	// Build phase - create hash table using efficient TupleKeyMap
-	// For temporal data, we need to deduplicate by keeping only the latest version
+	// Build phase - create hash table using efficient TupleKeyMap.
+	// This is a pure relational join: every build row is preserved. CRDT/temporal
+	// resolution is the storage layer's responsibility (EATV ordering), never
+	// inferred here from a column's name.
 	// Pre-size based on build relation size to avoid map growth
 	buildSize := buildRel.Size()
 	if buildSize < 0 {
@@ -288,20 +289,6 @@ func HashJoinWithOptions(left, right Relation, joinSyms []query.Symbol, opts Exe
 
 	if opts.EnableDebugLogging {
 		fmt.Printf("[HashJoin] Building hash table from relation with Size()=%d\n", buildRel.Size())
-	}
-
-	// Check if any symbol name matches transaction ID patterns
-	// We'll verify the actual type on the first tuple during iteration
-	txIndex := -1
-	for i, sym := range buildRel.Symbols() {
-		if sym == datalog.NewSymbol("?tx") || sym == datalog.NewSymbol("?t") ||
-			sym == datalog.NewSymbol("?txid") || sym == datalog.NewSymbol("?transaction") {
-			txIndex = i
-			if opts.EnableDebugLogging {
-				fmt.Printf("[HashJoin] Found potential tx symbol %s at index %d\n", sym, i)
-			}
-			break
-		}
 	}
 
 	// CRITICAL: Check if build relation was already consumed
@@ -337,183 +324,34 @@ func HashJoinWithOptions(left, right Relation, joinSyms []query.Symbol, opts Exe
 		return t
 	}
 
-	// Check first tuple to determine if we have a valid tx symbol
-	if txIndex >= 0 {
-		// Potential tx symbol found - check first tuple's type
-		if !buildIt.Next() {
-			// Empty relation - hash table stays empty
-			if opts.EnableDebugLogging {
-				fmt.Printf("[HashJoin] Build relation is empty\n")
-			}
+	// Pure relational build: group every build tuple by its join key. All rows
+	// are preserved; identical output tuples are deduplicated downstream by set
+	// semantics, not here. CRDT/temporal "latest transaction wins" resolution is
+	// handled by the storage layer (EATV index ordering), never inferred from a
+	// column's name.
+	buildCount := 0
+	var firstBuildKey *TupleKey
+	var firstBuildTuple Tuple
+	for buildIt.Next() {
+		tuple := buildIt.Tuple()
+		key := NewTupleKey(tuple, buildIndices)
+		if buildCount == 0 && opts.EnableDebugLogging {
+			firstBuildKey = &key
+			firstBuildTuple = tuple
+		}
+		if existing, ok := hashTable.Get(key); ok {
+			hashTable.Put(key, append(existing.([]Tuple), maybeCopy(tuple)))
 		} else {
-			firstTuple := buildIt.Tuple()
-			hasTxColumn := false
-			if txIndex < len(firstTuple) {
-				switch firstTuple[txIndex].(type) {
-				case uint64, int64, int, datalog.ElementID, *datalog.ElementID:
-					hasTxColumn = true
-					if opts.EnableDebugLogging {
-						fmt.Printf("[HashJoin] Confirmed tx symbol at index %d with type %T\n", txIndex, firstTuple[txIndex])
-					}
-				default:
-					if opts.EnableDebugLogging {
-						fmt.Printf("[HashJoin] Symbol at index %d is not a tx ID (type %T), using normal path\n", txIndex, firstTuple[txIndex])
-					}
-				}
-			}
-
-			// Process first tuple in the appropriate path
-			if hasTxColumn {
-				if opts.EnableDebugLogging {
-					fmt.Printf("[HashJoin] Using tx deduplication path (txIndex=%d, buildRel.Size()=%d)\n", txIndex, buildRel.Size())
-				}
-				// Deduplicate by keeping only the latest transaction
-				// Pre-size based on build relation size
-				latestTuples := NewTupleKeyMapWithCapacity(buildRel.Size())
-				latestTx := NewTupleKeyMapWithCapacity(buildRel.Size())
-
-				// Process first tuple
-				tuple := firstTuple
-				key := NewTupleKey(tuple, buildIndices)
-
-				// Extract transaction ID
-				var txID uint64
-				switch v := tuple[txIndex].(type) {
-				case uint64:
-					txID = v
-				case int64:
-					txID = uint64(v)
-				case int:
-					txID = uint64(v)
-				case datalog.ElementID:
-					txID = v.Lamport
-				case *datalog.ElementID:
-					if v != nil {
-						txID = v.Lamport
-					}
-				}
-
-				// Keep only if this is newer than what we have
-				if existingTxVal, exists := latestTx.Get(key); !exists || txID > existingTxVal.(uint64) {
-					latestTuples.Put(key, maybeCopy(tuple))
-					latestTx.Put(key, txID)
-				}
-
-				// Process remaining tuples
-				buildIterCount := 1
-				for buildIt.Next() {
-					buildIterCount++
-					tuple := buildIt.Tuple()
-					key := NewTupleKey(tuple, buildIndices)
-
-					// Extract transaction ID
-					switch v := tuple[txIndex].(type) {
-					case uint64:
-						txID = v
-					case int64:
-						txID = uint64(v)
-					case int:
-						txID = uint64(v)
-					case datalog.ElementID:
-						txID = v.Lamport
-					case *datalog.ElementID:
-						if v != nil {
-							txID = v.Lamport
-						}
-					}
-
-					// Keep only if this is newer than what we have
-					if existingTxVal, exists := latestTx.Get(key); !exists || txID > existingTxVal.(uint64) {
-						latestTuples.Put(key, maybeCopy(tuple))
-						latestTx.Put(key, txID)
-					}
-				}
-				if opts.EnableDebugLogging {
-					fmt.Printf("[HashJoin] Build iterator produced %d tuples, latestTuples has %d entries\n",
-						buildIterCount, len(latestTuples.m))
-				}
-
-				// Convert to the expected format
-				txDedupCount := 0
-				for _, entries := range latestTuples.m {
-					for _, entry := range entries {
-						// BUG FIX: Use the join key, not full tuple key!
-						// We need to hash by buildIndices, not all symbols
-						tuple := entry.value.(Tuple)
-						key := NewTupleKey(tuple, buildIndices)
-						hashTable.Put(key, []Tuple{tuple})
-						txDedupCount++
-					}
-				}
-				if opts.EnableDebugLogging {
-					fmt.Printf("[HashJoin] Built hash table with %d tuples after tx deduplication\n", txDedupCount)
-				}
-			} else {
-				// No transaction symbol or not a valid tx type, use normal path
-				// Process first tuple
-				tuple := firstTuple
-				key := NewTupleKey(tuple, buildIndices)
-				if existing, ok := hashTable.Get(key); ok {
-					hashTable.Put(key, append(existing.([]Tuple), maybeCopy(tuple)))
-				} else {
-					hashTable.Put(key, []Tuple{maybeCopy(tuple)})
-				}
-
-				buildCount := 1
-				var firstBuildKey *TupleKey
-				var firstBuildTuple Tuple
-				if opts.EnableDebugLogging {
-					firstBuildKey = &key
-					firstBuildTuple = tuple
-				}
-
-				// Process remaining tuples
-				for buildIt.Next() {
-					tuple := buildIt.Tuple()
-					key := NewTupleKey(tuple, buildIndices)
-					if existing, ok := hashTable.Get(key); ok {
-						hashTable.Put(key, append(existing.([]Tuple), maybeCopy(tuple)))
-					} else {
-						hashTable.Put(key, []Tuple{maybeCopy(tuple)})
-					}
-					buildCount++
-				}
-				if opts.EnableDebugLogging {
-					if firstBuildKey != nil {
-						fmt.Printf("[HashJoin] Built hash table with %d tuples, first key: %v, first tuple: %v\n",
-							buildCount, firstBuildKey, firstBuildTuple)
-					} else {
-						fmt.Printf("[HashJoin] Built hash table with %d tuples from iterator\n", buildCount)
-					}
-				}
-			}
+			hashTable.Put(key, []Tuple{maybeCopy(tuple)})
 		}
-	} else {
-		// No potential tx symbol - use normal path for all tuples
-		buildCount := 0
-		var firstBuildKey *TupleKey
-		var firstBuildTuple Tuple
-		for buildIt.Next() {
-			tuple := buildIt.Tuple()
-			key := NewTupleKey(tuple, buildIndices)
-			if buildCount == 0 && opts.EnableDebugLogging {
-				firstBuildKey = &key
-				firstBuildTuple = tuple
-			}
-			if existing, ok := hashTable.Get(key); ok {
-				hashTable.Put(key, append(existing.([]Tuple), maybeCopy(tuple)))
-			} else {
-				hashTable.Put(key, []Tuple{maybeCopy(tuple)})
-			}
-			buildCount++
-		}
-		if opts.EnableDebugLogging {
-			if firstBuildKey != nil {
-				fmt.Printf("[HashJoin] Built hash table with %d tuples, first key: %v, first tuple: %v\n",
-					buildCount, firstBuildKey, firstBuildTuple)
-			} else {
-				fmt.Printf("[HashJoin] Built hash table with %d tuples from iterator\n", buildCount)
-			}
+		buildCount++
+	}
+	if opts.EnableDebugLogging {
+		if firstBuildKey != nil {
+			fmt.Printf("[HashJoin] Built hash table with %d tuples, first key: %v, first tuple: %v\n",
+				buildCount, firstBuildKey, firstBuildTuple)
+		} else {
+			fmt.Printf("[HashJoin] Built hash table with %d tuples from iterator\n", buildCount)
 		}
 	}
 

--- a/datalog/executor/join_tx_name_dedup_test.go
+++ b/datalog/executor/join_tx_name_dedup_test.go
@@ -1,0 +1,67 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestHashJoin_TxNameVariablesDoNotDropRows is a regression test for
+// BUG_HASHJOIN_TX_SYMBOL_NAME_DROPS_ROWS.
+//
+// HashJoin must perform a pure relational join. It must NOT infer
+// "latest-transaction-wins" deduplication from a build-side column's *name*.
+// ?t, ?tx, ?txid, and ?transaction are ordinary user variables (time, ticker,
+// task, type, ...). Distinct rows that share the join key but differ in such a
+// column must all survive the join. CRDT/temporal resolution belongs to the
+// storage layer (EATV ordering), not to a generic join operator.
+func TestHashJoin_TxNameVariablesDoNotDropRows(t *testing.T) {
+	for _, name := range []string{"?t", "?tx", "?txid", "?transaction"} {
+		t.Run(name, func(t *testing.T) {
+			// Build side (smaller of the two → selected as the hash build side):
+			// two distinct rows sharing the join key ?g, differing only in the
+			// name-clashing column, with integer values that the buggy path
+			// treats as transaction IDs.
+			buildCols := []query.Symbol{datalog.NewSymbol("?g"), datalog.NewSymbol(name)}
+			buildTuples := []Tuple{
+				{"g1", int64(1)},
+				{"g1", int64(2)},
+			}
+			build := NewMaterializedRelation(buildCols, buildTuples)
+
+			// Probe side (larger → not the build side): one matching key.
+			probeCols := []query.Symbol{datalog.NewSymbol("?g"), datalog.NewSymbol("?label")}
+			probeTuples := []Tuple{
+				{"g1", "x"},
+				{"g2", "y"},
+				{"g3", "z"},
+			}
+			probe := NewMaterializedRelation(probeCols, probeTuples)
+
+			joined := HashJoinWithOptions(build, probe,
+				[]query.Symbol{datalog.NewSymbol("?g")}, ExecutorOptions{})
+			got := collectTuples(joined)
+
+			if len(got) != 2 {
+				t.Fatalf("%s used as an ordinary build-side column: expected 2 rows "+
+					"(both values preserved), got %d: %v", name, len(got), got)
+			}
+
+			tIdx := SymbolIndex(joined, datalog.NewSymbol(name))
+			if tIdx < 0 {
+				t.Fatalf("output is missing column %s; symbols=%v", name, joined.Symbols())
+			}
+			seen := map[int64]bool{}
+			for _, row := range got {
+				if v, ok := row[tIdx].(int64); ok {
+					seen[v] = true
+				}
+			}
+			if !seen[1] || !seen[2] {
+				t.Fatalf("%s: expected both values 1 and 2 in output, got %v (rows=%v)",
+					name, seen, got)
+			}
+		})
+	}
+}

--- a/docs/bugs/resolved/BUG_HASHJOIN_TX_SYMBOL_NAME_DROPS_ROWS.md
+++ b/docs/bugs/resolved/BUG_HASHJOIN_TX_SYMBOL_NAME_DROPS_ROWS.md
@@ -1,0 +1,146 @@
+# Bug: HashJoin Treats Ordinary `?t` Variables as Transaction Columns
+
+## Summary
+
+`executor.HashJoin` has a name-based special case for transaction columns. If the build-side relation contains a symbol named `?tx`, `?t`, `?txid`, or `?transaction`, and the first tuple at that position is numeric or an `ElementID`, the join enters a "latest transaction wins" dedup path.
+
+That is unsafe. `?t` is a normal user variable name, commonly used for "task", "ticker", "time", "type", or arbitrary tuple data. A natural join should preserve all matching rows unless relational set semantics deduplicate identical output tuples. This path can silently collapse distinct build-side rows that share the join key.
+
+## Trigger
+
+Any hash join where:
+
+1. The build-side relation has a column named `?t`, `?tx`, `?txid`, or `?transaction`.
+2. The value in that column is `uint64`, `int64`, `int`, `datalog.ElementID`, or `*datalog.ElementID`.
+3. Multiple build rows share the join key but differ in other columns.
+
+Example shape:
+
+```clojure
+[:find ?e ?t ?label
+ :where [?e :entity/group ?g]
+        ;; ?t is ordinary data, not a transaction ID
+        [(ground [[1 "a"] [2 "b"]]) [[?t ?label]]]
+        [?other :entity/group ?g]]
+```
+
+If the relation containing `?t` is chosen as the hash-join build side and joins on `?g` or another key, rows can be collapsed by the largest `?t`.
+
+## Code Evidence
+
+`HashJoinWithOptions` infers transaction semantics from symbol names:
+
+```go
+txIndex := -1
+for i, sym := range buildRel.Symbols() {
+	if sym == datalog.NewSymbol("?tx") || sym == datalog.NewSymbol("?t") ||
+		sym == datalog.NewSymbol("?txid") || sym == datalog.NewSymbol("?transaction") {
+		txIndex = i
+		break
+	}
+}
+```
+
+It then verifies only the Go value type, not the query semantics:
+
+```go
+switch firstTuple[txIndex].(type) {
+case uint64, int64, int, datalog.ElementID, *datalog.ElementID:
+	hasTxColumn = true
+}
+```
+
+Once enabled, the path keeps only the tuple with the largest transaction-like value for each join key:
+
+```go
+key := NewTupleKey(tuple, buildIndices)
+if existingTxVal, exists := latestTx.Get(key); !exists || txID > existingTxVal.(uint64) {
+	latestTuples.Put(key, maybeCopy(tuple))
+	latestTx.Put(key, txID)
+}
+```
+
+This is not a property of natural joins. It is a storage/temporal resolution rule leaking into a generic join operator.
+
+## Impact
+
+- Silent wrong query results.
+- Data loss depends on join order and build-side selection, so the same logical query may pass or fail depending on planner choices and relation sizes.
+- The variable name `?t` is especially dangerous because it is short and idiomatic.
+- Users cannot know that a harmless variable name changes join semantics.
+
+## Expected Behavior
+
+`HashJoin` should perform a pure relational join. It should not infer CRDT or temporal resolution from column names.
+
+If transaction deduplication is required anywhere, it should be represented explicitly in the relation metadata, storage matcher output, or a dedicated operator with a clear semantic contract.
+
+## Suggested Fix
+
+Remove the name-based transaction dedup path from generic `HashJoin`.
+
+If a caller truly needs latest-by-transaction behavior:
+
+1. Add explicit metadata to the relation or query plan indicating the transaction column and dedup key.
+2. Apply the dedup as a separate operator before or after the join.
+3. Require the column to be proven to be a transaction position from a four-element data pattern, not guessed from the symbol name.
+
+## Tests Needed
+
+- A unit test where a relation with symbol `?t` and integer values joins on another symbol and preserves multiple distinct rows.
+- The same test with both relations swapped in size so the `?t` relation is selected as the build side.
+- Tests for `?tx`, `?txid`, and `?transaction` as ordinary user variables.
+- A regression test proving storage history/as-of queries still get correct temporal behavior after removing this path.
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved.** The name-based transaction-dedup path was removed from `HashJoin`
+outright, with no replacement. `HashJoinWithOptions` now runs a single pure
+relational build loop that preserves every row.
+
+- `datalog/executor/join.go` — deleted the `?tx`/`?t`/`?txid`/`?transaction`
+  symbol-name detection, the first-tuple type sniff, and the ~150-line
+  "latest-transaction-wins" branch (≈190 lines out, ≈28 in). Dropped the
+  now-unused `datalog` import.
+- `datalog/executor/join_tx_name_dedup_test.go` —
+  `TestHashJoin_TxNameVariablesDoNotDropRows` exercises all four names as
+  ordinary build-side integer columns. It dropped a row before the fix and
+  preserves both rows after.
+
+### Corrections to this report's assumptions
+
+This report's Suggested Fix and Tests Needed assumed latest-by-transaction
+behavior is "required somewhere" and should be preserved via explicit metadata,
+a dedicated operator, or a proven four-element tx position. That assumption is
+wrong on three counts:
+
+1. **No caller needs join-level transaction dedup.** With the path simply
+   deleted, the entire suite (`go test -count=1 ./...`) is green — including
+   every history/as-of/CRDT test in `storage`, `db`, `query`, and `parser`.
+   There are zero consumers whose behavior must be preserved. The proposed
+   metadata/operator alternatives would build machinery for nobody; they are a
+   tidier restatement of the same category error, so none were implemented. The
+   report's last "Tests Needed" item is satisfied by the existing temporal
+   tests, which already stay green without the path.
+
+2. **CRDT/temporal resolution already happens in the storage layer, not the
+   join.** The EATV index stores Tx in descending order, so the matcher /
+   `CRDTResolvingIterator` resolve "latest wins" (and add-wins / RGA) before any
+   datom reaches the executor. By the time relations are joined, resolution is
+   already complete. This path was therefore not a misplaced-but-needed feature
+   — it was pure redundancy for storage data and actively wrong for non-storage
+   relations (ground values, computed `?t`, in-memory sources).
+
+3. **Even a "principled" version of the heuristic is wrong.** Suggested Fix #3
+   (prove the column is a tx position from a four-element pattern, then dedup)
+   still embeds resolution semantics inside a generic relational operator. A
+   join must not resolve CRDTs under any circumstances — proven position or not.
+   The correct contract is simply: the join preserves rows; storage owns
+   resolution.
+
+### Verification
+
+`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green; the new
+regression test fails on the pre-fix code and passes after.


### PR DESCRIPTION
## Bug

`HashJoin` inferred "latest-transaction-wins" deduplication from a build-side column's *name* — `?t`, `?tx`, `?txid`, `?transaction` — confirmed by type-sniffing the first tuple. But `?t` is an idiomatic user variable (time, ticker, task, type, ...), so the join silently collapsed distinct rows that shared a join key, keeping only the one with the largest "transaction-like" value. Because it only triggers on the *build* side, the same logical query could pass or fail depending on the planner's size-based build-side choice.

Three compounding problems in one path: semantics inferred from a variable name, the guess confirmed by runtime type-sniffing, and a CRDT resolution rule buried inside the generic join operator that every query uses.

## Why removal (not metadata/operator)

The path was vestigial. The storage layer already resolves CRDT/temporal semantics via EATV index ordering (`CRDTResolvingIterator`) before any datom reaches the executor — by join time, resolution is already done. With the path simply deleted, the **entire suite is green**, including every history/as-of/CRDT test in `storage`, `db`, `query`, and `parser`. That proves there are zero consumers of join-level dedup, so the report's suggested metadata/operator alternatives would build machinery for nobody. The correct contract is: the join preserves rows; storage owns resolution.

## Changes

- `datalog/executor/join.go`: replaced the name-detection loop, type-sniff, and ~150-line latest-tx-wins branch with a single pure relational build loop that preserves every row. Dropped the now-unused `datalog` import.
- `datalog/executor/join_tx_name_dedup_test.go`: regression test covering all four names as ordinary build-side integer columns — fails on the pre-fix code (drops a row), passes after.

## Verification

`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green.

Resolves `docs/bugs/resolved/BUG_HASHJOIN_TX_SYMBOL_NAME_DROPS_ROWS.md` (amended with the resolution and corrections to the report's assumptions).