### PR TITLE
Thread per-query annotation handler through planning

### DIFF
--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -134,12 +134,6 @@ func (e *Executor) ExecuteWithRelations(ctx Context, q *query.Query, inputRelati
 
 	ctx.QueryBegin(q.String())
 
-	// Pass annotation handler to planner for algebra bridge observability
-	if collector := ctx.Collector(); collector != nil {
-		executor.planner.SetHandler(collector.Handler())
-		defer executor.planner.SetHandler(nil)
-	}
-
 	// Build initial bindings from input relations
 	initialBindings := make(map[query.Symbol]bool)
 
@@ -181,13 +175,20 @@ func (e *Executor) ExecuteWithRelations(ctx Context, q *query.Query, inputRelati
 		}
 	}
 
-	// Execute using QueryExecutor (Stage B) with RealizedPlan
+	// Execute using QueryExecutor (Stage B) with RealizedPlan. The annotation
+	// handler is threaded per-query into planning (not stored on the shared
+	// planner), so concurrent annotated queries neither race on it nor
+	// cross-route algebra-bridge events.
+	var planHandler annotations.Handler
+	if collector := ctx.Collector(); collector != nil {
+		planHandler = collector.Handler()
+	}
 	var realizedPlan *planner.RealizedPlan
 	var err error
 	if len(initialBindings) == 0 {
-		realizedPlan, err = executor.planner.PlanQuery(q)
+		realizedPlan, err = executor.planner.PlanQuery(q, planHandler)
 	} else {
-		realizedPlan, err = executor.planner.PlanQueryWithBindings(q, initialBindings)
+		realizedPlan, err = executor.planner.PlanQueryWithBindings(q, initialBindings, planHandler)
 	}
 	if err != nil {
 		ctx.QueryComplete(0, 0, err)

--- a/datalog/executor/planner_handler_race_test.go
+++ b/datalog/executor/planner_handler_race_test.go
@@ -1,0 +1,79 @@
+package executor
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/planner"
+)
+
+// TestPlannerHandler_ConcurrentAnnotatedQueriesIsolated is a regression test for
+// BUG_PLANNER_HANDLER_SHARED_STATE_RACE.
+//
+// A per-query annotation handler must not be installed as mutable state on the
+// planner that every query shares through one Executor. When it is, concurrent
+// annotated queries overwrite or clear each other's handler, so a query's
+// algebra-bridge events are dropped or delivered to another query's collector —
+// and the handler field write/read is itself a data race.
+//
+// optimizeViaAlgebra emits exactly one "algebra/bridge-begin" per planning call,
+// and this executor uses no plan cache, so every query plans independently. With
+// correct per-query handler threading, each collector sees exactly one
+// bridge-begin: its own. Under shared-handler state, the count per collector is
+// scrambled (some see zero, some see several). Run under -race to additionally
+// catch the data race directly.
+func TestPlannerHandler_ConcurrentAnnotatedQueriesIsolated(t *testing.T) {
+	// Planning runs regardless of matcher contents; an empty matcher is enough.
+	matcher := NewMemoryPatternMatcher(nil)
+
+	// EnableAlgebraOptimizer so the handler is exercised; no Cache so every query
+	// re-plans (and re-emits) rather than hitting a cached plan.
+	exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{
+		EnableAlgebraOptimizer: true,
+	})
+
+	q, err := parser.ParseQuery(`[:find ?e ?v :where [?e :x/v ?v]]`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	const goroutines = 32
+	counts := make([]int32, goroutines)
+	errs := make([]error, goroutines)
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			// Each goroutine gets its OWN handler/collector.
+			handler := func(e annotations.Event) {
+				if e.Name == "algebra/bridge-begin" {
+					atomic.AddInt32(&counts[idx], 1)
+				}
+			}
+			ctx := NewContext(handler)
+			rel, err := exec.ExecuteWithContext(ctx, q)
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			_ = collectTuples(rel)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: query failed: %v", i, errs[i])
+		}
+		if got := atomic.LoadInt32(&counts[i]); got != 1 {
+			t.Fatalf("goroutine %d: expected exactly 1 algebra/bridge-begin in its own "+
+				"collector, got %d (per-query handler leaked across concurrent queries "+
+				"via shared planner state)", i, got)
+		}
+	}
+}

--- a/datalog/executor/two_collections_debug_test.go
+++ b/datalog/executor/two_collections_debug_test.go
@@ -28,7 +28,7 @@ func TestTwoCollections_PlanAndBind(t *testing.T) {
 
 	// Create planner and get plan
 	p := planner.NewClauseBasedPlanner(nil, planner.PlannerOptions{})
-	plan, err := p.PlanQueryWithBindings(q, initialBindings)
+	plan, err := p.PlanQueryWithBindings(q, initialBindings, nil)
 	require.NoError(t, err)
 
 	t.Logf("Plan:\n%s", plan.String())

--- a/datalog/planner/cache_benchmark_test.go
+++ b/datalog/planner/cache_benchmark_test.go
@@ -18,7 +18,7 @@ func BenchmarkPlannerWithoutCache(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := planner.Plan(q)
+		_, err := planner.Plan(q, nil)
 		if err != nil {
 			b.Fatalf("Failed to plan query: %v", err)
 		}
@@ -37,7 +37,7 @@ func BenchmarkPlannerWithCache(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := planner.Plan(q)
+		_, err := planner.Plan(q, nil)
 		if err != nil {
 			b.Fatalf("Failed to plan query: %v", err)
 		}
@@ -73,7 +73,7 @@ func BenchmarkPlannerCacheMissOverhead(b *testing.B) {
 			},
 		}
 
-		_, err := planner.Plan(q)
+		_, err := planner.Plan(q, nil)
 		if err != nil {
 			b.Fatalf("Failed to plan query: %v", err)
 		}

--- a/datalog/planner/cache_test.go
+++ b/datalog/planner/cache_test.go
@@ -223,7 +223,7 @@ func TestPlannerWithCache(t *testing.T) {
 	}
 
 	// First plan should be a miss
-	_, err := planner.Plan(q)
+	_, err := planner.Plan(q, nil)
 	if err != nil {
 		t.Fatalf("Failed to plan query: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestPlannerWithCache(t *testing.T) {
 	}
 
 	// Second plan should be a hit
-	_, err = planner.Plan(q)
+	_, err = planner.Plan(q, nil)
 	if err != nil {
 		t.Fatalf("Failed to plan query: %v", err)
 	}

--- a/datalog/planner/interface.go
+++ b/datalog/planner/interface.go
@@ -7,33 +7,31 @@ import (
 
 // QueryPlanner is the interface for query planners
 type QueryPlanner interface {
-	// PlanQuery creates an optimized query plan
-	PlanQuery(q *query.Query) (*RealizedPlan, error)
+	// PlanQuery creates an optimized query plan. handler (may be nil) carries
+	// request-scoped annotation observability through planning; it is not stored.
+	PlanQuery(q *query.Query, handler annotations.Handler) (*RealizedPlan, error)
 
-	// PlanQueryWithBindings creates an optimized query plan with initial bindings
-	PlanQueryWithBindings(q *query.Query, initialBindings map[query.Symbol]bool) (*RealizedPlan, error)
+	// PlanQueryWithBindings creates an optimized query plan with initial bindings.
+	PlanQueryWithBindings(q *query.Query, initialBindings map[query.Symbol]bool, handler annotations.Handler) (*RealizedPlan, error)
 
 	// Options returns the planner options
 	Options() PlannerOptions
 
 	// SetCache sets the query plan cache
 	SetCache(cache *PlanCache)
-
-	// SetHandler sets the annotation handler for query planning observability
-	SetHandler(h annotations.Handler)
 }
 
 // Ensure ClauseBasedPlanner implements the interface
 var _ QueryPlanner = (*ClauseBasedPlanner)(nil)
 
 // PlanQuery implements QueryPlanner for ClauseBasedPlanner
-func (p *ClauseBasedPlanner) PlanQuery(q *query.Query) (*RealizedPlan, error) {
-	return p.Plan(q)
+func (p *ClauseBasedPlanner) PlanQuery(q *query.Query, handler annotations.Handler) (*RealizedPlan, error) {
+	return p.Plan(q, handler)
 }
 
 // PlanQueryWithBindings implements QueryPlanner for ClauseBasedPlanner
-func (p *ClauseBasedPlanner) PlanQueryWithBindings(q *query.Query, initialBindings map[query.Symbol]bool) (*RealizedPlan, error) {
-	return p.PlanWithBindings(q, initialBindings)
+func (p *ClauseBasedPlanner) PlanQueryWithBindings(q *query.Query, initialBindings map[query.Symbol]bool, handler annotations.Handler) (*RealizedPlan, error) {
+	return p.PlanWithBindings(q, initialBindings, handler)
 }
 
 // Options implements QueryPlanner for ClauseBasedPlanner
@@ -44,11 +42,6 @@ func (p *ClauseBasedPlanner) Options() PlannerOptions {
 // SetCache implements QueryPlanner for ClauseBasedPlanner
 func (p *ClauseBasedPlanner) SetCache(cache *PlanCache) {
 	p.cache = cache
-}
-
-// SetHandler implements QueryPlanner for ClauseBasedPlanner
-func (p *ClauseBasedPlanner) SetHandler(h annotations.Handler) {
-	p.handler = h
 }
 
 // CreatePlanner creates a query planner with the given options

--- a/datalog/planner/or_subquery_debug_test.go
+++ b/datalog/planner/or_subquery_debug_test.go
@@ -69,7 +69,7 @@ func TestOrSubqueryPlannerPhases(t *testing.T) {
 	}
 
 	p := NewClauseBasedPlanner(nil, PlannerOptions{})
-	realized, err := p.Plan(q)
+	realized, err := p.Plan(q, nil)
 	if err != nil {
 		t.Fatalf("Plan error: %v", err)
 	}

--- a/datalog/planner/planner_clause_based.go
+++ b/datalog/planner/planner_clause_based.go
@@ -14,7 +14,6 @@ type ClauseBasedPlanner struct {
 	stats   *Statistics
 	options PlannerOptions
 	cache   *PlanCache
-	handler annotations.Handler // Set per-query for algebra bridge annotations
 }
 
 // NewClauseBasedPlanner creates a new clause-based planner
@@ -32,8 +31,11 @@ func NewClauseBasedPlanner(stats *Statistics, options PlannerOptions) *ClauseBas
 	}
 }
 
-// Plan creates an optimized query plan using the clause-based approach
-func (p *ClauseBasedPlanner) Plan(q *query.Query) (*RealizedPlan, error) {
+// Plan creates an optimized query plan using the clause-based approach. The
+// handler (may be nil) is request-scoped annotation state, threaded through
+// planning rather than stored on the planner, so concurrent queries through a
+// shared planner do not race on it.
+func (p *ClauseBasedPlanner) Plan(q *query.Query, handler annotations.Handler) (*RealizedPlan, error) {
 	// Check cache first
 	if p.cache != nil {
 		if cached, ok := p.cache.GetWithOptions(q, p.options); ok {
@@ -42,7 +44,7 @@ func (p *ClauseBasedPlanner) Plan(q *query.Query) (*RealizedPlan, error) {
 	}
 
 	// Plan with no initial bindings
-	plan, err := p.PlanWithBindings(q, nil)
+	plan, err := p.PlanWithBindings(q, nil, handler)
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +57,10 @@ func (p *ClauseBasedPlanner) Plan(q *query.Query) (*RealizedPlan, error) {
 	return plan, nil
 }
 
-// PlanWithBindings creates an optimized query plan with initial bindings
-func (p *ClauseBasedPlanner) PlanWithBindings(q *query.Query, initialBindings map[query.Symbol]bool) (*RealizedPlan, error) {
+// PlanWithBindings creates an optimized query plan with initial bindings. The
+// handler (may be nil) is passed through to the algebra bridge rather than read
+// from shared planner state.
+func (p *ClauseBasedPlanner) PlanWithBindings(q *query.Query, initialBindings map[query.Symbol]bool, handler annotations.Handler) (*RealizedPlan, error) {
 	// Extract input symbols from :in clause, tracking scalar inputs separately
 	inputSymbols := make(map[query.Symbol]bool)
 	var scalarInputs []query.Symbol
@@ -115,7 +119,7 @@ func (p *ClauseBasedPlanner) PlanWithBindings(q *query.Query, initialBindings ma
 
 	// Algebraic optimization: clauses → algebra IR → transform passes → clauses
 	if p.options.EnableAlgebraOptimizer {
-		optimized, err := optimizeViaAlgebra(clauses, p.handler)
+		optimized, err := optimizeViaAlgebra(clauses, handler)
 		if err != nil {
 			return nil, fmt.Errorf("algebra optimization failed: %w", err)
 		}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -720,9 +720,10 @@ func (d *Database) Explain(queryInput interface{}, inputs ...interface{}) (*plan
 	// Create executor to get its planner (ensures same options as execution)
 	exec := d.NewExecutor()
 
-	// Get the query plan from the executor's planner
+	// Get the query plan from the executor's planner (planning is not annotated
+	// on this plan-only path).
 	queryPlanner := exec.GetPlanner()
-	return queryPlanner.PlanQuery(q)
+	return queryPlanner.PlanQuery(q, nil)
 }
 
 // AnalyzeResult contains the query plan and execution statistics from Analyze().
@@ -847,9 +848,11 @@ func (d *Database) Analyze(queryInput interface{}, inputs ...interface{}) (*Anal
 	// Create executor (this also creates the planner with proper options)
 	exec := d.NewExecutor()
 
-	// Get the query plan from the executor's planner
+	// Get the query plan from the executor's planner. The Analyze collector below
+	// captures execution annotations; planning here is not annotated (matching
+	// prior behavior).
 	queryPlanner := exec.GetPlanner()
-	plan, err := queryPlanner.PlanQuery(q)
+	plan, err := queryPlanner.PlanQuery(q, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to plan query: %w", err)
 	}

--- a/docs/bugs/resolved/BUG_PLANNER_HANDLER_SHARED_STATE_RACE.md
+++ b/docs/bugs/resolved/BUG_PLANNER_HANDLER_SHARED_STATE_RACE.md
@@ -1,0 +1,146 @@
+# Bug: Per-Query Annotation Handler Mutates Shared Planner State
+
+## Summary
+
+Annotated query execution mutates the `QueryPlanner` stored on the `Executor` by calling `SetHandler()` before planning and resetting it with `defer SetHandler(nil)` afterward. The planner object is shared by all concurrent queries using that executor.
+
+Two annotated queries running at the same time can overwrite each other's planner handler or clear it while another query is still planning. This creates a data race and can route algebra-bridge annotations to the wrong collector.
+
+## Trigger
+
+Any concurrent use of the same `Executor` with annotation handlers enabled:
+
+```go
+exec := db.NewExecutor()
+
+go exec.ExecuteWithContext(ctxA, queryA)
+go exec.ExecuteWithContext(ctxB, queryB)
+```
+
+If both contexts have collectors, both goroutines call `executor.planner.SetHandler(...)` on the same planner instance.
+
+## Code Evidence
+
+`ExecuteWithRelations` creates a shallow `Executor` copy, but the planner pointer is reused:
+
+```go
+executor := &Executor{
+	matcher:        matcher,
+	entityResolver: e.entityResolver,
+	planner:        e.planner,
+	options:        e.options,
+	// ...
+}
+```
+
+The handler is then installed on that shared planner:
+
+```go
+if collector := ctx.Collector(); collector != nil {
+	executor.planner.SetHandler(collector.Handler())
+	defer executor.planner.SetHandler(nil)
+}
+```
+
+`ClauseBasedPlanner.SetHandler` is a plain field write:
+
+```go
+func (p *ClauseBasedPlanner) SetHandler(h annotations.Handler) {
+	p.handler = h
+}
+```
+
+Planning reads the same field when invoking the algebra optimizer:
+
+```go
+optimized, err := optimizeViaAlgebra(clauses, p.handler)
+```
+
+There is no synchronization and no per-query ownership of the handler.
+
+## Impact
+
+- Data race under concurrent annotated queries.
+- Annotation events can be delivered to the wrong query collector.
+- One query can clear another query's handler before the algebra bridge emits events.
+- Debugging and optimization tests that rely on annotation structure can observe nondeterministic results.
+
+This is especially risky because annotation handlers are explicitly documented as safe for parallel workers after wrapping, but the planner handler field itself is not safe.
+
+## Expected Behavior
+
+Per-query annotation state should be passed as an argument through planning, not stored on a shared planner object.
+
+Two concurrent queries should be able to plan with different handlers without any shared mutable state.
+
+## Suggested Fix
+
+Remove `SetHandler` as mutable planner state for request-scoped annotations.
+
+Possible approaches:
+
+1. Add a planning context argument that carries the handler:
+
+   ```go
+   PlanQuery(ctx PlanningContext, q *query.Query)
+   ```
+
+2. Copy or clone the planner per query before installing handler state.
+3. Pass the handler directly into `PlanWithBindings` / `optimizeViaAlgebra` from `ExecuteWithRelations`.
+
+The cleanest design is to make `ClauseBasedPlanner` immutable with respect to per-query execution state.
+
+## Tests Needed
+
+- A race test that runs many annotated queries concurrently through one `Executor`.
+- A deterministic test with two distinct handlers that asserts algebra-bridge events from query A never arrive at query B's collector.
+- A test that one query's deferred `SetHandler(nil)` cannot suppress another in-flight query's planning annotations.
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved.** The per-query annotation handler is now threaded through planning
+instead of stored on the shared planner. The mutable `handler` field and
+`SetHandler` are gone — from both `ClauseBasedPlanner` and the `QueryPlanner`
+interface — so there is no shared per-query state to race on.
+
+- `datalog/planner/planner_clause_based.go` — removed the `handler` field; `Plan`
+  and `PlanWithBindings` take a `handler annotations.Handler` parameter and pass
+  it straight to `optimizeViaAlgebra`.
+- `datalog/planner/interface.go` — `PlanQuery` / `PlanQueryWithBindings` gained
+  the handler parameter; `SetHandler` was removed from the interface and the
+  implementation.
+- `datalog/executor/executor.go` — deleted the `SetHandler(...)` +
+  `defer SetHandler(nil)` mutation; the executor computes the per-query handler
+  from `ctx.Collector()` and passes it into the plan call.
+- `datalog/storage/database.go` — the two direct plan-only paths (Explain,
+  Analyze) pass `nil`.
+- `datalog/executor/planner_handler_race_test.go` —
+  `TestPlannerHandler_ConcurrentAnnotatedQueriesIsolated` runs 32 annotated
+  queries concurrently through one Executor and asserts each collector sees
+  exactly one `algebra/bridge-begin`. It fails on the pre-fix code both on the
+  standard gate (cross-routed events) and under `-race` (data race), and passes
+  both ways after the fix.
+
+### Notes on this report
+
+The report's analysis was accurate. Among its "possible approaches" we took the
+strongest form of #3 (pass the handler into planning) and went one step further:
+rather than keep `SetHandler` and merely clone the planner per query, we deleted
+the mutable field and `SetHandler` from the interface entirely. That achieves the
+report's stated goal — "make `ClauseBasedPlanner` immutable with respect to
+per-query execution state" — and removes the footgun instead of avoiding it on
+one path. A `PlanningContext` struct (approach #1) was unnecessary for a single
+field; a plain parameter is simpler.
+
+One clarification: the bug was not limited to concurrency. The direct plan-only
+paths in `database.go` (Explain, Analyze) called `PlanQuery` without ever setting
+a handler, so under the old code they read whatever stale handler the last
+executor query had left on the shared field. Threading makes that explicit
+(`nil`).
+
+### Verification
+
+`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green; the new
+regression test fails (standard gate and `-race`) before the fix and passes after.

--- a/tests/parameterized_cartesian_product_test.go
+++ b/tests/parameterized_cartesian_product_test.go
@@ -114,7 +114,7 @@ func TestParameterizedQueryCartesianProduct(t *testing.T) {
 		}
 
 		// Debug: Check what plan is created
-		plan, err := exec.GetPlanner().PlanQuery(q)
+		plan, err := exec.GetPlanner().PlanQuery(q, nil)
 		if err != nil {
 			t.Fatalf("Failed to create plan: %v", err)
 		}


### PR DESCRIPTION
## Bug

Annotated query execution installed the per-query handler on the planner that *every* query shares through one `Executor` — `executor.planner.SetHandler(collector.Handler())` with `defer SetHandler(nil)` — and planning read it back via `optimizeViaAlgebra(clauses, p.handler)`. Two annotated queries running concurrently raced on that field and cross-routed or dropped each other's algebra-bridge events. The shallow per-query `Executor` copy reused the same `*ClauseBasedPlanner` pointer, so the copy gave no isolation.

## Fix

Thread the handler through planning instead of storing it (the report's recommended direction, taken to its strongest form):

- `Plan` / `PlanWithBindings` and the `PlanQuery` / `PlanQueryWithBindings` interface methods now take a `handler annotations.Handler` parameter, passed straight to `optimizeViaAlgebra`.
- The mutable `handler` field **and** `SetHandler` are removed from `ClauseBasedPlanner` and the `QueryPlanner` interface. The planner holds no per-query state — the footgun is gone, not just avoided.
- The executor computes the handler from `ctx.Collector()` and passes it into the plan call (no more `SetHandler`/`defer`).
- `database.go`'s plan-only Explain/Analyze paths pass `nil` — they never annotated planning and previously read whatever stale handler the last query left behind.

`ClauseBasedPlanner` is the only `QueryPlanner` implementer, so the interface change rippled only to call sites (mostly passing `nil`).

## Test

`datalog/executor/planner_handler_race_test.go` runs 32 annotated queries concurrently through one `Executor`; with no plan cache each query re-plans, so each collector must see exactly one `algebra/bridge-begin`. It fails before the fix **both** on the standard gate (cross-routed events: a collector saw another query's begin) and under `-race` (data race on the field), and passes both ways after.

## Verification

`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green; repro also verified clean under `-race`.

Resolves `docs/bugs/resolved/BUG_PLANNER_HANDLER_SHARED_STATE_RACE.md` (amended with the resolution and notes on the report).