### PR TITLE
Hash time.Time deterministically in TupleKey (fixes CI)

### DIFF
--- a/datalog/executor/tuple_key.go
+++ b/datalog/executor/tuple_key.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"time"
 	"unsafe"
 
 	"github.com/wbrown/janus-datalog/datalog"
@@ -117,6 +118,15 @@ func hashValue(v interface{}) uint64 {
 		// TupleKeyMap — breaking joins and dedup on byte-valued attributes.
 		return hashBytes(val)
 
+	case time.Time:
+		// Hash by the absolute instant. Without this case, time.Time falls
+		// through to the address-based default below, so equal times hash
+		// differently across call sites and never match in a TupleKeyMap —
+		// breaking joins and dedup on time-valued attributes (e.g. :created-at)
+		// nondeterministically by platform/stack layout. Consistent with
+		// datalog.ValuesEqual, which compares time.Time by instant (Equal).
+		return hashTime(val)
+
 	case int:
 		return uint64(val)
 
@@ -164,6 +174,20 @@ func hashBytes(b []byte) uint64 {
 		hash *= prime
 	}
 
+	return hash
+}
+
+// hashTime hashes a time.Time by its absolute instant (seconds + nanoseconds),
+// consistent with datalog.ValuesEqual's instant-based comparison: two times that
+// compare Equal hash identically. Uses Unix()+Nanosecond() rather than UnixNano()
+// to avoid int64 overflow for out-of-range times (e.g. the 0001-01-01 default).
+func hashTime(t time.Time) uint64 {
+	const prime = 1099511628211
+	hash := uint64(14695981039346656037)
+	hash ^= uint64(t.Unix())
+	hash *= prime
+	hash ^= uint64(t.Nanosecond())
+	hash *= prime
 	return hash
 }
 

--- a/datalog/executor/tuple_key_time_test.go
+++ b/datalog/executor/tuple_key_time_test.go
@@ -1,0 +1,62 @@
+package executor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// hashValueAtDepth calls hashValue from `depth` extra stack frames down, so the
+// address of hashValue's parameter differs from a shallow call. Recursion is not
+// inlined, so this reliably changes the stack address.
+func hashValueAtDepth(v interface{}, depth int) uint64 {
+	if depth <= 0 {
+		return hashValue(v)
+	}
+	return hashValueAtDepth(v, depth-1)
+}
+
+// TestHashValue_TimeIsDeterministic is a regression test for the time.Time gap in
+// hashValue. Like the []byte case above it, a time.Time value must hash by its
+// content, not by the address-based default — otherwise equal times hash to
+// different buckets in a TupleKeyMap and never match, making joins and dedup on
+// time-valued tuples nondeterministic across platforms.
+func TestHashValue_TimeIsDeterministic(t *testing.T) {
+	tm := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	shallow := hashValue(tm)
+	deep := hashValueAtDepth(tm, 32)
+	if shallow != deep {
+		t.Fatalf("hashValue(time.Time) is not deterministic across call sites: %d vs %d "+
+			"(time.Time falls through to the pointer-address default)", shallow, deep)
+	}
+}
+
+// TestTupleKeyMap_TimeValuedTuplesRoundTrip ensures a TupleKeyMap keyed on a
+// tuple containing a time.Time can find that tuple again when the lookup key is
+// built from a separately-constructed equal time at a different stack depth —
+// the pattern a hash join exercises (build vs probe). With the bug the lookup
+// misses and the row is silently dropped from the join.
+func TestTupleKeyMap_TimeValuedTuplesRoundTrip(t *testing.T) {
+	id := datalog.NewIdentity("e1")
+	tm := time.Date(2026, 5, 24, 9, 30, 0, 0, time.UTC)
+
+	m := NewTupleKeyMap()
+	m.Put(NewTupleKeyFull(Tuple{id, tm}), "v")
+
+	// Build the lookup key from an equal but separately-constructed time, hashed
+	// from a different stack depth (mirroring build-side vs probe-side hashing).
+	lookupTime := time.Date(2026, 5, 24, 9, 30, 0, 0, time.UTC)
+	key := tupleKeyAtDepth(Tuple{id, lookupTime}, 32)
+	if _, ok := m.Get(key); !ok {
+		t.Fatalf("TupleKeyMap lost a time-valued tuple: Get missed an equal key "+
+			"(time.Time hashed nondeterministically)")
+	}
+}
+
+func tupleKeyAtDepth(tuple Tuple, depth int) TupleKey {
+	if depth <= 0 {
+		return NewTupleKeyFull(tuple)
+	}
+	return tupleKeyAtDepth(tuple, depth-1)
+}

--- a/docs/bugs/BUG_TUPLEKEY_TIME_HASH_NONDETERMINISTIC.md
+++ b/docs/bugs/BUG_TUPLEKEY_TIME_HASH_NONDETERMINISTIC.md
@@ -1,0 +1,137 @@
+# Bug: TupleKey Hash Is Non-Deterministic for time.Time
+
+**Date**: 2026-05-25
+**Severity**: High — silently dropped rows / wrong results; platform-dependent, so it passes locally and fails in CI
+**Status**: Fix applied; CI verification pending
+**Affected**: `datalog/executor/tuple_key.go` (`hashValue`), and every `TupleKeyMap` consumer — hash joins, join/union dedup, subquery input dedup
+
+## Summary
+
+`hashValue` (the per-value hash behind `TupleKey` / `TupleKeyMap`) has no `time.Time`
+case, so `time.Time` values fall through to the `default` branch, which returns
+`uint64(uintptr(unsafe.Pointer(&v)))` — the address of the function's interface
+parameter. That address varies call to call (it depends on stack/frame layout), so
+the *same* time value hashes to *different* values at different call sites.
+
+`TupleKeyMap` buckets entries by hash and only compares values (via
+`datalog.ValuesEqual`) *within* a bucket. When two equal times hash to different
+buckets, the value comparison never runs and they are treated as distinct. In a hash
+join the build side stores a row under one hash and the probe side looks it up under
+another — the lookup misses and the row is silently dropped.
+
+`datalog.ValuesEqual` *does* handle `time.Time` correctly (by instant, via `Equal`).
+The defect is purely that `hashValue` and `ValuesEqual` disagree about `time.Time`:
+equal values, unequal hashes.
+
+## Trigger
+
+Any query whose hash-joined or deduplicated tuples carry a `time.Time` value — e.g.
+attributes like `:created-at`, `:updated-at`, or a `(max ?ts)` subquery result. The
+failure is non-deterministic *across* platforms because it depends on stack
+addresses: it can pass on one OS/arch/Go-version and fail on another, and each
+outcome is stable within a platform.
+
+## Evidence
+
+- CI (`linux/amd64`, Go 1.25) went red the moment the unrelated PR #73 merged and
+  stayed red; the last green run was #72. Failing tests: `TestGetElseComplex_OrSemantics`,
+  `TestGetElseComplex_ParsedOr`, `TestGetElseComplex_QBOr`, and
+  `TestCorrelatedSubqueryAlgebraOptimizerWithDefaults` — all queries over the items DB
+  with `:created-at` / `:updated-at` timestamps.
+- The symptom is a non-deterministic row count: the OR-union query should yield 9 rows;
+  CI's base executor yields 8, dropping the `proj:2` row (the project with no items,
+  whose timestamp is the `0001-01-01` ground default).
+- The same suite passes locally (`darwin/arm64`, Go 1.26.3) every time — including 50×
+  repeats, `GOMAXPROCS=2`, and `GOARCH=amd64` via Rosetta — because this machine's stack
+  addresses happen to coincide between the build and probe hashes.
+- Reproduced directly and deterministically with two unit tests (below): `hashValue(t)`
+  returns different values for the same `time.Time` when called at different stack
+  depths, and a `TupleKeyMap` loses a time-valued tuple on lookup.
+
+## Root Cause
+
+```go
+// hashValue, default branch (datalog/executor/tuple_key.go)
+default:
+    // Fallback: use pointer as hash
+    return uint64(uintptr(unsafe.Pointer(&v)))
+```
+
+`time.Time` is not in the type switch, so it hits this branch. `&v` is the address of
+the interface parameter, not anything derived from the value, so the hash is neither
+stable nor value-derived.
+
+This is the *same class* of bug as the previously-fixed `[]byte` case, whose comment
+already warns: "Without this case, []byte falls through to the default pointer-address
+hash below, so two equal byte slices get different (nondeterministic) hashes and never
+collide in a TupleKeyMap." `time.Time` was simply overlooked.
+
+PR #73 (removal of the name-based transaction dedup in `HashJoin`) did **not** cause
+this — it only perturbed execution/stack layout enough to flip the address coincidence
+on CI. The defect is latent and predates this session.
+
+## Why Local Testing Missed It
+
+The pre-push hook runs `go test ./...` on the developer machine (`darwin/arm64`,
+Go 1.26.3), where the addresses align and the tests pass. CI runs `linux/amd64` with
+the Go version from `go.mod` (1.25), where they do not. A green local run — and a green
+pre-push hook — is not evidence of a green CI run for layout-dependent bugs. CI is the
+source of truth.
+
+## Fix
+
+Add a `time.Time` case to `hashValue` that hashes by the absolute instant, consistent
+with `ValuesEqual`:
+
+```go
+case time.Time:
+    return hashTime(val)
+
+// ...
+func hashTime(t time.Time) uint64 {
+    const prime = 1099511628211
+    hash := uint64(14695981039346656037)
+    hash ^= uint64(t.Unix())
+    hash *= prime
+    hash ^= uint64(t.Nanosecond())
+    hash *= prime
+    return hash
+}
+```
+
+`Unix()`+`Nanosecond()` (rather than `UnixNano()`) avoids int64 overflow for
+out-of-range times such as the `0001-01-01` ground default. Two times that compare
+`Equal` have the same `Unix()` and `Nanosecond()`, so they hash identically — keeping
+`hashValue` and `ValuesEqual` in agreement.
+
+## Tests
+
+- `TestHashValue_TimeIsDeterministic` — `hashValue(t)` must return the same value when
+  called at different stack depths. Fails before the fix, passes after.
+- `TestTupleKeyMap_TimeValuedTuplesRoundTrip` — a `TupleKeyMap` keyed on a time-valued
+  tuple must find that tuple when the lookup key is built from a separately-constructed
+  equal time at a different stack depth (the build-vs-probe pattern). Fails before,
+  passes after.
+
+## Broader Class (Follow-up)
+
+`hashValue` and `ValuesEqual` must agree for *every* value type. They still disagree for
+two more cases that hit the same nondeterministic default:
+
+- `query.Symbol` / `datalog.Symbol` used as a value (e.g. source markers). `ValuesEqual`
+  handles `Symbol`; `hashValue` does not. (`BUG_SUBQUERY_INPUT_DEDUP_STRING_COLLISION`
+  already works around this by excluding source markers from its dedup key.)
+- Non-`[]byte` slices (`[]string`, `[]int64`, `[]interface{}`). `ValuesEqual` compares
+  these recursively; `hashValue` only handles `[]byte`.
+
+Neither is known to cause failures today (such values rarely appear in join/dedup keys),
+but both are the same time bomb. Options: add explicit cases, or replace the
+address-based `default` with a deterministic fallback so no type can ever hash
+non-deterministically. Tracked here for a decision.
+
+## Verification
+
+`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` green locally; the two new
+tests fail before the fix and pass after. Final confirmation that the
+`TestGetElseComplex_*` CI failures are resolved requires a green CI run on `linux/amd64`
+(the bug cannot be reproduced on `darwin/arm64`).

--- a/docs/bugs/resolved/BUG_TUPLEKEY_TIME_HASH_NONDETERMINISTIC.md
+++ b/docs/bugs/resolved/BUG_TUPLEKEY_TIME_HASH_NONDETERMINISTIC.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-25
 **Severity**: High — silently dropped rows / wrong results; platform-dependent, so it passes locally and fails in CI
-**Status**: Fix applied; CI verification pending
+**Status**: Resolved (2026-05-25) — CI green on linux/amd64 (PR #76)
 **Affected**: `datalog/executor/tuple_key.go` (`hashValue`), and every `TupleKeyMap` consumer — hash joins, join/union dedup, subquery input dedup
 
 ## Summary
@@ -132,6 +132,9 @@ non-deterministically. Tracked here for a decision.
 ## Verification
 
 `go build ./...`, `go vet ./...`, and `go test -count=1 ./...` green locally; the two new
-tests fail before the fix and pass after. Final confirmation that the
-`TestGetElseComplex_*` CI failures are resolved requires a green CI run on `linux/amd64`
-(the bug cannot be reproduced on `darwin/arm64`).
+tests fail before the fix and pass after.
+
+**Confirmed on CI**: the `TestGetElseComplex_*` and
+`TestCorrelatedSubqueryAlgebraOptimizerWithDefaults` failures are resolved on
+`linux/amd64` / Go 1.25 (PR #76 CI green) — the environment where the bug manifested and
+which cannot be reproduced on `darwin/arm64`.


### PR DESCRIPTION
## Bug

`hashValue` (behind `TupleKey` / `TupleKeyMap`) had no `time.Time` case, so time values fell through to the address-based `default` (`uintptr(unsafe.Pointer(&v))` — the address of the interface *parameter*). That address varies by call site, so the same time hashed differently at different points in the code.

`TupleKeyMap` buckets by hash and only compares values (`datalog.ValuesEqual`) *within* a bucket. Equal times in different buckets are never compared, so they're treated as distinct — a hash join's build side stores a row under one hash and the probe side looks it up under another, the lookup misses, and **the row is silently dropped**.

`ValuesEqual` already compares `time.Time` correctly (by instant). The defect was purely that `hashValue` and `ValuesEqual` disagreed: equal values, unequal hashes — the same class as the previously-fixed `[]byte` case.

## Why CI was red but local was green

The outcome depends on stack/platform layout, so it's stable *within* a platform but differs *across* them. It passed on `darwin/arm64` (and the pre-push hook) every time — 50× repeats, `GOMAXPROCS=2`, `GOARCH=amd64` via Rosetta — and failed deterministically on CI's `linux/amd64` / Go 1.25. CI went red the moment the unrelated PR #73 merged; #73 only perturbed layout enough to surface this latent defect.

This is the root cause of the CI failures since #73: `TestGetElseComplex_{OrSemantics,ParsedOr,QBOr}` and `TestCorrelatedSubqueryAlgebraOptimizerWithDefaults` — all queries over `:created-at` / `:updated-at` timestamped data, where the OR-union row count came out 8 instead of 9 (dropping the timestamped `proj:2`).

## Fix

Add a `time.Time` case to `hashValue` hashing by instant (`Unix()` + `Nanosecond()`, avoiding `UnixNano()` overflow for the `0001-01-01` ground default), consistent with `ValuesEqual.Equal`. Mirrors the existing `[]byte` case.

## Tests

Both force different stack depths to expose the nondeterminism (it hides at a single call depth):

- `TestHashValue_TimeIsDeterministic` — `hashValue(t)` must be equal across call depths.
- `TestTupleKeyMap_TimeValuedTuplesRoundTrip` — a `TupleKeyMap` keyed on a time-valued tuple must find it when the lookup key is built from a separately-constructed equal time (the build-vs-probe pattern).

Both fail before the fix, pass after.

## Verification

`go build ./...`, `go vet ./...`, `go test -count=1 ./...` green locally. **The get-else CI failures can only be confirmed fixed by a green CI run on `linux/amd64`** — the bug cannot be reproduced on `darwin/arm64`. Watching this PR's CI.

## Follow-up (documented in the bug report)

`hashValue` and `ValuesEqual` still disagree for `query.Symbol`-as-value and non-`[]byte` slices (same address-based default). Not known to fail today, but the same time bomb — flagged for a decision (add cases, or make the `default` deterministic).

Full write-up: `docs/bugs/BUG_TUPLEKEY_TIME_HASH_NONDETERMINISTIC.md`.
