### PR TITLE
Propagate iterator errors through materialization paths and Sorted()

### DIFF
--- a/datalog/executor/aggregation.go
+++ b/datalog/executor/aggregation.go
@@ -629,7 +629,7 @@ func (r *StreamingAggregateRelation) ProjectFromPattern(pattern *query.DataPatte
 }
 
 // Sorted returns tuples sorted by the relation's symbols
-func (r *StreamingAggregateRelation) Sorted() []Tuple {
+func (r *StreamingAggregateRelation) Sorted() ([]Tuple, error) {
 	r.Iterator()
 	return r.materialized.Sorted()
 }

--- a/datalog/executor/collect_tuples_guard_test.go
+++ b/datalog/executor/collect_tuples_guard_test.go
@@ -1,0 +1,43 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCollectTuplesInto_ErrorNeverDropped is a static guard for
+// BUG_ITERATOR_ERRORS_DROPPED_IN_MATERIALIZATION_PATHS. Every collectTuplesInto
+// call in production code must capture its returned error; a bare call statement
+// silently launders a failed partial stream into a clean materialized relation.
+//
+// A captured call reads "err := collectTuplesInto(...)" or
+// "if err := collectTuplesInto(...)"; a dropped call is the bare statement
+// "collectTuplesInto(...)". This guard flags the latter.
+func TestCollectTuplesInto_ErrorNeverDropped(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	require.NoError(t, err)
+
+	var violations []string
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		require.NoError(t, err)
+		for i, line := range strings.Split(string(src), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "collectTuplesInto(") {
+				violations = append(violations, fmt.Sprintf("%s:%d", f, i+1))
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("collectTuplesInto called without capturing its error (launders iterator "+
+			"failures into clean relations):\n  %s", strings.Join(violations, "\n  "))
+	}
+}

--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -533,7 +533,9 @@ func (e *Executor) executeRealizedWithRelationInputIterationParallel(
 
 	// Collect all tuples first (needed for worker pool)
 	var tuples []Tuple
-	collectTuplesInto(&tuples, iterationRelation)
+	if err := collectTuplesInto(&tuples, iterationRelation); err != nil {
+		return nil, err
+	}
 
 	if len(tuples) == 0 {
 		return NewMaterializedRelation(extractFindSymbols(plan.Query.Find), []Tuple{}), nil

--- a/datalog/executor/executor_utils.go
+++ b/datalog/executor/executor_utils.go
@@ -80,7 +80,7 @@ func extractFindSymbols(findElements []query.FindElement) []query.Symbol {
 // This is a pure function that collects all tuples from the iterator into memory.
 func MaterializeResult(rel Relation, symbols []query.Symbol) Relation {
 	var tuples []Tuple
-	collectTuplesInto(&tuples, rel)
+	err := collectTuplesInto(&tuples, rel)
 
 	// Note: an earlier debug assertion here panicked with
 	// "BUG DETECTED" when the first and last tuples were
@@ -94,7 +94,12 @@ func MaterializeResult(rel Relation, symbols []query.Symbol) Relation {
 
 	// Extract options from source relation to preserve configuration
 	opts := rel.Options()
-	return NewMaterializedRelationWithOptions(symbols, tuples, opts)
+	mat := NewMaterializedRelationWithOptions(symbols, tuples, opts)
+	if err != nil {
+		// Carry a deferred source error so it isn't laundered by materialization.
+		mat.err = err
+	}
+	return mat
 }
 
 // Result is deprecated - use Relation instead.
@@ -107,7 +112,7 @@ type Result = MaterializedRelation
 func SortRelation(rel Relation, orderBy []query.OrderByClause) Relation {
 	// Materialize if not already materialized
 	var tuples []Tuple
-	collectTuplesInto(&tuples, rel)
+	err := collectTuplesInto(&tuples, rel)
 
 	// Get symbol indices for sort variables
 	symbols := rel.Symbols()
@@ -147,7 +152,12 @@ func SortRelation(rel Relation, orderBy []query.OrderByClause) Relation {
 	})
 
 	opts := rel.Options()
-	return NewMaterializedRelationWithOptions(symbols, tuples, opts)
+	mat := NewMaterializedRelationWithOptions(symbols, tuples, opts)
+	if err != nil {
+		// Carry a deferred source error so it isn't laundered by materialization.
+		mat.err = err
+	}
+	return mat
 }
 
 // computeAggregate computes an aggregate over all values in a symbol
@@ -307,10 +317,14 @@ func BindQueryInputs(q *query.Query, inputRelations []Relation) Relation {
 				if rel.Size() > 0 && len(inp.Symbols) == len(rel.Symbols()) {
 					// Create a new relation with the input variables as symbol names
 					tuples := make([]Tuple, 0, rel.Size())
-					collectTuplesInto(&tuples, rel)
+					err := collectTuplesInto(&tuples, rel)
 
 					opts := rel.Options()
-					boundRelations = append(boundRelations, NewMaterializedRelationWithOptions(inp.Symbols, tuples, opts))
+					bound := NewMaterializedRelationWithOptions(inp.Symbols, tuples, opts)
+					if err != nil {
+						bound.err = err
+					}
+					boundRelations = append(boundRelations, bound)
 				}
 				relationIndex++
 			}

--- a/datalog/executor/indexed_memory_matcher.go
+++ b/datalog/executor/indexed_memory_matcher.go
@@ -196,12 +196,16 @@ func (m *IndexedMemoryMatcher) MatchWithConstraints(
 		relOpts = opts
 	}
 
+	sorted, err := bindingRel.Sorted()
+	if err != nil {
+		return nil, err
+	}
 	iterator := &boundDatomIterator{
 		matcher:     m,
 		pattern:     pattern,
 		symbols:     symbols,
 		constraints: constraints,
-		boundTuples: bindingRel.Sorted(),
+		boundTuples: sorted,
 		bindingRel:  bindingRel,
 		boundIdx:    -1,
 		datomIdx:    0,

--- a/datalog/executor/indexed_memory_matcher_test.go
+++ b/datalog/executor/indexed_memory_matcher_test.go
@@ -250,8 +250,14 @@ func TestIndexedMatcher_CorrectnessVsLinear(t *testing.T) {
 			}
 
 			// Compare contents (sort for comparison)
-			linearTuples := linearResult.Sorted()
-			indexedTuples := indexedResult.Sorted()
+			linearTuples, err := linearResult.Sorted()
+			if err != nil {
+				t.Fatalf("linear Sorted() failed: %v", err)
+			}
+			indexedTuples, err := indexedResult.Sorted()
+			if err != nil {
+				t.Fatalf("indexed Sorted() failed: %v", err)
+			}
 
 			if len(linearTuples) != len(indexedTuples) {
 				t.Fatalf("Tuple count mismatch: linear=%d, indexed=%d",

--- a/datalog/executor/lazy_seq_relation.go
+++ b/datalog/executor/lazy_seq_relation.go
@@ -74,7 +74,7 @@ func (r *LazySeqRelation) String() string {
 }
 
 func (r *LazySeqRelation) Table() string                         { return r.Materialize().Table() }
-func (r *LazySeqRelation) Sorted() []Tuple                       { return r.Materialize().Sorted() }
+func (r *LazySeqRelation) Sorted() ([]Tuple, error)             { return r.Materialize().Sorted() }
 func (r *LazySeqRelation) Sort(o []query.OrderByClause) Relation { return r.Materialize().Sort(o) }
 func (r *LazySeqRelation) Filter(f Filter) Relation              { return FilterRelation(r, f) }
 func (r *LazySeqRelation) Select(pred func(Tuple) bool) Relation { return Select(r, pred) }

--- a/datalog/executor/materialization_error_propagation_test.go
+++ b/datalog/executor/materialization_error_propagation_test.go
@@ -1,0 +1,41 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// Reproductions for BUG_ITERATOR_ERRORS_DROPPED_IN_MATERIALIZATION_PATHS.md
+//
+// Several materialization/union paths call collectTuplesInto and ignore its
+// returned error, turning a failed partial stream into a clean materialized
+// relation. Each must instead carry the error onto the derived relation (replayed
+// at the next public boundary via Iterator().Error()).
+
+// TestMaterializeResult_PropagatesIteratorError: MaterializeResult must not launder
+// a failed source into a clean materialized relation.
+func TestMaterializeResult_PropagatesIteratorError(t *testing.T) {
+	src := newFailingStream(1, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	rel := MaterializeResult(src, testSymbols())
+	require.ErrorIs(t, driveErr(rel), errInjectedIterator)
+}
+
+// TestSortRelation_PropagatesIteratorError: SortRelation collects then sorts; a
+// source failure must survive materialization rather than yield clean sorted rows.
+func TestSortRelation_PropagatesIteratorError(t *testing.T) {
+	src := newFailingStream(1, Tuple{int64(3)}, Tuple{int64(1)}, Tuple{int64(2)})
+	rel := SortRelation(src, []query.OrderByClause{{Variable: datalog.NewSymbol("?x")}})
+	require.ErrorIs(t, driveErr(rel), errInjectedIterator)
+}
+
+// TestCombineSubqueryResultsSimple_PropagatesIteratorError: unioning subquery
+// results must not drop an error from one branch and return the others as success.
+func TestCombineSubqueryResultsSimple_PropagatesIteratorError(t *testing.T) {
+	clean := NewMaterializedRelation(testSymbols(), []Tuple{{int64(1)}})
+	failing := newFailingStream(0, Tuple{int64(2)})
+	rel := combineSubqueryResultsSimple([]Relation{clean, failing})
+	require.ErrorIs(t, driveErr(rel), errInjectedIterator)
+}

--- a/datalog/executor/multi_match_optimization_test.go
+++ b/datalog/executor/multi_match_optimization_test.go
@@ -42,7 +42,11 @@ func (m *MockPatternMatcherWithStats) MatchWithRelation(pattern *query.DataPatte
 	seen := make(map[string]bool)
 
 	// Process each tuple in one go
-	for _, tuple := range projected.Sorted() {
+	sortedProjected, err := projected.Sorted()
+	if err != nil {
+		return nil, err
+	}
+	for _, tuple := range sortedProjected {
 		// Simulate matching with this tuple's bindings
 		for _, d := range m.datoms {
 			if m.matchesWithTuple(d, pattern, tuple, projected) {

--- a/datalog/executor/or_fallback_relation.go
+++ b/datalog/executor/or_fallback_relation.go
@@ -270,7 +270,7 @@ func (r *OrFallbackRelation) ProjectFromPattern(pattern *query.DataPattern) Rela
 	return r.Materialize().ProjectFromPattern(pattern)
 }
 
-func (r *OrFallbackRelation) Sorted() []Tuple {
+func (r *OrFallbackRelation) Sorted() ([]Tuple, error) {
 	return r.Materialize().Sorted()
 }
 
@@ -280,13 +280,17 @@ func (r *OrFallbackRelation) Project(symbols []query.Symbol) (Relation, error) {
 
 func (r *OrFallbackRelation) Materialize() Relation {
 	var tuples []Tuple
-	collectTuplesInto(&tuples, r)
+	err := collectTuplesInto(&tuples, r)
 
 	syms := r.symbols
 	if syms == nil {
 		syms = r.Symbols()
 	}
-	return NewMaterializedRelationWithOptions(syms, tuples, r.options)
+	mat := NewMaterializedRelationWithOptions(syms, tuples, r.options)
+	if err != nil {
+		mat.err = err
+	}
+	return mat
 }
 
 func (r *OrFallbackRelation) Sort(orderBy []query.OrderByClause) Relation {

--- a/datalog/executor/prepended_relation.go
+++ b/datalog/executor/prepended_relation.go
@@ -74,7 +74,7 @@ func (r *PrependedRelation) ProjectFromPattern(pattern *query.DataPattern) Relat
 	return r.Materialize().ProjectFromPattern(pattern)
 }
 
-func (r *PrependedRelation) Sorted() []Tuple {
+func (r *PrependedRelation) Sorted() ([]Tuple, error) {
 	return r.Materialize().Sorted()
 }
 

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -914,11 +914,18 @@ func combineSubqueryResultsSimple(results []Relation) Relation {
 	symbols := results[0].Symbols()
 	var allTuples []Tuple
 
+	var collectErr error
 	for _, result := range results {
-		collectTuplesInto(&allTuples, result)
+		if err := collectTuplesInto(&allTuples, result); err != nil && collectErr == nil {
+			collectErr = err
+		}
 	}
 
-	return NewMaterializedRelation(symbols, allTuples)
+	mat := NewMaterializedRelation(symbols, allTuples)
+	if collectErr != nil {
+		mat.err = collectErr
+	}
+	return mat
 }
 
 // extractBindingSymbols extracts symbols from a binding form

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -129,7 +129,9 @@ type Relation interface {
 
 	// Sorted returns tuples sorted by the relation's symbols
 	// First symbol is primary sort key, second is secondary, etc.
-	Sorted() []Tuple
+	// Returns the source iterator's deferred error if iteration failed, so a
+	// failed sort source isn't laundered into clean sorted tuples.
+	Sorted() ([]Tuple, error)
 
 	// Project returns a new relation with only the specified symbols
 	// Returns an error if any requested symbol doesn't exist
@@ -606,7 +608,11 @@ func (r *MaterializedRelation) ProjectFromPattern(pattern *query.DataPattern) Re
 
 // Sorted returns tuples sorted by the relation's symbols
 // First symbol is primary sort key, second is secondary, etc.
-func (r *MaterializedRelation) Sorted() []Tuple {
+func (r *MaterializedRelation) Sorted() ([]Tuple, error) {
+	// Surface a deferred source error rather than returning sorted partial data.
+	if r.err != nil {
+		return nil, r.err
+	}
 	// Create a copy of tuples to sort (preserving immutability)
 	sorted := make([]Tuple, len(r.tuples))
 	copy(sorted, r.tuples)
@@ -624,7 +630,7 @@ func (r *MaterializedRelation) Sorted() []Tuple {
 		return len(sorted[i]) < len(sorted[j])
 	})
 
-	return sorted
+	return sorted, nil
 }
 
 // Project returns a new relation with only the specified symbols
@@ -1157,14 +1163,17 @@ func (r *StreamingRelation) ProjectFromPattern(pattern *query.DataPattern) Relat
 }
 
 // Sorted returns tuples sorted by the relation's symbols
-func (r *StreamingRelation) Sorted() []Tuple {
+func (r *StreamingRelation) Sorted() ([]Tuple, error) {
 	// Sorted() requires all data in memory
 	// Set shouldCache flag so iteration builds the cache
 	r.Materialize()
 
-	// Now consume iterator to build cache
+	// Now consume iterator to build cache; surface a deferred source error
+	// rather than returning sorted partial data.
 	var tuples []Tuple
-	collectTuplesInto(&tuples, r)
+	if err := collectTuplesInto(&tuples, r); err != nil {
+		return nil, err
+	}
 
 	// Sort tuples lexicographically by symbols
 	sort.Slice(tuples, func(i, j int) bool {
@@ -1179,7 +1188,7 @@ func (r *StreamingRelation) Sorted() []Tuple {
 		return len(tuples[i]) < len(tuples[j])
 	})
 
-	return tuples
+	return tuples, nil
 }
 
 // Project returns a new relation with only the specified symbols
@@ -1484,7 +1493,7 @@ func (p *ProductRelation) ProjectFromPattern(pattern *query.DataPattern) Relatio
 	return p.Materialize().ProjectFromPattern(pattern)
 }
 
-func (p *ProductRelation) Sorted() []Tuple {
+func (p *ProductRelation) Sorted() ([]Tuple, error) {
 	return p.Materialize().Sorted()
 }
 

--- a/datalog/executor/streaming_union.go
+++ b/datalog/executor/streaming_union.go
@@ -59,11 +59,20 @@ func (s *StreamingUnionBuilder) unionMaterialized(relations []Relation) Relation
 	symbols := relations[0].Symbols()
 	var allTuples []Tuple
 
+	var collectErr error
 	for _, rel := range relations {
-		collectTuplesInto(&allTuples, rel)
+		if err := collectTuplesInto(&allTuples, rel); err != nil && collectErr == nil {
+			collectErr = err
+		}
 	}
 
-	return NewMaterializedRelation(symbols, allTuples)
+	mat := NewMaterializedRelation(symbols, allTuples)
+	if collectErr != nil {
+		// A branch failed mid-iteration: carry the error rather than returning
+		// the other branches as a clean union.
+		mat.err = collectErr
+	}
+	return mat
 }
 
 // UnionWithColumns combines relations and ensures specific symbol schema

--- a/datalog/executor/subquery.go
+++ b/datalog/executor/subquery.go
@@ -409,7 +409,9 @@ func combineSubqueryResults(allResults []Relation, subqPlan planner.SubqueryPlan
 	symbols := validResults[0].Symbols()
 
 	for _, rel := range validResults {
-		collectTuplesInto(&allTuples, rel)
+		if err := collectTuplesInto(&allTuples, rel); err != nil {
+			return nil, fmt.Errorf("subquery result union failed: %w", err)
+		}
 	}
 
 	result := NewMaterializedRelation(symbols, allTuples)

--- a/datalog/executor/table_formatter.go
+++ b/datalog/executor/table_formatter.go
@@ -37,7 +37,9 @@ func (tf *TableFormatter) FormatRelation(rel Relation) string {
 
 	// Collect all tuples
 	var tuples []Tuple
-	collectTuplesInto(&tuples, rel)
+	if err := collectTuplesInto(&tuples, rel); err != nil {
+		return fmt.Sprintf("_error reading relation: %v_", err)
+	}
 
 	symbols := rel.Symbols()
 	return tf.formatTable(symbols, tuples)

--- a/datalog/executor/time_range_integration_test.go
+++ b/datalog/executor/time_range_integration_test.go
@@ -107,8 +107,14 @@ func TestTimeRangeMetadataFlow(t *testing.T) {
 	}
 
 	// Sort both results by first symbol (hour) for deterministic comparison
-	baselineSorted := baselineResult.Sorted()
-	optimizedSorted := optimizedResult.Sorted()
+	baselineSorted, err := baselineResult.Sorted()
+	if err != nil {
+		t.Fatalf("baseline Sorted() failed: %v", err)
+	}
+	optimizedSorted, err := optimizedResult.Sorted()
+	if err != nil {
+		t.Fatalf("optimized Sorted() failed: %v", err)
+	}
 
 	// Verify actual values match
 	for i := 0; i < len(baselineSorted) && i < len(optimizedSorted); i++ {

--- a/datalog/executor/union_relation.go
+++ b/datalog/executor/union_relation.go
@@ -122,7 +122,7 @@ func (ur *UnionRelation) ProjectFromPattern(pattern *query.DataPattern) Relation
 }
 
 // Sorted returns sorted tuples (forces materialization)
-func (ur *UnionRelation) Sorted() []Tuple {
+func (ur *UnionRelation) Sorted() ([]Tuple, error) {
 	return ur.Materialize().Sorted()
 }
 

--- a/datalog/executor/wrapper_relation_copy_test.go
+++ b/datalog/executor/wrapper_relation_copy_test.go
@@ -35,7 +35,7 @@ func (r *mockUnsafeRelation) Get(i int) Tuple                                   
 func (r *mockUnsafeRelation) String() string                                         { return "mockUnsafeRelation" }
 func (r *mockUnsafeRelation) Table() string                                          { return "" }
 func (r *mockUnsafeRelation) ProjectFromPattern(*query.DataPattern) Relation         { return nil }
-func (r *mockUnsafeRelation) Sorted() []Tuple                                        { return nil }
+func (r *mockUnsafeRelation) Sorted() ([]Tuple, error)                               { return nil, nil }
 func (r *mockUnsafeRelation) Project([]query.Symbol) (Relation, error)               { return nil, nil }
 func (r *mockUnsafeRelation) Materialize() Relation                                  { return r }
 func (r *mockUnsafeRelation) Sort([]query.OrderByClause) Relation                    { return nil }

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -565,7 +565,10 @@ func (m *BadgerMatcher) matchWithMergeJoin(
 ) (executor.Relation, error) {
 	// PHASE 1: Sort binding relation by join key
 	// Sorted() will auto-materialize if needed
-	sortedTuples := bindingRel.Sorted()
+	sortedTuples, err := bindingRel.Sorted()
+	if err != nil {
+		return nil, err
+	}
 
 	if len(sortedTuples) == 0 {
 		// No bindings - return empty result

--- a/datalog/storage/iterator_reuse_regression_test.go
+++ b/datalog/storage/iterator_reuse_regression_test.go
@@ -77,7 +77,11 @@ func TestIteratorReuseRegression(t *testing.T) {
 	if symbolResult.Size() > 0 {
 		// Check first few values
 		count := 0
-		for _, tuple := range symbolResult.Sorted() {
+		sortedSymbolTuples, err := symbolResult.Sorted()
+		if err != nil {
+			t.Fatalf("Sorted() failed: %v", err)
+		}
+		for _, tuple := range sortedSymbolTuples {
 			if count >= 3 {
 				break
 			}

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -509,7 +509,10 @@ func (m *BadgerMatcher) matchWithIteratorReuse(
 	// Get sorted tuples - THIS IS CRITICAL!
 	// Without sorted tuples, we cannot use Seek() to jump forward in the iterator
 	// Sorted() will auto-materialize if needed
-	sortedTuples := bindingRel.Sorted()
+	sortedTuples, err := bindingRel.Sorted()
+	if err != nil {
+		return nil, err
+	}
 
 	// Create streaming iterator that will reuse storage iterator
 	iter := &reusingIterator{
@@ -558,7 +561,10 @@ func (m *BadgerMatcher) matchWithVValidation(
 		})
 	}
 	// Get sorted tuples for efficient iteration
-	sortedTuples := bindingRel.Sorted()
+	sortedTuples, err := bindingRel.Sorted()
+	if err != nil {
+		return nil, err
+	}
 
 	// Create validating iterator
 	iter := &validatingVBoundIterator{

--- a/docs/bugs/resolved/BUG_ITERATOR_ERRORS_DROPPED_IN_MATERIALIZATION_PATHS.md
+++ b/docs/bugs/resolved/BUG_ITERATOR_ERRORS_DROPPED_IN_MATERIALIZATION_PATHS.md
@@ -1,0 +1,166 @@
+# Bug: Some Materialization Paths Drop Iterator Errors
+
+## Summary
+
+The iterator contract requires callers to check `Iterator.Error()` after `Next()` returns false. The repository has already fixed several public boundaries by using `collectTuplesInto`, which returns deferred iterator and close errors.
+
+However, several materialization/union paths call `collectTuplesInto` and ignore its returned error, or manually iterate without checking `Error()`. These paths can turn a failed partial stream into a clean materialized relation.
+
+## Trigger
+
+Any storage iterator or composed relation that emits some tuples and then reports an error through `Iterator.Error()`, when consumed through one of the affected materializers.
+
+Examples:
+
+- Subquery result union.
+- `MaterializeResult`.
+- Streaming union materialized fallback.
+- Table formatting/debug output.
+- Legacy project/sort/materialize utilities.
+
+## Code Evidence
+
+`combineSubqueryResults` ignores the returned error:
+
+```go
+for _, rel := range validResults {
+	collectTuplesInto(&allTuples, rel)
+}
+
+result := NewMaterializedRelation(symbols, allTuples)
+return result, nil
+```
+
+`MaterializeResult` ignores the returned error:
+
+```go
+func MaterializeResult(rel Relation, symbols []query.Symbol) Relation {
+	var tuples []Tuple
+	collectTuplesInto(&tuples, rel)
+
+	opts := rel.Options()
+	return NewMaterializedRelationWithOptions(symbols, tuples, opts)
+}
+```
+
+`StreamingUnionBuilder.unionMaterialized` ignores branch errors:
+
+```go
+for _, rel := range relations {
+	collectTuplesInto(&allTuples, rel)
+}
+
+return NewMaterializedRelation(symbols, allTuples)
+```
+
+`TableFormatter.FormatRelation` also consumes without surfacing errors:
+
+```go
+var tuples []Tuple
+collectTuplesInto(&tuples, rel)
+
+symbols := rel.Symbols()
+return tf.formatTable(symbols, tuples)
+```
+
+Some nearby code already demonstrates the expected pattern:
+
+```go
+err := collectTuplesInto(&tuples, r)
+mat := NewMaterializedRelationWithOptions(r.symbols, tuples, r.options)
+mat.err = err
+```
+
+## Impact
+
+- Query results can be incomplete but appear successful.
+- Subquery unions can drop an error from one branch and return partial data from other branches.
+- Debug/table output can consume a stream and hide the reason rows are missing.
+- Error handling behavior depends on which internal materialization path the planner/executor happens to choose.
+
+This undermines the iterator error propagation fixes already documented elsewhere.
+
+## Expected Behavior
+
+Every path that consumes an iterator must do one of:
+
+1. Return the error immediately.
+2. Store the error on the derived `MaterializedRelation` so it is replayed at the next public boundary.
+3. Explicitly document why the error is irrelevant, if such a case exists.
+
+No path should silently discard the result of `collectTuplesInto`.
+
+## Suggested Fix
+
+Audit all calls to `collectTuplesInto` and all manual `Iterator()` loops.
+
+For functions that return `(Relation, error)`, return the error directly.
+
+For functions that only return `Relation`, attach the error to the materialized relation:
+
+```go
+err := collectTuplesInto(&tuples, rel)
+mat := NewMaterializedRelationWithOptions(symbols, tuples, rel.Options())
+mat.err = err
+return mat
+```
+
+For formatting/debug functions, include the error in the rendered output or return an error from the formatting API.
+
+## Tests Needed
+
+- A failing iterator that yields one tuple and then reports `Error()`.
+- Regression tests for:
+  - `combineSubqueryResults`
+  - `MaterializeResult`
+  - `StreamingUnionBuilder.unionMaterialized`
+  - `TableFormatter.FormatRelation`
+- End-to-end query test where a subquery branch fails after partial output and the public query returns an error, not partial rows.
+- A grep-based or static test that fails when `collectTuplesInto` is called without using its returned error, except for explicitly whitelisted debug paths.
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved.** All ten paths that consumed an iterator and dropped the error now
+propagate it — either by returning it (functions that already return an error) or
+by carrying it onto the derived `MaterializedRelation.err` (functions that return
+only a `Relation`), which is replayed at the next public boundary via
+`Iterator().Error()`. No whitelist was needed: every `collectTuplesInto` call now
+captures its result.
+
+### `collectTuplesInto` sites (9)
+
+- Attach to `mat.err`: `MaterializeResult`, `SortRelation`, `BindQueryInputs`
+  (input binding), `StreamingUnionBuilder.unionMaterialized`,
+  `OrFallbackRelation.Materialize`, `combineSubqueryResultsSimple`.
+- Return the error: `combineSubqueryResults`, the parallel-subquery collector in
+  `executor.go`.
+- Formatter: `TableFormatter.FormatRelation` renders the error inline instead of
+  silently showing partial rows.
+
+### `Relation.Sorted()` (the 10th path) — interface change
+
+`Sorted()` returned `[]Tuple` with no error channel, so it could only drop a
+failed sort source. Leaving it lossy vs. fixing it is itself an architectural
+choice, so it was decided explicitly (not whitelisted): **the interface method
+became `Sorted() ([]Tuple, error)`**, updated across all implementations
+(`Materialized`, `Streaming`, `Product`, `OrFallback`, `Prepended`, `Union`,
+`LazySeq`, `StreamingAggregate`) and all callers (the storage matchers in
+`hash_join_matcher.go` / `matcher_relations.go` and `indexed_memory_matcher.go`
+now return the error). `MaterializedRelation.Sorted()` surfaces a carried
+`r.err`; `StreamingRelation.Sorted()` returns the collect error.
+
+### Tests
+
+- `materialization_error_propagation_test.go` — a failing iterator
+  (`newFailingStream`) through `MaterializeResult`, `SortRelation`, and
+  `combineSubqueryResultsSimple` must surface the error (fails before, passes
+  after).
+- `collect_tuples_guard_test.go` — static guard that scans the package source and
+  fails if any `collectTuplesInto` call is a bare statement (error dropped). No
+  whitelist entries.
+
+### Verification
+
+`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green.


### PR DESCRIPTION
## Bug

Ten paths consumed an iterator and **dropped its deferred error**, laundering a failed partial stream into a clean materialized relation. The `Iterator` contract requires checking `Error()` after `Next()` returns false; these paths called `collectTuplesInto` (or `Sorted()`) and ignored the result, so a query could return truncated rows as success.

## Fix

**Nine `collectTuplesInto` sites** now capture the error and either return it or carry it onto `MaterializedRelation.err` (replayed at the next public boundary via `Iterator().Error()`):

- Attach to `mat.err`: `MaterializeResult`, `SortRelation`, `BindQueryInputs` (input binding), `StreamingUnionBuilder.unionMaterialized`, `OrFallbackRelation.Materialize`, `combineSubqueryResultsSimple`.
- Return: `combineSubqueryResults`, the parallel-subquery collector in `executor.go`.
- `TableFormatter.FormatRelation` renders the error inline instead of showing partial rows.

**The tenth path, `Relation.Sorted()`**, returned `[]Tuple` with no error channel — it could only drop a failed sort source. Leaving it lossy vs. fixing it is itself an architectural choice, so it was decided explicitly rather than whitelisted: the interface method changed to **`Sorted() ([]Tuple, error)`**, updated across all implementations (`Materialized`/`Streaming`/`Product`/`OrFallback`/`Prepended`/`Union`/`LazySeq`/`StreamingAggregate`) and all callers (the storage matchers in `hash_join_matcher.go`/`matcher_relations.go` and `indexed_memory_matcher.go` now return the error). `MaterializedRelation.Sorted()` surfaces a carried `r.err`; `StreamingRelation.Sorted()` returns the collect error (preserving the existing `Materialize()`-then-iterate order that keeps the single-use stream re-iterable).

## Tests

- `materialization_error_propagation_test.go` — drives a failing iterator (`newFailingStream`) through `MaterializeResult`, `SortRelation`, and `combineSubqueryResultsSimple`; each must surface the error. Fails before, passes after.
- `collect_tuples_guard_test.go` — static guard that scans the package source and fails if any `collectTuplesInto` call is a bare statement (error dropped). No whitelist entries — every call now captures its error.

## Verification

`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green.

Resolves `docs/bugs/resolved/BUG_ITERATOR_ERRORS_DROPPED_IN_MATERIALIZATION_PATHS.md`.
