### PR TITLE
Remove Identity L85 cache; key in-memory indices on interned pointers

### DIFF
--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -607,6 +607,36 @@ This dual approach maintains backward compatibility while following "Datalog is 
 algebra optimizer (`EnableAlgebraOptimizer: true`); there is no
 `EnableConditionalAggregateRewriting` option (removed 2026-05).
 
+### 15. Interned-Pointer Index Keys & L85 Cache Removal (COMPLETE - May 2026)
+**Status**: ✅ In-memory indices and entity-dedup sets key on interned pointers; the `Identity.l85` cache was removed
+
+**What changed**:
+- The in-memory matcher's entity/EA indices and the BadgerMatcher entity-dedup set
+  keyed on `Identity.L85()` strings (`E.L85()`, `E.L85()+"|"+A.String()`). Since
+  identities and keywords are interned (pointer equality ⟺ value equality), these
+  now key on the interned pointers directly — `map[datalog.Identity][]int` and
+  `map[eaIndexKey][]int` (an `{Identity, Keyword}` pair). No Base85 encode, no
+  per-key string concatenation.
+- With no hot `L85()` callers left (only `String()`'s fallback and export), the
+  lazily-cached `l85` field on `identity` was removed; `Identity.L85()` now computes
+  on demand. This also fixed a data race — the lazy cache write mutated
+  globally-interned, shared identities without synchronization
+  (`BUG_IDENTITY_L85_LAZY_RACE`).
+
+**Benchmark** (`datalog/executor/index_key_bench_test.go`; (E,A) index build+lookup,
+1000 entities × 8 attrs; the string variant uses precomputed L85 to model the prior
+cache fairly):
+
+| key | ns/op | B/op | allocs/op |
+|-----|-------|------|-----------|
+| string (old) | 644,085 | 1,619,084 | 24,033 |
+| interned pointer (new) | 240,159 | 851,076 | 8,033 |
+
+~2.7× faster, ~47% less memory, and 1/3 the allocations on the index path — before
+counting the removed race and the per-identity L85 string.
+
+**Details**: See `docs/bugs/resolved/BUG_IDENTITY_L85_LAZY_RACE.md`
+
 ---
 
 ## Profiling Results (October 2025)

--- a/datalog/executor/index_key_bench_test.go
+++ b/datalog/executor/index_key_bench_test.go
@@ -1,0 +1,77 @@
+package executor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// BenchmarkInMemoryIndexKeys compares the in-memory matcher's (E,A) index using
+// the old string key (E.L85()+"|"+A.String()) against the new interned-pointer
+// key (eaIndexKey{E, A}). It models the build + lookup the matcher does per datom.
+//
+// The string variant uses PRECOMPUTED L85 strings, which is the fair model of the
+// old design: L85 was cached on the identity, so the per-datom cost was the "|"
+// concatenation + a ~50-char map hash, not the Base85 encode. The pointer variant
+// builds a 16-byte two-pointer key with no allocation and a 16-byte hash.
+func BenchmarkInMemoryIndexKeys(b *testing.B) {
+	const numEntities, numAttrs = 1000, 8
+
+	entities := make([]datalog.Identity, numEntities)
+	eL85 := make([]string, numEntities)
+	for i := range entities {
+		entities[i] = datalog.NewIdentity(fmt.Sprintf("entity:%d", i))
+		eL85[i] = entities[i].L85()
+	}
+	attrs := make([]datalog.Keyword, numAttrs)
+	aStr := make([]string, numAttrs)
+	for i := range attrs {
+		attrs[i] = datalog.NewKeyword(fmt.Sprintf(":attr/%d", i))
+		aStr[i] = attrs[i].String()
+	}
+
+	b.Run("string_key", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			idx := make(map[string][]int, numEntities*numAttrs)
+			for i := 0; i < numEntities; i++ {
+				for j := 0; j < numAttrs; j++ {
+					key := eL85[i] + "|" + aStr[j]
+					idx[key] = append(idx[key], i*numAttrs+j)
+				}
+			}
+			sink := 0
+			for i := 0; i < numEntities; i++ {
+				for j := 0; j < numAttrs; j++ {
+					sink += len(idx[eL85[i]+"|"+aStr[j]])
+				}
+			}
+			if sink != numEntities*numAttrs {
+				b.Fatalf("sink=%d", sink)
+			}
+		}
+	})
+
+	b.Run("pointer_key", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			idx := make(map[eaIndexKey][]int, numEntities*numAttrs)
+			for i := 0; i < numEntities; i++ {
+				for j := 0; j < numAttrs; j++ {
+					key := eaIndexKey{e: entities[i], a: attrs[j]}
+					idx[key] = append(idx[key], i*numAttrs+j)
+				}
+			}
+			sink := 0
+			for i := 0; i < numEntities; i++ {
+				for j := 0; j < numAttrs; j++ {
+					sink += len(idx[eaIndexKey{e: entities[i], a: attrs[j]}])
+				}
+			}
+			if sink != numEntities*numAttrs {
+				b.Fatalf("sink=%d", sink)
+			}
+		}
+	})
+}

--- a/datalog/executor/indexed_memory_matcher.go
+++ b/datalog/executor/indexed_memory_matcher.go
@@ -15,10 +15,10 @@ type IndexedMemoryMatcher struct {
 
 	// Lazy-initialized indices (protected by buildMutex)
 	buildMutex     sync.Once
-	entityIndex    map[string][]int // E.L85() → datom positions
-	attributeIndex map[string][]int // A.String() → datom positions
-	valueIndex     map[uint64][]int // hash(V) → datom positions (NOTE: values are interface{}, indexed by hash; collisions filtered by exact match)
-	eavIndex       map[string][]int // E.L85()+"|"+A.String() → datom positions (all, for cardinality-many)
+	entityIndex    map[datalog.Identity][]int // E (interned pointer) → datom positions
+	attributeIndex map[string][]int           // A.String() → datom positions
+	valueIndex     map[uint64][]int           // hash(V) → datom positions (NOTE: values are interface{}, indexed by hash; collisions filtered by exact match)
+	eavIndex       map[eaIndexKey][]int        // (E, A) interned pointers → datom positions (all, for cardinality-many)
 
 	// Optional collector for annotations (protected by collectorMutex for concurrent access)
 	collectorMutex sync.RWMutex
@@ -27,6 +27,14 @@ type IndexedMemoryMatcher struct {
 	// ExecutorOptions for configuring relation behavior (protected by optionsMutex)
 	optionsMutex sync.RWMutex
 	options      ExecutorOptions
+}
+
+// eaIndexKey keys the (entity, attribute) index by the interned E and A pointers,
+// avoiding per-datom L85/string allocation. Interning makes pointer equality
+// equivalent to value equality, so the pointers are stable, comparable map keys.
+type eaIndexKey struct {
+	e datalog.Identity
+	a datalog.Keyword
 }
 
 // boundDatomIterator lazily matches bound patterns during iteration
@@ -98,15 +106,14 @@ func (m *IndexedMemoryMatcher) buildIndices() {
 			estimatedSize = 16
 		}
 
-		m.entityIndex = make(map[string][]int, estimatedSize)
+		m.entityIndex = make(map[datalog.Identity][]int, estimatedSize)
 		m.attributeIndex = make(map[string][]int, estimatedSize)
 		m.valueIndex = make(map[uint64][]int, estimatedSize)
-		m.eavIndex = make(map[string][]int, estimatedSize)
+		m.eavIndex = make(map[eaIndexKey][]int, estimatedSize)
 
 		for i, datom := range m.datoms {
 			// Entity index: E → [positions]
-			eKey := datom.E.L85()
-			m.entityIndex[eKey] = append(m.entityIndex[eKey], i)
+			m.entityIndex[datom.E] = append(m.entityIndex[datom.E], i)
 
 			// Attribute index: A → [positions]
 			aKey := datom.A.String()
@@ -121,7 +128,7 @@ func (m *IndexedMemoryMatcher) buildIndices() {
 
 			// EA index: (E, A) → [positions]
 			// Store all datoms for each (E, A) pair to support cardinality-many attributes
-			eaKey := eKey + "|" + aKey
+			eaKey := eaIndexKey{e: datom.E, a: datom.A}
 			m.eavIndex[eaKey] = append(m.eavIndex[eaKey], i)
 		}
 	})
@@ -357,13 +364,11 @@ func (m *IndexedMemoryMatcher) getCandidates(strategy matchStrategy) []int {
 	switch s := strategy.(type) {
 	case useEAIndex:
 		// O(1) lookup in EA index - returns all positions for cardinality-many
-		key := s.e.L85() + "|" + s.a.String()
-		return m.eavIndex[key]
+		return m.eavIndex[eaIndexKey{e: s.e, a: s.a}]
 
 	case useEntityIndex:
 		// O(1) lookup in entity index
-		key := s.e.L85()
-		return m.entityIndex[key]
+		return m.entityIndex[s.e]
 
 	case useAttributeIndex:
 		// O(1) lookup in attribute index

--- a/datalog/executor/indexed_memory_matcher_test.go
+++ b/datalog/executor/indexed_memory_matcher_test.go
@@ -23,14 +23,12 @@ func TestIndexedMatcher_IndexBuilding(t *testing.T) {
 
 	// Verify entity index
 	e1 := datalog.NewIdentity("e1")
-	e1Key := e1.L85()
-	if positions := matcher.entityIndex[e1Key]; len(positions) != 2 {
+	if positions := matcher.entityIndex[e1]; len(positions) != 2 {
 		t.Errorf("Entity index for e1: expected 2 datoms, got %d", len(positions))
 	}
 
 	e2 := datalog.NewIdentity("e2")
-	e2Key := e2.L85()
-	if positions := matcher.entityIndex[e2Key]; len(positions) != 2 {
+	if positions := matcher.entityIndex[e2]; len(positions) != 2 {
 		t.Errorf("Entity index for e2: expected 2 datoms, got %d", len(positions))
 	}
 
@@ -48,8 +46,7 @@ func TestIndexedMatcher_IndexBuilding(t *testing.T) {
 	}
 
 	// Verify EA index
-	e1NameKey := e1Key + "|" + nameKey
-	if _, ok := matcher.eavIndex[e1NameKey]; !ok {
+	if _, ok := matcher.eavIndex[eaIndexKey{e: e1, a: nameKw}]; !ok {
 		t.Errorf("EA index missing entry for (e1, :name)")
 	}
 

--- a/datalog/executor/subquery.go
+++ b/datalog/executor/subquery.go
@@ -1004,7 +1004,7 @@ func (sc *subqueryContext) matchesWithRelation(datom datalog.Datom, pattern *que
 				// Compare values - handle Identity specially
 				if id1, ok1 := boundValue.(datalog.Identity); ok1 {
 					if id2, ok2 := elem.datomValue.(datalog.Identity); ok2 {
-						if id1.L85() != id2.L85() {
+						if !id1.Equal(id2) {
 							return false
 						}
 					} else {

--- a/datalog/identity.go
+++ b/datalog/identity.go
@@ -9,10 +9,8 @@ import (
 
 // identity is the unexported base type for entity identifiers.
 type identity struct {
-	value       [20]byte // SHA1 hash
-	l85         string   // Lazily computed L85 encoding
-	str         string   // Original string (if known)
-	l85Computed bool     // Whether l85 has been computed
+	value [20]byte // SHA1 hash
+	str   string   // Original string (if known)
 }
 
 // Identity is the exported pointer type, always interned.
@@ -28,7 +26,9 @@ func NewIdentity(s string) Identity {
 		return val.(Identity)
 	}
 
-	// Slow path: allocate and intern
+	// Slow path: allocate and intern. The identity is immutable; L85 is a pure
+	// function of value computed on demand, so there is no cached field to race
+	// on (nor one kept resident for identities that never need it).
 	id := &identity{
 		value: hash,
 		str:   s,
@@ -56,11 +56,11 @@ func (i Identity) L85() string {
 	if i == nil {
 		return ""
 	}
-	if !i.l85Computed {
-		i.l85 = codec.EncodeL85(i.value[:])
-		i.l85Computed = true
-	}
-	return i.l85
+	// Pure function of the immutable hash, computed on demand. Not cached: L85 is
+	// no longer used on hot paths (joins, dedup, and the in-memory indices key on
+	// the interned identity/keyword pointers), so a cache would only add memory
+	// and a field to race on.
+	return codec.EncodeL85(i.value[:])
 }
 
 // String returns a string representation

--- a/datalog/identity_concurrency_test.go
+++ b/datalog/identity_concurrency_test.go
@@ -1,0 +1,30 @@
+package datalog
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestIdentityL85ConcurrentAccess is a regression test for
+// BUG_IDENTITY_L85_LAZY_RACE. Identity values are globally interned and shared
+// across goroutines, so L85()/String() must not mutate the shared identity.
+//
+// Run under -race: before the fix, L85() lazily writes l85/l85Computed on the
+// shared interned object, so concurrent calls race. After the fix the identity is
+// immutable (l85 is computed at construction), so concurrent reads are safe.
+func TestIdentityL85ConcurrentAccess(t *testing.T) {
+	id := NewIdentity("race-target")
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				_ = id.L85()
+				_ = id.String()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/datalog/intern.go
+++ b/datalog/intern.go
@@ -3,8 +3,6 @@ package datalog
 import (
 	"strings"
 	"sync"
-
-	"github.com/wbrown/janus-datalog/datalog/codec"
 )
 
 // keywordInternCache provides keyword interning to avoid repeated allocations
@@ -109,14 +107,12 @@ func InternIdentityFromHash(hash [20]byte) Identity {
 		return val.(Identity)
 	}
 
-	// Slow path: create and store
-	// CRITICAL: Compute L85 eagerly so String() returns it correctly
-	// Identities from storage have empty str field, so we use L85 representation
+	// Slow path: create and store. Identities from storage have an empty str
+	// field, so String() falls back to L85() (a pure function of the hash,
+	// computed on demand).
 	id := &identity{
-		value:       hash,
-		l85:         codec.EncodeL85(hash[:]),
-		str:         "", // Unknown - use L85 representation
-		l85Computed: true,
+		value: hash,
+		str:   "", // Unknown - String() uses L85() (computed on demand)
 	}
 	actual, _ := identityIntern.cache.LoadOrStore(hash, id)
 	return actual.(Identity)

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -450,7 +450,7 @@ func (m *BadgerMatcher) MatchAsOf(pattern *query.DataPattern, targetTx datalog.E
 // scanTimeRanges performs multi-range scanning on AVET index for time optimization
 func (m *BadgerMatcher) scanTimeRanges(attr datalog.Keyword, tx interface{}) ([]datalog.Datom, error) {
 	// Use map to deduplicate by entity ID (entities might appear in multiple ranges)
-	seen := make(map[string]bool)
+	seen := make(map[datalog.Identity]bool)
 	var results []datalog.Datom
 
 	encoder := m.store.encoder
@@ -518,10 +518,9 @@ func (m *BadgerMatcher) scanTimeRanges(attr datalog.Keyword, tx interface{}) ([]
 				}
 			}
 
-			// Deduplicate by entity ID
-			eKey := datom.E.L85()
-			if !seen[eKey] {
-				seen[eKey] = true
+			// Deduplicate by entity (interned pointer is a stable, comparable key)
+			if !seen[datom.E] {
+				seen[datom.E] = true
 				results = append(results, *datom)
 			}
 		}

--- a/docs/bugs/resolved/BUG_IDENTITY_L85_LAZY_RACE.md
+++ b/docs/bugs/resolved/BUG_IDENTITY_L85_LAZY_RACE.md
@@ -1,0 +1,259 @@
+# BUG: Identity.L85() Mutates Interned Identity Without Synchronization
+
+**Date**: 2026-05-25
+**Severity**: Concurrency / Correctness (Medium)
+**Status**: Open
+**Affected**: Concurrent calls to `Identity.L85()` or `Identity.String()` on identities created by `NewIdentity`
+
+## Summary
+
+`Identity` values are globally interned and shared across goroutines, but
+`Identity.L85()` lazily writes cached fields without synchronization. Two
+goroutines can call `L85()` or `String()` on the same identity at the same time
+and race on `l85` and `l85Computed`.
+
+This is a data race in the Go memory model. The encoded value is deterministic,
+so the symptom is unlikely to be an incorrect string in normal execution, but
+race-detector failures and undefined concurrent behavior are enough to treat it
+as a real bug.
+
+## Code Evidence
+
+`Identity` stores mutable cached encoding fields:
+
+```go
+// identity.go
+type identity struct {
+    value       [20]byte
+    l85         string
+    str         string
+    l85Computed bool
+}
+```
+
+The constructor interns identities by hash, so callers share the same pointer:
+
+```go
+// identity.go
+func NewIdentity(s string) Identity {
+    hash := sha1.Sum([]byte(s))
+
+    if val, ok := identityIntern.cache.Load(hash); ok {
+        return val.(Identity)
+    }
+
+    id := &identity{
+        value: hash,
+        str:   s,
+    }
+    actual, _ := identityIntern.cache.LoadOrStore(hash, id)
+    return actual.(Identity)
+}
+```
+
+`L85()` mutates the shared interned object without a lock, atomic, or
+`sync.Once`:
+
+```go
+// identity.go
+func (i Identity) L85() string {
+    if i == nil {
+        return ""
+    }
+    if !i.l85Computed {
+        i.l85 = codec.EncodeL85(i.value[:])
+        i.l85Computed = true
+    }
+    return i.l85
+}
+```
+
+`String()` calls `L85()` for identities decoded from storage, and can therefore
+participate in the same race:
+
+```go
+// identity.go
+func (i Identity) String() string {
+    if i == nil {
+        return ""
+    }
+    if i.str != "" {
+        return i.str
+    }
+    return i.L85()
+}
+```
+
+The storage decode path often creates identities with an eagerly populated L85
+string:
+
+```go
+// intern.go
+id := &identity{
+    value:       hash,
+    l85:         codec.EncodeL85(hash[:]),
+    str:         "",
+    l85Computed: true,
+}
+```
+
+But identities created through `NewIdentity` leave `l85Computed` false until
+first use. Those are the affected objects.
+
+## Failure Mode
+
+The race is straightforward:
+
+```text
+goroutine A: sees l85Computed == false
+goroutine B: sees l85Computed == false
+goroutine A: writes i.l85
+goroutine B: writes i.l85
+goroutine A: writes i.l85Computed
+goroutine B: writes i.l85Computed
+```
+
+The writes compute the same bytes, but unsynchronized read/write access to the
+same memory is still a Go data race.
+
+## Reproduction Sketch
+
+Run under the race detector:
+
+```go
+func TestIdentityL85ConcurrentAccessRace(t *testing.T) {
+    id := datalog.NewIdentity("race-target")
+
+    var wg sync.WaitGroup
+    for g := 0; g < 16; g++ {
+        wg.Add(1)
+        go func() {
+            defer wg.Done()
+            for i := 0; i < 1000; i++ {
+                _ = id.L85()
+                _ = id.String()
+            }
+        }()
+    }
+    wg.Wait()
+}
+```
+
+Expected:
+
+```bash
+go test -race ./datalog -run TestIdentityL85ConcurrentAccessRace
+```
+
+The race detector should report concurrent reads/writes to the `identity`'s
+`l85` or `l85Computed` fields.
+
+## Impact
+
+- Any application that logs, formats, serializes, or compares identities from
+  multiple goroutines can trigger a race.
+- Query execution uses parallel subqueries by default, so concurrent formatting
+  or annotation paths may encounter shared interned identities.
+- Race detector failures make the package harder to validate in concurrent
+  applications, even if normal results appear stable.
+
+## Fix Direction
+
+Prefer making `identity` immutable after construction.
+
+Options:
+
+1. Compute `l85` eagerly in `NewIdentity`, matching `InternIdentityFromHash`.
+   Then remove `l85Computed` entirely or leave it always true.
+2. Remove the cached fields and compute `codec.EncodeL85(i.value[:])` each time.
+   This is simpler but may regress hot formatting paths.
+3. Add `sync.Once` or atomic synchronization to the identity struct.
+
+Option 1 is the cleanest fit for interned identities: all constructors return a
+fully initialized immutable pointer. The memory cost is one cached string per
+identity, which the current type already allows for once `L85()` is called.
+
+## Verification Plan
+
+Add a race-focused regression test in `datalog/identity_test.go` or a dedicated
+concurrency test file:
+
+- `TestIdentityL85ConcurrentAccess`
+
+Then run:
+
+```bash
+go test -race ./datalog -run TestIdentityL85ConcurrentAccess
+go test -count=1 ./...
+```
+
+The race test should be skipped only if the project explicitly decides not to
+include race-detector-only tests in the normal suite. It should still be kept as
+documentation of the concurrency contract.
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved** by removing the L85 cache entirely (compute on demand) and keying the
+per-datom dedup/index maps on the interned pointers instead of L85 strings. We got
+here by asking "do we actually need to store L85?" — and the answer was no.
+
+### The cache existed to prop up string-keyed maps
+
+The on-disk BadgerDB keys never use `identity.L85()` — the key encoders encode the
+hash bytes directly. The cached string's real consumers were a few *per-datom*
+`map[string]` keys: the in-memory matcher's entity/EA indices (`E.L85()`,
+`E.L85()+"|"+A.String()`), the Badger dedup `seen` set, and one identity
+comparison. Identities and keywords are interned (pointer equality ⟺ value
+equality), so those maps can key on the pointers directly — no encode, no string.
+Once they do, `L85()` has only cool callers (`String()` fallback and `export`), so
+the cache is pure liability.
+
+### Changes
+
+- `datalog/identity.go`, `datalog/intern.go`: dropped the `l85`/`l85Computed`
+  fields. `identity` is now `{value [20]byte, str string}` — immutable. `L85()`
+  computes on demand (`codec.EncodeL85(i.value[:])`). No cached field → no race and
+  no permanent ~25-byte L85 string per interned identity. (Removed the now-unused
+  `codec` import from `intern.go`.)
+- `datalog/executor/indexed_memory_matcher.go`: `entityIndex` →
+  `map[datalog.Identity][]int`; `eavIndex` → `map[eaIndexKey][]int` with
+  `eaIndexKey{e datalog.Identity, a datalog.Keyword}` — a pair of interned pointers.
+- `datalog/storage/matcher.go`: the entity-dedup `seen` set →
+  `map[datalog.Identity]bool`.
+- `datalog/executor/subquery.go`: `id1.L85() != id2.L85()` → `!id1.Equal(id2)`.
+
+### Why not just make the cache safe (eager / sync.Once)
+
+Eager compute pays a Base85 encode per unique identity and keeps a ~25-byte string
+resident for every interned identity forever — including the many used only for
+equality/joins. `sync.Once` keeps lazy compute but adds ~16B and a synchronized
+check per call. Both retain a cache that, once the map keys stop using it, serves
+almost nothing. Removing it is simpler and strictly cheaper.
+
+### Benchmark (`index_key_bench_test.go`)
+
+(E,A) index build + lookup, 1000 entities × 8 attrs. The string key uses
+precomputed L85 to model the old cache fairly (L85 was cached, so the per-datom
+cost was the concat + long hash, not the encode):
+
+| key | ns/op | B/op | allocs/op |
+|-----|-------|------|-----------|
+| string (old) | 644,085 | 1,619,084 | 24,033 |
+| interned pointer (new) | 240,159 | 851,076 | 8,033 |
+
+~2.7× faster, ~47% less memory, 1/3 the allocations — before even counting the
+removed race and the per-identity string.
+
+### Test
+
+`datalog/identity_concurrency_test.go` — `TestIdentityL85ConcurrentAccess` hammers
+`L85()`/`String()` from 16 goroutines. Under `-race` it reports a data race on the
+lazy write before the fix and is clean after; it passes under the standard gate
+too (kept as the concurrency-contract regression).
+
+### Verification
+
+`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green;
+`go test -race ./datalog -run TestIdentityL85ConcurrentAccess` clean.


### PR DESCRIPTION
Fixes `BUG_IDENTITY_L85_LAZY_RACE` — by removing the cache rather than making it safe.

## Bug

`Identity.L85()` lazily wrote `l85`/`l85Computed` on a **globally-interned, shared** identity with no synchronization, so concurrent `L85()`/`String()` calls race (deterministic value, but a real `-race` failure).

## Why remove the cache instead of locking it

Tracing the consumers: the on-disk BadgerDB keys never use `identity.L85()` (the key encoders encode the hash bytes directly). The cached string's real consumers were a few **per-datom `map[string]` keys** — the in-memory matcher's entity/EA indices (`E.L85()`, `E.L85()+"|"+A.String()`), the Badger entity-dedup `seen` set, and one identity comparison. Identities and keywords are **interned** (pointer equality ⟺ value equality), so those maps can key on the pointers directly. Once they do, `L85()` has only cool callers (`String()` fallback, `export`), so the cache is pure liability — eager/`sync.Once` would just keep a footgun that serves almost nothing.

## Changes

- `identity.go` / `intern.go`: dropped the `l85`/`l85Computed` fields. `identity` is now `{value [20]byte, str string}` — immutable. `L85()` computes on demand. No cached field → no race, no permanent ~25-byte L85 string per interned identity. (Removed the now-unused `codec` import from `intern.go`.)
- `indexed_memory_matcher.go`: `entityIndex` → `map[datalog.Identity][]int`; `eavIndex` → `map[eaIndexKey][]int` with `eaIndexKey{e datalog.Identity, a datalog.Keyword}` (a pair of interned pointers).
- `matcher.go`: entity-dedup `seen` → `map[datalog.Identity]bool`.
- `subquery.go`: `id1.L85() != id2.L85()` → `!id1.Equal(id2)`.

## Benchmark

`index_key_bench_test.go` — (E,A) index build + lookup, 1000 entities × 8 attrs. The string variant uses precomputed L85 to model the prior cache fairly:

| key | ns/op | B/op | allocs/op |
|-----|-------|------|-----------|
| string (old) | 644,085 | 1,619,084 | 24,033 |
| interned pointer (new) | 240,159 | 851,076 | 8,033 |

**~2.7× faster, ~47% less memory, 1/3 the allocations** on the index path — before counting the removed race and the per-identity string. Documented in `PERFORMANCE_STATUS.md` (entry 15).

## Tests

- `datalog/identity_concurrency_test.go` — 16 goroutines hammering `L85()`/`String()`; reports a data race before the fix under `-race`, clean after.
- Updated the white-box `IndexedMemoryMatcher` index test for the new key types.

## Verification

`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green; `go test -race ./datalog -run TestIdentityL85ConcurrentAccess` clean.

Resolves `docs/bugs/resolved/BUG_IDENTITY_L85_LAZY_RACE.md`.
