### PR TITLE
Forward non-relation :in inputs through relation-input iteration

### DIFF
--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -424,9 +424,14 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 // executeRealizedWithRelationInputIteration handles RelationInput iteration for QueryExecutor path
 // This iterates over each tuple in the RelationInput and executes the plan once per tuple.
 func (e *Executor) executeRealizedWithRelationInputIteration(ctx Context, plan *planner.RealizedPlan, inputRelations []Relation) (Relation, error) {
-	// Find the RelationInput and its corresponding relation
+	// Find the RelationInput, its corresponding relation, and that relation's index
+	// within inputRelations. The index lets each per-tuple execution forward the
+	// OTHER input relations (scalars, collections) in their original positions
+	// rather than dropping them
+	// (see docs/bugs/resolved/BUG_SCALAR_PLUS_RELATION_INPUT_DROPS_OTHER_INPUTS.md).
 	var relationInput query.RelationInput
 	var iterationRelation Relation
+	iterationIndex := -1
 	relationIndex := 0
 
 	for _, input := range plan.Query.In {
@@ -437,6 +442,7 @@ func (e *Executor) executeRealizedWithRelationInputIteration(ctx Context, plan *
 			relationInput = inp
 			if relationIndex < len(inputRelations) {
 				iterationRelation = inputRelations[relationIndex]
+				iterationIndex = relationIndex
 			}
 			relationIndex++
 		case query.ScalarInput, query.TupleInput, query.CollectionInput:
@@ -452,9 +458,33 @@ func (e *Executor) executeRealizedWithRelationInputIteration(ctx Context, plan *
 
 	// Dispatch to parallel or sequential implementation
 	if e.enableParallelSubqueries {
-		return e.executeRealizedWithRelationInputIterationParallel(ctx, plan, inputRelations, relationInput, iterationRelation)
+		return e.executeRealizedWithRelationInputIterationParallel(ctx, plan, inputRelations, relationInput, iterationRelation, iterationIndex)
 	}
-	return e.executeRealizedWithRelationInputIterationSequential(ctx, plan, inputRelations, relationInput, iterationRelation)
+	return e.executeRealizedWithRelationInputIterationSequential(ctx, plan, inputRelations, relationInput, iterationRelation, iterationIndex)
+}
+
+// perTupleInputRelations builds the full ordered input-relation list for one
+// iteration of a RelationInput: every original input relation is forwarded in its
+// original position, except the iteration relation (at iterationIndex), which is
+// replaced by one single-value relation per RelationInput symbol drawn from this
+// tuple. Forwarding the non-iteration inputs (scalars, collections) in place keeps
+// them aligned with executeRealizedNonIterating's in-place :in rewrite; without it
+// they are dropped and BindQueryInputs binds the wrong values
+// (see docs/bugs/resolved/BUG_SCALAR_PLUS_RELATION_INPUT_DROPS_OTHER_INPUTS.md).
+func perTupleInputRelations(inputRelations []Relation, iterationIndex int, relationInput query.RelationInput, tuple Tuple) []Relation {
+	out := make([]Relation, 0, len(inputRelations)+len(relationInput.Symbols))
+	for j, rel := range inputRelations {
+		if j == iterationIndex {
+			for i, sym := range relationInput.Symbols {
+				if i < len(tuple) {
+					out = append(out, NewMaterializedRelation([]query.Symbol{sym}, []Tuple{{tuple[i]}}))
+				}
+			}
+			continue
+		}
+		out = append(out, rel)
+	}
+	return out
 }
 
 // executeRealizedWithRelationInputIterationSequential executes QueryExecutor path sequentially for RelationInput
@@ -464,6 +494,7 @@ func (e *Executor) executeRealizedWithRelationInputIterationSequential(
 	inputRelations []Relation,
 	relationInput query.RelationInput,
 	iterationRelation Relation,
+	iterationIndex int,
 ) (Relation, error) {
 	// Collect results from each tuple iteration
 	var allResults []Relation
@@ -475,17 +506,10 @@ func (e *Executor) executeRealizedWithRelationInputIterationSequential(
 	for it.Next() {
 		tuple := it.Tuple()
 
-		// Create scalar input relations for this tuple
-		var tupleInputRelations []Relation
-		for i, sym := range relationInput.Symbols {
-			if i < len(tuple) {
-				scalarRel := NewMaterializedRelation(
-					[]query.Symbol{sym},
-					[]Tuple{{tuple[i]}},
-				)
-				tupleInputRelations = append(tupleInputRelations, scalarRel)
-			}
-		}
+		// Per-tuple inputs: this tuple's values as scalars in the relation's slot,
+		// with every other input relation forwarded in place (so scalars/collections
+		// survive — see perTupleInputRelations).
+		tupleInputRelations := perTupleInputRelations(inputRelations, iterationIndex, relationInput, tuple)
 
 		// Execute the plan with these scalar inputs using QueryExecutor
 		result, err := e.executeRealizedNonIterating(ctx, plan, tupleInputRelations, relationInput)
@@ -524,6 +548,7 @@ func (e *Executor) executeRealizedWithRelationInputIterationParallel(
 	inputRelations []Relation,
 	relationInput query.RelationInput,
 	iterationRelation Relation,
+	iterationIndex int,
 ) (Relation, error) {
 	// Determine number of workers
 	numWorkers := e.maxSubqueryWorkers
@@ -562,17 +587,9 @@ func (e *Executor) executeRealizedWithRelationInputIterationParallel(
 				done <- struct{}{}
 			}()
 
-			// Create scalar input relations for this tuple
-			var tupleInputRelations []Relation
-			for i, sym := range relationInput.Symbols {
-				if i < len(tup) {
-					scalarRel := NewMaterializedRelation(
-						[]query.Symbol{sym},
-						[]Tuple{{tup[i]}},
-					)
-					tupleInputRelations = append(tupleInputRelations, scalarRel)
-				}
-			}
+			// Per-tuple inputs: this tuple's values as scalars in the relation's slot,
+			// with every other input relation forwarded in place.
+			tupleInputRelations := perTupleInputRelations(inputRelations, iterationIndex, relationInput, tup)
 
 			// Execute the plan with these scalar inputs. Each worker gets its
 			// own forked context: a Context's per-query state (queryStart,

--- a/datalog/executor/multi_tuple_binding_test.go
+++ b/datalog/executor/multi_tuple_binding_test.go
@@ -8,6 +8,36 @@ import (
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
+// TestJoin_NoSharedColumns_CrossProduct isolates whether Join cross-products two
+// relations that share no variables (the scalar-input + relation-input case:
+// rel(?grp) ⋈ rel(?name ?owner)). If this returns 0, crossProduct/Join is the bug;
+// if it returns 1, the bug is upstream in how :in inputs are seeded/combined.
+func TestJoin_NoSharedColumns_CrossProduct(t *testing.T) {
+	grp := datalog.NewIdentity("grp")
+	ownerX := datalog.NewIdentity("owner-x")
+
+	left := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?grp")},
+		[]Tuple{{grp}},
+	)
+	right := NewMaterializedRelation(
+		[]query.Symbol{datalog.NewSymbol("?name"), datalog.NewSymbol("?owner")},
+		[]Tuple{{"A", ownerX}},
+	)
+
+	result := left.Join(right)
+	count := 0
+	it := result.Iterator()
+	for it.Next() {
+		count++
+	}
+	it.Close()
+	assert.Equal(t, 1, count, "no-shared-column Join must cross-product (1×1 = 1 row)")
+	assert.ElementsMatch(t,
+		[]query.Symbol{datalog.NewSymbol("?grp"), datalog.NewSymbol("?name"), datalog.NewSymbol("?owner")},
+		result.Symbols())
+}
+
 func TestMultiRowRelationBinding(t *testing.T) {
 	// Create test data: multiple entities with ages
 	alice := datalog.NewIdentity("user:alice")

--- a/datalog/storage/query_inputs_test.go
+++ b/datalog/storage/query_inputs_test.go
@@ -67,6 +67,118 @@ func TestExecuteQuery(t *testing.T) {
 	}
 }
 
+// TestRelationInput_RefAndKeywordColumns isolates whether a relation-input join
+// [[?a ?b] ...] matches when a join column is an entity REF (datalog.Identity value) or a
+// KEYWORD value — vs the canonical string/int64 columns. A scalar binding of the same
+// values matches (control), so a relation miss here pins exactly which value type the
+// multi-column relation join fails to compare. Repro for a narrative-generators batch
+// content query returning 0 rows on [[?key ?subject] ...].
+func TestRelationInput_RefAndKeywordColumns(t *testing.T) {
+	dir, err := os.MkdirTemp("", "query-relinput-ref-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	defer db.Close()
+
+	a := datalog.NewIdentity("a")
+	b := datalog.NewIdentity("b")
+	ownerX := datalog.NewIdentity("owner-x")
+	ownerY := datalog.NewIdentity("owner-y")
+
+	tx := db.NewTransaction()
+	tx.Add(a, datalog.NewKeyword(":t/name"), "A")
+	tx.Add(a, datalog.NewKeyword(":t/owner"), ownerX)
+	tx.Add(a, datalog.NewKeyword(":t/tag"), datalog.NewKeyword(":tag/red"))
+	tx.Add(b, datalog.NewKeyword(":t/name"), "B")
+	tx.Add(b, datalog.NewKeyword(":t/owner"), ownerY)
+	tx.Add(b, datalog.NewKeyword(":t/tag"), datalog.NewKeyword(":tag/blue"))
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Control: scalar identity input matches a ref-valued attribute.
+	scalarRef, err := executor.CollectTuples(db.Query(
+		`[:find ?e :in $ ?owner :where [?e :t/owner ?owner]]`, ownerX))
+	if err != nil {
+		t.Fatalf("scalar ref query: %v", err)
+	}
+	if len(scalarRef) != 1 {
+		t.Errorf("scalar identity input: expected 1, got %d", len(scalarRef))
+	}
+
+	// Relation with a string + IDENTITY column.
+	relRef, err := executor.CollectTuples(db.Query(
+		`[:find ?e :in $ [[?name ?owner] ...] :where [?e :t/name ?name] [?e :t/owner ?owner]]`,
+		[][]any{{"A", ownerX}}))
+	if err != nil {
+		t.Fatalf("relation ref query: %v", err)
+	}
+	if len(relRef) != 1 {
+		t.Errorf("relation with identity column: expected 1, got %d", len(relRef))
+	}
+
+	// Relation with a string + KEYWORD column.
+	relKw, err := executor.CollectTuples(db.Query(
+		`[:find ?e :in $ [[?name ?tag] ...] :where [?e :t/name ?name] [?e :t/tag ?tag]]`,
+		[][]any{{"A", datalog.NewKeyword(":tag/red")}}))
+	if err != nil {
+		t.Fatalf("relation kw query: %v", err)
+	}
+	if len(relKw) != 1 {
+		t.Errorf("relation with keyword column: expected 1, got %d", len(relKw))
+	}
+
+	// Bisect toward the failing narrative-generators query shape: a SCALAR input before
+	// the relation, finding the input-relation vars, plus wildcard / (not ...) clauses.
+	tx2 := db.NewTransaction()
+	grp := datalog.NewIdentity("grp-1")
+	tx2.Add(a, datalog.NewKeyword(":t/grp"), grp)
+	tx2.Add(b, datalog.NewKeyword(":t/grp"), grp)
+	tx2.Add(a, datalog.NewKeyword(":t/x"), int64(1))
+	tx2.Add(b, datalog.NewKeyword(":t/x"), int64(1))
+	if _, err := tx2.Commit(); err != nil {
+		t.Fatalf("commit2: %v", err)
+	}
+
+	check := func(label, q string, want int, args ...any) {
+		got, err := executor.CollectTuples(db.Query(q, args...))
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		if len(got) != want {
+			t.Errorf("%s: expected %d, got %d", label, want, len(got))
+		}
+	}
+
+	check("scalar+relation find ?e",
+		`[:find ?e :in $ ?grp [[?name ?owner] ...] :where [?e :t/grp ?grp] [?e :t/name ?name] [?e :t/owner ?owner]]`,
+		1, grp, [][]any{{"A", ownerX}})
+	check("find input vars",
+		`[:find ?name ?owner :in $ ?grp [[?name ?owner] ...] :where [?e :t/grp ?grp] [?e :t/name ?name] [?e :t/owner ?owner]]`,
+		1, grp, [][]any{{"A", ownerX}})
+	check("wildcard clause",
+		`[:find ?name ?owner :in $ ?grp [[?name ?owner] ...] :where [?e :t/grp ?grp] [?e :t/name ?name] [?e :t/owner ?owner] [?e :t/x _]]`,
+		1, grp, [][]any{{"A", ownerX}})
+	check("not clause",
+		`[:find ?name ?owner :in $ ?grp [[?name ?owner] ...] :where [?e :t/grp ?grp] [?e :t/name ?name] [?e :t/owner ?owner] (not [?e :t/del true])]`,
+		1, grp, [][]any{{"A", ownerX}})
+
+	// Order independence: scalar AFTER the relation.
+	check("relation+scalar",
+		`[:find ?name :in $ [[?name ?owner] ...] ?grp :where [?e :t/grp ?grp] [?e :t/name ?name] [?e :t/owner ?owner]]`,
+		1, [][]any{{"A", ownerX}}, grp)
+	// A collection input (not scalar) preceding the relation must also survive.
+	check("collection+relation",
+		`[:find ?name :in $ [?g ...] [[?name ?owner] ...] :where [?e :t/grp ?g] [?e :t/name ?name] [?e :t/owner ?owner]]`,
+		1, []datalog.Identity{grp}, [][]any{{"A", ownerX}})
+}
+
 // TestExecuteQueryWithScalarInput tests single scalar input parameter
 func TestExecuteQueryWithScalarInput(t *testing.T) {
 	dir, err := os.MkdirTemp("", "query-scalar-test-*")

--- a/docs/bugs/resolved/BUG_SCALAR_PLUS_RELATION_INPUT_DROPS_OTHER_INPUTS.md
+++ b/docs/bugs/resolved/BUG_SCALAR_PLUS_RELATION_INPUT_DROPS_OTHER_INPUTS.md
@@ -1,0 +1,182 @@
+# Bug: Scalar (or other) `:in` Input Dropped When Combined With a Relation Input
+
+**Status**: Resolved (2026-05-25) — see Resolution at the end
+**Discovered**: 2026-05-25
+
+## Symptoms
+
+A query that combines a **scalar** `:in` input with a **relation** input
+(`[[?a ?b] ...]`), where the scalar's variable is used in a `:where` clause,
+returns **zero rows**. The relation-only form and the scalar-only form each work
+in isolation — only the combination fails.
+
+```clojure
+;; Returns 0 rows (expected 1):
+[:find ?e
+ :in $ ?grp [[?name ?owner] ...]
+ :where [?e :t/grp ?grp]
+        [?e :t/name ?name]
+        [?e :t/owner ?owner]]
+;; args: grp, [][]any{{"A", ownerX}}
+
+;; Works (relation only):
+[:find ?e :in $ [[?name ?owner] ...] :where [?e :t/name ?name] [?e :t/owner ?owner]]
+
+;; Works (scalar only):
+[:find ?e :in $ ?owner :where [?e :t/owner ?owner]]
+```
+
+It is not specific to value type: the dropped scalar can be a string, int,
+`datalog.Keyword`, or `datalog.Identity` (ref). It is the *combination* —
+scalar-then-relation — that fails, regardless of clause shape (`(not …)`,
+wildcard `_`, finding the input vars, etc. all reproduce).
+
+Reproduced by `TestRelationInput_RefAndKeywordColumns` in
+`datalog/storage/query_inputs_test.go` (the "scalar+relation" sub-checks).
+`TestJoin_NoSharedColumns_CrossProduct` (`datalog/executor`) confirms the cross
+product itself is correct — the bug is upstream in input binding, not the join.
+
+## Root Cause
+
+A query containing a `RelationInput` takes a dedicated iteration path —
+`Executor.ExecuteRealized` routes to `executeRealizedWithRelationInputIteration`,
+which runs the plan once per relation tuple (`executor/executor.go:211`):
+
+```go
+if hasRelationInput(plan.Query) && len(inputRelations) > 0 {
+    return e.executeRealizedWithRelationInputIteration(ctx, plan, inputRelations)
+}
+```
+
+### 1. The iteration builds per-tuple inputs from the relation only (executor/executor.go)
+
+In `executeRealizedWithRelationInputIterationSequential` (and its `…Parallel`
+twin), the per-tuple input relations are built **solely** from
+`relationInput.Symbols`. The other input relations in `inputRelations` — the
+scalar `?grp`/`?root`, any collections, etc. — are never forwarded:
+
+```go
+for it.Next() {
+    tuple := it.Tuple()
+
+    // Create scalar input relations for this tuple
+    var tupleInputRelations []Relation
+    for i, sym := range relationInput.Symbols {   // <-- ONLY the relation's columns
+        if i < len(tuple) {
+            tupleInputRelations = append(tupleInputRelations,
+                NewMaterializedRelation([]query.Symbol{sym}, []Tuple{{tuple[i]}}))
+        }
+    }
+    result, err := e.executeRealizedNonIterating(ctx, plan, tupleInputRelations, relationInput)
+    // ...
+}
+```
+
+`inputRelations` (which holds `[rel(?grp), rel(?name,?owner)]`) is a parameter to
+this function but is otherwise unused — the scalar is silently discarded.
+
+### 2. The per-tuple query keeps the scalar spec, causing positional misalignment (executor/executor.go)
+
+`executeRealizedNonIterating` rebuilds the query, replacing the `RelationInput`
+with one `ScalarInput` per relation symbol but **keeping every other input spec**:
+
+```go
+for _, input := range modifiedQuery.In {
+    if _, isRelInput := input.(query.RelationInput); isRelInput {
+        for _, sym := range relationInput.Symbols {
+            newIn = append(newIn, query.ScalarInput{Symbol: sym})
+        }
+    } else {
+        newIn = append(newIn, input)   // <-- keeps ScalarInput(?grp)
+    }
+}
+modifiedQuery.In = newIn
+boundRelation := BindQueryInputs(&modifiedQuery, scalarInputRelations)
+```
+
+So for `:in $ ?grp [[?name ?owner] ...]` the modified `:in` becomes
+`[$, ScalarInput(?grp), ScalarInput(?name), ScalarInput(?owner)]`, but
+`scalarInputRelations` passed from the iterator is only `[rel(?name), rel(?owner)]`.
+`BindQueryInputs` consumes inputs by positional `relationIndex`, so:
+
+- `ScalarInput(?grp)`   ← `scalarInputRelations[0]` = `rel(?name)` → **`?grp` bound to the name value (wrong)**
+- `ScalarInput(?name)`  ← `scalarInputRelations[1]` = `rel(?owner)` → **`?name` bound to the owner value (wrong)**
+- `ScalarInput(?owner)` ← index out of range → **skipped, `?owner` unbound**
+
+The `:where` clauses then join on garbage/unbound variables and match nothing →
+empty result. A scalar placed *after* the relation shifts differently but is
+equally broken; the invariant — non-relation inputs must survive the iteration —
+is violated either way.
+
+## Fix Direction
+
+Forward the non-iteration input relations through the relation-input iteration so
+each per-tuple execution binds them **alongside** the relation tuple's scalarized
+values, keeping `modifiedQuery.In` and the passed `scalarInputRelations` aligned
+(same order, same count). The cross-product machinery already handles the
+no-shared-variable combination correctly once the relations all reach
+`BindQueryInputs`.
+
+## Impact
+
+Any query mixing a scalar (or other non-relation) `:in` input with a relation
+input silently returns empty — e.g. a root-scoped batch lookup
+`:in $ ?root [[?key ?subject] ...]`. Discovered while implementing a batched
+task-content read (`BatchGetTaskContents`) in the narrative-generators project,
+which returned 0 rows for exactly this query shape.
+
+## Test Coverage (to add with the fix)
+
+- `datalog/storage/query_inputs_test.go` — `TestRelationInput_RefAndKeywordColumns`
+  (scalar+relation, identity and keyword columns; already present, currently red).
+- Library-level cases for `scalar + relation`, `collection + relation`,
+  `tuple + relation`, and relation followed by scalar — each must bind both.
+- `datalog/executor` — direct coverage that the iteration path forwards
+  non-iteration inputs per tuple.
+
+## Files (to change with the fix)
+
+1. `datalog/executor/executor.go` — `executeRealizedWithRelationInputIterationSequential`,
+   `executeRealizedWithRelationInputIterationParallel`, and
+   `executeRealizedNonIterating` (thread non-iteration inputs through; align specs).
+2. `datalog/storage/query_inputs_test.go` / `datalog/executor/*_test.go` — tests above.
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved**, exactly as the Fix Direction prescribed: the relation-input
+iteration now forwards the non-iteration input relations through each per-tuple
+execution, keeping them aligned with `executeRealizedNonIterating`'s in-place `:in`
+rewrite.
+
+- `datalog/executor/executor.go`: `executeRealizedWithRelationInputIteration` now
+  records the iteration relation's index within `inputRelations` (`iterationIndex`)
+  and threads it into the sequential and parallel paths. A new helper,
+  `perTupleInputRelations`, builds the per-tuple input list — every original input
+  relation is forwarded in its original slot, and only the iteration relation's
+  slot is replaced by one single-value relation per `RelationInput` symbol drawn
+  from the tuple. Both paths call it instead of building inputs from the relation's
+  columns alone.
+
+### Tests
+
+- `datalog/storage/query_inputs_test.go` — `TestRelationInput_RefAndKeywordColumns`:
+  scalar+relation (find `?e`, find input vars, wildcard `_`, `(not …)`),
+  relation+scalar (order independence), collection+relation, and ref/keyword
+  column types. Red before the fix, green after.
+- `datalog/executor/multi_tuple_binding_test.go` —
+  `TestJoin_NoSharedColumns_CrossProduct`: confirms the no-shared-column cross
+  product is correct, isolating the bug to input binding rather than the join.
+
+### Provenance
+
+Diagnosed and fixed in a downstream GOPATH checkout (at PR #75) while building a
+batched task-content read in the narrative-generators project, then ported to
+`main` on top of the current `executor.go` — preserving the iterator-error
+handling that `BUG_ITERATOR_ERRORS_DROPPED_IN_MATERIALIZATION_PATHS` added to the
+same parallel function in the interim.
+
+### Verification
+
+`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green.


### PR DESCRIPTION
Fixes `BUG_SCALAR_PLUS_RELATION_INPUT_DROPS_OTHER_INPUTS` — diagnosed and fixed in a downstream GOPATH checkout (narrative-generators batch read), ported here on top of current `main`.

## Bug

A query mixing a scalar (or collection/tuple) `:in` input with a relation input silently returns **0 rows**:

```clojure
[:find ?e :in $ ?grp [[?name ?owner] ...]
 :where [?e :t/grp ?grp] [?e :t/name ?name] [?e :t/owner ?owner]]
;; args: grp, [][]any{{"A", ownerX}}  → expected 1, got 0
```

The relation-input iteration path (`executeRealizedWithRelationInputIteration…`) built each per-tuple input list from the **relation's columns alone**, while `executeRealizedNonIterating` rewrote `:in` keeping the scalar spec. So `BindQueryInputs` consumed inputs by position, misaligned: `?grp` ← the name value, `?name` ← the owner value, `?owner` ← out of range (unbound). The `:where` then joined on garbage → empty.

## Fix

`executeRealizedWithRelationInputIteration` now records the iteration relation's **index within `inputRelations`** (`iterationIndex`) and threads it into the sequential and parallel paths. A new helper `perTupleInputRelations` builds the per-tuple input list: every original input relation is forwarded in its **original slot**, and only the iteration relation's slot is replaced by one single-value relation per `RelationInput` symbol from the tuple. This keeps the per-tuple relations aligned with the in-place `:in` rewrite, so non-relation inputs survive the iteration.

## Porting note

The downstream fix was made at #75; this re-applies it onto the current `executor.go`, which `#77` changed in the **same** parallel function (`collectTuplesInto` error handling). The fix's changes (signature + per-tuple loop) and #77's (results-collection error check) are in different lines, so both are preserved here.

## Tests

- `datalog/storage/query_inputs_test.go` — `TestRelationInput_RefAndKeywordColumns`: scalar+relation (find `?e`, find input vars, wildcard `_`, `(not …)`), relation+scalar (order independence), collection+relation, and entity-ref / keyword column types. Red before, green after.
- `datalog/executor/multi_tuple_binding_test.go` — `TestJoin_NoSharedColumns_CrossProduct`: confirms the no-shared-column cross product is correct, isolating the bug to input binding rather than the join.

## Verification

`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green.

Resolves `docs/bugs/resolved/BUG_SCALAR_PLUS_RELATION_INPUT_DROPS_OTHER_INPUTS.md`.

Credit: diagnosis, fix, and tests authored downstream; ported and reconciled with current `main`.
