### PR TITLE
Add ATEV index for O(1) attribute high-water mark

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -257,7 +257,7 @@ For each phase in plan:
                            ▼
                     ┌──────────────┐
                     │   BadgerDB   │
-                    │  7 indices   │
+                    │  8 indices   │
                     │  per datom   │
                     └──────────────┘
 ```
@@ -276,7 +276,7 @@ For each phase in plan:
 3. **`tx.Commit()`** — Atomic:
    - Uniqueness validation (for `:db.unique/value` and `:db.unique/identity` attributes)
    - `store.Retract(retracts)` — write tombstones
-   - `store.Assert(datoms)` — write to all 7 indices per datom
+   - `store.Assert(datoms)` — write to all 8 indices per datom
    - Transaction metadata datom (`tx:N :db/txInstant time`)
    - EA cache invalidation for touched (entity, attribute) pairs
 
@@ -374,7 +374,7 @@ type Store interface {
 }
 ```
 
-Raw datom storage with 7 indices. Currently only `BadgerStore` (BadgerDB). The `BadgerMatcher` bridges this to the executor by implementing `PatternMatcher` — it chooses the optimal index based on which pattern components are bound, scans BadgerDB, and wraps results as `StreamingRelation`.
+Raw datom storage with 8 indices. Currently only `BadgerStore` (BadgerDB). The `BadgerMatcher` bridges this to the executor by implementing `PatternMatcher` — it chooses the optimal index based on which pattern components are bound, scans BadgerDB, and wraps results as `StreamingRelation`.
 
 ### EntityResolver — CRDT Resolution
 
@@ -394,7 +394,7 @@ Returns all attributes for an entity with CRDT conflict resolution applied. Used
 - **Fixed-size keys**: 69 bytes (E:20 + A:32 + Tx:16 + Op:1), plus optional 16-byte AfterRef for RGA
 - **Variable-size values**: 2-byte size prefix + 1-byte type tag + data
 - **L85 encoding**: Custom sort-preserving Base85 for range scans
-- **Seven indices**: Each serves different access patterns:
+- **Eight indices**: Each serves different access patterns:
 
 | Index | Use Case |
 |-------|----------|
@@ -402,6 +402,7 @@ Returns all attributes for an entity with CRDT conflict resolution applied. Used
 | EATV  | Entity lookups, LWW resolution (cardinality-one/vector) |
 | AEVT  | Attribute scans across entities |
 | AETV  | Attribute scans with temporal ordering |
+| ATEV  | O(1) attribute high-water mark; AsOf-by-attribute access |
 | AVET  | Value-based lookups (uniqueness, reverse lookup) |
 | VAET  | Reverse reference traversal |
 | TAEV  | Transaction-based queries, history |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ This is **standard database query optimization** (similar to Selinger's algorith
 - **Fixed 69-byte keys**: E(20) + A(32) + Tx(16) + Op(1) for efficient indexing
 - **Unbounded values**: Stored last with 2-byte size prefix and 1-byte type
 - **L85 encoding**: Custom Base85 variant preserving sort order (see below)
-- **Seven indices**: EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV for different access patterns and cardinalities
+- **Eight indices**: EAVT, EATV, AEVT, AETV, ATEV, AVET, VAET, TAEV for different access patterns and cardinalities. ATEV's `[A][Tx↓][E][V]` layout gives O(1) attribute high-water mark for cache freshness and direct AsOf-by-attribute scans.
 - **CRDT semantics**: LWW for cardinality-one, add-wins for cardinality-many, RGA for cardinality-vector
 - **Keyword interning**: Keywords hashed once and reused
 - **RefValues**: 20-byte entity references are L85-encoded like E/Tx components
@@ -236,7 +236,7 @@ This separation ensures the query engine remains simple and focused on logic, wh
 ### Storage Integration
 The storage layer connects the query engine to BadgerDB:
 - **Database API**: High-level interface for creating transactions and querying
-- **Transaction API**: Write datoms with automatic indexing across all 7 indices
+- **Transaction API**: Write datoms with automatic indexing across all 8 indices
 - **BadgerMatcher**: Implements PatternMatcher interface for the executor
   - Chooses optimal index based on bound values in patterns
   - Converts between user types (Identity, Keyword) and storage types ([20]byte for E/Tx, [32]byte for A)

--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -25,6 +25,7 @@ The Janus Datalog engine delivers production-ready performance through architect
 - ✅ **CRDT allocation optimization**: **90% faster** (1.9×), **2.2× less memory** than pre-CRDT main branch while adding full CRDT semantics (verified 2026-02-02)
 - ✅ **AETV index & value elimination**: **5% faster**, **19% less memory**, **17% fewer allocations** (geomean); complex queries see **35% memory reduction** (verified 2026-02-06)
 - ✅ **LZ77+FSE compression codec**: **2.1-2.4 GB/s decompression** (7 allocs), **3.6x on prose**, **10-13x on structured/repetitive** data (verified 2026-03-28)
+- ✅ **ATEV index & attribute high-water mark**: `MaxElementIDForAttribute` and every `Cache.IsAttributeFresh` call become **O(1) (~1 µs)** instead of O(datoms-for-A); **2.2× → 555× faster** at 10–10,000 datoms-per-attribute (verified 2026-05-25). Costs ~14% more write work per commit (1 of 8 indices).
 
 ### Claims Requiring Qualification
 - ⚠️ **Plan quality**: "13% better plans" not supported by current benchmarks (planners perform identically)
@@ -636,6 +637,75 @@ cache fairly):
 counting the removed race and the per-identity L85 string.
 
 **Details**: See `docs/bugs/resolved/BUG_IDENTITY_L85_LAZY_RACE.md`
+
+### 16. ATEV Index — O(1) Attribute High-Water Mark (COMPLETE - May 2026)
+**Status**: ✅ New `[A][Tx↓][E][V]` index; `MaxElementIDForAttribute` and every
+`Cache.IsAttributeFresh` call are now a single forward seek
+
+**What changed**:
+- Added an 8th index, **ATEV** (`[prefix][A][Tx↓][E][type][V][AfterRef?][Op]`),
+  positioned so that under a `[A]` prefix the entries sort by `Tx` descending
+  across all entities for that attribute. The first entry is therefore the global
+  max-Tx datom for the attribute.
+- `BadgerStore.MaxElementIDForAttribute` is now a single `Seek([ATEV][A])` plus
+  a Tx decode — O(1), where previously it forward-scanned every datom for the
+  attribute on AEVT (O(datoms-for-A)) while documentation claimed "O(1) reverse seek."
+- **Cache freshness inherits this directly.** `Cache.IsAttributeFresh` always calls
+  `MaxElementIDForAttribute` to compute the current store max for comparison
+  against `attrVersions`, so every A-bound cached query path (the gate in front
+  of attribute-resolved CRDT lookups) is now constant-time, not linear in the
+  attribute's datom count.
+- `BadgerMatcher.chooseIndex` routes A-bound + Tx-bound + V-unbound patterns to
+  ATEV. `hash_join_matcher.chooseIndexForValues` and `simple_batch_scanner.buildKey`
+  both learned the ATEV layout so joined/batched scans through ATEV produce a
+  tight `[A][Tx↓][E]` prefix instead of degrading to a full-attribute scan.
+
+**Read-side measurement** (`atev_index_bench_test.go`,
+`BenchmarkMaxElementIDForAttribute_ATEVSeek_vs_AEVTScan`, Apple M5, Badger v4):
+
+| N (datoms-for-A) | ATEV seek | AEVT scan | Speedup |
+|------------------|-----------|-----------|---------|
+| 10               | 876 ns    | 1,943 ns  | 2.2×    |
+| 100              | 995 ns    | 8,505 ns  | 8.5×    |
+| 1,000            | 1,045 ns  | 70 µs     | 67×     |
+| 10,000           | 1,121 ns  | 622 µs    | **555×**|
+
+ATEV is flat across four orders of magnitude (876 ns → 1,121 ns — true O(1)); the
+AEVT scan it replaces grows linearly (10× per decade). At narrative-generators-scale
+(`:task/status` across thousands of tasks), every freshness gate that fronted an
+A-bound cache lookup was previously paying tens to hundreds of microseconds and
+now pays ~1 µs.
+
+**Write-side measurement** (`BenchmarkAssert_WriteCost`, same hardware):
+
+| Batch size | ns/op  | Per-datom |
+|------------|--------|-----------|
+| 100        | 627 µs | ~6.3 µs   |
+| 1,000      | 6.7 ms | ~6.7 µs   |
+
+ATEV adds 1 of 8 indices, so its share of the per-datom write cost is roughly
+~0.8 µs (~14% more than a 7-index baseline) — an estimate from the index ratio,
+not a direct 7-vs-8 measurement. The marginal cost is dominated by Badger's
+`Set` and the per-index key construction, not value encoding (which is amortized
+once per datom across all indices via `EncodeKeyWithValueBytes`).
+
+**Crossover** (writes to amortize one saved freshness check at N=10K): saved
+~621 µs ÷ added ~0.8 µs/datom ≈ 775 datoms. Any commit smaller than that into a
+10K-cardinality attribute is "paid for" by a single subsequent freshness check
+that would have scanned. Read-mostly workloads (the narrative-generators shape)
+win convincingly; bulk-import-then-never-query workloads pay the ~14% tax with
+no read recovery.
+
+**Migration**: None required. ATEV is populated by every commit; the freshness
+seek finds nothing (zero ElementID, treated as "no data") on attributes that have
+no writes since the index was added.
+
+**Defensive-code cleanup that came with it**: `extractElementIDFromKey` now
+panics on an unknown index type (it previously returned `ElementID{}` silently,
+which is how a missing ATEV case slipped past the first test run). Five
+historical `case` blocks that branched on `tx.(uint64)` for legacy Lamport-only
+Tx values were removed along with `NewTxFromUint`/`toStorageTx` — Tx is always
+an `ElementID` now, and the previously dead branch is gone.
 
 ---
 

--- a/datalog/storage/atev_index_bench_test.go
+++ b/datalog/storage/atev_index_bench_test.go
@@ -1,0 +1,176 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// maxElementIDViaAEVTScan replicates the pre-ATEV implementation of
+// MaxElementIDForAttribute: forward-scan every AEVT entry under the attribute
+// prefix and track the maximum Tx. Kept here purely so the benchmark can
+// compare against the post-ATEV single-seek path on identical data.
+func maxElementIDViaAEVTScan(s *BadgerStore, a []byte) (datalog.ElementID, error) {
+	var maxID datalog.ElementID
+	err := s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		aevtPrefix := make([]byte, 1+32)
+		aevtPrefix[0] = byte(AEVT)
+		copy(aevtPrefix[1:33], a)
+
+		it.Seek(aevtPrefix)
+		for it.Valid() {
+			key := it.Item().Key()
+			if key[0] != byte(AEVT) || !bytesEqual(key[1:33], aevtPrefix[1:33]) {
+				break
+			}
+			_, _, _, tx, _, _, err := s.encoder.DecodeKey(AEVT, key)
+			if err != nil {
+				it.Next()
+				continue
+			}
+			elemID := Tx(tx).ToElementID()
+			if elemID.Compare(maxID) > 0 {
+				maxID = elemID
+			}
+			it.Next()
+		}
+		return nil
+	})
+	return maxID, err
+}
+
+// populateAttribute writes `count` distinct (E, A, V, Tx) datoms for attribute
+// `a`. Each entity gets a unique Identity and a monotonically increasing Tx so
+// the freshness check has a clear answer (max Tx == count) and so the scan
+// must actually traverse the full attribute range.
+func populateAttribute(b *testing.B, store *BadgerStore, a datalog.Keyword, count int) {
+	b.Helper()
+	datoms := make([]datalog.Datom, count)
+	for i := 0; i < count; i++ {
+		datoms[i] = datalog.Datom{
+			E:  datalog.NewIdentity(fmt.Sprintf("entity-%d", i)),
+			A:  a,
+			V:  int64(i),
+			Tx: datalog.ElementID{Lamport: uint64(i + 1), ReplicaID: 1},
+		}
+	}
+	if err := store.Assert(datoms); err != nil {
+		b.Fatalf("assert: %v", err)
+	}
+}
+
+// BenchmarkMaxElementIDForAttribute_ATEVSeek_vs_AEVTScan measures the
+// freshness-path win at several attribute cardinalities. The ATEV column is
+// the production path (single forward seek); the AEVT column is the
+// pre-existing forward scan.
+//
+// Expectation: ATEV is roughly constant-time; AEVT scales linearly with the
+// number of datoms for the attribute.
+func BenchmarkMaxElementIDForAttribute_ATEVSeek_vs_AEVTScan(b *testing.B) {
+	cardinalities := []int{10, 100, 1000, 10000}
+	for _, n := range cardinalities {
+		b.Run(fmt.Sprintf("ATEV_seek/N=%d", n), func(b *testing.B) {
+			dir, err := os.MkdirTemp("", "atev-bench-seek-*")
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+			store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer store.Close()
+
+			a := datalog.NewKeyword(":bench/attr")
+			populateAttribute(b, store, a, n)
+			var aBytes [32]byte
+			copy(aBytes[:], a.String())
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := store.MaxElementIDForAttribute(aBytes[:]); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("AEVT_scan/N=%d", n), func(b *testing.B) {
+			dir, err := os.MkdirTemp("", "atev-bench-scan-*")
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+			store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer store.Close()
+
+			a := datalog.NewKeyword(":bench/attr")
+			populateAttribute(b, store, a, n)
+			var aBytes [32]byte
+			copy(aBytes[:], a.String())
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := maxElementIDViaAEVTScan(store, aBytes[:]); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkAssert_WriteCost measures the cost of writing N datoms with the
+// 8-index ATEV configuration. Each additional index is roughly 1/8 of the
+// total key-write cost, so the ATEV tax is approximately ns_per_datom / 8.
+// Run alongside removing ATEV from Indices on a comparison branch to validate
+// the ~14% extra-cost estimate empirically.
+func BenchmarkAssert_WriteCost(b *testing.B) {
+	for _, n := range []int{100, 1000} {
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				dir, err := os.MkdirTemp("", "atev-bench-write-*")
+				if err != nil {
+					b.Fatal(err)
+				}
+				store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+				if err != nil {
+					b.Fatal(err)
+				}
+				datoms := make([]datalog.Datom, n)
+				a := datalog.NewKeyword(":bench/write")
+				for j := 0; j < n; j++ {
+					datoms[j] = datalog.Datom{
+						E:  datalog.NewIdentity(fmt.Sprintf("we-%d-%d", i, j)),
+						A:  a,
+						V:  int64(j),
+						Tx: datalog.ElementID{Lamport: uint64(j + 1), ReplicaID: 1},
+					}
+				}
+				b.StartTimer()
+
+				if err := store.Assert(datoms); err != nil {
+					b.Fatal(err)
+				}
+
+				b.StopTimer()
+				store.Close()
+				os.RemoveAll(dir)
+				b.StartTimer()
+			}
+		})
+	}
+}

--- a/datalog/storage/atev_index_test.go
+++ b/datalog/storage/atev_index_test.go
@@ -1,0 +1,659 @@
+package storage
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"os"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestATEVEncoderRoundTrip verifies that the ATEV index key encodes and decodes
+// to the same datom components for both the binary and L85 encoders.
+func TestATEVEncoderRoundTrip(t *testing.T) {
+	entity := sha1.Sum([]byte("atev-entity"))
+	datom := &datalog.Datom{
+		E:  datalog.NewIdentityFromHash(entity),
+		A:  datalog.NewKeyword(":atev/attribute"),
+		V:  "atev value",
+		Tx: datalog.ElementID{Lamport: 42, ReplicaID: 7},
+	}
+
+	encoders := []struct {
+		name    string
+		encoder KeyEncoder
+	}{
+		{"Binary", NewKeyEncoder(BinaryStrategy)},
+		{"L85", NewKeyEncoder(L85Strategy)},
+	}
+
+	for _, tc := range encoders {
+		t.Run(tc.name, func(t *testing.T) {
+			key := tc.encoder.EncodeKey(ATEV, datom)
+			if len(key) == 0 {
+				t.Fatal("empty ATEV key")
+			}
+			if key[0] != byte(ATEV) {
+				t.Errorf("first byte should be ATEV prefix, got %d", key[0])
+			}
+
+			e, _, v, tx, _, _, err := tc.encoder.DecodeKey(ATEV, key)
+			if err != nil {
+				t.Fatalf("decode ATEV: %v", err)
+			}
+			if !bytes.Equal(e[:], entity[:]) {
+				t.Errorf("entity mismatch: got %x, want %x", e, entity)
+			}
+			if len(v) < 1 || !bytes.Equal(v[1:], []byte("atev value")) {
+				t.Errorf("value mismatch: got %q", v)
+			}
+			var zeroTx [16]byte
+			if tx == zeroTx {
+				t.Error("decoded tx is zero")
+			}
+		})
+	}
+}
+
+// TestATEVDescendingTxOrder verifies the key property that makes
+// MaxElementIDForAttribute O(1): within a single attribute prefix, the
+// lowest-byte (lexicographically first) ATEV key is the one with the highest Tx.
+// This is what lets a single forward seek on [ATEV][A] yield the global max Tx.
+func TestATEVDescendingTxOrder(t *testing.T) {
+	entity := sha1.Sum([]byte("atev-order"))
+	attr := datalog.NewKeyword(":atev/order")
+	encoder := &BinaryKeyEncoder{}
+
+	mkKey := func(lamport uint64) []byte {
+		d := &datalog.Datom{
+			E:  datalog.NewIdentityFromHash(entity),
+			A:  attr,
+			V:  "v",
+			Tx: datalog.ElementID{Lamport: lamport, ReplicaID: 1},
+		}
+		return encoder.EncodeKey(ATEV, d)
+	}
+
+	low := mkKey(1)
+	mid := mkKey(100)
+	high := mkKey(10000)
+
+	// Highest Tx (10000) must sort first; lowest Tx (1) must sort last.
+	if bytes.Compare(high, mid) >= 0 {
+		t.Errorf("high-Tx ATEV key should sort before mid-Tx: high=%x mid=%x", high, mid)
+	}
+	if bytes.Compare(mid, low) >= 0 {
+		t.Errorf("mid-Tx ATEV key should sort before low-Tx: mid=%x low=%x", mid, low)
+	}
+}
+
+// TestATEVIsPopulatedOnCommit catches regressions where the write path stops
+// writing ATEV. If ATEV is not populated, MaxElementIDForAttribute returns zero
+// even though the attribute has data, breaking cache freshness checks.
+func TestATEVIsPopulatedOnCommit(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-populate-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	e := datalog.NewIdentity("e1")
+	a := datalog.NewKeyword(":atev/populate")
+	tx := datalog.ElementID{Lamport: 99, ReplicaID: 3}
+
+	if err := store.Assert([]datalog.Datom{
+		{E: e, A: a, V: "hello", Tx: tx},
+	}); err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+
+	// Scan the ATEV prefix for this attribute; we should see exactly one key,
+	// and decoding it should yield our Tx.
+	var aStorage [32]byte
+	copy(aStorage[:], a.String())
+	atevPrefix := append([]byte{byte(ATEV)}, aStorage[:]...)
+	atevEnd := incrementLastByte(atevPrefix)
+
+	it, err := store.Scan(ATEV, atevPrefix, atevEnd)
+	if err != nil {
+		t.Fatalf("scan ATEV: %v", err)
+	}
+	defer it.Close()
+
+	count := 0
+	for it.Next() {
+		count++
+		got := it.ElementID()
+		if got.Lamport != tx.Lamport || got.ReplicaID != tx.ReplicaID {
+			t.Errorf("ATEV entry Tx mismatch: got %+v want %+v", got, tx)
+		}
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 ATEV entry for attribute, got %d", count)
+	}
+}
+
+// TestMaxElementIDForAttributeUsesATEV verifies that MaxElementIDForAttribute
+// returns the maximum Tx after multiple writes to the same attribute on different
+// entities. The contract: highest Tx across all (E, V) for the attribute.
+// Without ATEV (or with a broken ATEV path), this would either return a stale
+// value or scan AEVT linearly.
+func TestMaxElementIDForAttributeUsesATEV(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-maxid-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	a := datalog.NewKeyword(":atev/maxid")
+	var aBytes [32]byte
+	copy(aBytes[:], a.String())
+
+	// Write three entities with increasing Tx values; max should be Tx=300.
+	datoms := []datalog.Datom{
+		{E: datalog.NewIdentity("e-low"), A: a, V: "low", Tx: datalog.ElementID{Lamport: 100, ReplicaID: 1}},
+		{E: datalog.NewIdentity("e-mid"), A: a, V: "mid", Tx: datalog.ElementID{Lamport: 200, ReplicaID: 1}},
+		{E: datalog.NewIdentity("e-high"), A: a, V: "high", Tx: datalog.ElementID{Lamport: 300, ReplicaID: 1}},
+	}
+	if err := store.Assert(datoms); err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+
+	maxID, err := store.MaxElementIDForAttribute(aBytes[:])
+	if err != nil {
+		t.Fatalf("MaxElementIDForAttribute: %v", err)
+	}
+	want := datalog.ElementID{Lamport: 300, ReplicaID: 1}
+	if maxID.Lamport != want.Lamport || maxID.ReplicaID != want.ReplicaID {
+		t.Errorf("MaxElementIDForAttribute returned %+v, want %+v", maxID, want)
+	}
+
+	// A non-existent attribute must return zero, not the previous attribute's max.
+	other := datalog.NewKeyword(":atev/never-written")
+	var otherBytes [32]byte
+	copy(otherBytes[:], other.String())
+	emptyID, err := store.MaxElementIDForAttribute(otherBytes[:])
+	if err != nil {
+		t.Fatalf("MaxElementIDForAttribute (empty): %v", err)
+	}
+	if emptyID != (datalog.ElementID{}) {
+		t.Errorf("MaxElementIDForAttribute on empty attribute = %+v, want zero", emptyID)
+	}
+}
+
+// TestChooseIndex_ABoundPlusTxBound_PicksATEV verifies that the matcher
+// selects ATEV when both A and Tx are bound (and V is unbound). Regressions
+// in chooseIndex would silently send these patterns back to AETV/TAEV.
+func TestChooseIndex_ABoundPlusTxBound_PicksATEV(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-matcher-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	matcher := NewBadgerMatcher(store)
+	a := datalog.NewKeyword(":atev/matcher")
+	tx := datalog.ElementID{Lamport: 42, ReplicaID: 1}
+
+	idx, start, end := matcher.chooseIndex(nil, a, nil, tx)
+	if idx != ATEV {
+		t.Errorf("chooseIndex(nil, A, nil, Tx) = %v, want ATEV", idx)
+	}
+	if len(start) == 0 || len(end) == 0 {
+		t.Error("ATEV prefix range start/end should be non-empty")
+	}
+	if bytes.Compare(start, end) >= 0 {
+		t.Error("ATEV prefix range start must sort before end")
+	}
+	if start[0] != byte(ATEV) {
+		t.Errorf("ATEV prefix range start should begin with ATEV byte (%d), got %d", byte(ATEV), start[0])
+	}
+}
+
+// TestChooseIndex_ABoundPlusTxBoundPlusVBound_DoesNotPickATEV pins the routing
+// boundary: when V is also bound, AVET wins over ATEV (V-tightening is more
+// selective than Tx-tightening on the typical workload). Locks the rule into
+// the test suite so future planner edits don't silently shift the boundary.
+func TestChooseIndex_ABoundPlusTxBoundPlusVBound_DoesNotPickATEV(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-no-v-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	matcher := NewBadgerMatcher(store)
+	a := datalog.NewKeyword(":atev/routing")
+	tx := datalog.ElementID{Lamport: 5, ReplicaID: 1}
+
+	idx, _, _ := matcher.chooseIndex(nil, a, "hello", tx)
+	if idx == ATEV {
+		t.Errorf("chooseIndex with V bound should NOT pick ATEV; got ATEV anyway")
+	}
+}
+
+// TestEndToEndABoundTxBoundQuery exercises the full pipeline:
+// chooseIndex selects ATEV → scan over ATEV → result tuples. Writes datoms at
+// several Tx values for the same attribute, runs a pattern with the Tx fixed
+// to one specific value, and asserts only the matching datom comes back.
+//
+// This is the regression that catches breakage in chooseIndex, the ATEV scan
+// range, the CRDT iterator's ATEV handling, and result conversion all at once
+// — none of those is individually exercised end-to-end by other tests.
+func TestEndToEndABoundTxBoundQuery(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-e2e-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	attr := datalog.NewKeyword(":atev/e2e")
+	e1 := datalog.NewIdentity("e2e-one")
+	e2 := datalog.NewIdentity("e2e-two")
+	e3 := datalog.NewIdentity("e2e-three")
+	tx1 := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+	tx2 := datalog.ElementID{Lamport: 200, ReplicaID: 1}
+	tx3 := datalog.ElementID{Lamport: 300, ReplicaID: 1}
+
+	if err := store.Assert([]datalog.Datom{
+		{E: e1, A: attr, V: "first", Tx: tx1},
+		{E: e2, A: attr, V: "second", Tx: tx2},
+		{E: e3, A: attr, V: "third", Tx: tx3},
+	}); err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+
+	// History-mode matcher so the ATEV scan returns raw datoms without
+	// CRDT resolution stripping non-latest entries.
+	matcher := NewBadgerMatcher(store).History()
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: attr},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+			query.Constant{Value: tx2},
+		},
+	}
+
+	result, err := matcher.Match(pattern, nil)
+	if err != nil {
+		t.Fatalf("match: %v", err)
+	}
+
+	count := 0
+	it := result.Iterator()
+	for it.Next() {
+		tuple := it.Tuple()
+		count++
+		// Symbol order is [?e, ?v] (Tx is constant, not projected).
+		if got, ok := tuple[0].(datalog.Identity); !ok || !got.Equal(e2) {
+			t.Errorf("expected ?e = %v, got %v", e2, tuple[0])
+		}
+		if got, ok := tuple[1].(string); !ok || got != "second" {
+			t.Errorf("expected ?v = \"second\", got %v", tuple[1])
+		}
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	it.Close()
+
+	if count != 1 {
+		t.Errorf("expected exactly 1 result for tx=%v, got %d", tx2, count)
+	}
+}
+
+// TestMaxElementIDForAttribute_AfterRetraction documents the actual retract
+// semantics. BadgerStore.Retract deletes the matching (E,A,V) entries from
+// every index using the *stored* Tx and discards the passed-in Tx — no
+// tombstone is written. So an attribute's high-water mark can drop after a
+// retract, all the way to zero when the last entry is removed.
+//
+// Cache freshness still works because IsAttributeFresh compares cachedMax to
+// storeMax for inequality (not direction): any change, even a downward one,
+// stales the cache. This test pins both behaviors.
+func TestMaxElementIDForAttribute_AfterRetraction(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-retract-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	a := datalog.NewKeyword(":atev/retract")
+	var aBytes [32]byte
+	copy(aBytes[:], a.String())
+
+	e1 := datalog.NewIdentity("retract-e1")
+	e2 := datalog.NewIdentity("retract-e2")
+	tx1 := datalog.ElementID{Lamport: 50, ReplicaID: 1}
+	tx2 := datalog.ElementID{Lamport: 100, ReplicaID: 1}
+
+	if err := store.Assert([]datalog.Datom{
+		{E: e1, A: a, V: "v1", Tx: tx1},
+		{E: e2, A: a, V: "v2", Tx: tx2},
+	}); err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+
+	// Pre-retract: max across both entities is tx2.
+	maxID, err := store.MaxElementIDForAttribute(aBytes[:])
+	if err != nil {
+		t.Fatalf("MaxElementIDForAttribute: %v", err)
+	}
+	if maxID.Lamport != tx2.Lamport || maxID.ReplicaID != tx2.ReplicaID {
+		t.Fatalf("pre-retract: got %+v, want %+v", maxID, tx2)
+	}
+
+	// Retract e2 (the higher-Tx datom). The passed-in retract Tx is
+	// irrelevant — Retract finds by (E,A,V) and deletes by stored Tx.
+	if err := store.Retract([]datalog.Datom{
+		{E: e2, A: a, V: "v2", Tx: datalog.ElementID{Lamport: 999, ReplicaID: 9}},
+	}); err != nil {
+		t.Fatalf("retract e2: %v", err)
+	}
+
+	// After retracting the tx2 entry, max drops back to tx1 (e1 remains).
+	maxID, err = store.MaxElementIDForAttribute(aBytes[:])
+	if err != nil {
+		t.Fatalf("MaxElementIDForAttribute after retract: %v", err)
+	}
+	if maxID.Lamport != tx1.Lamport || maxID.ReplicaID != tx1.ReplicaID {
+		t.Errorf("after retracting e2: got %+v, want %+v (e1's Tx)", maxID, tx1)
+	}
+
+	// Retract e1 too — no entries remain, max is zero.
+	if err := store.Retract([]datalog.Datom{
+		{E: e1, A: a, V: "v1", Tx: datalog.ElementID{Lamport: 1000, ReplicaID: 9}},
+	}); err != nil {
+		t.Fatalf("retract e1: %v", err)
+	}
+
+	maxID, err = store.MaxElementIDForAttribute(aBytes[:])
+	if err != nil {
+		t.Fatalf("MaxElementIDForAttribute after all retracted: %v", err)
+	}
+	if maxID != (datalog.ElementID{}) {
+		t.Errorf("after retracting all entries: got %+v, want zero (no remaining datoms)", maxID)
+	}
+}
+
+// TestMaxElementIDForAttribute_MultipleWritesToSameEA verifies that the
+// high-water mark tracks the latest Tx when an attribute is overwritten on
+// the same entity. Without this, freshness checks would lock onto the first
+// write's Tx and miss subsequent overwrites — a real LWW-on-cardinality-one
+// invalidation hazard.
+func TestMaxElementIDForAttribute_MultipleWritesToSameEA(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-overwrite-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	a := datalog.NewKeyword(":atev/overwrite")
+	var aBytes [32]byte
+	copy(aBytes[:], a.String())
+	e := datalog.NewIdentity("overwrite-target")
+
+	if err := store.Assert([]datalog.Datom{
+		{E: e, A: a, V: "v1", Tx: datalog.ElementID{Lamport: 10, ReplicaID: 1}},
+	}); err != nil {
+		t.Fatalf("first assert: %v", err)
+	}
+	if err := store.Assert([]datalog.Datom{
+		{E: e, A: a, V: "v2", Tx: datalog.ElementID{Lamport: 20, ReplicaID: 1}},
+	}); err != nil {
+		t.Fatalf("second assert: %v", err)
+	}
+	if err := store.Assert([]datalog.Datom{
+		{E: e, A: a, V: "v3", Tx: datalog.ElementID{Lamport: 30, ReplicaID: 1}},
+	}); err != nil {
+		t.Fatalf("third assert: %v", err)
+	}
+
+	maxID, err := store.MaxElementIDForAttribute(aBytes[:])
+	if err != nil {
+		t.Fatalf("MaxElementIDForAttribute: %v", err)
+	}
+	want := datalog.ElementID{Lamport: 30, ReplicaID: 1}
+	if maxID.Lamport != want.Lamport || maxID.ReplicaID != want.ReplicaID {
+		t.Errorf("after three writes to same (E,A), MaxElementIDForAttribute = %+v, want %+v",
+			maxID, want)
+	}
+}
+
+// TestCache_IsAttributeFresh_Integration wires Cache.IsAttributeFresh together
+// with a real BadgerStore.MaxElementIDForAttribute (now backed by the ATEV
+// seek) to confirm cache freshness flips correctly after a write. The
+// pre-existing cache_test.go uses a mockStore that bypasses the production
+// MaxElementIDForAttribute path entirely.
+func TestCache_IsAttributeFresh_Integration(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-cache-fresh-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	a := datalog.NewKeyword(":atev/cache-fresh")
+	var aBytes Attribute
+	copy(aBytes[:], a.String())
+	e := datalog.NewIdentity("cache-fresh-e")
+
+	tx1 := datalog.ElementID{Lamport: 7, ReplicaID: 1}
+	if err := store.Assert([]datalog.Datom{
+		{E: e, A: a, V: "first", Tx: tx1},
+	}); err != nil {
+		t.Fatalf("assert: %v", err)
+	}
+
+	cache := NewCache()
+	// Simulate cache warming: snapshot the current max into attrVersions.
+	cache.UpdateAttributeVersion(aBytes, tx1)
+
+	if !cache.IsAttributeFresh(aBytes, store) {
+		t.Error("IsAttributeFresh = false immediately after warming; should be true")
+	}
+
+	// Write a newer datom. The cached attrVersion stays at tx1, but the store
+	// max moves to tx2 — freshness must flip to false.
+	tx2 := datalog.ElementID{Lamport: 17, ReplicaID: 1}
+	if err := store.Assert([]datalog.Datom{
+		{E: e, A: a, V: "second", Tx: tx2},
+	}); err != nil {
+		t.Fatalf("second assert: %v", err)
+	}
+
+	if cache.IsAttributeFresh(aBytes, store) {
+		t.Error("IsAttributeFresh = true after a newer write; should be false")
+	}
+}
+
+// TestChooseIndexForValues_ATEV exercises the hash-join path's prefix builder
+// for ATEV. Without this, the ATEV case in hash_join_matcher.go could be
+// silently wrong and every existing test would still pass — the matcher
+// integration would degrade to an empty-prefix full-ATEV scan under hash joins.
+func TestChooseIndexForValues_ATEV(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-hashjoin-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	matcher := NewBadgerMatcher(store)
+	a := datalog.NewKeyword(":atev/hashjoin")
+	var aStorage Attribute
+	copy(aStorage[:], a.String())
+	tx := datalog.ElementID{Lamport: 99, ReplicaID: 1}
+	e := datalog.NewIdentity("hashjoin-e")
+	eHash := e.Hash()
+
+	t.Run("A+Tx_only", func(t *testing.T) {
+		_, start, end := matcher.chooseIndexForValues(ATEV, nil, a, nil, tx)
+		expected := matcher.store.encoder.EncodePrefix(ATEV, aStorage[:],
+			matcher.store.encoder.EncodeTxForPrefix(NewTxFromElementID(tx)))
+		if !bytes.HasPrefix(start, expected) {
+			t.Errorf("ATEV [A][Tx] prefix: start = %x, expected prefix %x", start, expected)
+		}
+		if bytes.Compare(start, end) >= 0 {
+			t.Error("range start must sort before end")
+		}
+	})
+
+	t.Run("A+Tx+E", func(t *testing.T) {
+		_, start, end := matcher.chooseIndexForValues(ATEV, e, a, nil, tx)
+		expected := matcher.store.encoder.EncodePrefix(ATEV, aStorage[:],
+			matcher.store.encoder.EncodeTxForPrefix(NewTxFromElementID(tx)),
+			eHash[:])
+		if !bytes.HasPrefix(start, expected) {
+			t.Errorf("ATEV [A][Tx][E] prefix: start = %x, expected prefix %x", start, expected)
+		}
+		if bytes.Compare(start, end) >= 0 {
+			t.Error("range start must sort before end")
+		}
+	})
+}
+
+// TestSimpleBatchScanner_BuildKey_ATEV_VVaries covers buildKey's ATEV branch
+// for position=2 (V varies across bindings, with A and Tx fixed as pattern
+// constants). The position=0 case is already covered by
+// TestSimpleBatchScanner_BuildKey_AllIndices; this fills the other half.
+func TestSimpleBatchScanner_BuildKey_ATEV_VVaries(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-batch-v-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	matcher := NewBadgerMatcher(store)
+	a := datalog.NewKeyword(":atev/batch-v")
+	var aBytes Attribute
+	copy(aBytes[:], a.String())
+	tx := datalog.ElementID{Lamport: 11, ReplicaID: 1}
+	constT := matcher.store.encoder.EncodeTxForPrefix(NewTxFromElementID(tx))
+
+	scanner := &simpleBatchScanner{
+		matcher:  matcher,
+		index:    ATEV,
+		position: 2, // V varies
+	}
+
+	// V is between Tx and the trailing positions in ATEV [A][Tx][E][V]; with E
+	// unbound, tightening stops at [A][Tx]. Any V value should produce that
+	// same prefix.
+	got := scanner.buildKey("any-value", aBytes[:], constT)
+	if got == nil {
+		t.Fatal("buildKey(ATEV, position=2) returned nil")
+	}
+	expected := matcher.store.encoder.EncodePrefix(ATEV, aBytes[:], constT)
+	if !bytes.Equal(got, expected) {
+		t.Errorf("ATEV position=2 key mismatch: got %x, want %x", got, expected)
+	}
+}
+
+// TestChooseIndex_TxOnly_TAEV_WithElementID is the regression check for the
+// uint64-fallback removal. The previous TAEV case branched on tx.(uint64)
+// before DerefElementID; with the legacy branch gone, this test pins that
+// passing an ElementID still routes to TAEV with a proper prefix range.
+func TestChooseIndex_TxOnly_TAEV_WithElementID(t *testing.T) {
+	dir, err := os.MkdirTemp("", "atev-taev-regression-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewBadgerStore(dir, NewKeyEncoder(BinaryStrategy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	matcher := NewBadgerMatcher(store)
+	tx := datalog.ElementID{Lamport: 77, ReplicaID: 1}
+
+	idx, start, end := matcher.chooseIndex(nil, nil, nil, tx)
+	if idx != TAEV {
+		t.Errorf("chooseIndex(nil, nil, nil, ElementID) = %v, want TAEV", idx)
+	}
+	if len(start) == 0 || len(end) == 0 {
+		t.Error("TAEV prefix range start/end should be non-empty")
+	}
+	if bytes.Compare(start, end) >= 0 {
+		t.Error("TAEV prefix range start must sort before end")
+	}
+	if start[0] != byte(TAEV) {
+		t.Errorf("TAEV prefix range start should begin with TAEV byte (%d), got %d", byte(TAEV), start[0])
+	}
+
+	// Same Tx passed through *ElementID — DerefElementID handles both, so the
+	// pointer form should produce identical routing.
+	idxPtr, startPtr, _ := matcher.chooseIndex(nil, nil, nil, &tx)
+	if idxPtr != TAEV {
+		t.Errorf("chooseIndex with *ElementID = %v, want TAEV", idxPtr)
+	}
+	if !bytes.Equal(start, startPtr) {
+		t.Errorf("ElementID and *ElementID should produce identical prefix; got %x vs %x", start, startPtr)
+	}
+}

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -258,8 +258,12 @@ func (s *BadgerStore) MaxElementID() (datalog.ElementID, error) {
 
 // MaxElementIDForAttribute returns the highest ElementID for any (E, A) with this attribute.
 // Used for fast cache freshness checks on A-bound queries.
-// Uses AEVT index with forward scan - first entry has highest Tx due to bitwise NOT encoding.
-// Returns zero ElementID if no data exists for this attribute.
+//
+// O(1): single forward seek on the ATEV index. ATEV orders A → Tx↓ → E → V, so the
+// first entry under prefix [A] has the global maximum Tx for the attribute (Tx is
+// encoded with bitwise NOT for descending sort within (A) groups).
+//
+// Returns zero ElementID if no ATEV data exists for this attribute.
 func (s *BadgerStore) MaxElementIDForAttribute(a []byte) (datalog.ElementID, error) {
 	var maxID datalog.ElementID
 
@@ -270,62 +274,29 @@ func (s *BadgerStore) MaxElementIDForAttribute(a []byte) (datalog.ElementID, err
 		it := txn.NewIterator(opts)
 		defer it.Close()
 
-		// Build AEVT prefix for this attribute: [prefix:1][A:32]
-		aevtPrefix := make([]byte, 1+32)
-		aevtPrefix[0] = byte(AEVT)
-		copy(aevtPrefix[1:33], a)
+		// Build ATEV prefix for this attribute: [prefix:1][A:32]
+		atevPrefix := make([]byte, 1+32)
+		atevPrefix[0] = byte(ATEV)
+		copy(atevPrefix[1:33], a)
 
-		it.Seek(aevtPrefix)
-
-		if it.Valid() {
-			key := it.Item().Key()
-			// Verify this key is for our attribute (prefix match)
-			if len(key) >= 33 && key[0] == byte(AEVT) {
-				if !bytesEqual(key[1:33], aevtPrefix[1:33]) {
-					// Different attribute - no data for this attribute
-					return nil
-				}
-				// Found an AEVT key for this attribute
-				// AEVT layout: [prefix:1][A:32][E:20][V:var][Tx:16][Op:1][AfterRef?:16]
-				// However, Tx is NOT the first component after A, so we can't rely on first entry
-				// having highest Tx. We need to scan through entries for this attribute.
-				//
-				// Actually, for AEVT, the key order is: A → E → V → Tx (descending)
-				// So within the same (A, E, V), first entry has highest Tx.
-				// But we want highest across ALL (E, V) for this A.
-				//
-				// For a true O(1) solution, we'd need an index like EATV where Tx comes earlier.
-				// For now, we scan entries until we find a different attribute.
-				// In practice, we only need to find ONE entry to know the attribute has data,
-				// and track the max as we go.
-				for it.Valid() {
-					key := it.Item().Key()
-					// Check if still in our attribute's prefix
-					if len(key) < 33 || key[0] != byte(AEVT) {
-						break
-					}
-					if !bytesEqual(key[1:33], aevtPrefix[1:33]) {
-						break // Different attribute
-					}
-
-					// Decode the Tx from this key
-					_, _, _, tx, _, _, err := s.encoder.DecodeKey(AEVT, key)
-					if err != nil {
-						it.Next()
-						continue
-					}
-					elemID := Tx(tx).ToElementID()
-					if elemID.Compare(maxID) > 0 {
-						maxID = elemID
-					}
-
-					it.Next()
-				}
-				return nil
-			}
+		it.Seek(atevPrefix)
+		if !it.Valid() {
+			return nil
 		}
 
-		// No AEVT entries found for this attribute
+		// Seek may land past the attribute's ATEV range (different index or
+		// different attribute) when no ATEV entries exist for this attribute.
+		key := it.Item().Key()
+		if key[0] != byte(ATEV) || !bytesEqual(key[1:33], atevPrefix[1:33]) {
+			return nil
+		}
+
+		// First entry under [ATEV][A] holds the global max Tx for the attribute.
+		_, _, _, tx, _, _, decodeErr := s.encoder.DecodeKey(ATEV, key)
+		if decodeErr != nil {
+			return decodeErr
+		}
+		maxID = Tx(tx).ToElementID()
 		return nil
 	})
 
@@ -567,6 +538,11 @@ func extractElementIDFromKey(index IndexType, key []byte) datalog.ElementID {
 		}
 		txBytes = key[offset : offset+txSize]
 
+	case ATEV:
+		// ATEV: [prefix:1][A:32][Tx:16][E:20][V:var][AfterRef?:16][Op:1]
+		// Tx is immediately after A
+		txBytes = key[prefixSize+attrSize : prefixSize+attrSize+txSize]
+
 	case EAVT, AEVT, AVET, VAET:
 		// These indices have Tx near the tail, but the tail also
 		// carries Op (1 byte, always last) and optionally AfterRef
@@ -590,7 +566,11 @@ func extractElementIDFromKey(index IndexType, key []byte) datalog.ElementID {
 		txBytes = key[len(key)-tailAfterTx-txSize : len(key)-tailAfterTx]
 
 	default:
-		return datalog.ElementID{}
+		// Programmer error: a new IndexType was added without teaching this
+		// switch where Tx lives in its layout. Silent zero return here once
+		// hid a missing ATEV case — surface it loudly instead. Matches the
+		// encoder switches in key_encoder_{binary,l85}.go.
+		panic(fmt.Sprintf("extractElementIDFromKey: unknown index type %v", index))
 	}
 
 	// Reverse bitwise NOT to get original ElementID

--- a/datalog/storage/badger_store_test.go
+++ b/datalog/storage/badger_store_test.go
@@ -665,8 +665,8 @@ func TestTimeBasedQueries(t *testing.T) {
 		startTime := time.Date(2024, 1, 1, 10, 30, 0, 0, time.UTC)
 		endTime := time.Date(2024, 1, 1, 11, 30, 0, 0, time.UTC)
 
-		startTx := NewTxFromUint(uint64(startTime.UnixNano()))
-		endTx := NewTxFromUint(uint64(endTime.UnixNano()))
+		startTx := NewTxFromElementID(datalog.ElementID{Lamport: uint64(startTime.UnixNano())})
+		endTx := NewTxFromElementID(datalog.ElementID{Lamport: uint64(endTime.UnixNano())})
 
 		// With bitwise NOT encoding, higher Tx encodes to lower bytes
 		// So for range [startTime, endTime], scan from encoded(endTime) to encoded(startTime)

--- a/datalog/storage/cache.go
+++ b/datalog/storage/cache.go
@@ -198,8 +198,9 @@ func (c *Cache) InvalidateAttribute(a Attribute) {
 // IsAttributeFresh checks if the entire attribute is fresh in cache
 // Used for A-bound queries like [?e :name "Bob"] to avoid checking every entity
 //
-// IMPLEMENTATION NOTE: MaxElementIDForAttribute() performs an O(1) reverse seek
-// on the AEVT index to find the highest Tx for any entity with this attribute.
+// IMPLEMENTATION NOTE: MaxElementIDForAttribute() performs an O(1) forward seek
+// on the ATEV index. ATEV is ordered A → Tx↓ → E → V, so the first entry under
+// prefix [A] is the global max-Tx datom for the attribute in a single seek.
 //
 // EDGE CASE - Initial population after restart:
 // After process restart, attrVersions is empty. The first A-bound query will:

--- a/datalog/storage/correctness_bugs_test.go
+++ b/datalog/storage/correctness_bugs_test.go
@@ -200,7 +200,7 @@ func TestSimpleBatchScanner_BuildKey_AETV(t *testing.T) {
 	var aBytes Attribute
 	copy(aBytes[:], name.String())
 
-	got := scanner.buildKey(alice, aBytes[:])
+	got := scanner.buildKey(alice, aBytes[:], nil)
 	require.NotNil(t, got, "buildKey must not return nil for AETV with E-bound + A-constant")
 
 	// The expected prefix for AETV with E+A bound is [prefix][A][E].
@@ -231,19 +231,26 @@ func TestSimpleBatchScanner_BuildKey_AllIndices(t *testing.T) {
 	// combination its signature admits — silent nil returns cause
 	// silent zero-result scans, the exact failure mode the external
 	// review flagged for this function.
+	// Tx constant used by the ATEV case below; the value chosen doesn't
+	// matter so long as it encodes to a non-empty constT.
+	constTBytes := matcher.store.encoder.EncodeTxForPrefix(
+		NewTxFromElementID(datalog.ElementID{Lamport: 1, ReplicaID: 1}),
+	)
 	for _, tc := range []struct {
 		name     string
 		index    IndexType
 		position int
 		value    interface{}
 		constA   []byte
+		constT   []byte
 	}{
-		{"EAVT_Ebound", EAVT, 0, alice, aBytes[:]},
-		{"EATV_Ebound", EATV, 0, alice, aBytes[:]},
-		{"AEVT_Ebound", AEVT, 0, alice, aBytes[:]},
-		{"AETV_Ebound", AETV, 0, alice, aBytes[:]},
-		{"AVET_Abound", AVET, 1, name, nil},
-		{"VAET_Vbound", VAET, 0, "some-value", nil},
+		{"EAVT_Ebound", EAVT, 0, alice, aBytes[:], nil},
+		{"EATV_Ebound", EATV, 0, alice, aBytes[:], nil},
+		{"AEVT_Ebound", AEVT, 0, alice, aBytes[:], nil},
+		{"AETV_Ebound", AETV, 0, alice, aBytes[:], nil},
+		{"ATEV_Ebound", ATEV, 0, alice, aBytes[:], constTBytes},
+		{"AVET_Abound", AVET, 1, name, nil, nil},
+		{"VAET_Vbound", VAET, 0, "some-value", nil, nil},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			scanner := &simpleBatchScanner{
@@ -251,7 +258,7 @@ func TestSimpleBatchScanner_BuildKey_AllIndices(t *testing.T) {
 				index:    tc.index,
 				position: tc.position,
 			}
-			got := scanner.buildKey(tc.value, tc.constA)
+			got := scanner.buildKey(tc.value, tc.constA, tc.constT)
 			require.NotNil(t, got,
 				"buildKey returned nil for index %s, position %d — scanner would silently produce no results",
 				indexName(tc.index), tc.position)
@@ -282,7 +289,7 @@ func TestSimpleBatchScanner_BuildKey_AVET_PositionSemantics(t *testing.T) {
 	// Case 1: A varies across bindings (position=1, value is a Keyword).
 	// Scan range: [A] prefix over AVET.
 	scanner := &simpleBatchScanner{matcher: matcher, index: AVET, position: 1}
-	got := scanner.buildKey(emailKw, nil)
+	got := scanner.buildKey(emailKw, nil, nil)
 
 	expected := matcher.store.encoder.EncodePrefix(AVET, aBytes[:])
 	require.NotNil(t, got,
@@ -299,7 +306,7 @@ func TestSimpleBatchScanner_BuildKey_AVET_PositionSemantics(t *testing.T) {
 	// key range rather than nil.
 	alice := datalog.NewIdentity("alice")
 	scanner = &simpleBatchScanner{matcher: matcher, index: AVET, position: 0}
-	got = scanner.buildKey(alice, aBytes[:])
+	got = scanner.buildKey(alice, aBytes[:], nil)
 	require.NotNil(t, got,
 		"AVET position=0 with Identity value: buildKey returned nil")
 }

--- a/datalog/storage/hash_join_matcher.go
+++ b/datalog/storage/hash_join_matcher.go
@@ -347,6 +347,29 @@ func (m *BadgerMatcher) chooseIndexForValues(index IndexType, e, a, v, tx interf
 			}
 		}
 
+	case ATEV: // A → Tx↓ → E → V — chosen by chooseIndex when both A and Tx
+		// are bound. Contract: a is a Keyword, tx is an ElementID,
+		// e (if set) is an Identity. Type assertions surface a planner bug
+		// loudly rather than degrading to a full scan.
+		var attr Attribute
+		copy(attr[:], a.(datalog.Keyword).String())
+		startParts = append(startParts, attr[:])
+		endParts = append(endParts, attr[:])
+
+		eid, ok := datalog.DerefElementID(tx)
+		if !ok {
+			panic(fmt.Sprintf("Tx must be ElementID, got %T", tx))
+		}
+		encTx := encoder.EncodeTxForPrefix(NewTxFromElementID(eid))
+		startParts = append(startParts, encTx)
+		endParts = append(endParts, encTx)
+
+		if e != nil {
+			hash := e.(datalog.Identity).Hash()
+			startParts = append(startParts, hash[:])
+			endParts = append(endParts, hash[:])
+		}
+
 	case AVET:
 		if a != nil {
 			if kw, ok := a.(datalog.Keyword); ok {
@@ -395,20 +418,17 @@ func (m *BadgerMatcher) chooseIndexForValues(index IndexType, e, a, v, tx interf
 		}
 
 	case TAEV:
-		// TAEV: Transaction-Attribute-Entity-Value
-		// Tx must be encoded with bitwise-NOT for descending sort order
+		// TAEV: Transaction-Attribute-Entity-Value.
+		// Tx is always an ElementID by contract; encode with bitwise-NOT for
+		// descending sort order.
 		if tx != nil {
-			if txID, ok := tx.(uint64); ok {
-				storageTx := NewTxFromUint(txID)
-				encTx := encoder.EncodeTxForPrefix(storageTx)
-				startParts = append(startParts, encTx)
-				endParts = append(endParts, encTx)
-			} else if eid, ok := datalog.DerefElementID(tx); ok {
-				storageTx := NewTxFromElementID(eid)
-				encTx := encoder.EncodeTxForPrefix(storageTx)
-				startParts = append(startParts, encTx)
-				endParts = append(endParts, encTx)
+			eid, ok := datalog.DerefElementID(tx)
+			if !ok {
+				panic(fmt.Sprintf("Tx must be ElementID, got %T", tx))
 			}
+			encTx := encoder.EncodeTxForPrefix(NewTxFromElementID(eid))
+			startParts = append(startParts, encTx)
+			endParts = append(endParts, encTx)
 		}
 	}
 

--- a/datalog/storage/key_encoder_binary.go
+++ b/datalog/storage/key_encoder_binary.go
@@ -44,6 +44,7 @@ func txFromDescending(encoded []byte) [16]byte {
 //	EATV: [prefix][E][A][Tx↓][type][value][AfterRef?][Op]  - first entry is current (E-primary CRDT)
 //	AEVT: [prefix][A][E][type][value][Tx↓][AfterRef?][Op]  - by attribute (V before Tx)
 //	AETV: [prefix][A][E][Tx↓][type][value][AfterRef?][Op]  - first entry is current (A-primary CRDT)
+//	ATEV: [prefix][A][Tx↓][E][type][value][AfterRef?][Op]  - first entry is global max Tx for A (O(1) freshness + AsOf-by-attribute)
 //	AVET: [prefix][A][type][value][E][Tx↓][AfterRef?][Op]  - value lookup
 //	VAET: [prefix][type][value][A][E][Tx↓][AfterRef?][Op]  - reverse refs
 //	TAEV: [prefix][Tx↓][A][E][type][value][AfterRef?][Op]  - transaction log
@@ -129,6 +130,15 @@ func (e *BinaryKeyEncoder) encodeKeyWithParts(index IndexType, sd *StorageDatom,
 		}
 		key = append(key, byte(sd.Op))
 		return key
+	case ATEV:
+		// [A][Tx↓][E][V][AfterRef?][Op]
+		key := concatBytes(prefix, sd.A[:], txDesc[:], sd.E[:], vBytes)
+		if sd.Op.HasAfterRef() {
+			afterRefDesc := txToDescending(sd.AfterRef)
+			key = append(key, afterRefDesc[:]...)
+		}
+		key = append(key, byte(sd.Op))
+		return key
 	case AVET:
 		// [A][V][E][Tx↓][AfterRef?][Op]
 		key := concatBytes(prefix, sd.A[:], vBytes, sd.E[:], txDesc[:])
@@ -174,6 +184,7 @@ func (e *BinaryKeyEncoder) encodeKeyWithParts(index IndexType, sd *StorageDatom,
 //	EATV: [prefix][E][A][Tx↓][type][value][AfterRef?][Op]
 //	AEVT: [prefix][A][E][type][value][Tx↓][AfterRef?][Op]
 //	AETV: [prefix][A][E][Tx↓][type][value][AfterRef?][Op]
+//	ATEV: [prefix][A][Tx↓][E][type][value][AfterRef?][Op]
 //	AVET: [prefix][A][type][value][E][Tx↓][AfterRef?][Op]
 //	VAET: [prefix][type][value][A][E][Tx↓][AfterRef?][Op]
 //	TAEV: [prefix][Tx↓][A][E][type][value][AfterRef?][Op]
@@ -252,6 +263,18 @@ func (e *BinaryKeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]by
 		copy(entity[:], key[attrSize:attrSize+entitySize])
 		tx = txFromDescending(key[attrSize+entitySize : attrSize+entitySize+txSize])
 		vStart := attrSize + entitySize + txSize
+		value = key[vStart : len(key)-tailSize]
+
+	case ATEV:
+		// [A][Tx↓][E][V][AfterRef?][Op]
+		minSize := attrSize + txSize + entitySize + tailSize
+		if len(key) < minSize {
+			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("ATEV key too short")
+		}
+		copy(attr[:], key[0:attrSize])
+		tx = txFromDescending(key[attrSize : attrSize+txSize])
+		copy(entity[:], key[attrSize+txSize : attrSize+txSize+entitySize])
+		vStart := attrSize + txSize + entitySize
 		value = key[vStart : len(key)-tailSize]
 
 	case AVET:

--- a/datalog/storage/key_encoder_l85.go
+++ b/datalog/storage/key_encoder_l85.go
@@ -50,6 +50,9 @@ func (e *L85KeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 	case AETV:
 		// [A][E][Tx][V][Op]
 		return concatBytes(prefix, []byte(aL85), []byte(eL85), []byte(txL85), vBytes, opByte)
+	case ATEV:
+		// [A][Tx][E][V][Op]
+		return concatBytes(prefix, []byte(aL85), []byte(txL85), []byte(eL85), vBytes, opByte)
 	case AVET:
 		// [A][V][E][Tx][Op]
 		return concatBytes(prefix, []byte(aL85), vBytes, []byte(eL85), []byte(txL85), opByte)
@@ -76,6 +79,7 @@ func (e *L85KeyEncoder) EncodeKey(index IndexType, d *datalog.Datom) []byte {
 //	EATV: [prefix][E][A][Tx][V][Op]
 //	AEVT: [prefix][A][E][V][Tx][Op]
 //	AETV: [prefix][A][E][Tx][V][Op]
+//	ATEV: [prefix][A][Tx][E][V][Op]
 //	AVET: [prefix][A][V][E][Tx][Op]
 //	VAET: [prefix][V][A][E][Tx][Op]
 //	TAEV: [prefix][Tx][A][E][V][Op]
@@ -187,6 +191,28 @@ func (e *L85KeyEncoder) DecodeKey(index IndexType, key []byte) (entity [20]byte,
 			value = valueBytes
 		}
 
+	case ATEV:
+		// [A][Tx][E][V][Op]
+		minSize := l85SizeAttr + l85Size16 + l85Size20 + opSize
+		if len(key) < minSize {
+			return entity, attr, nil, tx, 0, afterRef, fmt.Errorf("ATEV key too short")
+		}
+		attr, _ = codec.DecodeFixed32(string(key[0:l85SizeAttr]))
+		tx, _ = codec.DecodeFixed16(string(key[l85SizeAttr : l85SizeAttr+l85Size16]))
+		entity, _ = codec.DecodeFixed20(string(key[l85SizeAttr+l85Size16 : l85SizeAttr+l85Size16+l85Size20]))
+		// V is between E and Op
+		vStart := l85SizeAttr + l85Size16 + l85Size20
+		valueBytes := key[vStart : len(key)-opSize]
+		if len(valueBytes) == l85Size20 {
+			if decoded, decErr := codec.DecodeFixed20(string(valueBytes)); decErr == nil {
+				value = decoded[:]
+			} else {
+				value = valueBytes
+			}
+		} else {
+			value = valueBytes
+		}
+
 	case AVET:
 		// [A][V][E][Tx][Op]
 		if len(key) < l85SizeAttr+l85Size20+l85Size16+opSize {
@@ -276,6 +302,10 @@ func (e *L85KeyEncoder) EncodePrefix(index IndexType, parts ...[]byte) []byte {
 		case AEVT:
 			shouldEncode = (i == 0 || i == 1 || i == 3)
 			isValuePosition = (i == 2)
+		case ATEV:
+			// [A][Tx][E][V] — positions 0,1,2 are fixed-size; position 3 is value
+			shouldEncode = (i == 0 || i == 1 || i == 2)
+			isValuePosition = (i == 3)
 		case AVET:
 			shouldEncode = (i == 0 || i == 2 || i == 3)
 			isValuePosition = (i == 1)

--- a/datalog/storage/key_encoder_test.go
+++ b/datalog/storage/key_encoder_test.go
@@ -44,7 +44,7 @@ func TestKeyEncoders(t *testing.T) {
 			encoder := tc.encoder
 
 			// Test all index types
-			indices := []IndexType{EAVT, AEVT, AVET, VAET, TAEV}
+			indices := []IndexType{EAVT, AEVT, AETV, ATEV, AVET, VAET, TAEV}
 
 			for _, idx := range indices {
 				// Encode key

--- a/datalog/storage/matcher.go
+++ b/datalog/storage/matcher.go
@@ -627,6 +627,19 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 			aPtr := datalog.NewKeyword(aKw.String())
 			aStorage := ToStorageDatom(datalog.Datom{A: aPtr}).A
 
+			// A and Tx bound (V unbound) — ATEV gives a direct [A][Tx↓] prefix scan,
+			// landing on the exact (or nearest-descending) Tx for the attribute. The
+			// equivalent on AETV would scan every entity, on AEVT every value.
+			if tx != nil && v == nil {
+				eid, ok := datalog.DerefElementID(tx)
+				if !ok {
+					panic(fmt.Sprintf("Tx must be ElementID, got %T", tx))
+				}
+				encTx := encoder.EncodeTxForPrefix(NewTxFromElementID(eid))
+				start, end := encoder.EncodePrefixRange(ATEV, aStorage[:], encTx)
+				return ATEV, start, end
+			}
+
 			if v != nil {
 				// A and V bound - use AVET index
 				valueBytes := encodeValueForSearch(v, encoder)
@@ -660,18 +673,14 @@ func (m *BadgerMatcher) chooseIndex(e, a, v, tx interface{}) (IndexType, []byte,
 		start, end := encoder.EncodePrefixRange(VAET, valueBytes)
 		return VAET, start, end
 	} else if tx != nil {
-		// Use TAEV index
-		var storageTx Tx
-		if txID, ok := tx.(uint64); ok {
-			storageTx = NewTxFromUint(txID)
-		} else if eid, ok := datalog.DerefElementID(tx); ok {
-			storageTx = NewTxFromElementID(eid)
+		// Use TAEV index. Tx is always an ElementID by contract.
+		eid, ok := datalog.DerefElementID(tx)
+		if !ok {
+			panic(fmt.Sprintf("Tx must be ElementID, got %T", tx))
 		}
-		if storageTx != (Tx{}) {
-			encTx := encoder.EncodeTxForPrefix(storageTx)
-			start, end := encoder.EncodePrefixRange(TAEV, encTx)
-			return TAEV, start, end
-		}
+		encTx := encoder.EncodeTxForPrefix(NewTxFromElementID(eid))
+		start, end := encoder.EncodePrefixRange(TAEV, encTx)
+		return TAEV, start, end
 	}
 
 	// Full scan on EATV for CRDT resolution
@@ -776,6 +785,8 @@ func indexName(idx IndexType) string {
 		return "AEVT"
 	case AETV:
 		return "AETV"
+	case ATEV:
+		return "ATEV"
 	case AVET:
 		return "AVET"
 	case VAET:

--- a/datalog/storage/simple_batch_scanner.go
+++ b/datalog/storage/simple_batch_scanner.go
@@ -157,13 +157,24 @@ func (s *simpleBatchScanner) calculateScanRange(bindingSet map[string]executor.T
 		}
 	}
 
+	// Same for the Tx slot — ATEV's [A][Tx↓][E][V] layout needs constTx
+	// after constA to produce a tight prefix. Tx is always an ElementID.
+	var constT []byte
+	if c, ok := s.pattern.GetT().(query.Constant); ok {
+		eid, ok := datalog.DerefElementID(c.Value)
+		if !ok {
+			panic(fmt.Sprintf("Tx constant must be ElementID, got %T", c.Value))
+		}
+		constT = s.matcher.store.encoder.EncodeTxForPrefix(NewTxFromElementID(eid))
+	}
+
 	// Find min and max keys from binding values
 	for _, tuple := range bindingSet {
 		if s.position >= len(tuple) {
 			continue
 		}
 
-		key := s.buildKey(tuple[s.position], constA)
+		key := s.buildKey(tuple[s.position], constA, constT)
 		if key == nil {
 			continue
 		}
@@ -197,7 +208,7 @@ func (s *simpleBatchScanner) calculateScanRange(bindingSet map[string]executor.T
 //   - *uint64 is a non-interned boxed scalar sometimes used for
 //     comparable-value workarounds; dereference it for uniform
 //     handling.
-func (s *simpleBatchScanner) buildKey(value interface{}, constA []byte) []byte {
+func (s *simpleBatchScanner) buildKey(value interface{}, constA, constT []byte) []byte {
 	if ptr, ok := value.(*uint64); ok {
 		value = *ptr
 	}
@@ -264,6 +275,23 @@ func (s *simpleBatchScanner) buildKey(value interface{}, constA []byte) []byte {
 				return encoder.EncodePrefix(s.index, attr[:])
 			}
 		}
+	case ATEV:
+		// ATEV: [A][Tx↓][E][V] — chosen when both A and Tx are constants.
+		// Position 0 (E varies):  [A][Tx][hash(E)] — fully tightened.
+		// Position 2 (V varies):  [A][Tx] — E sits between Tx and V and is
+		//                         unbound, so we can't include V in the prefix.
+		if constA == nil || constT == nil {
+			return nil
+		}
+		switch s.position {
+		case 0:
+			if e, ok := value.(datalog.Identity); ok {
+				hash := e.Hash()
+				return encoder.EncodePrefix(s.index, constA, constT, hash[:])
+			}
+		case 2:
+			return encoder.EncodePrefix(s.index, constA, constT)
+		}
 	case AVET:
 		// AVET: [A][type+V][E][Tx]. Useful prefixes:
 		//   position=1 (A varies):  [A] prefix from the binding keyword
@@ -313,17 +341,14 @@ func (s *simpleBatchScanner) buildKey(value interface{}, constA []byte) []byte {
 		}
 		return encoder.EncodePrefix(s.index, parts...)
 	case TAEV:
-		// TAEV: [Tx][A][E][V] — Tx encoded with bitwise-NOT for
-		// descending sort.
-		if eid, ok := datalog.DerefElementID(value); ok {
-			txBytes := NewTxFromElementID(eid)
-			encTx := encoder.EncodeTxForPrefix(txBytes)
-			return encoder.EncodePrefix(s.index, encTx)
-		} else if tx, ok := value.(uint64); ok {
-			txBytes := NewTxFromUint(tx)
-			encTx := encoder.EncodeTxForPrefix(txBytes)
-			return encoder.EncodePrefix(s.index, encTx)
+		// TAEV: [Tx][A][E][V] — Tx encoded with bitwise-NOT for descending sort.
+		// The binding value is always an ElementID.
+		eid, ok := datalog.DerefElementID(value)
+		if !ok {
+			panic(fmt.Sprintf("Tx binding must be ElementID, got %T", value))
 		}
+		encTx := encoder.EncodeTxForPrefix(NewTxFromElementID(eid))
+		return encoder.EncodePrefix(s.index, encTx)
 	}
 	return nil
 }

--- a/datalog/storage/store.go
+++ b/datalog/storage/store.go
@@ -12,13 +12,14 @@ const (
 	EATV                  // Entity-Attribute-Tx-Value (for cardinality-one: first = current)
 	AEVT                  // Attribute-Entity-Value-Tx
 	AETV                  // Attribute-Entity-Tx-Value (for A-primary CRDT: first = current)
+	ATEV                  // Attribute-Tx-Entity-Value (for O(1) attribute high-water mark + AsOf-by-attribute)
 	AVET                  // Attribute-Value-Entity-Tx
 	VAET                  // Value-Attribute-Entity-Tx
 	TAEV                  // Tx-Attribute-Entity-Value (for clock recovery, audit log)
 )
 
 // Indices lists all indices used for queries
-var Indices = []IndexType{EAVT, EATV, AEVT, AETV, AVET, VAET, TAEV}
+var Indices = []IndexType{EAVT, EATV, AEVT, AETV, ATEV, AVET, VAET, TAEV}
 
 // Store is the interface for datom storage
 type Store interface {
@@ -37,7 +38,8 @@ type Store interface {
 
 	// MaxElementIDForAttribute returns the highest ElementID for any (E, A) with this attribute.
 	// Used for fast cache freshness checks on A-bound queries.
-	// Performs an O(1) reverse seek on the AEVT index.
+	// Performs an O(1) forward seek on the ATEV index — first entry under [A]
+	// is the global max-Tx datom because ATEV orders A → Tx↓ → E → V.
 	// Returns zero ElementID if no data exists for this attribute.
 	MaxElementIDForAttribute(a []byte) (datalog.ElementID, error)
 

--- a/datalog/storage/types.go
+++ b/datalog/storage/types.go
@@ -62,16 +62,6 @@ func NewTxFromTime(t time.Time) Tx {
 	return tx
 }
 
-// NewTxFromUint creates a transaction ID from a uint64
-// Useful for sequential transaction numbers (Lamport-like)
-// ReplicaID is set to 0
-func NewTxFromUint(n uint64) Tx {
-	var tx Tx
-	binary.BigEndian.PutUint64(tx[0:8], n)
-	// ReplicaID (bytes 8-16) remains zero
-	return tx
-}
-
 // String returns the entity as hex string (first 8 bytes)
 func (e Entity) String() string {
 	return fmt.Sprintf("e:%x", e[:8])
@@ -256,7 +246,3 @@ func toStorageValue(v interface{}) datalog.Value {
 	}
 }
 
-// toStorageTx converts user transaction ID to storage format
-func toStorageTx(tx uint64) Tx {
-	return NewTxFromUint(tx)
-}

--- a/docs/bugs/resolved/BUG_CACHE_ATTRIBUTE_FRESHNESS_NOT_O1.md
+++ b/docs/bugs/resolved/BUG_CACHE_ATTRIBUTE_FRESHNESS_NOT_O1.md
@@ -1,0 +1,241 @@
+# BUG: Attribute Cache Freshness Check Is Not O(1)
+
+**Date**: 2026-05-25
+**Severity**: Performance / Documentation Drift (Medium)
+**Status**: Resolved (2026-05-25) — see Resolution at the end
+**Affected**: A-bound cache freshness checks, `Cache.IsAttributeFresh`, `BadgerStore.MaxElementIDForAttribute`
+
+## Summary
+
+The cache documentation says attribute freshness checks are O(1), but
+`MaxElementIDForAttribute` scans all keys for the attribute in the AEVT index to
+compute the maximum ElementID.
+
+This is not a correctness bug, but it can make warm-cache A-bound queries scale
+with attribute cardinality despite comments describing constant-time behavior.
+
+## Code Evidence
+
+`Cache.IsAttributeFresh` calls into storage on every whole-attribute freshness
+check:
+
+```go
+func (c *Cache) IsAttributeFresh(a Attribute, store Store) bool {
+    val, ok := c.attrVersions.Load(a)
+    if !ok {
+        return false
+    }
+    cachedMax := val.(datalog.ElementID)
+    storeMax, err := store.MaxElementIDForAttribute(a[:])
+    if err != nil {
+        return false
+    }
+    return cachedMax == storeMax
+}
+```
+
+The implementation of `MaxElementIDForAttribute` scans the AEVT range for the
+attribute:
+
+```go
+for it.Valid() {
+    key := it.Item().Key()
+    if len(key) < 33 || key[0] != byte(AEVT) {
+        break
+    }
+    if !bytesEqual(key[1:33], aevtPrefix[1:33]) {
+        break
+    }
+
+    _, _, _, tx, _, _, err := s.encoder.DecodeKey(AEVT, key)
+    if err != nil {
+        it.Next()
+        continue
+    }
+    elemID := Tx(tx).ToElementID()
+    if elemID.Compare(maxID) > 0 {
+        maxID = elemID
+    }
+
+    it.Next()
+}
+```
+
+The comments around the cache and store interface describe this as O(1), but the
+actual cost is O(number of datoms for the attribute).
+
+## Root Cause
+
+AEVT is ordered by:
+
+```text
+A -> E -> V -> Tx
+```
+
+Within a single `(A, E, V)` group, the first entry has the highest Tx. But the
+highest Tx for the whole attribute may be in any entity/value group. A forward
+seek to the attribute prefix cannot reveal the global maximum Tx without either:
+
+- scanning the attribute range, or
+- maintaining a separate index/metadata value where Tx sorts before E/V.
+
+## Expected Behavior
+
+Either:
+
+1. The comments and docs should state the true complexity, or
+2. The storage/cache design should provide a real O(1) or O(log n) attribute
+   high-water mark.
+
+## Actual Behavior
+
+The implementation performs a range scan over every key for the attribute while
+claiming O(1) freshness checks.
+
+## Impact
+
+For high-cardinality attributes, this can make "warm" A-bound queries pay a
+large freshness-check cost before deciding whether cached attribute results are
+usable. The bug is most visible for attributes shared by many entities, such as:
+
+- `:entity/type`
+- `:person/name`
+- time-series attributes
+- unique or lookup-heavy attributes
+
+## Fix Direction
+
+Options:
+
+1. Documentation-only fix: update comments in `Store`, `Cache`, and
+   `BadgerStore` to describe the scan honestly.
+2. Metadata fix: maintain an attribute max-ElementID value during commit and
+   read it directly during freshness checks.
+3. Index fix: add an A-Tx-primary index such as `[A][Tx↓][E][V]` if the query
+   planner can also benefit from it.
+
+The metadata approach is probably the smallest targeted fix if the only need is
+cache freshness.
+
+## Verification Plan
+
+Add a benchmark or regression guard that creates many entities with the same
+attribute and measures `IsAttributeFresh` / A-bound cache checks. The benchmark
+should make the current linear behavior visible and prevent future comments from
+claiming constant-time cost unless the implementation changes.
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved by adding a new ATEV index** (option 3 from Fix Direction, chosen
+for consistency with the existing 7-index design and to unlock AsOf-by-attribute
+access patterns beyond the freshness check).
+
+### Correcting one assumption in the original report
+
+The report (and my first reading of it) treated reverse-Tx ordering as if it
+might already give O(1) somewhere. It does not. Tx **is** bitwise-NOT encoded
+(descending) in AEVT, AETV, AVET, VAET, and TAEV — but in each of those it sits
+*after* at least one other sort component, so the descending-Tx ordering only
+applies *within* fixed (A,E,V) or (A,E) groups, not across the whole attribute.
+No reverse-seek on any of the existing seven indices yields the global max-Tx
+for an attribute in one operation; the `cache.go:201` "O(1) reverse seek" comment
+was wrong on physics, not just doc drift. The implementation in
+`badger_store.go:263` was honest about this in its own inline comments ("for a
+true O(1) solution, we'd need an index like EATV where Tx comes earlier").
+
+### What changed
+
+- **New index**: **ATEV** = `[prefix][A][Tx↓][E][type][V][AfterRef?][Op]`.
+  Positioned so the first entry under prefix `[A]` is the global max-Tx datom
+  for the attribute. `MaxElementIDForAttribute` is now a single forward seek
+  plus a Tx decode — genuinely O(1). The previously misleading comments in
+  `cache.go` and `store.go` are now accurate.
+- **Matcher integration**: `chooseIndex` routes A-bound + Tx-bound +
+  V-unbound patterns to ATEV. `chooseIndexForValues` (hash-join path) and
+  `simple_batch_scanner.buildKey` learned the ATEV layout so joined/batched
+  scans produce a tight `[A][Tx↓][E]` prefix instead of degrading.
+- **Cache integration**: `Cache.IsAttributeFresh` is unchanged in shape — it
+  calls `MaxElementIDForAttribute` and compares — but the call it makes is now
+  constant-time.
+
+### Defensive-code cleanup that came with the work
+
+Two latent silent-error patterns surfaced and were fixed in the same PR:
+
+1. `extractElementIDFromKey` used to `return datalog.ElementID{}` for unknown
+   indexes (conflating "iterator not positioned" with "programmer added an
+   index and forgot to update this switch"). It now panics on unknown index,
+   matching the encoder switches in `key_encoder_{binary,l85}.go`. This is
+   how a missing ATEV case got caught by a test that asserted the *value* of
+   the returned Tx — without that, `"HEAD"` would have looked like a normal
+   empty result.
+2. Five `case` blocks that branched on `tx.(uint64)` for a legacy Lamport-only
+   Tx form (`chooseIndex` ATEV+TAEV; `chooseIndexForValues` ATEV+TAEV;
+   `simple_batch_scanner.buildKey` TAEV; plus the `constT` extraction I had
+   freshly added). `Tx` is always an `ElementID` — the `uint64` branches were
+   dead code that silently routed contract violations into wrong-shape keys.
+   `NewTxFromUint` and `toStorageTx` were deleted with no remaining callers.
+
+### Tests added (`datalog/storage/atev_index_test.go`)
+
+- `TestATEVEncoderRoundTrip` — binary + L85 encode/decode
+- `TestATEVDescendingTxOrder` — first entry under `[A]` is the max-Tx datom
+- `TestATEVIsPopulatedOnCommit` — write path populates ATEV
+- `TestMaxElementIDForAttributeUsesATEV` — multi-entity max via the new path
+- `TestMaxElementIDForAttribute_AfterRetraction` — documents that retracts
+  *delete* (no tombstone), so the high-water mark can drop after a retract;
+  cache freshness still works because the comparison is inequality, not
+  direction
+- `TestMaxElementIDForAttribute_MultipleWritesToSameEA` — LWW overwrite case
+- `TestCache_IsAttributeFresh_Integration` — full chain on a real BadgerStore
+- `TestChooseIndex_ABoundPlusTxBound_PicksATEV` and
+  `TestChooseIndex_ABoundPlusTxBoundPlusVBound_DoesNotPickATEV` — routing
+- `TestChooseIndexForValues_ATEV` — hash-join prefix builder (A+Tx, A+Tx+E)
+- `TestSimpleBatchScanner_BuildKey_ATEV_VVaries` — batch scanner V-varies case
+- `TestEndToEndABoundTxBoundQuery` — full pipeline against a real BadgerStore
+- `TestChooseIndex_TxOnly_TAEV_WithElementID` — pin TAEV routing after the
+  uint64-branch removal (covers `ElementID` and `*ElementID`)
+
+### Measurements (`datalog/storage/atev_index_bench_test.go`, Apple M5)
+
+`BenchmarkMaxElementIDForAttribute_ATEVSeek_vs_AEVTScan`:
+
+| N (datoms-for-A) | ATEV seek | AEVT scan | Speedup |
+|------------------|-----------|-----------|---------|
+| 10               | 876 ns    | 1,943 ns  | 2.2×    |
+| 100              | 995 ns    | 8,505 ns  | 8.5×    |
+| 1,000            | 1,045 ns  | 70 µs     | 67×     |
+| 10,000           | 1,121 ns  | 622 µs    | 555×    |
+
+ATEV is flat across four orders of magnitude (true O(1)); the AEVT scan it
+replaces grows linearly (10× per decade) — exactly as the asymptotic prediction
+required.
+
+`BenchmarkAssert_WriteCost`: ~6.5 µs/datom across the 8-index write path. ATEV
+is one of those 8, so the marginal cost it adds is ≈ 0.8 µs/datom (~14%). This
+is estimated from the index ratio, not directly measured 7-vs-8; the per-index
+key construction and Badger `Set` are the variable cost (value encoding is
+amortized via `EncodeKeyWithValueBytes`).
+
+### Files
+
+- `datalog/storage/store.go` — `ATEV` added to `IndexType` and `Indices`; doc
+- `datalog/storage/key_encoder_binary.go`, `key_encoder_l85.go` — ATEV encode/decode
+- `datalog/storage/badger_store.go` — `MaxElementIDForAttribute` is the
+  single-seek path; `extractElementIDFromKey` panics on unknown index
+- `datalog/storage/matcher.go` — `chooseIndex` ATEV case; `indexName`; TAEV cleanup
+- `datalog/storage/hash_join_matcher.go` — `chooseIndexForValues` ATEV case;
+  TAEV cleanup
+- `datalog/storage/simple_batch_scanner.go` — `constT` extraction; `buildKey`
+  ATEV case; TAEV cleanup
+- `datalog/storage/cache.go` — comments now accurate
+- `datalog/storage/types.go` — `NewTxFromUint` and `toStorageTx` removed
+- `datalog/storage/atev_index_test.go` (new) — 13 tests
+- `datalog/storage/atev_index_bench_test.go` (new) — read + write benchmarks
+- `ARCHITECTURE.md`, `CLAUDE.md`, `PERFORMANCE_STATUS.md` — updated
+
+### Verification
+
+`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green.


### PR DESCRIPTION
## Summary

Adds an 8th index, **ATEV** (`[prefix][A][Tx↓][E][V][AfterRef?][Op]`), positioned so that under prefix `[A]` the first entry is the global max-Tx datom for the attribute. `MaxElementIDForAttribute` and every `Cache.IsAttributeFresh` call become constant-time instead of scaling linearly with attribute cardinality.

The previous `BadgerStore.MaxElementIDForAttribute` forward-scanned every AEVT entry for the attribute while `cache.go` claimed "O(1) reverse seek" — that claim wasn't just doc drift, it was physically impossible with any of the seven prior indices (Tx wasn't positioned early enough in any of them to yield a single-seek answer for the *global* max-Tx; `badger_store.go`'s own inline comments admitted this). ATEV puts Tx immediately after A, so the comment is now accurate.

Resolves [`docs/bugs/resolved/BUG_CACHE_ATTRIBUTE_FRESHNESS_NOT_O1.md`](https://github.com/wbrown/janus-datalog/blob/feat/atev-index/docs/bugs/resolved/BUG_CACHE_ATTRIBUTE_FRESHNESS_NOT_O1.md).

## Read-side measurement

`BenchmarkMaxElementIDForAttribute_ATEVSeek_vs_AEVTScan` (Apple M5, Badger v4):

| N (datoms-for-A) | ATEV seek | AEVT scan | Speedup |
|------------------|-----------|-----------|---------|
| 10               | 876 ns    | 1,943 ns  | 2.2×    |
| 100              | 995 ns    | 8,505 ns  | 8.5×    |
| 1,000            | 1,045 ns  | 70 µs     | 67×     |
| 10,000           | 1,121 ns  | 622 µs    | **555×** |

ATEV stays flat across four orders of magnitude (true O(1)); the AEVT scan it replaces grows linearly (10× per decade). `Cache.IsAttributeFresh` inherits this directly — every A-bound cached query path now pays ~1 µs for the freshness gate regardless of attribute cardinality.

## Write-side measurement

`BenchmarkAssert_WriteCost`: ~6.5 µs/datom across the 8-index write path. ATEV is one of 8 indices, so the marginal cost it adds is ≈ 0.8 µs/datom (~14% over a 7-index baseline) — estimated from the index ratio, not a direct 7-vs-8 measurement.

Crossover (writes to amortize one saved freshness check at N=10K): ~775 datoms. Read-mostly workloads win convincingly; bulk-import-then-never-query workloads pay the ~14% tax with no read recovery.

## Matcher integration

- `chooseIndex` routes A-bound + Tx-bound + V-unbound patterns to ATEV (V-bound continues to route to AVET).
- `chooseIndexForValues` (hash-join path) builds tight `[A][Tx][E]` prefixes when bindings supply E.
- `simple_batch_scanner.buildKey` learned the ATEV layout, with `constT` plumbed alongside `constA` so position=0 (E-varies) and position=2 (V-varies) both produce tight prefixes.
- `indexName` and `extractElementIDFromKey` updated for ATEV.

## Defensive-code cleanup that came with the work

Two latent silent-error patterns surfaced and were fixed in the same PR:

1. **`extractElementIDFromKey` panics on unknown index** instead of `return datalog.ElementID{}`. The silent zero return was conflating "iterator not positioned" with "programmer added an index and forgot to update this switch" — that's how a missing ATEV case got past the first test run (the test caught it only because it asserted the *value* of the Tx, not just non-zero). Matches the encoder switches in `key_encoder_{binary,l85}.go`.
2. **Removed five `tx.(uint64)` dead branches** for a legacy Lamport-only Tx representation (`chooseIndex` ATEV+TAEV; `chooseIndexForValues` ATEV+TAEV; `simple_batch_scanner.buildKey` TAEV; plus the new `constT` extraction). `Tx` is always an `ElementID`; `DerefElementID` handles both value and pointer forms. `NewTxFromUint` and `toStorageTx` deleted with no remaining callers.

## Migration

None. ATEV is populated by every commit. The freshness seek finds nothing (zero ElementID — treated as "no data") on attributes that have no writes since the index was added; correctness is preserved throughout.

## Tests

`datalog/storage/atev_index_test.go` (13 cases):

- `TestATEVEncoderRoundTrip` — binary + L85 encode/decode
- `TestATEVDescendingTxOrder` — first entry under `[A]` is the global max-Tx datom
- `TestATEVIsPopulatedOnCommit` — write path populates ATEV
- `TestMaxElementIDForAttributeUsesATEV` — multi-entity high-water mark via the new path
- `TestMaxElementIDForAttribute_AfterRetraction` — documents that `Retract` *deletes* (no tombstone), so the high-water mark can drop; cache freshness still works via inequality comparison
- `TestMaxElementIDForAttribute_MultipleWritesToSameEA` — LWW overwrite case
- `TestCache_IsAttributeFresh_Integration` — full chain on a real `BadgerStore`
- `TestChooseIndex_ABoundPlusTxBound_PicksATEV` and `TestChooseIndex_ABoundPlusTxBoundPlusVBound_DoesNotPickATEV` — routing assertions
- `TestChooseIndexForValues_ATEV` — hash-join prefix builder (A+Tx; A+Tx+E)
- `TestSimpleBatchScanner_BuildKey_ATEV_VVaries` — batch scanner V-varies branch
- `TestEndToEndABoundTxBoundQuery` — full pipeline against a real `BadgerStore`
- `TestChooseIndex_TxOnly_TAEV_WithElementID` — pin TAEV routing after the uint64-branch removal (covers both `ElementID` and `*ElementID`)

Existing tests updated:
- `key_encoder_test.go` — ATEV added to round-trip index list
- `correctness_bugs_test.go` — `buildKey` calls updated for the new signature; ATEV row added to `TestSimpleBatchScanner_BuildKey_AllIndices`
- `badger_store_test.go` — `NewTxFromUint` call sites switched to `NewTxFromElementID`

Benchmarks: `datalog/storage/atev_index_bench_test.go` (`BenchmarkMaxElementIDForAttribute_ATEVSeek_vs_AEVTScan`, `BenchmarkAssert_WriteCost`).

## Verification

`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green locally (Apple M5, darwin/arm64). Pre-push hook ran the suite before push.
