### PR TITLE
Propagate iterator and eval errors through relation_ops + duplicate sites

### DIFF
--- a/datalog/executor/iterator_composition.go
+++ b/datalog/executor/iterator_composition.go
@@ -289,7 +289,8 @@ type FunctionEvaluatorIterator struct {
 	symbols      []query.Symbol // Original symbols
 	newSymbols   []query.Symbol // Symbols after adding function output (or same if unifying)
 	current      Tuple
-	existingIdx  int // >=0 if outputSymbol already in symbols (unification mode)
+	existingIdx  int   // >=0 if outputSymbol already in symbols (unification mode)
+	err          error // First eval error; replayed via Error() at iteration end
 }
 
 // NewFunctionEvaluatorIterator creates an iterator that adds a symbol via function evaluation.
@@ -326,6 +327,9 @@ func NewFunctionEvaluatorIterator(source Iterator, symbols []query.Symbol, funct
 
 // Next advances to the next tuple and evaluates the function
 func (it *FunctionEvaluatorIterator) Next() bool {
+	if it.err != nil {
+		return false
+	}
 	for it.source.Next() {
 		sourceTuple := it.source.Tuple()
 
@@ -337,11 +341,24 @@ func (it *FunctionEvaluatorIterator) Next() bool {
 			}
 		}
 
-		// Evaluate function
+		// Evaluate function. Fail-fast on eval errors — store the deferred
+		// error so Error() returns it after Next() reports exhaustion.
+		// Silently `continue`ing here laundered real Eval failures into a
+		// clean iteration end indistinguishable from "no more tuples."
 		result, err := it.function.Eval(bindings)
 		if err != nil {
-			// Skip tuples where function evaluation fails
-			continue
+			it.err = err
+			return false
+		}
+
+		// get-some signals "no attribute matched" via Found=false (not via
+		// error). Skip the tuple in that case — that's a soft no-match, not
+		// the error-as-signal misuse the swallowing loop existed to absorb.
+		if gsr, ok := result.(*query.GetSomeResult); ok {
+			if !gsr.Found {
+				continue
+			}
+			result = gsr.Value
 		}
 
 		if it.existingIdx >= 0 {
@@ -373,7 +390,12 @@ func (it *FunctionEvaluatorIterator) Close() error {
 	return it.source.Close()
 }
 
-func (it *FunctionEvaluatorIterator) Error() error { return it.source.Error() }
+func (it *FunctionEvaluatorIterator) Error() error {
+	if it.err != nil {
+		return it.err
+	}
+	return it.source.Error()
+}
 
 // DedupIterator removes duplicate tuples based on full tuple equality
 type DedupIterator struct {

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -605,13 +605,15 @@ func (e *DefaultQueryExecutor) executeExpression(ctx Context, expr *query.Expres
 				result, err = expr.Function.Eval(evalBindings)
 			}
 			if err != nil {
-				// Expression evaluation failed (e.g., entity doesn't have requested attrs)
-				// Return empty result, not an error
-				return []Relation{}, nil
+				return nil, err
 			}
 
-			// Handle get-some result type (extracts Value from GetSomeResult)
+			// Handle get-some result type. Found=false signals "no attribute
+			// matched"; emit an empty relation rather than a tuple.
 			if gsr, ok := result.(*query.GetSomeResult); ok {
+				if !gsr.Found {
+					return []Relation{}, nil
+				}
 				result = gsr.Value
 			}
 

--- a/datalog/executor/relation.go
+++ b/datalog/executor/relation.go
@@ -599,10 +599,14 @@ func (r *MaterializedRelation) ProjectFromPattern(pattern *query.DataPattern) Re
 		return NewMaterializedRelationWithOptions([]query.Symbol{}, []Tuple{}, r.options)
 	}
 
-	// Project to needed symbols using method (preserves materialized state)
-	result, _ := r.Project(neededSymbols)
-	// Ignore error as neededSymbols are derived from the pattern elements
-	// which must exist if we got this far
+	// Project to needed symbols. neededSymbols are derived from the pattern
+	// elements above and intersected with `symbolIndices`, so they must exist
+	// in the relation. If Project errors anyway, that's a contract violation —
+	// surface it loudly instead of silently returning a half-broken result.
+	result, err := r.Project(neededSymbols)
+	if err != nil {
+		panic(fmt.Sprintf("ProjectFromPattern: Project of derived symbols failed: %v", err))
+	}
 	return result
 }
 
@@ -771,8 +775,11 @@ func (r *MaterializedRelation) EvaluateFunction(fn query.Function, outputSymbol 
 	// Add the output symbol
 	newSymbols := append(r.symbols, outputSymbol)
 
-	// Process each tuple
+	// Process each tuple. Fail-fast on eval errors and propagate them via
+	// result.err — silently `continue`ing past a failed Eval would launder
+	// real errors into a clean (truncated) materialized relation.
 	var newTuples []Tuple
+	var evalErr error
 	for _, tuple := range r.tuples {
 		// Create bindings from tuple
 		bindings := make(map[query.Symbol]interface{})
@@ -783,8 +790,17 @@ func (r *MaterializedRelation) EvaluateFunction(fn query.Function, outputSymbol 
 		// Evaluate the function
 		result, err := fn.Eval(bindings)
 		if err != nil {
-			// Skip tuples where function evaluation fails
-			continue
+			evalErr = err
+			break
+		}
+
+		// get-some signals "no attribute matched" via Found=false (not via
+		// error). Skip the tuple in that case, not the eval-error path.
+		if gsr, ok := result.(*query.GetSomeResult); ok {
+			if !gsr.Found {
+				continue
+			}
+			result = gsr.Value
 		}
 
 		// Create new tuple with function result
@@ -792,7 +808,14 @@ func (r *MaterializedRelation) EvaluateFunction(fn query.Function, outputSymbol 
 		newTuples = append(newTuples, newTuple)
 	}
 
-	return NewMaterializedRelation(newSymbols, newTuples)
+	mat := NewMaterializedRelation(newSymbols, newTuples)
+	if evalErr != nil {
+		mat.err = evalErr
+	} else if r.err != nil {
+		// Inherit the source relation's deferred error.
+		mat.err = r.err
+	}
+	return mat
 }
 
 // contains checks if a symbol is in a slice
@@ -1154,11 +1177,15 @@ func (r *StreamingRelation) ProjectFromPattern(pattern *query.DataPattern) Relat
 		return NewMaterializedRelationWithOptions([]query.Symbol{}, []Tuple{}, r.options)
 	}
 
-	// Use the StreamingRelation's Project method which creates a streaming projection iterator
-	// instead of the global Project() function which materializes
-	result, _ := r.Project(neededSymbols)
-	// Ignore error as neededSymbols are derived from the pattern elements
-	// which must exist if we got this far
+	// Use the StreamingRelation's Project method which creates a streaming
+	// projection iterator instead of the global Project() function which
+	// materializes. neededSymbols are derived from pattern elements above and
+	// intersected with the relation's symbols, so they must exist. A Project
+	// error here is a contract violation — surface it loudly.
+	result, err := r.Project(neededSymbols)
+	if err != nil {
+		panic(fmt.Sprintf("ProjectFromPattern: Project of derived symbols failed: %v", err))
+	}
 	return result
 }
 

--- a/datalog/executor/relation_ops.go
+++ b/datalog/executor/relation_ops.go
@@ -57,7 +57,7 @@ func materializeRelationsForPattern(pattern *query.DataPattern, relations Relati
 
 // filterWithPredicateAndLookup filters a relation using a predicate with optional database lookup.
 // constantBindings are pre-resolved scalar values that are not present as relation symbols.
-func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup query.EntityLookup, constantBindings map[query.Symbol]interface{}) Relation {
+func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup query.EntityLookup, constantBindings map[query.Symbol]interface{}) (result Relation) {
 	symbols := rel.Symbols()
 	needsCopy := rel.RequiresCopy()
 
@@ -75,8 +75,25 @@ func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup que
 	// Check if this is a DatabaseFunctionPredicate that needs lookup
 	dbFuncPred, isDbFuncPred := pred.(*query.DatabaseFunctionPredicate)
 
+	// Failed iteration or evaluation surfaces via result.err — replayed at the
+	// next public boundary by Iterator().Error(). Named return + closure so the
+	// deferred Close() also runs on panic (predicate Eval is user-supplied code
+	// and can panic), without losing the Close error.
+	var iterErr error
 	iter := rel.Iterator()
-	defer iter.Close()
+	defer func() {
+		if closeErr := iter.Close(); closeErr != nil && iterErr == nil {
+			iterErr = closeErr
+		}
+		// Panic path: result is nil; iter.Close above still ran.
+		if iterErr == nil || result == nil {
+			return
+		}
+		if m, ok := result.(*MaterializedRelation); ok && m.err == nil {
+			m.err = iterErr
+		}
+	}()
+
 	for iter.Next() {
 		tuple := iter.Tuple()
 
@@ -101,8 +118,11 @@ func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup que
 			passes, err = pred.Eval(bindings)
 		}
 		if err != nil {
-			// Log error but continue processing
-			continue
+			// Fail fast — predicate eval errors are real errors, not
+			// "treat as false." Surface to the consumer; do not silently
+			// drop the tuple as if the predicate had said no.
+			iterErr = err
+			break
 		}
 
 		if passes {
@@ -112,17 +132,21 @@ func filterWithPredicateAndLookup(rel Relation, pred query.Predicate, lookup que
 			filtered = append(filtered, tuple)
 		}
 	}
+	if iterErr == nil {
+		iterErr = iter.Error()
+	}
 
 	// Extract options from source relation to preserve configuration
 	opts := rel.Options()
-	return NewMaterializedRelationWithOptions(symbols, filtered, opts)
+	result = NewMaterializedRelationWithOptions(symbols, filtered, opts)
+	return
 }
 
 // evaluateExpressionWithLookup evaluates an expression with optional database lookup support.
 // If lookup is non-nil and the expression is a DatabaseFunction, it uses EvalWithLookup.
 // Otherwise, it falls back to the standard Eval method.
 // constantBindings are pre-resolved scalar values that are not present as relation symbols.
-func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup query.EntityLookup, constantBindings map[query.Symbol]interface{}) Relation {
+func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup query.EntityLookup, constantBindings map[query.Symbol]interface{}) (result Relation) {
 	symbols := rel.Symbols()
 
 	// Determine binding symbols and whether they already exist
@@ -174,8 +198,24 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 		}
 	}
 
+	// Failed iteration or evaluation surfaces via result.err — replayed at the
+	// next public boundary by Iterator().Error(). Named return + closure so the
+	// deferred Close() also runs on panic (expression Function.Eval is
+	// user-supplied code and can panic), without losing the Close error.
+	var iterErr error
 	iter := rel.Iterator()
-	defer iter.Close()
+	defer func() {
+		if closeErr := iter.Close(); closeErr != nil && iterErr == nil {
+			iterErr = closeErr
+		}
+		if iterErr == nil || result == nil {
+			return
+		}
+		if m, ok := result.(*MaterializedRelation); ok && m.err == nil {
+			m.err = iterErr
+		}
+	}()
+
 	for iter.Next() {
 		tuple := iter.Tuple()
 
@@ -193,26 +233,33 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 
 		// Evaluate the expression
 		// Check if this is a database function that needs lookup access
-		var result interface{}
+		var evalResult interface{}
 		var err error
 		if dbFunc, ok := expr.Function.(query.DatabaseFunction); ok && lookup != nil {
-			result, err = dbFunc.EvalWithLookup(bindings, lookup)
+			evalResult, err = dbFunc.EvalWithLookup(bindings, lookup)
 		} else {
-			result, err = expr.Function.Eval(bindings)
+			evalResult, err = expr.Function.Eval(bindings)
 		}
 		if err != nil {
-			// Skip tuples where expression fails
-			continue
+			// Fail fast — expression eval errors are real errors. Surface
+			// to the consumer; do not silently drop the tuple.
+			iterErr = err
+			break
 		}
 
 		// Extract value from GetSomeResult if needed
-		// get-some returns a struct with Attr and Value; we just want the Value for binding
-		if gsr, ok := result.(*query.GetSomeResult); ok {
-			result = gsr.Value
+		// get-some returns a struct with Attr, Value, and Found; we just want
+		// the Value for binding. Found=false signals "no attribute matched":
+		// drop this tuple without surfacing an error.
+		if gsr, ok := evalResult.(*query.GetSomeResult); ok {
+			if !gsr.Found {
+				continue
+			}
+			evalResult = gsr.Value
 		}
 
 		// Handle multi-tuple expansion (e.g., enumerate returns [][]interface{})
-		if multiRows, ok := result.([][]interface{}); ok {
+		if multiRows, ok := evalResult.([][]interface{}); ok {
 			if tb, ok := expr.Binding.(query.TupleBinding); ok {
 				for _, subTuple := range multiRows {
 					if len(subTuple) != len(tb.Variables) {
@@ -253,9 +300,9 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 			// Update existing symbols
 			newTuple := make(Tuple, len(tuple))
 			copy(newTuple, tuple)
-			// Handle tuple binding - result should be []interface{}
+			// Handle tuple binding - evalResult should be []interface{}
 			if tb, ok := expr.Binding.(query.TupleBinding); ok {
-				values, ok := result.([]interface{})
+				values, ok := evalResult.([]interface{})
 				if ok && len(values) == len(tb.Variables) {
 					for i, bindSym := range tb.Variables {
 						if idx, exists := existingBindingIndices[bindSym]; exists {
@@ -267,7 +314,7 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 				// Scalar binding
 				for i, sym := range symbols {
 					if bindSym, ok := expr.Binding.(query.Symbol); ok && sym == bindSym {
-						newTuple[i] = result
+						newTuple[i] = evalResult
 						break
 					}
 				}
@@ -277,9 +324,9 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 			// Add new symbols
 			newTuple := make(Tuple, len(newColumns))
 			copy(newTuple, tuple)
-			// Handle tuple binding - result should be []interface{}
+			// Handle tuple binding - evalResult should be []interface{}
 			if tb, ok := expr.Binding.(query.TupleBinding); ok {
-				values, ok := result.([]interface{})
+				values, ok := evalResult.([]interface{})
 				if ok && len(values) == len(tb.Variables) {
 					for i, bindSym := range tb.Variables {
 						// Find position of this symbol in newColumns
@@ -293,19 +340,23 @@ func evaluateExpressionWithLookup(rel Relation, expr *query.Expression, lookup q
 				}
 			} else {
 				// Scalar binding - add to end
-				newTuple[len(tuple)] = result
+				newTuple[len(tuple)] = evalResult
 			}
 			newTuples = append(newTuples, newTuple)
 		}
 	}
+	if iterErr == nil {
+		iterErr = iter.Error()
+	}
 
 	// Extract options from source relation to preserve configuration
 	opts := rel.Options()
-	return NewMaterializedRelationWithOptions(newColumns, newTuples, opts)
+	result = NewMaterializedRelationWithOptions(newColumns, newTuples, opts)
+	return
 }
 
 // projectToSymbols projects a relation to the specified symbols
-func projectToSymbols(rel Relation, syms []query.Symbol, opts ExecutorOptions) Relation {
+func projectToSymbols(rel Relation, syms []query.Symbol, opts ExecutorOptions) (result Relation) {
 	relSyms := rel.Symbols()
 
 	// Build symbol index mapping
@@ -325,8 +376,24 @@ func projectToSymbols(rel Relation, syms []query.Symbol, opts ExecutorOptions) R
 		}
 	}
 
+	// Failed iteration surfaces via result.err — replayed at the next public
+	// boundary by Iterator().Error(). Named return + closure so iter.Close runs
+	// on panic without losing the Close error.
+	var iterErr error
 	var projected []Tuple
 	iter := rel.Iterator()
+	defer func() {
+		if closeErr := iter.Close(); closeErr != nil && iterErr == nil {
+			iterErr = closeErr
+		}
+		if iterErr == nil || result == nil {
+			return
+		}
+		if m, ok := result.(*MaterializedRelation); ok && m.err == nil {
+			m.err = iterErr
+		}
+	}()
+
 	for iter.Next() {
 		tuple := iter.Tuple()
 		newTuple := make(Tuple, len(syms))
@@ -335,9 +402,10 @@ func projectToSymbols(rel Relation, syms []query.Symbol, opts ExecutorOptions) R
 		}
 		projected = append(projected, newTuple)
 	}
-	iter.Close()
+	iterErr = iter.Error()
 
-	return NewMaterializedRelationWithOptions(syms, projected, opts)
+	result = NewMaterializedRelationWithOptions(syms, projected, opts)
+	return
 }
 
 // collectInnerVars collects all variables from inner clauses

--- a/datalog/executor/relation_ops_error_propagation_test.go
+++ b/datalog/executor/relation_ops_error_propagation_test.go
@@ -1,0 +1,146 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+var errInjectedEval = errors.New("injected eval failure")
+
+// erroringFunction is a query.Function that always fails. Used by the
+// expression-evaluation eval-error regression tests.
+type erroringFunction struct{}
+
+func (erroringFunction) String() string                                            { return "errorFn" }
+func (erroringFunction) RequiredSymbols() []query.Symbol                           { return nil }
+func (erroringFunction) Eval(map[query.Symbol]interface{}) (interface{}, error)    { return nil, errInjectedEval }
+func (erroringFunction) ReturnType() string                                        { return "any" }
+
+// Reproductions for docs/bugs/BUG_RELATION_TRANSFORMS_DROP_ITERATOR_ERRORS.md
+//
+// filterWithPredicateAndLookup, evaluateExpressionWithLookup, and
+// projectToSymbols in relation_ops.go consume their source iterator via a
+// hand-rolled `for iter.Next()` loop and return a fresh MaterializedRelation
+// without checking iter.Error() or capturing the Close() error. Same class as
+// the collectTuplesInto sites fixed in BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES
+// and the SemiJoin/AntiJoin sites fixed in BUG_ITERATOR_ERRORS_DROPPED_IN_MATERIALIZATION_PATHS.
+// These three slipped past both sweeps because they are manual loops, not
+// collectTuplesInto calls (the static guard) and not join helpers.
+//
+// The failing-iterator helpers (failingIterator, newFailingStream, driveErr,
+// errInjectedIterator) live in iterator_error_boundary_test.go.
+
+// alwaysTrue is a Predicate that always passes. `[(!= 1 2)]` evaluates true
+// for every binding; using a real query.Predicate (rather than a test stub)
+// avoids re-implementing the Clause interface's package-private clause()
+// marker outside the query package.
+func alwaysTrue() query.Predicate {
+	return &query.Comparison{
+		Op:    query.OpNE,
+		Left:  query.ConstantTerm{Value: int64(1)},
+		Right: query.ConstantTerm{Value: int64(2)},
+	}
+}
+
+// TestFilterWithPredicateAndLookup_PropagatesIteratorError: a deferred
+// iterator failure must not be laundered into a clean filtered relation.
+func TestFilterWithPredicateAndLookup_PropagatesIteratorError(t *testing.T) {
+	src := newFailingStream(0, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	rel := filterWithPredicateAndLookup(src, alwaysTrue(), nil, nil)
+	require.ErrorIs(t, driveErr(rel), errInjectedIterator)
+}
+
+// TestFilterWithPredicateAndLookup_PropagatesAfterPartialResults: same, but
+// after the iterator has yielded some tuples and then failed. The pre-fix
+// function returns a clean MaterializedRelation containing only the tuples
+// that survived the predicate before the failure — a truncated success.
+func TestFilterWithPredicateAndLookup_PropagatesAfterPartialResults(t *testing.T) {
+	src := newFailingStream(1, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	rel := filterWithPredicateAndLookup(src, alwaysTrue(), nil, nil)
+	require.ErrorIs(t, driveErr(rel), errInjectedIterator)
+}
+
+// TestEvaluateExpressionWithLookup_PropagatesIteratorError: same shape for
+// the expression-evaluation transform. expr.Function never runs because the
+// loop body never runs; only the pre-loop Binding inspection executes.
+func TestEvaluateExpressionWithLookup_PropagatesIteratorError(t *testing.T) {
+	src := newFailingStream(0, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	expr := &query.Expression{Binding: datalog.NewSymbol("?y")}
+	rel := evaluateExpressionWithLookup(src, expr, nil, nil)
+	require.ErrorIs(t, driveErr(rel), errInjectedIterator)
+}
+
+// TestProjectToSymbols_PropagatesIteratorError: projection must not launder a
+// failed source into a clean projected result.
+func TestProjectToSymbols_PropagatesIteratorError(t *testing.T) {
+	src := newFailingStream(0, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	rel := projectToSymbols(src, testSymbols(), ExecutorOptions{})
+	require.ErrorIs(t, driveErr(rel), errInjectedIterator)
+}
+
+// TestProjectToSymbols_PropagatesAfterPartialResults: same, but after partial
+// projection succeeds and the iterator fails partway through.
+func TestProjectToSymbols_PropagatesAfterPartialResults(t *testing.T) {
+	src := newFailingStream(1, Tuple{int64(1)}, Tuple{int64(2)}, Tuple{int64(3)})
+	rel := projectToSymbols(src, testSymbols(), ExecutorOptions{})
+	require.ErrorIs(t, driveErr(rel), errInjectedIterator)
+}
+
+// TestFilterWithPredicateAndLookup_PropagatesEvalError: a predicate that fails
+// to evaluate (here: references a variable that isn't in the source's bindings,
+// so Comparison.Eval returns "cannot resolve...") must surface the error, not
+// silently `continue` past the tuple. Fail-fast: first eval error stops the
+// loop, surviving tuples are not reported as a clean filtered result.
+func TestFilterWithPredicateAndLookup_PropagatesEvalError(t *testing.T) {
+	src := NewMaterializedRelation(testSymbols(), []Tuple{{int64(1)}, {int64(2)}})
+	// ?missing isn't a column in `src`, so every tuple's bindings lack it
+	// and Comparison.Eval returns ("cannot resolve left term ?missing").
+	pred := &query.Comparison{
+		Op:    query.OpEQ,
+		Left:  query.VariableTerm{Symbol: datalog.NewSymbol("?missing")},
+		Right: query.ConstantTerm{Value: int64(1)},
+	}
+	rel := filterWithPredicateAndLookup(src, pred, nil, nil)
+	err := driveErr(rel)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot resolve")
+}
+
+// TestEvaluateExpressionWithLookup_PropagatesEvalError: an expression whose
+// Function returns an error must surface it. The previous behavior was a bare
+// `continue` past the failing tuple — the result looked like the function had
+// "no answer" rather than failing.
+func TestEvaluateExpressionWithLookup_PropagatesEvalError(t *testing.T) {
+	src := NewMaterializedRelation(testSymbols(), []Tuple{{int64(1)}, {int64(2)}})
+	expr := &query.Expression{
+		Function: erroringFunction{},
+		Binding:  datalog.NewSymbol("?y"),
+	}
+	rel := evaluateExpressionWithLookup(src, expr, nil, nil)
+	require.ErrorIs(t, driveErr(rel), errInjectedEval)
+}
+
+// TestMaterializedRelation_EvaluateFunction_PropagatesEvalError: same shape as
+// the relation_ops fix, but for the MaterializedRelation method that
+// duplicated the swallowing pattern (relation.go EvaluateFunction).
+func TestMaterializedRelation_EvaluateFunction_PropagatesEvalError(t *testing.T) {
+	src := NewMaterializedRelation(testSymbols(), []Tuple{{int64(1)}, {int64(2)}})
+	rel := src.EvaluateFunction(erroringFunction{}, datalog.NewSymbol("?y"))
+	require.ErrorIs(t, driveErr(rel), errInjectedEval)
+}
+
+// TestFunctionEvaluatorIterator_PropagatesEvalError: streaming counterpart of
+// the above (iterator_composition.go FunctionEvaluatorIterator). Eval failures
+// now stop iteration and surface via Error(), instead of silently skipping.
+func TestFunctionEvaluatorIterator_PropagatesEvalError(t *testing.T) {
+	src := NewMaterializedRelation(testSymbols(), []Tuple{{int64(1)}, {int64(2)}}).Iterator()
+	it := NewFunctionEvaluatorIterator(src, testSymbols(), erroringFunction{}, datalog.NewSymbol("?y"))
+	for it.Next() {
+	}
+	require.ErrorIs(t, it.Error(), errInjectedEval)
+	_ = it.Close()
+}

--- a/datalog/executor/union_relation.go
+++ b/datalog/executor/union_relation.go
@@ -131,9 +131,12 @@ func (ur *UnionRelation) Project(symbols []query.Symbol) (Relation, error) {
 	return ur.Materialize().Project(symbols)
 }
 
-// Materialize forces consumption of all relations and returns a materialized result
-// Note: This doesn't return errors because Relation.Materialize() doesn't have error return
-// Errors from Close() are silently dropped (limitation of Relation interface)
+// Materialize forces consumption of all relations and returns a materialized result.
+// collectTuplesInto captures both deferred iteration errors and the Close() error
+// of the union iterator, and the first non-nil one is attached to the returned
+// relation as mat.err so it replays via Iterator().Error() at the next public
+// boundary. The Relation interface's lack of an (error) return doesn't drop
+// errors — they ride the result.
 func (ur *UnionRelation) Materialize() Relation {
 	var allTuples []Tuple
 	err := collectTuplesInto(&allTuples, ur)

--- a/datalog/query/database_function.go
+++ b/datalog/query/database_function.go
@@ -150,10 +150,15 @@ type GetSomeFunction struct {
 	Attrs  []datalog.Keyword // Attributes to try, in order
 }
 
-// GetSomeResult holds the result of a get-some evaluation
+// GetSomeResult holds the result of a get-some evaluation.
+// Found=false signals "no attribute matched" and is the canonical way for
+// consumers to drop the tuple — get-some no longer uses error-as-signal
+// for this (which conflated soft "no match" with real eval failures and
+// forced upstream loops to swallow every eval error to make it work).
 type GetSomeResult struct {
 	Attr  datalog.Keyword
 	Value interface{}
+	Found bool
 }
 
 func (gs *GetSomeFunction) RequiredSymbols() []Symbol {
@@ -183,12 +188,13 @@ func (gs *GetSomeFunction) EvalWithLookup(bindings map[Symbol]interface{}, looku
 	// Try each attribute in order
 	for _, attr := range gs.Attrs {
 		if value, found := lookup.LookupAttribute(entity, attr); found {
-			return &GetSomeResult{Attr: attr, Value: value}, nil
+			return &GetSomeResult{Attr: attr, Value: value, Found: true}, nil
 		}
 	}
 
-	// No attribute found - return nil (will cause tuple to be filtered out)
-	return nil, fmt.Errorf("get-some: no attribute found for entity")
+	// No attribute found — return Found=false so the caller can drop the
+	// tuple without abusing error as a soft signal.
+	return &GetSomeResult{Found: false}, nil
 }
 
 func (gs *GetSomeFunction) ReturnType() string {

--- a/docs/bugs/resolved/BUG_RELATION_TRANSFORMS_DROP_ITERATOR_ERRORS.md
+++ b/docs/bugs/resolved/BUG_RELATION_TRANSFORMS_DROP_ITERATOR_ERRORS.md
@@ -1,0 +1,240 @@
+# BUG: Relation Transforms Drop Deferred Iterator Errors
+
+**Date**: 2026-05-25
+**Severity**: Correctness (High)
+**Status**: Resolved (2026-05-25) — see Resolution at the end
+**Affected**: expression evaluation, predicate filtering, projection/materialization-style loops in `executor/relation_ops.go`
+
+## Summary
+
+The executor has a documented iterator contract: after `Next()` returns false,
+callers must check `Iterator.Error()` before treating iteration as successful.
+Several relation transforms still consume an iterator, build a clean
+`MaterializedRelation`, and return it without checking `Error()` or `Close()`.
+
+This can turn a storage decode failure or other deferred iterator failure into a
+successful empty or truncated relation.
+
+## Code Evidence
+
+The contract is explicit:
+
+```go
+type Iterator interface {
+    Next() bool
+    Tuple() Tuple
+    Close() error
+
+    // Error returns any error encountered during iteration.
+    // Callers must check Error() after Next() returns false to
+    // distinguish normal exhaustion from execution failure.
+    Error() error
+}
+```
+
+But `evaluateExpressionWithLookup` does not check it:
+
+```go
+iter := rel.Iterator()
+defer iter.Close()
+for iter.Next() {
+    tuple := iter.Tuple()
+    // evaluate expression and append tuples
+}
+
+opts := rel.Options()
+return NewMaterializedRelationWithOptions(newColumns, newTuples, opts)
+```
+
+`filterWithPredicateAndLookup` and `projectToSymbols` follow the same pattern:
+consume the source iterator, ignore `iter.Error()`, ignore `Close()` errors, and
+return a clean materialized relation.
+
+## Why This Matters
+
+Storage iterator failures are often deferred. For example, a Tier-3 blob value
+stores a content hash in the key and the compressed bytes in the blob store. If
+the blob is missing, the scan may only surface the failure through
+`Iterator.Error()` after `Next()` returns false.
+
+The codebase already has regression tests proving this class at public
+boundaries. The remaining risk is inside transforms:
+
+1. A scan yields a prefix of tuples.
+2. A transform consumes the scan and never checks `Error()`.
+3. The transform returns a clean `MaterializedRelation`.
+4. The public boundary correctly checks the transformed relation and sees no
+   error, because the error was laundered earlier.
+
+This is especially dangerous for predicates and expressions because a decode
+failure can look identical to "no tuple passed the filter."
+
+## Expected Behavior
+
+Every internal loop that drains a relation must preserve the iterator outcome:
+
+- If source iteration fails, the derived relation must replay that error via
+  its own `Iterator().Error()`.
+- If `Close()` fails and no earlier iteration/function error occurred, that
+  error should also be surfaced.
+- Partial tuples from a failed stream must not be reported as clean success.
+
+## Actual Behavior
+
+Some transforms return `NewMaterializedRelationWithOptions(...)` directly after
+iteration, without carrying any deferred source error onto the result relation.
+
+## Suspect Sites
+
+- `filterWithPredicateAndLookup` in `datalog/executor/relation_ops.go`
+- `evaluateExpressionWithLookup` in `datalog/executor/relation_ops.go`
+- `projectToSymbols` in `datalog/executor/relation_ops.go`
+- Any other `for iter.Next() { ... }` loop that constructs a derived relation
+  without checking `iter.Error()` and `iter.Close()`
+
+## Fix Direction
+
+Use the existing error-preserving iteration utilities consistently:
+
+- Prefer `ForEach` for tuple-by-tuple transforms.
+- Prefer `collectTuplesInto` when materializing whole relations.
+- When returning a materialized relation after a transform, attach the first
+  source iterator error to the result so public boundaries can observe it.
+
+## Verification Plan
+
+Add regression tests that inject a failing source relation through each transform:
+
+- expression transform over a failing relation
+- predicate transform over a failing relation
+- projection over a failing relation
+- storage-backed integration using a corrupted Tier-3 blob plus an expression or
+  predicate in the query
+
+Each test should fail if the transformed relation reports clean success.
+
+---
+
+## Resolution (2026-05-25)
+
+**Resolved** with a wider scope than the original report described, because
+the review surfaced four related defects in the same loops that the "iterator
+error" framing had let slide. All from the same root pattern: silent
+`continue` past errors, with comments either lying ("Log error but continue
+processing" — nothing logs) or asserting a contract that the code didn't
+enforce.
+
+### What was fixed
+
+1. **Iterator errors propagate** in the three `relation_ops.go` transforms
+   (`filterWithPredicateAndLookup`, `evaluateExpressionWithLookup`,
+   `projectToSymbols`). Each captures `iter.Error()` and the `iter.Close()`
+   error, attaches the first non-nil to `result.err` (replayed via
+   `Iterator().Error()` at the next public boundary).
+
+2. **Predicate / expression evaluation errors propagate, not swallowed.**
+   The bare `continue` on `pred.Eval` / `expr.Function.Eval` errors silently
+   treated any failure as "predicate said no" / "expression produced no
+   result." Now the first eval error stops the loop and surfaces via
+   `result.err`. Fail-fast, matching the rest of the codebase.
+
+3. **`iter.Close()` runs on panic.** The three transforms use named-return
+   + `defer` + closure so `Close()` is called whether the loop completes,
+   breaks on an eval error, or unwinds via panic from user-supplied `Eval`
+   code. The Close error is still captured and folded into `result.err`.
+
+4. **Two duplicate sites of the same eval-error bug** outside `relation_ops.go`:
+   - `MaterializedRelation.EvaluateFunction` (`relation.go:~770`) — the
+     materialized counterpart of expression evaluation. Same `result, err :=
+     fn.Eval(bindings); if err != nil { continue }` pattern; same fix.
+   - `FunctionEvaluatorIterator.Next` (`iterator_composition.go:~327`) — the
+     streaming counterpart. Added an `err` field on the iterator; eval errors
+     stop iteration and surface via `Error()` rather than being skipped past.
+
+5. **Two `Project()` error-discards** that asserted a contract via comment
+   instead of enforcing it (`relation.go:603`, `:1182`):
+   ```go
+   result, _ := r.Project(neededSymbols)
+   // Ignore error as neededSymbols are derived from the pattern elements
+   // which must exist if we got this far
+   ```
+   Both now `panic` on Project error, matching the
+   `extractElementIDFromKey` / encoder-switch convention that the project
+   adopted alongside the ATEV index work: silent zero/empty returns hid
+   programmer-error contract violations; panic surfaces them loudly.
+
+6. **`UnionRelation.Materialize` comment** corrected — the comment claimed
+   "Errors from Close() are silently dropped (limitation of Relation
+   interface)" but the code already propagates close errors via
+   `mat.err = err` (the result-ride pattern). Comment now describes the
+   actual behavior.
+
+### `get-some` API change
+
+Fail-fast on eval errors exposed that `query.GetSomeFunction.EvalWithLookup`
+was using `error` as a soft signal for "no attribute matched" — the comment at
+the no-match return path literally said *"return nil (will cause tuple to be
+filtered out)"*, relying on the upstream `continue` that this PR removes.
+This was the actual reason the swallowing loops existed.
+
+Aligned `get-some` with the rest of the database-function family
+(`get-else`, `missing?`), neither of which uses error-as-signal:
+
+- Added `Found bool` to `query.GetSomeResult`.
+- Match returns `&GetSomeResult{Attr, Value, Found: true}, nil`.
+- No-match returns `&GetSomeResult{Found: false}, nil` (no error).
+- All `GetSomeResult` consumers (`evaluateExpressionWithLookup`,
+  `query_executor.go`, `MaterializedRelation.EvaluateFunction`,
+  `FunctionEvaluatorIterator`) check `Found` and drop the tuple without
+  surfacing an error.
+
+### Why the original transforms slipped past prior sweeps
+
+The earlier iterator-error fixes covered `collectTuplesInto` call sites
+(caught by a static guard) and the SemiJoin/AntiJoin helpers. The transforms
+in relation_ops, the matching EvaluateFunction sites, and the Project-error
+discards are all hand-rolled `for/if` patterns that bypass `collectTuplesInto`
+and aren't join helpers. Only direct regression tests surface them.
+
+### Tests added
+
+`datalog/executor/relation_ops_error_propagation_test.go` (9 cases total):
+
+- `TestFilterWithPredicateAndLookup_PropagatesIteratorError` — failAfter=0
+- `TestFilterWithPredicateAndLookup_PropagatesAfterPartialResults` — failAfter=1
+- `TestFilterWithPredicateAndLookup_PropagatesEvalError` — predicate references
+  `?missing`, `Comparison.Eval` returns "cannot resolve" for every tuple
+- `TestEvaluateExpressionWithLookup_PropagatesIteratorError`
+- `TestEvaluateExpressionWithLookup_PropagatesEvalError`
+- `TestProjectToSymbols_PropagatesIteratorError`
+- `TestProjectToSymbols_PropagatesAfterPartialResults`
+- `TestMaterializedRelation_EvaluateFunction_PropagatesEvalError`
+- `TestFunctionEvaluatorIterator_PropagatesEvalError`
+
+Pre-existing tests covering `get-some` no-match semantics
+(`TestGetSomeNoMatch`, `TestGetSome_WithScalarInput_NoMatch`) continue to
+pass against the new `Found`-based signal.
+
+The shared failing-iterator helpers (`failingIterator`, `newFailingStream`,
+`driveErr`, `errInjectedIterator`) live in `iterator_error_boundary_test.go`.
+
+### Files
+
+- `datalog/executor/relation_ops.go` — three transforms rewritten with named
+  return + closure, fail-fast on eval errors, deferred Close that captures
+  the close error
+- `datalog/executor/relation.go` — `MaterializedRelation.EvaluateFunction`
+  fail-fast + result.err; two `ProjectFromPattern` Project-error discards
+  replaced with panic
+- `datalog/executor/iterator_composition.go` — `FunctionEvaluatorIterator`
+  gains an `err` field; `Next` fails fast, `Error` surfaces it
+- `datalog/executor/union_relation.go` — comment corrected
+- `datalog/executor/query_executor.go` — `GetSomeResult.Found` consumer
+  updated
+- `datalog/query/database_function.go` — `GetSomeResult.Found` added,
+  `GetSomeFunction.EvalWithLookup` no-match returns a value (not an error)
+- `datalog/executor/relation_ops_error_propagation_test.go` (new) — 9 tests
+
+### Verification
+
+`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green.


### PR DESCRIPTION
## Summary

The three transforms in `datalog/executor/relation_ops.go` each consume their source iterator via a hand-rolled `for iter.Next()` loop and return a fresh `MaterializedRelation` without checking `iter.Error()` or `iter.Close()`. Review surfaced that the same loops also silently swallowed `pred.Eval` / `expr.Function.Eval` errors via bare `continue` (the comment claimed *"Log error but continue processing"* — nothing logs), and that two duplicate copies of that eval-swallow pattern live in `MaterializedRelation.EvaluateFunction` and `FunctionEvaluatorIterator.Next`. All fixed together as the same systemic issue.

Resolves [`docs/bugs/resolved/BUG_RELATION_TRANSFORMS_DROP_ITERATOR_ERRORS.md`](https://github.com/wbrown/janus-datalog/blob/fix/relation-transforms-iterator-errors/docs/bugs/resolved/BUG_RELATION_TRANSFORMS_DROP_ITERATOR_ERRORS.md).

## What's fixed

### 1. Iterator errors propagate (`relation_ops.go` × 3)

`filterWithPredicateAndLookup`, `evaluateExpressionWithLookup`, `projectToSymbols` now capture `iter.Error()` and `iter.Close()` after the loop and attach the first non-nil to `result.err`, replayed via `Iterator().Error()` at the next public boundary. Matches the `MaterializedRelation.err` pattern established by the prior iterator-error PRs.

### 2. Eval errors fail-fast, not swallowed (`relation_ops.go` × 3)

```go
// Before:
if err != nil {
    // Log error but continue processing  ← lie. nothing logs.
    continue
}

// After:
if err != nil {
    iterErr = err
    break  // surface via result.err
}
```

### 3. Panic safety (`relation_ops.go` × 3)

User-supplied `Eval` code can panic. The three transforms now use named-return + `defer` + closure so `iter.Close()` runs whether the loop completes, breaks on an eval error, or unwinds via panic. The Close error is still captured and folded into `result.err`.

### 4. Two duplicate eval-swallow sites outside `relation_ops`

- **`MaterializedRelation.EvaluateFunction`** (`relation.go:~770`) — same `result, err := fn.Eval(bindings); if err != nil { continue }` pattern. Same fix: fail-fast + `result.err`.
- **`FunctionEvaluatorIterator.Next`** (`iterator_composition.go:~327`) — streaming counterpart. Iterator now has an `err` field; `Next` fails fast, `Error()` surfaces it.

### 5. Two `Project()`-error discards now panic on contract violation

`MaterializedRelation.ProjectFromPattern` and `StreamingRelation.ProjectFromPattern` had:

```go
result, _ := r.Project(neededSymbols)
// Ignore error as neededSymbols are derived from the pattern elements
// which must exist if we got this far
```

The comment asserted a contract; the code didn't enforce it. Replaced with `panic(err)` on Project failure — matches the `extractElementIDFromKey` unknown-index convention that this project adopted during the ATEV index work (silent zero/empty returns hide programmer-error contract violations; panic surfaces them).

### 6. `UnionRelation.Materialize` comment corrected

The comment claimed *"Errors from Close() are silently dropped (limitation of Relation interface)"* but `collectTuplesInto` already captures the close error and the code does `mat.err = err`. Comment now describes what actually happens.

### 7. `get-some` API alignment with rest of database-function family

Fail-fast on eval errors exposed that `GetSomeFunction.EvalWithLookup` was using `error` as a soft signal for "no attribute matched" (the comment literally said *"return nil (will cause tuple to be filtered out)"*). That was the actual reason the swallowing loops existed. `get-else` and `missing?` don't use error-as-signal; `get-some` shouldn't either.

- Added `Found bool` to `query.GetSomeResult`.
- Match returns `&GetSomeResult{Attr, Value, Found: true}, nil`.
- No-match returns `&GetSomeResult{Found: false}, nil` (no error).
- All `GetSomeResult` consumers (in `relation_ops.go`, `relation.go`, `iterator_composition.go`, `query_executor.go`) check `Found` and skip the tuple without surfacing an error.

## Tests

`datalog/executor/relation_ops_error_propagation_test.go` (9 cases):

- iterator-error propagation × 5 (each transform, with `failAfter=0` and where relevant `failAfter=1` for partial-results)
- eval-error propagation × 4: `filterWithPredicateAndLookup` (Comparison referencing `?missing`), `evaluateExpressionWithLookup`, `MaterializedRelation.EvaluateFunction`, `FunctionEvaluatorIterator` (the latter three using an `erroringFunction` Function stub)

Pre-existing tests covering `get-some` no-match semantics (`TestGetSomeNoMatch`, `TestGetSome_WithScalarInput_NoMatch`) continue to pass against the new `Found`-based signal.

## Verification

`go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all green locally. Pre-push hook ran the suite.
