### PR TITLE
Widen LZJ compression header counts to uint32 (fix large-value data loss)

### DIFF
--- a/datalog/codec/compress.go
+++ b/datalog/codec/compress.go
@@ -10,7 +10,21 @@ import (
 // If the algorithm changes, increment this. The decompressor rejects
 // unknown versions. The format is frozen per version — same input must
 // always produce same output for a given version.
-const CompressionVersion byte = 0x01
+//
+// v1 (0x01): sequence/match counts are uint16 — overflowed and silently
+//   truncated above 65535 sequences, producing unreadable blobs for large,
+//   compressible, densely-structured values. Read-only now; never written.
+// v2 (0x02): sequence/match counts widened to uint32. Decompress reads both
+//   versions; Compress always writes v2.
+const CompressionVersion byte = 0x02
+
+// maxSequenceCount is the largest sequence/match count the v2 header can encode
+// (uint32). Compress declines (returns nil → value stored raw) above this rather
+// than truncating the count and writing a blob that later fails to decompress.
+// Unreachable for any real value — each sequence needs ≥3 bytes, so exceeding
+// this implies a >12 GB input — it is a belt-and-suspenders invariant against a
+// future header-width regression, not a limit reached in practice.
+const maxSequenceCount = 0xFFFFFFFF
 
 // Compress compresses input using LZ77 + FSE.
 // Returns compressed bytes with header, or nil if compression provides
@@ -32,6 +46,15 @@ func Compress(input []byte) []byte {
 		if seq.Offset > 0 {
 			numMatches++
 		}
+	}
+
+	// Correctness guard: the v2 header encodes both counts as uint32. If a value
+	// ever produced more sequences/matches than that, the count would truncate on
+	// write and the blob would be unrecoverable on read. Decline instead so the
+	// caller stores the value raw (Compress == nil ⇒ uncompressed). Unreachable in
+	// practice; see maxSequenceCount.
+	if len(sb.Sequences) > maxSequenceCount || numMatches > maxSequenceCount {
+		return nil
 	}
 
 	// Build extra bits bitstream
@@ -61,12 +84,12 @@ func Compress(input []byte) []byte {
 	extraBlock := rawBlock(extraBits)
 
 	// Assemble output
-	// Header: [version:1][originalLen:4 BE][numSequences:2][numMatches:2][numLiterals:4]
+	// Header (v2): [version:1][originalLen:4 BE][numSequences:4][numMatches:4][numLiterals:4]
 	result := make([]byte, 0, len(input))
 	result = append(result, CompressionVersion)
 	result = binary.BigEndian.AppendUint32(result, uint32(len(input)))
-	result = binary.BigEndian.AppendUint16(result, uint16(len(sb.Sequences)))
-	result = binary.BigEndian.AppendUint16(result, uint16(numMatches))
+	result = binary.BigEndian.AppendUint32(result, uint32(len(sb.Sequences)))
+	result = binary.BigEndian.AppendUint32(result, uint32(numMatches))
 	result = binary.BigEndian.AppendUint32(result, uint32(len(sb.Literals)))
 
 	// Blocks
@@ -84,23 +107,41 @@ func Compress(input []byte) []byte {
 	return result
 }
 
-// Decompress decompresses data produced by Compress.
+// Decompress decompresses data produced by Compress. It reads both header
+// formats: v1 (uint16 sequence/match counts, 13-byte header) and v2 (uint32
+// counts, 17-byte header). The version-dispatch below runs once per value,
+// outside the per-byte decode loop, so the dual-read path costs nothing in the
+// hot path. Compress only ever writes v2.
 func Decompress(compressed []byte) ([]byte, error) {
-	if len(compressed) < 13 { // minimum header
+	if len(compressed) < 1 {
 		return nil, errors.New("compress: data too short")
 	}
 
-	// Parse header
+	// Parse header — field widths and offsets depend on the version byte.
 	version := compressed[0]
-	if version != CompressionVersion {
-		return nil, fmt.Errorf("compress: unsupported version %d (expected %d)", version, CompressionVersion)
+	var originalLen, numSequences, numMatches, numLiterals, pos int
+	switch version {
+	case 1:
+		if len(compressed) < 13 { // minimum v1 header
+			return nil, errors.New("compress: data too short")
+		}
+		originalLen = int(binary.BigEndian.Uint32(compressed[1:5]))
+		numSequences = int(binary.BigEndian.Uint16(compressed[5:7]))
+		numMatches = int(binary.BigEndian.Uint16(compressed[7:9]))
+		numLiterals = int(binary.BigEndian.Uint32(compressed[9:13]))
+		pos = 13
+	case 2:
+		if len(compressed) < 17 { // minimum v2 header
+			return nil, errors.New("compress: data too short")
+		}
+		originalLen = int(binary.BigEndian.Uint32(compressed[1:5]))
+		numSequences = int(binary.BigEndian.Uint32(compressed[5:9]))
+		numMatches = int(binary.BigEndian.Uint32(compressed[9:13]))
+		numLiterals = int(binary.BigEndian.Uint32(compressed[13:17]))
+		pos = 17
+	default:
+		return nil, fmt.Errorf("compress: unsupported version %d (expected 1 or 2)", version)
 	}
-	originalLen := int(binary.BigEndian.Uint32(compressed[1:5]))
-	numSequences := int(binary.BigEndian.Uint16(compressed[5:7]))
-	numMatches := int(binary.BigEndian.Uint16(compressed[7:9]))
-	numLiterals := int(binary.BigEndian.Uint32(compressed[9:13]))
-
-	pos := 13
 
 	// Read and decompress blocks
 	literals, n, err := readDecompressBlock(compressed, pos, numLiterals)

--- a/datalog/codec/compress_test.go
+++ b/datalog/codec/compress_test.go
@@ -169,7 +169,7 @@ func TestCompress_Header_Truncated(t *testing.T) {
 
 func TestCompress_Header_WrongVersion(t *testing.T) {
 	data := make([]byte, 20)
-	data[0] = 0x02 // wrong version
+	data[0] = 0x03 // unsupported version (1 and 2 are valid)
 	binary.BigEndian.PutUint32(data[1:], 100)
 	_, err := Decompress(data)
 	assert.Error(t, err)
@@ -384,43 +384,51 @@ func TestCompress_Ratio_SourceCode(t *testing.T) {
 type goldenTest struct {
 	name        string
 	input       []byte
-	expectedHex string // hex-encoded expected compressed output (empty = not yet recorded)
+	expectedHex string // hex-encoded expected v2 compressed output (empty = not yet recorded)
+	v1Hex       string // captured v1 (uint16-header) blob; dual-read back-compat fixture
 	minRatio    float64
 }
 
 // Golden tests: frozen compressed outputs. If ANY of these change, the codec
 // determinism guarantee is broken and the change MUST be rejected.
-// Recorded 2026-03-28 from CompressionVersion 0x01.
+// expectedHex re-recorded 2026-05-30 from CompressionVersion 0x02 (uint32 counts).
+// v1Hex retains the original 2026-03-28 0x01 (uint16 counts) blobs as real
+// captured fixtures proving Decompress still reads legacy v1 data.
 var goldenTests = []goldenTest{
 	{
 		name:        "paragraph_500",
 		input:       []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", 11))[:500],
 		minRatio:    2.0,
-		expectedHex: "01000001f4000300030000002e0000002e010000002e54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f672e2000000000030100000003140001000000030100000003171701000000030100000003050500000000040100000004fd6ead06",
+		expectedHex: "02000001f400000003000000030000002e0000002e010000002e54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f672e2000000000030100000003140001000000030100000003171701000000030100000003050500000000040100000004fd6ead06",
+		v1Hex:       "01000001f4000300030000002e0000002e010000002e54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f672e2000000000030100000003140001000000030100000003171701000000030100000003050500000000040100000004fd6ead06",
 	},
 	{
 		name:        "prose_1kb",
 		input:       []byte(strings.Repeat("To be or not to be, that is the question. Whether tis nobler in the mind to suffer the slings and arrows. ", 10))[:1024],
 		minRatio:    2.0,
-		expectedHex: "01000004000008000800000059000000590100000059546f206265206f72206e6f7420742c207468617420697320746865207175657374696f6e2e205768657468657220746973206e6f626c657220696e6d696e6473756666686520736c696e677320616e64206172726f77732e200000000801000000080e14040412000000000000080100000008010201011717171600000008010000000803050505060606060000000a010000000a6dc2836ff5adbed55e05",
+		expectedHex: "0200000400000000080000000800000059000000590100000059546f206265206f72206e6f7420742c207468617420697320746865207175657374696f6e2e205768657468657220746973206e6f626c657220696e6d696e6473756666686520736c696e677320616e64206172726f77732e200000000801000000080e14040412000000000000080100000008010201011717171600000008010000000803050505060606060000000a010000000a6dc2836ff5adbed55e05",
+		v1Hex:       "01000004000008000800000059000000590100000059546f206265206f72206e6f7420742c207468617420697320746865207175657374696f6e2e205768657468657220746973206e6f626c657220696e6d696e6473756666686520736c696e677320616e64206172726f77732e200000000801000000080e14040412000000000000080100000008010201011717171600000008010000000803050505060606060000000a010000000a6dc2836ff5adbed55e05",
 	},
 	{
 		name:        "edn_1kb",
 		input:       []byte(strings.Repeat("[#identity \"hash25\" :test/attr \"some value here\" [42 1] :op/none]\n", 16))[:1024],
 		minRatio:    2.0,
-		expectedHex: "010000040000040004000000420000004201000000425b236964656e74697479202268617368323522203a746573742f617474722022736f6d652076616c7565206865726522205b343220315d203a6f702f6e6f6e655d0a000000040100000004150000000000000401000000041717171700000004010000000406060606000000080100000008f22dbc85b7501200",
+		expectedHex: "02000004000000000400000004000000420000004201000000425b236964656e74697479202268617368323522203a746573742f617474722022736f6d652076616c7565206865726522205b343220315d203a6f702f6e6f6e655d0a000000040100000004150000000000000401000000041717171700000004010000000406060606000000080100000008f22dbc85b7501200",
+		v1Hex:       "010000040000040004000000420000004201000000425b236964656e74697479202268617368323522203a746573742f617474722022736f6d652076616c7565206865726522205b343220315d203a6f702f6e6f6e655d0a000000040100000004150000000000000401000000041717171700000004010000000406060606000000080100000008f22dbc85b7501200",
 	},
 	{
 		name:        "repetitive_1kb",
 		input:       bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 256),
 		minRatio:    5.0,
-		expectedHex: "01000004000004000400000004000000040100000004deadbeef0000000401000000040400000000000004010000000417171717000000040100000004020202020000000501000000056fdebc1903",
+		expectedHex: "0200000400000000040000000400000004000000040100000004deadbeef0000000401000000040400000000000004010000000417171717000000040100000004020202020000000501000000056fdebc1903",
+		v1Hex:       "01000004000004000400000004000000040100000004deadbeef0000000401000000040400000000000004010000000417171717000000040100000004020202020000000501000000056fdebc1903",
 	},
 	{
 		name:        "all_same_1kb",
 		input:       bytes.Repeat([]byte{'a'}, 1024),
 		minRatio:    10.0,
-		expectedHex: "0100000400000400040000000100000001010000000161000000040100000004010000000000000401000000041717171700000004010000000400000000000000040100000004eff7db0c",
+		expectedHex: "020000040000000004000000040000000100000001010000000161000000040100000004010000000000000401000000041717171700000004010000000400000000000000040100000004eff7db0c",
+		v1Hex:       "0100000400000400040000000100000001010000000161000000040100000004010000000000000401000000041717171700000004010000000400000000000000040100000004eff7db0c",
 	},
 }
 
@@ -469,6 +477,132 @@ func TestCompress_Determinism_Golden(t *testing.T) {
 				require.True(t, bytes.Equal(golden, compressed),
 					"%s: iteration %d differs", gt.name, i)
 			}
+		})
+	}
+}
+
+// ---- v1 → v2 back-compat (dual read) ----
+
+// TestDecompress_V1BlobStillReadable proves the v2 decoder still reads real
+// captured v1 (uint16-header) blobs. The fixtures are the original golden
+// outputs recorded under CompressionVersion 0x01 — genuine legacy bytes, not
+// synthesized — so this guards the dual-read path against regression.
+func TestDecompress_V1BlobStillReadable(t *testing.T) {
+	for _, gt := range goldenTests {
+		t.Run(gt.name, func(t *testing.T) {
+			v1, err := hex.DecodeString(gt.v1Hex)
+			require.NoError(t, err)
+			require.Equal(t, byte(0x01), v1[0], "fixture must be a v1 blob")
+
+			got, err := Decompress(v1)
+			require.NoError(t, err, "v1 blob must still decode under the v2 decoder")
+			assert.True(t, bytes.Equal(gt.input, got),
+				"v1 blob did not round-trip to its original input")
+		})
+	}
+}
+
+// ---- uint16 sequence-count overflow regression (data-loss fix) ----
+
+// jsonish builds the densest realistic content: a JSON-like array of small
+// uniform records. Sequence count scales with the number of distinct short
+// fields, so this crosses 65535 sequences (the old uint16 ceiling) well before
+// a few MB.
+func jsonish(n int) []byte {
+	var b bytes.Buffer
+	b.WriteByte('[')
+	for i := 0; b.Len() < n; i++ {
+		fmt.Fprintf(&b, `{"id":%d,"name":"alice","active":true,"score":%d},`,
+			100000+i, i%97)
+	}
+	return b.Bytes()[:n]
+}
+
+// adversarialDenseSequences emits a stream of recurring 4-byte tokens, each
+// followed by a pseudo-random separator byte. The tokens recur (so the 4-byte
+// match hash hits and a sequence is emitted) but the separator prevents match
+// extension and keeps the stream aperiodic, maximizing sequence count per byte.
+func adversarialDenseSequences(n int) []byte {
+	r := mathrand.New(mathrand.NewSource(1))
+	const poolSize = 256
+	pool := make([][4]byte, poolSize)
+	for i := range pool {
+		binary.BigEndian.PutUint32(pool[i][:], uint32(i)*2654435761)
+	}
+	out := make([]byte, 0, n+8)
+	for len(out) < n {
+		tok := pool[r.Intn(poolSize)]
+		out = append(out, tok[:]...)
+		out = append(out, byte(r.Intn(256)))
+	}
+	return out[:n]
+}
+
+// TestCompress_JSONLikeValueAboveUint16Sequences_RoundTrips is the core
+// regression: a ~2 MB densely-structured value produces more than 65535 LZ77
+// sequences. Under v1 the count truncated to uint16 and the blob became
+// permanently unreadable; under v2 it must round-trip exactly.
+func TestCompress_JSONLikeValueAboveUint16Sequences_RoundTrips(t *testing.T) {
+	input := jsonish(2 * 1024 * 1024)
+
+	seqs := len(FindMatches(input).Sequences)
+	require.Greater(t, seqs, 0xFFFF,
+		"test input must exceed the old uint16 cap (got %d sequences)", seqs)
+	t.Logf("jsonish 2 MB → %d sequences", seqs)
+
+	compressed := Compress(input)
+	require.NotNil(t, compressed, "structured value should compress")
+	require.Equal(t, CompressionVersion, compressed[0], "must be written as v2")
+
+	out, err := Decompress(compressed)
+	require.NoError(t, err, "value with >uint16 sequences must decompress")
+	assert.True(t, bytes.Equal(input, out), "round trip must be lossless")
+}
+
+// TestCompress_AdversarialDenseSequences_RoundTrips drives the sequence count
+// past the old cap with a much smaller (~512 KB) adversarial value.
+func TestCompress_AdversarialDenseSequences_RoundTrips(t *testing.T) {
+	input := adversarialDenseSequences(512 * 1024)
+
+	seqs := len(FindMatches(input).Sequences)
+	require.Greater(t, seqs, 0xFFFF,
+		"adversarial input must exceed the old uint16 cap (got %d sequences)", seqs)
+	t.Logf("adversarial 512 KB → %d sequences", seqs)
+
+	compressed := Compress(input)
+	if compressed == nil {
+		// Safety net engaged: stored raw, which is also safe (never unreadable).
+		t.Skip("adversarial value did not compress below original; stored raw (safe)")
+	}
+	require.Equal(t, CompressionVersion, compressed[0], "must be written as v2")
+
+	out, err := Decompress(compressed)
+	require.NoError(t, err, "value with >uint16 sequences must decompress")
+	assert.True(t, bytes.Equal(input, out), "round trip must be lossless")
+}
+
+// TestCompress_SequenceCountOverflow_DoesNotProduceUnreadableBlob asserts the
+// invariant directly: for inputs whose sequence count exceeds the old uint16
+// ceiling, Compress must EITHER produce a blob that decompresses correctly
+// (widened v2 header) OR decline (return nil ⇒ stored raw). It must never
+// produce a blob that Decompress rejects.
+func TestCompress_SequenceCountOverflow_DoesNotProduceUnreadableBlob(t *testing.T) {
+	inputs := map[string][]byte{
+		"jsonish_2mb":     jsonish(2 * 1024 * 1024),
+		"adversarial_512": adversarialDenseSequences(512 * 1024),
+	}
+	for name, input := range inputs {
+		t.Run(name, func(t *testing.T) {
+			require.Greater(t, len(FindMatches(input).Sequences), 0xFFFF,
+				"input must exceed the old uint16 cap to exercise the fix")
+
+			compressed := Compress(input)
+			if compressed == nil {
+				return // declined → stored raw → safe by construction
+			}
+			out, err := Decompress(compressed)
+			require.NoError(t, err, "compressed blob must never be unreadable")
+			assert.True(t, bytes.Equal(input, out))
 		})
 	}
 }

--- a/datalog/storage/large_compressed_value_test.go
+++ b/datalog/storage/large_compressed_value_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// jsonishStorage mirrors the codec test's densest realistic content: a JSON-like
+// array of small uniform records, which produces more than 65535 LZ77 sequences
+// at a couple of MB. Used to exercise the widened (v2/uint32) compression header
+// end-to-end through Tier-3 blob routing, not just the codec in isolation.
+func jsonishStorage(n int) string {
+	var b bytes.Buffer
+	b.WriteByte('[')
+	for i := 0; b.Len() < n; i++ {
+		fmt.Fprintf(&b, `{"id":%d,"name":"alice","active":true,"score":%d},`,
+			100000+i, i%97)
+	}
+	return b.String()[:n]
+}
+
+// TestLargeCompressedValue_RoundTripsThroughStorage writes a ~2 MB densely
+// structured string (well past the old uint16 sequence cap), commits, closes,
+// reopens the database from disk, and reads the value back byte-for-byte. Under
+// the v1 (uint16) header this value committed cleanly and then failed to
+// decompress on read — write-accept / read-fail data loss. With the v2 header it
+// must round-trip exactly.
+func TestLargeCompressedValue_RoundTripsThroughStorage(t *testing.T) {
+	path := t.TempDir()
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":doc/body"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	e := datalog.NewIdentity("doc1")
+	body := jsonishStorage(2 * 1024 * 1024)
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: path, Schema: s, ReplicaID: 1})
+	require.NoError(t, err)
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, datalog.NewKeyword(":doc/body"), body))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Reopen from disk and read the value back through the full decode path
+	// (Tier-3 blob fetch + Decompress).
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{Path: path, Schema: s, ReplicaID: 1})
+	require.NoError(t, err)
+	defer db2.Close()
+
+	rel, err := db2.Query(`[:find ?v :where [?e :doc/body ?v]]`)
+	require.NoError(t, err)
+	it := rel.Iterator()
+	defer it.Close()
+
+	require.True(t, it.Next(), "expected the stored value")
+	got, ok := it.Tuple()[0].(string)
+	require.True(t, ok, "value should decode as a string")
+	// Compare without dumping 2 MB on mismatch.
+	assert.Equal(t, len(body), len(got), "decoded length must match")
+	assert.True(t, body == got, "2 MB value must round-trip through storage")
+	assert.False(t, it.Next(), "expected exactly one row")
+	require.NoError(t, it.Error())
+}

--- a/docs/bugs/resolved/BUG_COMPRESSION_SEQUENCE_COUNT_UINT16_OVERFLOW.md
+++ b/docs/bugs/resolved/BUG_COMPRESSION_SEQUENCE_COUNT_UINT16_OVERFLOW.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-30
 **Severity**: Correctness / Data Loss (High)
-**Status**: Open
+**Status**: RESOLVED (2026-05-30) — header counts widened to `uint32` (`CompressionVersion` 0x01 → 0x02), `Decompress` dual-reads both formats, and a belt-and-suspenders `Compress` guard declines (stores raw) above the `uint32` ceiling. See [Resolution](#resolution).
 **Affected**: `datalog/codec/compress.go` (LZJ codec), all string/`[]byte` values large and compressible enough to exceed 65,535 LZ77 sequences; compression is on by default (threshold 512 bytes), so this is reachable without opt-in.
 
 ## Summary
@@ -218,3 +218,38 @@ If the header is widened, also add:
 - `TestDecompress_V1BlobStillReadable` — a captured v1 (uint16-header) blob
   decodes correctly under the v2 decoder (back-compat), or an explicit decision
   is recorded that no v1 data needs to be preserved.
+
+## Resolution
+
+Both directions from the fix were taken: the header was widened **and** the guard
+kept.
+
+- **Header widened to `uint32`, `CompressionVersion` 0x01 → 0x02.** The two count
+  fields are now `binary.BigEndian.AppendUint32` (v2 header is 17 bytes vs v1's
+  13). The header layout is otherwise unchanged, and the FSE/LZ blocks are
+  byte-identical to v1 for the same input — the version bump only widens the two
+  counts.
+- **Dual-read in `Decompress`.** A `switch` on the version byte reads v1 (uint16,
+  offsets 5:7 / 7:9, `pos` 13) or v2 (uint32, offsets 5:9 / 9:13, `pos` 17). It
+  runs once per value, outside the per-byte decode loop, so it costs nothing in
+  the hot path. Existing on-disk v1 blobs remain readable; `Compress` only ever
+  writes v2. Unknown versions still error.
+- **Belt-and-suspenders guard.** `Compress` returns `nil` (→ value stored raw via
+  the existing safety-net path) if `len(sb.Sequences)` or `numMatches` exceeds
+  `maxSequenceCount` (`0xFFFFFFFF`). Unreachable in practice (>12 GB input), it
+  documents the format ceiling and guards against a future header-width
+  regression.
+
+Regression tests added:
+
+- `codec`: `TestCompress_JSONLikeValueAboveUint16Sequences_RoundTrips`
+  (~2 MB JSON-ish, 77,821 sequences), `TestCompress_AdversarialDenseSequences_RoundTrips`
+  (~512 KB adversarial, 104,419 sequences), `TestCompress_SequenceCountOverflow_DoesNotProduceUnreadableBlob`
+  (round-trip-or-raw invariant), and `TestDecompress_V1BlobStillReadable`, which
+  decodes the original v1 golden blobs (genuine captured legacy bytes, retained as
+  `v1Hex` fixtures alongside the re-recorded v2 `expectedHex`).
+- `storage`: `TestLargeCompressedValue_RoundTripsThroughStorage` — writes a ~2 MB
+  structured value, commits, closes, reopens from disk, and reads it back equal,
+  exercising Tier-3 blob routing + decode end-to-end.
+
+Full suite green (`go test -count=1 ./...`).


### PR DESCRIPTION
## Problem

The v1 LZJ header stored `numSequences` and `numMatches` as `uint16`. A large, compressible, densely-structured value — ~1.7 MB JSON-ish (realistic worst case) or ~330 KB adversarial — produces more than 65,535 LZ77 sequences. The count truncated silently on write, `Compress` still returned a smaller blob, the transaction committed cleanly, and the value was persisted. The corruption is latent: a later read routes through `Decompress`, which detects the stream-length mismatch and errors. The value becomes permanently unreadable. Write-accept / read-fail data loss; compression is on by default (512-byte threshold), so it is reachable without opt-in.

## Fix

- Widen both count fields to `uint32` and bump `CompressionVersion` 0x01 → 0x02 (v2 header is 17 bytes; v1 was 13). The block payload is unchanged — only the two counts widen.
- `Decompress` dual-reads: a `switch` on the version byte reads v1 (uint16 counts) or v2 (uint32 counts). It runs once per value, outside the per-byte decode loop, so it costs nothing in the hot path. `Compress` only ever writes v2; existing on-disk v1 blobs remain readable.
- Belt-and-suspenders guard: `Compress` returns `nil` (value stored raw via the existing safety-net path) above `maxSequenceCount` (0xFFFFFFFF). Unreachable in practice (>12 GB input), it documents the ceiling and guards against a future header-width regression.

## Tests

- `codec`: `TestCompress_JSONLikeValueAboveUint16Sequences_RoundTrips` (2 MB JSON, 77,821 sequences), `TestCompress_AdversarialDenseSequences_RoundTrips` (512 KB, 104,419 sequences), `TestCompress_SequenceCountOverflow_DoesNotProduceUnreadableBlob` (round-trip-or-raw invariant).
- `codec`: `TestDecompress_V1BlobStillReadable` decodes the original v1 golden blobs under the v2 decoder. The golden fixtures now carry both `v1Hex` (genuine captured legacy bytes) and a re-recorded v2 `expectedHex`; `TestCompress_Header_WrongVersion` switched to 0x03 since 0x02 is now valid.
- `storage`: `TestLargeCompressedValue_RoundTripsThroughStorage` writes a 2 MB structured value, commits, closes, reopens from disk, and reads it back equal — exercising Tier-3 blob routing + decode end-to-end.

Full `go test -count=1 ./...` green.

Resolves the bug documented in `docs/bugs/resolved/BUG_COMPRESSION_SEQUENCE_COUNT_UINT16_OVERFLOW.md` (moved from `docs/bugs/` and marked RESOLVED with a Resolution section).