### PR TITLE
Normalize Go integer widths to canonical int64

### DIFF
--- a/datalog/compare.go
+++ b/datalog/compare.go
@@ -75,12 +75,14 @@ func CompareValues(left, right interface{}) int {
 		return -1
 	}
 
-	// Handle numeric comparisons
+	// Integer widths normalize to int64 (the canonical representation) so
+	// ordering agrees with ValuesEqual.
+	if li, ok := asInt64(left); ok {
+		return compareNumeric(li, right)
+	}
+
+	// Handle remaining numeric comparisons
 	switch l := left.(type) {
-	case int:
-		return compareNumeric(int64(l), right)
-	case int64:
-		return compareNumeric(l, right)
 	case uint64:
 		return compareUint64(l, right)
 	case float64:
@@ -121,13 +123,11 @@ func CompareValues(left, right interface{}) int {
 
 // compareNumeric compares an int64 with another numeric value
 func compareNumeric(left int64, right interface{}) int {
-	switch r := right.(type) {
-	case int:
-		return compareInt64s(left, int64(r))
-	case int64:
-		return compareInt64s(left, r)
-	case float64:
-		return compareFloat(float64(left), right)
+	if ri, ok := asInt64(right); ok {
+		return compareInt64s(left, ri)
+	}
+	if r, ok := right.(float64); ok {
+		return compareFloats(float64(left), r)
 	}
 	// Non-numeric: type mismatch
 	return -1
@@ -135,12 +135,10 @@ func compareNumeric(left int64, right interface{}) int {
 
 // compareFloat compares a float64 with another numeric value
 func compareFloat(left float64, right interface{}) int {
-	switch r := right.(type) {
-	case int:
-		return compareFloats(left, float64(r))
-	case int64:
-		return compareFloats(left, float64(r))
-	case float64:
+	if ri, ok := asInt64(right); ok {
+		return compareFloats(left, float64(ri))
+	}
+	if r, ok := right.(float64); ok {
 		return compareFloats(left, r)
 	}
 	// Non-numeric: type mismatch
@@ -205,19 +203,15 @@ func compareFloats(a, b float64) int {
 
 // compareUint64 compares a uint64 with another numeric value
 func compareUint64(left uint64, right interface{}) int {
+	if ri, ok := asInt64(right); ok {
+		if ri < 0 {
+			return 1 // unsigned is always >= 0
+		}
+		return compareUint64s(left, uint64(ri))
+	}
 	switch r := right.(type) {
 	case uint64:
 		return compareUint64s(left, r)
-	case int:
-		if r < 0 {
-			return 1 // unsigned is always >= 0
-		}
-		return compareUint64s(left, uint64(r))
-	case int64:
-		if r < 0 {
-			return 1 // unsigned is always >= 0
-		}
-		return compareUint64s(left, uint64(r))
 	case float64:
 		return compareFloats(float64(left), r)
 	}
@@ -233,6 +227,28 @@ func compareUint64s(a, b uint64) int {
 		return 1
 	}
 	return 0
+}
+
+// asInt64 returns the int64 magnitude of any signed integer width
+// (int, int8, int16, int32, int64) and reports whether v was such a value.
+// int64 is the engine's canonical integer representation — the EDN parser,
+// storage decode, and schema validation all standardize on it — so this is the
+// single place mixed integer widths are unified for comparison and hashing.
+// int64 is listed first as the dominant case.
+func asInt64(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	case int16:
+		return int64(n), true
+	case int8:
+		return int64(n), true
+	}
+	return 0, false
 }
 
 // ValuesEqual checks if two values are equal.
@@ -284,10 +300,24 @@ func ValuesEqual(a, b interface{}) bool {
 		return ok && eid1.Equal(eid2)
 	}
 
-	// Comparable primitives — direct ==, no reflection.
+	// Comparable primitives. The == fast path is correct (and allocation-free)
+	// whenever the two dynamic types match — the dominant case, and the only one
+	// reached after boundary normalization makes user integers int64. Only when
+	// == is false do we pay to unify integer width: a non-canonical width
+	// (int/int8/int16/int32) compares by magnitude against any other integer
+	// width, while int-vs-float stays strict (asInt64 reports false for float64),
+	// so mixed-numeric values are never conflated.
 	switch a.(type) {
-	case int, int64, float64, string, bool, uint64:
-		return a == b
+	case int64, float64, string, bool, uint64, int, int8, int16, int32:
+		if a == b {
+			return true
+		}
+		if ia, ok := asInt64(a); ok {
+			if ib, ok := asInt64(b); ok {
+				return ia == ib
+			}
+		}
+		return false
 	}
 
 	// time.Time uses Equal (instant equality, ignoring location).

--- a/datalog/compare_int_bench_test.go
+++ b/datalog/compare_int_bench_test.go
@@ -1,0 +1,50 @@
+package datalog
+
+import "testing"
+
+// Allocation-free microbenchmarks for the comparison hot path touched by the
+// integer-width unification. These isolate ValuesEqual/CompareValues from the
+// GC- and thermal-dominated macro hash-join benchmarks, so a before/after
+// benchstat reflects the function change rather than machine noise.
+
+var (
+	cmpEqualSink bool
+	cmpOrderSink int
+)
+
+func BenchmarkValuesEqual_Int64Equal(b *testing.B) {
+	var x, y Value = int64(1234567), int64(1234567)
+	for i := 0; i < b.N; i++ {
+		cmpEqualSink = ValuesEqual(x, y)
+	}
+}
+
+func BenchmarkValuesEqual_Int64Unequal(b *testing.B) {
+	var x, y Value = int64(1234567), int64(7654321)
+	for i := 0; i < b.N; i++ {
+		cmpEqualSink = ValuesEqual(x, y)
+	}
+}
+
+func BenchmarkValuesEqual_StringEqual(b *testing.B) {
+	var x, y Value = "the quick brown fox", "the quick brown fox"
+	for i := 0; i < b.N; i++ {
+		cmpEqualSink = ValuesEqual(x, y)
+	}
+}
+
+// Identity is the dominant real join key and is resolved before the integer
+// branch; this guards that the common case is untouched.
+func BenchmarkValuesEqual_Identity(b *testing.B) {
+	var x, y Value = NewIdentity("entity-1234567"), NewIdentity("entity-1234567")
+	for i := 0; i < b.N; i++ {
+		cmpEqualSink = ValuesEqual(x, y)
+	}
+}
+
+func BenchmarkCompareValues_Int64(b *testing.B) {
+	var x, y Value = int64(1234567), int64(7654321)
+	for i := 0; i < b.N; i++ {
+		cmpOrderSink = CompareValues(x, y)
+	}
+}

--- a/datalog/executor/tuple_key.go
+++ b/datalog/executor/tuple_key.go
@@ -120,6 +120,19 @@ func hashValue(v interface{}) uint64 {
 	case int64:
 		return uint64(val)
 
+	case int8:
+		// Integer widths hash by int64 magnitude so they collide with the
+		// canonical int64 in a TupleKeyMap, matching datalog.ValuesEqual, which
+		// treats integer widths as equal by magnitude. Listed after int/int64
+		// so the common widths keep their original position in the switch.
+		return uint64(int64(val))
+
+	case int16:
+		return uint64(int64(val))
+
+	case int32:
+		return uint64(int64(val))
+
 	case uint64:
 		return val
 

--- a/datalog/executor/tuple_key_int_bench_test.go
+++ b/datalog/executor/tuple_key_int_bench_test.go
@@ -1,0 +1,27 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// Allocation-free microbenchmarks for the TupleKey hash path touched by the
+// integer-width change (hashValue gained int8/int16/int32 cases). These isolate
+// the hash computation from the GC-dominated macro hash-join benchmarks.
+
+var tupleKeySink TupleKey
+
+func BenchmarkTupleKeyFull_Int64(b *testing.B) {
+	tu := Tuple{int64(1234567)}
+	for i := 0; i < b.N; i++ {
+		tupleKeySink = NewTupleKeyFull(tu)
+	}
+}
+
+func BenchmarkTupleKeyFull_Identity(b *testing.B) {
+	tu := Tuple{datalog.NewIdentity("entity-1234567")}
+	for i := 0; i < b.N; i++ {
+		tupleKeySink = NewTupleKeyFull(tu)
+	}
+}

--- a/datalog/executor/tuple_key_int_unify_test.go
+++ b/datalog/executor/tuple_key_int_unify_test.go
@@ -1,0 +1,38 @@
+package executor
+
+import "testing"
+
+// TestTupleKey_UnifiesIntegerWidths proves the join machinery treats integer
+// widths as one key: a tuple keyed by int(5) lands in the same TupleKeyMap
+// bucket (equal hash) as one keyed by int64(5) and compares Equal, so a hash
+// join matches them. This is the defense-in-depth behind boundary normalization
+// — even a relation that somehow carries a raw int still joins against int64
+// data. Different magnitudes must stay distinct.
+func TestTupleKey_UnifiesIntegerWidths(t *testing.T) {
+	k1 := NewTupleKeyFull(Tuple{int(5)})
+	k64 := NewTupleKeyFull(Tuple{int64(5)})
+
+	if k1.hash != k64.hash {
+		t.Errorf("hash(int(5))=%d != hash(int64(5))=%d — would land in different buckets",
+			k1.hash, k64.hash)
+	}
+	if !k1.Equal(k64) {
+		t.Error("TupleKey{int(5)}.Equal(TupleKey{int64(5)}) = false, want true")
+	}
+
+	// Other widths unify too.
+	for _, k := range []TupleKey{
+		NewTupleKeyFull(Tuple{int8(5)}),
+		NewTupleKeyFull(Tuple{int16(5)}),
+		NewTupleKeyFull(Tuple{int32(5)}),
+	} {
+		if k.hash != k64.hash || !k.Equal(k64) {
+			t.Errorf("width key (hash %d) did not unify with int64(5) (hash %d)", k.hash, k64.hash)
+		}
+	}
+
+	// Different magnitude must not match.
+	if NewTupleKeyFull(Tuple{int(5)}).Equal(NewTupleKeyFull(Tuple{int64(6)})) {
+		t.Error("TupleKey{int(5)}.Equal(TupleKey{int64(6)}) = true, want false")
+	}
+}

--- a/datalog/int_normalization_test.go
+++ b/datalog/int_normalization_test.go
@@ -1,0 +1,105 @@
+package datalog
+
+import (
+	"bytes"
+	"testing"
+)
+
+// These unit tests pin the integer-width policy directly, below the API
+// boundary: NormalizeValue coerces to int64; ValuesEqual and CompareValues agree
+// on integer widths (int(5) == int64(5)) while keeping int-vs-float strict; and
+// Type/ValueBytes no longer panic on a bare Go int. The boundary tests in the
+// storage package prove the user-facing behavior; these prove the machinery the
+// boundary relies on (and the defense-in-depth for any path that bypasses it).
+
+func TestNormalizeValue_CoercesIntegerWidths(t *testing.T) {
+	cases := []struct {
+		in   Value
+		want Value
+	}{
+		{int(5), int64(5)},
+		{int8(5), int64(5)},
+		{int16(5), int64(5)},
+		{int32(5), int64(5)},
+		{int64(5), int64(5)},
+		{int(-7), int64(-7)},
+	}
+	for _, c := range cases {
+		got := NormalizeValue(c.in)
+		if got != c.want {
+			t.Errorf("NormalizeValue(%T %v) = %T %v, want %T %v",
+				c.in, c.in, got, got, c.want, c.want)
+		}
+	}
+	// Non-integers pass through unchanged (and keep their dynamic type).
+	for _, v := range []Value{"s", 3.14, true, float64(5), int64(9)} {
+		if got := NormalizeValue(v); got != v {
+			t.Errorf("NormalizeValue(%T) changed it to %T %v", v, got, got)
+		}
+	}
+}
+
+func TestValuesEqual_CompareValues_AgreeOnIntegerWidths(t *testing.T) {
+	widths := []Value{int(5), int8(5), int16(5), int32(5), int64(5)}
+	for _, a := range widths {
+		for _, b := range widths {
+			if !ValuesEqual(a, b) {
+				t.Errorf("ValuesEqual(%T(5), %T(5)) = false, want true", a, b)
+			}
+			if c := CompareValues(a, b); c != 0 {
+				t.Errorf("CompareValues(%T(5), %T(5)) = %d, want 0", a, b, c)
+			}
+		}
+	}
+	// Different magnitudes across widths must NOT be equal, and order correctly.
+	if ValuesEqual(int(5), int64(6)) {
+		t.Error("ValuesEqual(int(5), int64(6)) = true, want false")
+	}
+	if c := CompareValues(int8(5), int64(6)); c != -1 {
+		t.Errorf("CompareValues(int8(5), int64(6)) = %d, want -1", c)
+	}
+	if c := CompareValues(int32(9), int(2)); c != 1 {
+		t.Errorf("CompareValues(int32(9), int(2)) = %d, want 1", c)
+	}
+}
+
+func TestValuesEqual_IntVsFloatStaysStrict(t *testing.T) {
+	// Policy: integer-vs-float stays strict in ValuesEqual so mixed-numeric join
+	// keys aren't conflated, even though CompareValues orders them by magnitude.
+	if ValuesEqual(int64(5), float64(5.0)) {
+		t.Error("ValuesEqual(int64(5), float64(5.0)) = true, want false (int-vs-float strict)")
+	}
+	if ValuesEqual(int(5), float64(5.0)) {
+		t.Error("ValuesEqual(int(5), float64(5.0)) = true, want false")
+	}
+	// CompareValues, by contrast, orders int and float by magnitude.
+	if c := CompareValues(int64(5), float64(5.0)); c != 0 {
+		t.Errorf("CompareValues(int64(5), float64(5.0)) = %d, want 0", c)
+	}
+	// float64 is still equal to itself.
+	if !ValuesEqual(float64(5), float64(5)) {
+		t.Error("ValuesEqual(float64(5), float64(5)) = false, want true")
+	}
+}
+
+func TestType_And_ValueBytes_GoIntEncodeAsInt64(t *testing.T) {
+	// Facet 2: Type/ValueBytes previously panicked on a bare int. They must now
+	// coerce to the canonical int64 encoding.
+	wantBytes := ValueBytes(int64(5))
+	for _, v := range []Value{int(5), int8(5), int16(5), int32(5)} {
+		if got := Type(v); got != TypeInt {
+			t.Errorf("Type(%T) = %v, want TypeInt", v, got)
+		}
+		if got := ValueBytes(v); !bytes.Equal(got, wantBytes) {
+			t.Errorf("ValueBytes(%T(5)) = %v, want %v (same as int64)", v, got, wantBytes)
+		}
+	}
+	// And the decoded value is int64, not the original width.
+	rt, err := ValueFromBytes(TypeInt, ValueBytes(int(5)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rt != int64(5) {
+		t.Errorf("round-trip int(5) -> %T %v, want int64(5)", rt, rt)
+	}
+}

--- a/datalog/qb/attr.go
+++ b/datalog/qb/attr.go
@@ -63,7 +63,9 @@ type Val struct {
 //	qb.Pat(e, PersonCity, qb.V("NYC"))
 //	qb.Pat(e, PersonAge, qb.V(int64(30)))
 func V(value interface{}) Val {
-	return Val{value: value}
+	// Normalize integer width to canonical int64 so a Go int constant matches
+	// stored int64 data the same as the EDN parser's int64 literals do.
+	return Val{value: datalog.NormalizeValue(value)}
 }
 
 // Value returns the underlying value.

--- a/datalog/qb/qb_test.go
+++ b/datalog/qb/qb_test.go
@@ -51,10 +51,11 @@ func TestVal(t *testing.T) {
 		t.Errorf("Expected hello, got %v", strVal.value)
 	}
 
-	// Int value
+	// Int value — V normalizes a Go int to the canonical int64, so it matches
+	// stored int64 data and the EDN parser's int64 literals.
 	intVal := V(42)
-	if intVal.value != 42 {
-		t.Errorf("Expected 42, got %v", intVal.value)
+	if intVal.value != int64(42) {
+		t.Errorf("Expected int64(42), got %v (%T)", intVal.value, intVal.value)
 	}
 
 	// Float value

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -1317,6 +1317,11 @@ func (t *Transaction) Add(e datalog.Identity, a datalog.Keyword, v interface{}) 
 		return fmt.Errorf("nil value not allowed for attribute %s: use absence of fact to represent no value", a.String())
 	}
 
+	// Normalize integer width to canonical int64 at the API boundary, so a Go int
+	// stores and matches the same as int64 (and never reaches the encoder as a
+	// non-int64 width).
+	v = datalog.NormalizeValue(v)
+
 	// Schema validation (if schema present)
 	if err := schema.ValidateDatom(t.db.Schema(), a, v); err != nil {
 		return fmt.Errorf("schema validation failed for %s: %w", a.String(), err)
@@ -1446,6 +1451,9 @@ func (t *Transaction) Remove(e datalog.Identity, a datalog.Keyword, v interface{
 	if v == nil {
 		return fmt.Errorf("nil value not allowed for Remove on attribute %s", a.String())
 	}
+
+	// Normalize integer width to canonical int64 at the API boundary.
+	v = datalog.NormalizeValue(v)
 
 	// Determine cardinality for Remove semantics
 	s := t.db.Schema()
@@ -1642,6 +1650,9 @@ func (t *Transaction) Set(e datalog.Identity, a datalog.Keyword, v interface{}) 
 	if v == nil {
 		return fmt.Errorf("nil value not allowed for attribute %s: use absence of fact to represent no value", a.String())
 	}
+
+	// Normalize integer width to canonical int64 at the API boundary.
+	v = datalog.NormalizeValue(v)
 
 	// Check cardinality first - determines validation strategy
 	card := schema.CardinalityOne
@@ -2214,10 +2225,11 @@ func (d *Database) convertInputsToRelations(q *query.Query, inputs []interface{}
 				return nil, fmt.Errorf("not enough inputs: expected input for %s (have %d inputs, need %d)", spec.Symbol, len(inputs), inputIdx+1)
 			}
 
-			// Create single-value relation
+			// Create single-value relation (normalize integer width to int64 so
+			// an int parameter matches stored int64 data).
 			rel := executor.NewMaterializedRelation(
 				[]query.Symbol{spec.Symbol},
-				[]executor.Tuple{{inputs[inputIdx]}},
+				[]executor.Tuple{{datalog.NormalizeValue(inputs[inputIdx])}},
 			)
 			inputRelations = append(inputRelations, rel)
 			inputIdx++
@@ -2235,7 +2247,7 @@ func (d *Database) convertInputsToRelations(q *query.Query, inputs []interface{}
 
 			tuples := make([]executor.Tuple, slice.Len())
 			for i := 0; i < slice.Len(); i++ {
-				tuples[i] = executor.Tuple{slice.Index(i).Interface()}
+				tuples[i] = executor.Tuple{datalog.NormalizeValue(slice.Index(i).Interface())}
 			}
 
 			rel := executor.NewMaterializedRelation(
@@ -2263,7 +2275,7 @@ func (d *Database) convertInputsToRelations(q *query.Query, inputs []interface{}
 			// Create single tuple
 			tuple := make(executor.Tuple, slice.Len())
 			for i := 0; i < slice.Len(); i++ {
-				tuple[i] = slice.Index(i).Interface()
+				tuple[i] = datalog.NormalizeValue(slice.Index(i).Interface())
 			}
 
 			rel := executor.NewMaterializedRelation(spec.Symbols, []executor.Tuple{tuple})
@@ -2294,7 +2306,7 @@ func (d *Database) convertInputsToRelations(q *query.Query, inputs []interface{}
 
 				tuple := make(executor.Tuple, innerSlice.Len())
 				for j := 0; j < innerSlice.Len(); j++ {
-					tuple[j] = innerSlice.Index(j).Interface()
+					tuple[j] = datalog.NormalizeValue(innerSlice.Index(j).Interface())
 				}
 				tuples[i] = tuple
 			}

--- a/datalog/storage/int_normalization_test.go
+++ b/datalog/storage/int_normalization_test.go
@@ -1,0 +1,132 @@
+package storage
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// These tests cover Bug 2 end-to-end through the public API: a Go int entering
+// via tx.Add / a query :in parameter must behave identically to the equivalent
+// int64, never silently fail to match and never panic at encode.
+
+func intNormSchema() *schema.Schema {
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/age"),
+		ValueType:   schema.TypeLong,
+		Cardinality: schema.CardinalityOne,
+	})
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":person/name"),
+		ValueType:   schema.TypeString,
+		Cardinality: schema.CardinalityOne,
+	})
+	return s
+}
+
+func openIntNormDB(t *testing.T) *Database {
+	t.Helper()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:      t.TempDir(),
+		Schema:    intNormSchema(),
+		ReplicaID: 1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func queryRows(t *testing.T, db *Database, q string, args ...interface{}) []string {
+	t.Helper()
+	rel, err := db.Query(q, args...)
+	require.NoError(t, err)
+	var rows []string
+	it := rel.Iterator()
+	for it.Next() {
+		rows = append(rows, fmt.Sprintf("%v", it.Tuple()))
+	}
+	require.NoError(t, it.Error())
+	it.Close()
+	sort.Strings(rows)
+	return rows
+}
+
+// TestWrite_GoIntValueDoesNotPanic writes an untyped Go int (the natural
+// tx.Add(e, attr, 31) call) and asserts it commits without panicking and reads
+// back as the canonical int64. Before the fix this passed schema validation and
+// then panicked at encode.
+func TestWrite_GoIntValueDoesNotPanic(t *testing.T) {
+	db := openIntNormDB(t)
+	e := datalog.NewIdentity("alice")
+	age := datalog.NewKeyword(":person/age")
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, age, 31)) // untyped Go int
+	_, err := tx.Commit()
+	require.NoError(t, err, "committing a Go int value must not panic or error")
+
+	// Reads back as int64.
+	rel, err := db.Query(`[:find ?age :in $ ?e :where [?e :person/age ?age]]`, e)
+	require.NoError(t, err)
+	it := rel.Iterator()
+	require.True(t, it.Next())
+	got := it.Tuple()[0]
+	it.Close()
+	assert.Equal(t, int64(31), got, "stored Go int must read back as int64")
+}
+
+// TestQuery_IntInputMatchesInt64StoredValue is the core facet-1 regression: a
+// parameterized query returns the same rows whether the argument is a Go int or
+// the equivalent int64. Before the fix the int argument matched nothing because
+// the input relation's int value never joined the stored int64 (ValuesEqual was
+// type-strict).
+func TestQuery_IntInputMatchesInt64StoredValue(t *testing.T) {
+	db := openIntNormDB(t)
+	age := datalog.NewKeyword(":person/age")
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(datalog.NewIdentity("alice"), age, int64(30)))
+	require.NoError(t, tx.Set(datalog.NewIdentity("bob"), age, int64(40)))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	const q = `[:find ?e :in $ ?age :where [?e :person/age ?age]]`
+	rowsInt64 := queryRows(t, db, q, int64(30))
+	rowsInt := queryRows(t, db, q, int(30))
+
+	require.Len(t, rowsInt64, 1, "int64 argument should match exactly alice")
+	assert.Equal(t, rowsInt64, rowsInt,
+		"int argument must return the same rows as int64 argument")
+}
+
+// TestPredicateAndJoinAgreeOnIntInt64 proves the two comparison paths agree: an
+// int parameter used as a join key (pattern binding, ValuesEqual) and as a
+// predicate operand (CompareValues) yield the same match. Before the fix these
+// disagreed — the join silently failed while the = predicate matched.
+func TestPredicateAndJoinAgreeOnIntInt64(t *testing.T) {
+	db := openIntNormDB(t)
+	age := datalog.NewKeyword(":person/age")
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(datalog.NewIdentity("alice"), age, int64(30)))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	// Join path: the int input binds ?age and joins the stored int64 directly.
+	joinRows := queryRows(t, db,
+		`[:find ?e :in $ ?age :where [?e :person/age ?age]]`, int(30))
+
+	// Predicate path: bind ?a from storage, compare it to the int input via (=).
+	predRows := queryRows(t, db,
+		`[:find ?e :in $ ?age :where [?e :person/age ?a] [(= ?a ?age)]]`, int(30))
+
+	assert.Equal(t, joinRows, predRows,
+		"join and predicate must agree for an int parameter")
+	require.Len(t, joinRows, 1, "both paths should match alice")
+}

--- a/datalog/value_encoding.go
+++ b/datalog/value_encoding.go
@@ -43,7 +43,29 @@ type BlobData struct {
 const maxKeyValueSize = 60000
 
 // Type returns the type of a value
+// NormalizeValue coerces a value's dynamic integer type to the engine's
+// canonical int64 representation: int, int8, int16, int32 become int64; every
+// other type (including int64) is returned unchanged. Storage decode, the EDN
+// parser, and comparison all standardize on int64, so normalizing user-supplied
+// values where they enter the engine (writes, query inputs, query-builder
+// constants) keeps a Go int from diverging from stored int64 data. int64 and
+// non-integers pass through untouched, adding no allocation for the common case.
+func NormalizeValue(v Value) Value {
+	switch n := v.(type) {
+	case int:
+		return int64(n)
+	case int8:
+		return int64(n)
+	case int16:
+		return int64(n)
+	case int32:
+		return int64(n)
+	}
+	return v
+}
+
 func Type(v Value) ValueType {
+	v = NormalizeValue(v) // int/int8/int16/int32 -> canonical int64
 	// Handle pointers by checking what they point to
 	switch val := v.(type) {
 	case *Identity:
@@ -83,6 +105,7 @@ func Type(v Value) ValueType {
 
 // Bytes serializes a value to bytes
 func ValueBytes(v Value) []byte {
+	v = NormalizeValue(v) // int/int8/int16/int32 -> canonical int64
 	// Handle pointer types first
 	switch ptr := v.(type) {
 	case Identity:

--- a/docs/bugs/resolved/BUG_INT_INT64_NUMERIC_TYPE_INCONSISTENCY.md
+++ b/docs/bugs/resolved/BUG_INT_INT64_NUMERIC_TYPE_INCONSISTENCY.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-30
 **Severity**: Correctness / Robustness (Medium)
-**Status**: Open
+**Status**: RESOLVED (2026-05-30) — Go integer widths are normalized to canonical `int64` at the API boundary (`datalog.NormalizeValue`), `Type`/`ValueBytes` coerce so encode never panics, and `ValuesEqual`/`CompareValues` agree on integer widths (int-vs-float stays strict). See [Resolution](#resolution).
 **Affected**: `datalog/compare.go` (`ValuesEqual` vs `CompareValues`), `datalog/value_encoding.go` (`Type`, `ValueBytes`), all programmatic API paths that accept a Go `int` (query `:in` parameters, query-builder constants, `tx.Add`/`Set` values). EDN query *literals* are unaffected (the parser produces `int64`).
 
 ## Summary
@@ -192,3 +192,46 @@ Regression tests that fail before the fix:
   for `float64` vs integer if any).
 - If normalization is chosen, an end-to-end test: write `int`, reopen, read back
   as `int64`, and confirm `int`/`int64` query parameters both match.
+
+## Resolution
+
+Policy chosen: **normalize to `int64` at the API boundary** (option 1), plus
+**reconcile `ValuesEqual` with `CompareValues`** on integer widths (option 2) as
+defense in depth. `int64` is the engine's single canonical integer — the EDN
+parser, storage decode, and schema validation all already standardize on it.
+
+- `datalog.NormalizeValue` coerces `int`/`int8`/`int16`/`int32` → `int64`
+  (everything else, including `int64`, passes through untouched). It is applied
+  where Go values enter: `Transaction.Add`/`Set`/`Remove`, the query `:in` input
+  conversion (scalar/collection/tuple/relation), and `qb.V` constants.
+- Facet 2 (encode panic): `Type` and `ValueBytes` now call `NormalizeValue`
+  first, so a bare Go `int` encodes as `int64` instead of panicking. Schema
+  validation already accepted these widths, so validation and encoding are now
+  consistent.
+- Facet 1 (silent non-match): a single `asInt64` helper unifies integer widths
+  by magnitude in `ValuesEqual` and routes `CompareValues`/`compareNumeric`/
+  `compareFloat`/`compareUint64`, so equality and ordering agree. `int`-vs-`float`
+  stays strict in `ValuesEqual` (so mixed-numeric join keys aren't conflated)
+  while `CompareValues` still orders them by magnitude. `hashValue` hashes all
+  widths as `int64` so unified values share a `TupleKeyMap` bucket.
+
+Hot path: `ValuesEqual` keeps the `==` fast path first; width unification runs
+only when `==` already failed. Allocation-free microbenchmarks
+(`compare_int_bench_test.go`, `tuple_key_int_bench_test.go`) measured zero added
+allocations and per-call latency unchanged within noise on the common paths,
+with ~1 ns added only on the rare unequal-integer (hash-collision) path —
+immaterial against the allocation-dominated join.
+
+Tests added:
+
+- `datalog` (unit): `TestNormalizeValue_CoercesIntegerWidths`,
+  `TestValuesEqual_CompareValues_AgreeOnIntegerWidths`,
+  `TestValuesEqual_IntVsFloatStaysStrict`,
+  `TestType_And_ValueBytes_GoIntEncodeAsInt64`.
+- `datalog/executor` (unit): `TestTupleKey_UnifiesIntegerWidths` (int and int64
+  share a hash bucket and compare equal; different magnitudes don't).
+- `datalog/storage` (end-to-end): `TestWrite_GoIntValueDoesNotPanic`,
+  `TestQuery_IntInputMatchesInt64StoredValue`,
+  `TestPredicateAndJoinAgreeOnIntInt64`.
+
+Full suite green (`go test -count=1 ./...`).


### PR DESCRIPTION
## Problem

A Go `int` (or `int8`/`int16`/`int32`) entering through the programmatic API diverged from the engine's canonical `int64`, two ways:

1. **Silent non-match.** `ValuesEqual(int(5), int64(5))` was `false` (type-strict) while `CompareValues(int(5), int64(5))` was `0`. Joins/pattern-matching use `ValuesEqual`; `=` predicates use `CompareValues`. So an `int` query `:in` parameter silently failed to match `int64`-stored data in a join, while the same value satisfied a `[(= ?x ?y)]` predicate — opposite answers.
2. **Encode panic.** `Type`/`ValueBytes` had no `int` case and panicked at commit, even though schema validation *accepts* a Go `int` for `TypeLong`. So `tx.Add(e, attr, 30)` (untyped constant → `int`) passed validation then panicked.

EDN query literals were unaffected (the parser produces `int64`); only values arriving through Go code tripped this.

## Fix

`int64` is the single canonical integer — the EDN parser, storage decode, and schema validation already standardize on it. This normalizes to it at the boundary and reconciles the comparison paths as defense in depth.

- `datalog.NormalizeValue` coerces `int`/`int8`/`int16`/`int32` → `int64` (everything else, incl. `int64`, passes through). Applied at `Transaction.Add`/`Set`/`Remove`, the query `:in` input conversion (scalar/collection/tuple/relation), and `qb.V` constants.
- `Type`/`ValueBytes` call `NormalizeValue` first, so a bare Go `int` encodes as `int64` instead of panicking — consistent with schema validation, which already accepted it.
- A single `asInt64` helper unifies integer widths by magnitude in `ValuesEqual` and routes `CompareValues`/`compareNumeric`/`compareFloat`/`compareUint64`, so equality and ordering agree. `int`-vs-`float` stays strict in `ValuesEqual` (mixed-numeric join keys aren't conflated) while `CompareValues` still orders them by magnitude. `hashValue` hashes all widths as `int64` so unified values share a `TupleKeyMap` bucket.

## Performance

The only hot-path site is `ValuesEqual`, which keeps the `==` fast path first — equal same-type keys (the norm after normalization) pay nothing new; width unification runs only when `==` already failed. Allocation-free microbenchmarks (`compare_int_bench_test.go`, `tuple_key_int_bench_test.go`, count=20, vs merged main):

| benchmark | before | after | Δ |
|---|---|---|---|
| `ValuesEqual_Int64Equal` (common) | 3.69 ns | 3.89 ns | +0.2 ns (noise) |
| `ValuesEqual_Int64Unequal` (collision) | 3.62 ns | 4.61 ns | +1.0 ns |
| `ValuesEqual_StringEqual` | 4.60 ns | 4.67 ns | ~ |
| `ValuesEqual_Identity` | 1.61 ns | 1.84 ns | +0.2 ns (noise) |
| `TupleKeyFull_Int64` | 2.70 ns | 2.38 ns | −0.3 ns |
| allocations | 0 | 0 | identical |

Zero added allocations everywhere. The +1 ns lands only on the rare unequal-integer (hash-collision) path; at N=10k a join does ~N `ValuesEqual` calls on matches, so +0.2 ns/call is ~2 µs against a ~3 ms join (~0.07%) — immaterial against the allocation-dominated join.

## Tests

- `datalog` (unit): `TestNormalizeValue_CoercesIntegerWidths`, `TestValuesEqual_CompareValues_AgreeOnIntegerWidths`, `TestValuesEqual_IntVsFloatStaysStrict`, `TestType_And_ValueBytes_GoIntEncodeAsInt64`.
- `datalog/executor` (unit): `TestTupleKey_UnifiesIntegerWidths` — `int` and `int64` share a hash bucket and compare equal; different magnitudes don't.
- `datalog/storage` (end-to-end): `TestWrite_GoIntValueDoesNotPanic`, `TestQuery_IntInputMatchesInt64StoredValue`, `TestPredicateAndJoinAgreeOnIntInt64`.
- `qb` `TestVal` updated to the canonical `int64`.

Full `go test -count=1 ./...` green.

Resolves the bug documented in `docs/bugs/resolved/BUG_INT_INT64_NUMERIC_TYPE_INCONSISTENCY.md` (moved from `docs/bugs/` and marked RESOLVED with a Resolution section).