### PR TITLE
Close the cache stale-read window across commit

### DIFF
--- a/datalog/storage/cache.go
+++ b/datalog/storage/cache.go
@@ -20,6 +20,12 @@ type CacheKey struct {
 
 // CacheEntry holds the resolved CRDT view for an (E, A) pair
 type CacheEntry struct {
+	// inFlight marks a placeholder entry stored while a commit to this (E, A) is
+	// in progress. Readers that see it bypass the cache and resolve directly from
+	// storage, and cache writers refuse to overwrite it, so no reader observes the
+	// pre-commit value once the storage commit is visible. The remaining fields
+	// are unset on a sentinel.
+	inFlight    bool
 	version     datalog.ElementID // Max ElementID when this entry was computed
 	cardinality schema.Cardinality
 
@@ -92,6 +98,48 @@ func NewCache() *Cache {
 	return &Cache{}
 }
 
+// inFlightEntry is the shared sentinel stored for an (E, A) while its commit is
+// in progress. It carries no resolved value — readers and writers key off the
+// inFlight flag alone — so a single shared instance is safe across all keys.
+var inFlightEntry = &CacheEntry{inFlight: true}
+
+// BeginInFlight marks the given keys as committing by storing the in-flight
+// sentinel for each, overwriting any cached entry. Called by Transaction.Commit
+// BEFORE the storage commit; the matching clear is Invalidate (called after the
+// commit, or after a failed commit), which deletes the entries. While a key is
+// in-flight, GetOrResolve resolves it from storage and storeIfNotInFlight refuses
+// to cache it, so the storage commit and the cache become visible atomically from
+// a reader's perspective.
+func (c *Cache) BeginInFlight(keys []CacheKey) {
+	for _, key := range keys {
+		c.entries.Store(key, inFlightEntry)
+	}
+}
+
+// storeIfNotInFlight stores entry for key unless an in-flight sentinel is
+// present, returning whether it stored. The compare-and-swap loop closes the
+// window where a concurrent rebuild, having resolved the pre-commit value, could
+// otherwise clobber a sentinel that BeginInFlight set in the meantime: if the
+// slot turned into (or already holds) a sentinel, the store is abandoned.
+func (c *Cache) storeIfNotInFlight(key CacheKey, entry *CacheEntry) bool {
+	for {
+		cur, ok := c.entries.Load(key)
+		if ok && cur.(*CacheEntry).inFlight {
+			return false // a commit owns this key; do not cache
+		}
+		if !ok {
+			if _, loaded := c.entries.LoadOrStore(key, entry); !loaded {
+				return true
+			}
+			continue // lost the race; re-check (the winner may be a sentinel)
+		}
+		if c.entries.CompareAndSwap(key, cur, entry) {
+			return true
+		}
+		// The slot changed under us (possibly to a sentinel); re-evaluate.
+	}
+}
+
 // GetOrResolve returns cached entry if fresh, rebuilds if stale
 //
 // Freshness is tracked via maxVersions sync.Map, updated atomically on every write.
@@ -101,6 +149,13 @@ func (c *Cache) GetOrResolve(key CacheKey, resolver CacheResolver) *CacheEntry {
 	// Fast path: load existing entry
 	if val, ok := c.entries.Load(key); ok {
 		entry := val.(*CacheEntry)
+
+		// In-flight: a commit to this (E, A) is in progress. Resolve from storage
+		// (the rebuild below) without caching, so the result reflects whichever
+		// side of the commit is currently durable — never a stale cache hit.
+		if entry.inFlight {
+			return c.rebuild(key, resolver)
+		}
 
 		// Check freshness: compare stored version with maxVersions (O(1) map lookup)
 		if maxVal, ok := c.maxVersions.Load(key); ok {
@@ -117,11 +172,14 @@ func (c *Cache) GetOrResolve(key CacheKey, resolver CacheResolver) *CacheEntry {
 	// That's fine - CRDT resolution is deterministic, both compute same result.
 	entry := c.rebuild(key, resolver)
 	if entry != nil {
-		c.entries.Store(key, entry)
-		// Update maxVersions to reflect what we just resolved
-		c.UpdateMaxVersion(key, entry.version)
-		// Track that we've cached this attribute for this entity
-		c.TrackEntityAttr(key.E, key.A)
+		// storeIfNotInFlight refuses to overwrite an in-flight sentinel, so a
+		// rebuild that raced a commit doesn't re-cache the pre-commit value.
+		if c.storeIfNotInFlight(key, entry) {
+			// Update maxVersions to reflect what we just resolved
+			c.UpdateMaxVersion(key, entry.version)
+			// Track that we've cached this attribute for this entity
+			c.TrackEntityAttr(key.E, key.A)
+		}
 	}
 	return entry
 }
@@ -272,9 +330,13 @@ func (c *Cache) GetCachedAttrs(e Entity) map[Attribute]bool {
 // crosses an attribute boundary, the accumulated datoms are resolved and
 // cached here in a single call.
 func (c *Cache) PopulateFromDatoms(key CacheKey, card schema.Cardinality, datoms []datalog.Datom) {
-	// Skip if already cached and fresh
+	// Skip if a commit to this (E, A) is in flight (the committer owns the cache
+	// for this key), or if already cached and fresh.
 	if val, ok := c.entries.Load(key); ok {
 		entry := val.(*CacheEntry)
+		if entry.inFlight {
+			return
+		}
 		if maxVal, ok := c.maxVersions.Load(key); ok {
 			if entry.version == maxVal.(datalog.ElementID) {
 				return
@@ -320,9 +382,11 @@ func (c *Cache) PopulateFromDatoms(key CacheKey, card schema.Cardinality, datoms
 	}
 
 	if entry != nil {
-		c.entries.Store(key, entry)
-		c.UpdateMaxVersion(key, entry.version)
-		c.TrackEntityAttr(key.E, key.A)
+		// Refuse to cache if a commit grabbed this key after the freshness check.
+		if c.storeIfNotInFlight(key, entry) {
+			c.UpdateMaxVersion(key, entry.version)
+			c.TrackEntityAttr(key.E, key.A)
+		}
 	}
 }
 

--- a/datalog/storage/cache_commit_inflight_test.go
+++ b/datalog/storage/cache_commit_inflight_test.go
@@ -1,0 +1,176 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// These tests cover the cache stale-read window: Transaction.Commit marks the
+// touched (E, A) keys in-flight before the storage commit, so a reader resolving
+// one of them in the window between stx.Commit() returning and the cache update
+// never sees the pre-commit value.
+
+func inFlightSchema() *schema.Schema {
+	s := schema.NewSchema()
+	s.Add(&schema.AttributeDefinition{
+		Ident:       datalog.NewKeyword(":counter/value"),
+		ValueType:   schema.TypeLong,
+		Cardinality: schema.CardinalityOne,
+	})
+	return s
+}
+
+func openInFlightDB(t *testing.T) *Database {
+	t.Helper()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:      t.TempDir(),
+		Schema:    inFlightSchema(),
+		ReplicaID: 1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func setAndCommit(t *testing.T, db *Database, e datalog.Identity, a datalog.Keyword, v any) {
+	t.Helper()
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(e, a, v))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+}
+
+// resolveOne reads (e, a) through exactly the cache path the bug lives in
+// (Cache.GetOrResolve), returning the resolved CardinalityOne value.
+func resolveOne(db *Database, e datalog.Identity, a datalog.Keyword) any {
+	var aBytes Attribute
+	copy(aBytes[:], a.String())
+	key := CacheKey{E: Entity(e.Hash()), A: aBytes}
+	matcher := NewBadgerMatcher(db.store)
+	matcher.SetSchema(db.schema)
+	entry := db.cache.GetOrResolve(key, matcher)
+	if entry == nil {
+		return nil
+	}
+	return entry.OneValue()
+}
+
+// TestCommit_NoStaleCachedReadAfterCommitReturns is the core regression. It warms
+// the cache for (e, k) at v1, then overwrites to v2 and — via the test-only
+// onCommitWindow hook, which fires after the storage commit but before the cache
+// update — resolves (e, k) in exactly the window where a stale cache hit was once
+// possible. With the in-flight fix the read sees v2; without it (maxVersions not
+// yet bumped, entry still v1) it would see the stale v1.
+func TestCommit_NoStaleCachedReadAfterCommitReturns(t *testing.T) {
+	db := openInFlightDB(t)
+	e := datalog.NewIdentity("e1")
+	k := datalog.NewKeyword(":counter/value")
+
+	setAndCommit(t, db, e, k, int64(1))
+	require.Equal(t, int64(1), resolveOne(db, e, k), "cache should be warmed at v1")
+
+	var windowValue any
+	db.onCommitWindow = func() { windowValue = resolveOne(db, e, k) }
+	setAndCommit(t, db, e, k, int64(2))
+	db.onCommitWindow = nil
+
+	assert.Equal(t, int64(2), windowValue,
+		"a cache read in the post-commit window must see the committed value, not the stale entry")
+
+	// And the cache serves v2 normally afterward.
+	assert.Equal(t, int64(2), resolveOne(db, e, k))
+}
+
+// TestCommit_ConcurrentReadersSeeCommittedValue hammers the in-flight machinery:
+// readers continuously resolve (e, k) through the cache while a writer overwrites
+// it with a monotonically increasing value. Values must always be valid and never
+// move backward for a given reader. Run under -race to catch data races in the
+// sentinel/CAS paths.
+func TestCommit_ConcurrentReadersSeeCommittedValue(t *testing.T) {
+	db := openInFlightDB(t)
+	e := datalog.NewIdentity("e1")
+	k := datalog.NewKeyword(":counter/value")
+
+	setAndCommit(t, db, e, k, int64(0))
+	resolveOne(db, e, k) // warm
+
+	const readers = 8
+	stop := make(chan struct{})
+	errCh := make(chan error, readers)
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var last int64 = -1
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				v := resolveOne(db, e, k)
+				if v == nil {
+					continue
+				}
+				iv, ok := v.(int64)
+				if !ok {
+					errCh <- fmt.Errorf("non-int64 value %T from cache", v)
+					return
+				}
+				if iv < last {
+					errCh <- fmt.Errorf("reader saw %d after %d (value moved backward)", iv, last)
+					return
+				}
+				last = iv
+			}
+		}()
+	}
+
+	for n := int64(1); n <= 200; n++ {
+		setAndCommit(t, db, e, k, n)
+	}
+	close(stop)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+// TestCommit_RollbackPathDoesNotPoisonCache exercises the commit-failure cleanup:
+// Commit marks keys in-flight before stx.Commit(), and on failure clears them via
+// Invalidate WITHOUT bumping maxVersions. This drives that exact sequence (storage
+// unchanged) and asserts the cache rebuilds the correct pre-"commit" value and
+// isn't left poisoned for the next real commit.
+func TestCommit_RollbackPathDoesNotPoisonCache(t *testing.T) {
+	db := openInFlightDB(t)
+	e := datalog.NewIdentity("e1")
+	k := datalog.NewKeyword(":counter/value")
+
+	setAndCommit(t, db, e, k, int64(7))
+	require.Equal(t, int64(7), resolveOne(db, e, k), "cache warmed at v7")
+
+	var aBytes Attribute
+	copy(aBytes[:], k.String())
+	key := CacheKey{E: Entity(e.Hash()), A: aBytes}
+
+	// Mimic Commit's failure path: mark in-flight, then (commit fails, storage
+	// unchanged) Invalidate — no UpdateMaxVersion.
+	db.cache.BeginInFlight([]CacheKey{key})
+	db.cache.Invalidate([]CacheKey{key})
+
+	// Storage still holds v7, and maxVersions was never bumped, so the cache must
+	// rebuild and serve v7 — no stale value, no permanent bypass.
+	assert.Equal(t, int64(7), resolveOne(db, e, k), "rollback must leave the pre-commit value")
+
+	// A subsequent real commit still takes effect (no lingering poison).
+	setAndCommit(t, db, e, k, int64(8))
+	assert.Equal(t, int64(8), resolveOne(db, e, k))
+}

--- a/datalog/storage/cache_getresolve_bench_test.go
+++ b/datalog/storage/cache_getresolve_bench_test.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+var getResolveSink *CacheEntry
+
+// BenchmarkGetOrResolve_FreshHit measures the cache-hit hot path — the path the
+// in-flight stale-read fix added a field read to (entry.inFlight). The resolver
+// is never invoked on a fresh hit, so a nil resolver is safe. Alloc-free; a
+// before/after benchstat shows whether the sentinel check costs anything.
+func BenchmarkGetOrResolve_FreshHit(b *testing.B) {
+	c := NewCache()
+	var e Entity
+	copy(e[:], "0123456789abcdef0123")
+	var a Attribute
+	copy(a[:], ":bench/attr")
+	key := CacheKey{E: e, A: a}
+
+	ver := datalog.ElementID{}
+	c.entries.Store(key, &CacheEntry{
+		version:     ver,
+		cardinality: schema.CardinalityOne,
+		oneValue:    int64(42),
+	})
+	c.maxVersions.Store(key, ver)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		getResolveSink = c.GetOrResolve(key, nil)
+	}
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -55,6 +55,12 @@ type Database struct {
 	replicaID         uint64                  // CRDT: This database's replica identifier
 	cache             *Cache                  // CRDT: Unified cache for resolved CRDT views
 	temporalTxID      *datalog.ElementID      // nil = current; set = temporal mode (AsOf/History)
+
+	// onCommitWindow, if set, is invoked inside Commit after the storage commit
+	// returns but before the cache is updated — the window where a stale cached
+	// read was once possible. Test-only (nil in production); lets a test run a
+	// reader deterministically in that window. See the cache stale-read tests.
+	onCommitWindow func()
 }
 
 // NewDatabase creates a new database with BadgerDB storage
@@ -2101,14 +2107,32 @@ func (t *Transaction) Commit() (datalog.ElementID, error) {
 		return datalog.ElementID{}, commitErr
 	}
 
+	// Mark every (E, A) this commit touches as in-flight BEFORE the storage
+	// commit. While in-flight, readers resolve those keys straight from storage,
+	// so the storage commit and the cache update become atomic from a reader's
+	// perspective — no reader observes the pre-commit value once stx.Commit()
+	// returns. Cleared by the Invalidate below (success) or on commit failure.
+	var touched []CacheKey
+	if t.db.cache != nil {
+		touched = t.touchedCacheKeys()
+		t.db.cache.BeginInFlight(touched)
+	}
+
 	if err := stx.Commit(); err != nil {
+		if t.db.cache != nil {
+			t.db.cache.Invalidate(touched) // clear in-flight sentinels
+		}
 		return datalog.ElementID{}, fmt.Errorf("failed to commit storage transaction: %w", err)
+	}
+
+	// Test-only: run a reader in the post-commit / pre-cache-update window.
+	if t.db.onCommitWindow != nil {
+		t.db.onCommitWindow()
 	}
 
 	// Update cache: track max versions and invalidate stale entries
 	// Skip if cache is disabled
 	if t.db.cache != nil {
-		touched := make([]CacheKey, 0, len(t.datoms)+len(t.retracts))
 		seenKeys := make(map[CacheKey]bool)
 
 		// Attributes written in this commit that are declared Unique.
@@ -2136,7 +2160,6 @@ func (t *Transaction) Commit() (datalog.ElementID, error) {
 			key := CacheKey{E: eBytes, A: aBytes}
 			if !seenKeys[key] {
 				seenKeys[key] = true
-				touched = append(touched, key)
 				t.db.cache.UpdateMaxVersion(key, d.Tx)
 			}
 			checkUnique(d.A, aBytes)
@@ -2152,13 +2175,15 @@ func (t *Transaction) Commit() (datalog.ElementID, error) {
 			key := CacheKey{E: eBytes, A: aBytes}
 			if !seenKeys[key] {
 				seenKeys[key] = true
-				touched = append(touched, key)
 				t.db.cache.UpdateMaxVersion(key, d.Tx)
 			}
 			checkUnique(d.A, aBytes)
 		}
 
-		// Invalidate cache entries for all touched (E, A) pairs
+		// Invalidate cache entries for all touched (E, A) pairs. This also
+		// deletes the in-flight sentinels set by BeginInFlight above, ending the
+		// in-flight window: subsequent reads rebuild from storage at the new
+		// value, and maxVersions was just bumped to match.
 		t.db.cache.Invalidate(touched)
 
 		// Conservative unique-attr invalidation: for each unique attribute
@@ -2178,6 +2203,30 @@ func (t *Transaction) Commit() (datalog.ElementID, error) {
 	// Return the metadata ElementID - it has the highest Lamport in this tx,
 	// making it the correct high-water mark for as-of queries
 	return metadataElemID, nil
+}
+
+// touchedCacheKeys returns the deduplicated set of (E, A) cache keys this
+// transaction's asserts and retracts touch. Computed before the storage commit
+// so the keys can be marked in-flight; reused afterward to invalidate them.
+func (t *Transaction) touchedCacheKeys() []CacheKey {
+	touched := make([]CacheKey, 0, len(t.datoms)+len(t.retracts))
+	seen := make(map[CacheKey]bool)
+	add := func(e datalog.Identity, a datalog.Keyword) {
+		var aBytes Attribute
+		copy(aBytes[:], a.String())
+		key := CacheKey{E: Entity(e.Hash()), A: aBytes}
+		if !seen[key] {
+			seen[key] = true
+			touched = append(touched, key)
+		}
+	}
+	for _, d := range t.datoms {
+		add(d.E, d.A)
+	}
+	for _, d := range t.retracts {
+		add(d.E, d.A)
+	}
+	return touched
 }
 
 // Rollback aborts the transaction

--- a/docs/bugs/resolved/BUG_CACHE_COMMIT_STALE_READ_WINDOW.md
+++ b/docs/bugs/resolved/BUG_CACHE_COMMIT_STALE_READ_WINDOW.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-30
 **Severity**: Consistency (Low–Moderate; concurrency-only, transient)
-**Status**: Open
+**Status**: RESOLVED (2026-05-30) — `Commit` marks the touched `(E, A)` keys in-flight in the cache *before* the storage commit (option-2 done with a clobber-proof sentinel); readers resolve in-flight keys straight from storage, so no reader observes the pre-commit value once `stx.Commit()` returns. See [Resolution](#resolution).
 **Affected**: `datalog/storage/database.go` (`Transaction.Commit`), `datalog/storage/cache.go` (EA cache freshness). Only manifests with concurrent readers on the same `*Database` while a writer commits, and only for `(E, A)` pairs that already have a cached entry. Single-writer / sequential usage is unaffected. History-mode reads (which bypass the cache) are unaffected.
 
 ## Summary
@@ -186,3 +186,53 @@ architectural decision for the owner, not a mechanical fix.
 - Run the concurrent tests under `go test -race` to catch any new data races
   introduced by the reordering (note: `-race` is not part of the standard gate;
   only add it for these targeted tests).
+
+## Resolution
+
+Chosen approach: **option 2 (invalidate before the storage commit), made
+clobber-proof with an in-flight sentinel** rather than a deletion. Picked over
+option 1 (pre-bump `maxVersions`) because `UpdateMaxVersion` is monotonic
+(`cache.go`), so option 1's rollback would have to *lower* `maxVersions` — a
+non-monotonic, race-prone revert (a too-high `maxVersions` permanently bypasses
+the cache for that key). Option 3 (storage-derived freshness) was rejected: a
+per-`(E, A)` freshness seek ≈ the CardinalityOne resolution cost, defeating the
+cache's purpose.
+
+Mechanism:
+
+- `Transaction.Commit` computes the touched `(E, A)` keys and calls
+  `Cache.BeginInFlight` to store a shared `inFlightEntry` sentinel for each,
+  **before** `stx.Commit()`. The post-commit `Invalidate` (which already deletes
+  the touched entries) clears the sentinels; on commit failure the same
+  `Invalidate` runs, and `maxVersions` was never pre-bumped, so there is nothing
+  to revert.
+- `GetOrResolve` returns `rebuild(...)` (resolve from storage, do **not** cache)
+  when it loads a sentinel, so an in-flight key always reflects current storage —
+  `V_old` before the commit is durable, `V_new` after.
+- The cache's two write paths (`GetOrResolve`'s rebuild-store and
+  `PopulateFromDatoms`) go through `storeIfNotInFlight`, a compare-and-swap that
+  refuses to overwrite a sentinel. This closes the clobber window where a
+  concurrent rebuild — having resolved the pre-commit value — would otherwise
+  re-cache it over a sentinel set in the meantime.
+- `maxVersions` stays monotonic throughout (only ever bumped, after the commit),
+  which is what keeps rollback trivial.
+
+Performance: the read hot path adds a single `entry.inFlight` field read on an
+already-loaded struct. `BenchmarkGetOrResolve_FreshHit` measured **16.35 → 16.43
+ns/op (+0.5%, within noise), 0 allocs** before/after. The cost concentrates on
+the rare commit path (one sentinel store per touched key) and on reads of the
+specific keys being committed during the brief commit window (they resolve from
+storage instead of hitting the cache — the intended correctness trade).
+
+Tests added (`datalog/storage/cache_commit_inflight_test.go`):
+
+- `TestCommit_NoStaleCachedReadAfterCommitReturns` — the regression, via the
+  test-only `Database.onCommitWindow` hook; verified to **fail** when
+  `BeginInFlight` is disabled (it observes the stale `V_old`).
+- `TestCommit_ConcurrentReadersSeeCommittedValue` — 8 readers vs a monotonic
+  writer; values never move backward. Race-clean under `-race`.
+- `TestCommit_RollbackPathDoesNotPoisonCache` — the failure-path cleanup
+  (`BeginInFlight` then `Invalidate`, no `UpdateMaxVersion`) leaves the cache
+  serving the correct pre-commit value and unpoisoned for the next commit.
+
+Full suite green (`go test -count=1 ./...`); storage package clean under `-race`.


### PR DESCRIPTION
## Problem

`Transaction.Commit` committed the storage transaction first, then updated the EA cache (max-version bump + entry invalidation) as a separate step. In the window between `stx.Commit()` returning and the cache update, a concurrent reader resolving an already-cached `(E, A)` would find `entry.version == maxVersions == V_old` and treat the entry as **fresh** — returning the pre-commit value even though `V_new` was already durable. Transient and self-healing, but a real read-your-writes / linearizability gap for concurrent readers. (New keys are unaffected — a miss rebuilds from storage; history-mode reads bypass the cache.)

## Fix (in-flight sentinel, set before the storage commit)

Make the store and cache transition atomically *from a reader's perspective* by marking the touched keys in-flight before the commit, rather than updating the cache after it:

- `Cache.BeginInFlight(touched)` stores a shared `inFlightEntry` sentinel for each touched `(E, A)`, called **before** `stx.Commit()`.
- `GetOrResolve` returns `rebuild(...)` (resolve from storage, **don't** cache) when it loads a sentinel, so an in-flight key always reflects current storage — `V_old` before the commit is durable, `V_new` after.
- The existing post-commit `Invalidate` clears the sentinels. On commit failure the same `Invalidate` runs, and `maxVersions` was never pre-bumped, so there is **nothing to revert**.
- Both cache write paths (`GetOrResolve`'s rebuild-store and `PopulateFromDatoms`) go through `storeIfNotInFlight`, a compare-and-swap that refuses to overwrite a sentinel — closing the clobber race where a concurrent rebuild, having resolved the pre-commit value, would re-cache it over a sentinel set in the meantime.
- `maxVersions` stays **monotonic** throughout. This is deliberately *not* the pre-bump approach (option 1): because `UpdateMaxVersion` only ever raises the max, pre-bumping would require a non-monotonic, race-prone lower-on-rollback, and a stuck too-high max permanently bypasses the cache. The sentinel avoids touching `maxVersions` pre-commit entirely.

## Performance

The read hot path adds a single `entry.inFlight` field read on the already-loaded struct. `BenchmarkGetOrResolve_FreshHit`, alloc-free, count=20, before/after vs `main`:

| | before | after | Δ |
|---|---|---|---|
| cache fresh-hit | 16.35 ns | 16.43 ns | +0.5% (within noise) |
| allocs | 0 | 0 | identical |

Cost concentrates on the rare commit path (one sentinel store per touched key) and on reads of the *specific keys being committed* during the brief window (they resolve from storage instead of hitting the cache — the intended correctness trade). Reads of all other keys are untouched.

## Tests (`cache_commit_inflight_test.go`)

- `TestCommit_NoStaleCachedReadAfterCommitReturns` — the regression, via a test-only `Database.onCommitWindow` hook that runs a cache read in exactly the post-commit window. **Verified to fail when `BeginInFlight` is disabled** (it observes the stale `V_old`).
- `TestCommit_ConcurrentReadersSeeCommittedValue` — 8 readers continuously resolving while a writer overwrites with a monotonic value; values never move backward. Race-clean.
- `TestCommit_RollbackPathDoesNotPoisonCache` — the failure-path cleanup (`BeginInFlight` then `Invalidate`, no `UpdateMaxVersion`) leaves the cache serving the correct pre-commit value and unpoisoned for the next commit.

Full `go test -count=1 ./...` green; storage package clean under `go test -race`.

Resolves the bug documented in `docs/bugs/resolved/BUG_CACHE_COMMIT_STALE_READ_WINDOW.md` (moved from `docs/bugs/` and marked RESOLVED with a Resolution section).