### PR TITLE
Preserve deferred iterator errors in the non-reusing matcher path

### DIFF
--- a/datalog/storage/matcher_iterator_nonreusing.go
+++ b/datalog/storage/matcher_iterator_nonreusing.go
@@ -55,9 +55,23 @@ func (it *nonReusingIterator) Next() bool {
 			}
 		}
 
-		// Done with current scan
-		it.currentScan.Close()
+		// Done with current scan. The scan may have exhausted because of an
+		// internal failure (CRDT unique-walk sub-scan, KeyOnly key decode)
+		// that surfaces only through Error() after Next() returns false —
+		// capture it before discarding so the query boundary sees it instead
+		// of clean exhaustion. A Close() error is a weaker signal and must not
+		// mask the iteration error. Abort on any error rather than scanning
+		// further bindings.
+		if scanErr := it.currentScan.Error(); scanErr != nil && it.err == nil {
+			it.err = scanErr
+		}
+		if closeErr := it.currentScan.Close(); closeErr != nil && it.err == nil {
+			it.err = closeErr
+		}
 		it.currentScan = nil
+		if it.err != nil {
+			return false
+		}
 	}
 
 	// Move to next binding tuple

--- a/datalog/storage/matcher_relations.go
+++ b/datalog/storage/matcher_relations.go
@@ -455,17 +455,21 @@ func (m *BadgerMatcher) matchWithoutIteratorReuse(pattern *query.DataPattern, bi
 		})
 	}
 
-	// We need to materialize the binding relation to iterate multiple times
-	// CRITICAL: Must copy tuples because iterator reuses buffer
+	// We need to materialize the binding relation to iterate multiple times.
+	// ForEach drives the iterator per the storage.Iterator contract: a deferred
+	// binding-relation failure (Tier-3 blob decode, CRDT unique-walk) surfaces
+	// only through Error()/Close() after Next() returns false, and must abort
+	// the match rather than be laundered into a clean partial result.
+	// CRITICAL: Must copy tuples because the iterator reuses its buffer.
 	var bindingTuples []executor.Tuple
-	it := bindingRel.Iterator()
-	for it.Next() {
-		tuple := it.Tuple()
+	if err := executor.ForEach(bindingRel, func(tuple executor.Tuple) error {
 		tupleCopy := make(executor.Tuple, len(tuple))
 		copy(tupleCopy, tuple)
 		bindingTuples = append(bindingTuples, tupleCopy)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
-	it.Close()
 
 	// Create iterator that will scan for each binding tuple
 	iter := &nonReusingIterator{

--- a/datalog/storage/nonreusing_matcher_error_propagation_test.go
+++ b/datalog/storage/nonreusing_matcher_error_propagation_test.go
@@ -1,0 +1,158 @@
+// Reproductions for docs/bugs/BUG_NONREUSING_MATCHER_DROPS_ITERATOR_ERRORS.md
+//
+// The non-reusing matcher path (NoReuse strategy) has two iterator-consuming
+// loops that, per the storage.Iterator contract, must check Error() after
+// Next() returns false — a deferred failure (Tier-3 blob decode, KeyOnly key
+// decode, CRDT unique-walk sub-scan) shows up only through Error(), not through
+// a Datom() error or a non-empty Next().
+//
+//  1. matchWithoutIteratorReuse drains the binding relation into bindingTuples.
+//  2. nonReusingIterator.Next consumes each per-binding storage scan.
+//
+// Both must surface a deferred error rather than launder it into a clean
+// (empty/truncated) result.
+
+package storage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// deferredErrorScan models the storage.Iterator deferred-failure contract:
+// it yields nothing and parks an error in Error(), the way a wrapping iterator
+// aborts (Next() == false) before emitting anything. The error is NOT returned
+// from Datom() — nonReusingIterator already handles immediate Datom() errors;
+// the loss site is specifically the deferred Error() channel.
+type deferredErrorScan struct {
+	remaining int
+	err       error
+	closed    bool
+}
+
+func (it *deferredErrorScan) Next() bool {
+	if it.remaining > 0 {
+		it.remaining--
+		return true
+	}
+	return false
+}
+func (it *deferredErrorScan) Datom() (*datalog.Datom, error)  { return &datalog.Datom{}, nil }
+func (it *deferredErrorScan) Close() error                    { it.closed = true; return nil }
+func (it *deferredErrorScan) Seek(key []byte)                 {}
+func (it *deferredErrorScan) ElementID() datalog.ElementID    { return datalog.ElementID{} }
+func (it *deferredErrorScan) Error() error                    { return it.err }
+
+var _ Iterator = (*deferredErrorScan)(nil)
+
+// deferredErrorBindingRel is an executor.Relation whose iterator yields its
+// tuples and then reports a deferred error via Error() after Next() returns
+// false — modeling a storage-backed binding relation that aborts mid-scan and
+// parks the failure in Error().
+type deferredErrorBindingRel struct {
+	executor.Relation
+	err error
+}
+
+func (r deferredErrorBindingRel) Iterator() executor.Iterator {
+	return &deferredErrorTupleIter{inner: r.Relation.Iterator(), err: r.err}
+}
+
+type deferredErrorTupleIter struct {
+	inner   executor.Iterator
+	err     error
+	drained bool
+}
+
+func (it *deferredErrorTupleIter) Next() bool {
+	if it.drained {
+		return false
+	}
+	if it.inner.Next() {
+		return true
+	}
+	it.drained = true // deferred failure: Next() == false, Error() reports it
+	return false
+}
+func (it *deferredErrorTupleIter) Tuple() executor.Tuple { return it.inner.Tuple() }
+func (it *deferredErrorTupleIter) Close() error          { return it.inner.Close() }
+func (it *deferredErrorTupleIter) Error() error {
+	if it.drained {
+		return it.err
+	}
+	return it.inner.Error()
+}
+
+var (
+	_ executor.Relation = deferredErrorBindingRel{}
+	_ executor.Iterator = (*deferredErrorTupleIter)(nil)
+)
+
+// TestNonReusingIterator_SurfacesDeferredScanError pins loss site #2: a
+// per-binding storage scan that exhausts (Next() == false) with a non-nil
+// deferred Error() must be surfaced by the outer nonReusingIterator, not
+// dropped when the scan is closed.
+func TestNonReusingIterator_SurfacesDeferredScanError(t *testing.T) {
+	sentinel := errors.New("deferred per-binding scan failure")
+
+	// One binding tuple, its scan already open and about to exhaust with a
+	// parked error. After the scan exhausts, currentIdx advances past the
+	// single binding and Next() returns false — the only place the deferred
+	// error can be captured is right before the scan is closed.
+	it := &nonReusingIterator{
+		currentScan:   &deferredErrorScan{err: sentinel},
+		currentIdx:    0,
+		bindingTuples: []executor.Tuple{{nil}},
+	}
+
+	require.False(t, it.Next(), "iterator should report exhaustion")
+	require.ErrorIs(t, it.Error(), sentinel,
+		"deferred per-binding scan error must surface via Error(), not be laundered into clean exhaustion")
+}
+
+// TestMatchWithoutIteratorReuse_SurfacesDeferredBindingError pins loss site #1:
+// when the binding relation's iterator yields a prefix and then reports a
+// deferred error, matchWithoutIteratorReuse must not launder it into a clean
+// result. The error must surface either from the call itself or from draining
+// the returned relation.
+func TestMatchWithoutIteratorReuse_SurfacesDeferredBindingError(t *testing.T) {
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: t.TempDir(), ReplicaID: 1})
+	require.NoError(t, err)
+	defer db.Close()
+	m := db.Matcher().(*BadgerMatcher)
+
+	sentinel := errors.New("deferred binding-relation scan failure")
+	eSym := datalog.NewSymbol("?e")
+	vSym := datalog.NewSymbol("?v")
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: eSym},
+			query.Constant{Value: datalog.NewKeyword(":test/attr")},
+			query.Variable{Name: vSym},
+		},
+	}
+	symbols := pattern.ExtractColumns()
+
+	// Binding relation yields one tuple, then defers the error.
+	base := executor.NewMaterializedRelation(
+		[]query.Symbol{eSym},
+		[]executor.Tuple{{datalog.NewIdentity("e1")}},
+	)
+	bindingRel := deferredErrorBindingRel{Relation: base, err: sentinel}
+
+	rel, err := m.matchWithoutIteratorReuse(pattern, bindingRel, symbols, nil)
+	if err != nil {
+		require.ErrorIs(t, err, sentinel)
+		return
+	}
+	// Fix may instead surface the error through the returned relation's
+	// iterator. Drive it to exhaustion via the contract-enforcing ForEach.
+	drainErr := executor.ForEach(rel, func(executor.Tuple) error { return nil })
+	require.ErrorIs(t, drainErr, sentinel,
+		"deferred binding-relation error must surface, not be laundered into a clean result")
+}

--- a/docs/bugs/resolved/BUG_NONREUSING_MATCHER_DROPS_ITERATOR_ERRORS.md
+++ b/docs/bugs/resolved/BUG_NONREUSING_MATCHER_DROPS_ITERATOR_ERRORS.md
@@ -1,0 +1,169 @@
+# BUG: Non-Reusing Matcher Path Drops Deferred Iterator Errors
+
+**Date**: 2026-05-30
+**Severity**: High — storage/decode/CRDT failures can become successful partial results
+**Status**: ✅ RESOLVED (2026-05-31)
+**Affected**: `storage.matchWithoutIteratorReuse`, `storage.nonReusingIterator`
+
+## Resolution
+
+Both loss sites now preserve the iterator outcome per the `storage.Iterator`
+contract ("Error() must be checked after Next() returns false").
+
+1. `matchWithoutIteratorReuse` (`matcher_relations.go`) drains the binding
+   relation via `executor.ForEach`, which returns, in priority order, an
+   iteration error then a `Close()` error; a non-nil result aborts the match
+   (`return nil, err`) instead of materializing a truncated `bindingTuples`.
+
+2. `nonReusingIterator.Next` (`matcher_iterator_nonreusing.go`) captures
+   `currentScan.Error()` (then `Close()`'s error, which cannot mask the
+   iteration error) into `it.err` before discarding the scan, and returns
+   `false` immediately on any error rather than scanning further bindings. This
+   mirrors the existing `validatingVBoundIterator` pattern in the same package.
+
+Regression coverage lives in
+`storage/nonreusing_matcher_error_propagation_test.go`: a deferred-error storage
+scan double pins site #2 directly on `nonReusingIterator`, and a deferred-error
+binding relation pins site #1 through `matchWithoutIteratorReuse`. Both were
+verified to fail (empty error chain) before the fix.
+
+## Summary
+
+The non-reusing storage matcher path consumes iterators without checking
+`Iterator.Error()` after `Next()` returns false. This can launder deferred
+storage failures into clean query results.
+
+This is the same bug class as the iterator-error propagation fixes documented in
+`BUG_ITERATOR_ERRORS_DROPPED_AT_PUBLIC_BOUNDARIES.md`,
+`BUG_ITERATOR_ERRORS_DROPPED_IN_MATERIALIZATION_PATHS.md`, and
+`BUG_RELATION_TRANSFORMS_DROP_ITERATOR_ERRORS.md`: a source iterator can stop
+because of a real error, but the consuming path treats it as normal exhaustion.
+
+Two loops are affected:
+
+1. materializing the binding relation before creating `nonReusingIterator`
+2. consuming each per-binding storage scan inside `nonReusingIterator.Next`
+
+## Code Evidence
+
+### 1. Binding relation materialization ignores `Error()` and `Close()`
+
+`matchWithoutIteratorReuse` drains the binding relation into `bindingTuples`,
+then closes the iterator without checking either the deferred iterator error or
+the close error:
+
+```go
+var bindingTuples []executor.Tuple
+it := bindingRel.Iterator()
+for it.Next() {
+	tuple := it.Tuple()
+	tupleCopy := make(executor.Tuple, len(tuple))
+	copy(tupleCopy, tuple)
+	bindingTuples = append(bindingTuples, tupleCopy)
+}
+it.Close()
+```
+
+If `bindingRel` is a streaming relation backed by storage, a decode/blob/CRDT
+failure may only appear through `it.Error()` after `Next()` returns false.
+
+### 2. Per-tuple storage scans ignore deferred scan errors
+
+`nonReusingIterator.Next` loops over the current scan and handles immediate
+`Datom()` errors, but when `Next()` returns false it closes the scan without
+checking `currentScan.Error()`:
+
+```go
+if it.currentScan != nil {
+	for it.currentScan.Next() {
+		datom, err := it.currentScan.Datom()
+		if err != nil {
+			it.err = err
+			return false
+		}
+		// ...
+	}
+
+	// Done with current scan
+	it.currentScan.Close()
+	it.currentScan = nil
+}
+```
+
+This misses the exact failure mode used by `KeyOnlyIterator` and
+`CRDTResolvingIterator`: `Next()` returns false and `Error()` carries the real
+failure.
+
+## Why This Matters
+
+The storage layer intentionally defers some failures to iterator `Error()`:
+
+- Tier-3 blob lookup/decode failures
+- key decode failures in `KeyOnlyIterator`
+- CRDT resolving failures, including unique-walk sub-scans
+- wrapped iterator failures that propagate through `Error()`
+
+Most of the executor has been hardened to preserve these errors. This path is a
+remaining hand-rolled loop outside the guarded materialization utilities.
+
+If this path is selected, a query can return:
+
+1. an empty successful result,
+2. a truncated successful result, or
+3. a result missing rows for some binding tuples,
+
+even though storage reported a real failure.
+
+## Expected Behavior
+
+Every iterator-consuming loop in this path should preserve the iterator outcome:
+
+- after draining `bindingRel`, check `it.Error()` and `it.Close()`
+- after each `currentScan` is exhausted, check `currentScan.Error()` and
+  `currentScan.Close()`
+- if either reports an error, store it on the returned iterator's `err` field so
+  the query boundary sees it
+
+## Actual Behavior
+
+Both loops treat `Next() == false` as normal exhaustion and discard the only
+error channel for deferred failures.
+
+## Suggested Fix
+
+In `matchWithoutIteratorReuse`, replace the manual binding materialization with
+the same error-preserving pattern used elsewhere:
+
+```go
+if err := executor.ForEach(bindingRel, func(tuple executor.Tuple) error {
+	tupleCopy := make(executor.Tuple, len(tuple))
+	copy(tupleCopy, tuple)
+	bindingTuples = append(bindingTuples, tupleCopy)
+	return nil
+}); err != nil {
+	return nil, err
+}
+```
+
+In `nonReusingIterator.Next`, before discarding `currentScan`, capture the first
+non-nil error from `currentScan.Error()` and `currentScan.Close()` into
+`it.err`.
+
+Be careful not to let `Close()` mask a more specific iterator/decode error.
+
+## Tests Needed
+
+Add regression coverage for both loss sites:
+
+1. A binding relation whose iterator yields one tuple and then reports a
+   deferred error. `matchWithoutIteratorReuse` should return an error or produce
+   a relation whose iterator reports that error.
+2. A `nonReusingIterator` current scan that returns `Next() == false` with a
+   non-nil `Error()`. The outer iterator must surface that error.
+3. End-to-end storage-backed query coverage where the planner/matcher selects
+   `NoReuse`, and a deferred storage error is injected after partial output.
+
+This should follow the style of `relation_ops_error_propagation_test.go` and
+`relation_input_parallel_correctness_test.go`: use a small failing iterator that
+models the storage contract directly, then add an integration-level test if
+fault injection is practical.


### PR DESCRIPTION
## Summary

The `NoReuse` storage matcher strategy had two iterator-consuming loops that discarded a *deferred* storage failure — the kind that surfaces only through `Iterator.Error()` after `Next()` returns false (Tier-3 blob decode, `KeyOnlyIterator` key decode, `CRDTResolvingIterator` unique-walk sub-scan), never as a `Datom()` error. Either loop could launder a real storage failure into a clean empty/truncated query result.

This is the same bug class already fixed at the public boundaries, in the materialization paths, and in the relation transforms; this was the remaining hand-rolled loop outside the guarded utilities.

## Fix

- **`matchWithoutIteratorReuse`** (`matcher_relations.go`) — drains the binding relation via `executor.ForEach`, which returns an iteration error (then a `Close()` error) in priority order. A non-nil result aborts the match (`return nil, err`) instead of materializing a truncated `bindingTuples`.
- **`nonReusingIterator.Next`** (`matcher_iterator_nonreusing.go`) — captures `currentScan.Error()` (then `Close()`'s error, which cannot mask the iteration error) into `it.err` before discarding the scan, and returns `false` immediately on any error rather than scanning further bindings. Mirrors the existing `validatingVBoundIterator` pattern in the same package.

## Tests

Regression coverage in `storage/nonreusing_matcher_error_propagation_test.go`, written before the fix and **verified to fail with an empty error chain** against the unfixed code:

- `TestNonReusingIterator_SurfacesDeferredScanError` — pins site #2 directly on a minimal `nonReusingIterator` whose scan exhausts with a parked `Error()`.
- `TestMatchWithoutIteratorReuse_SurfacesDeferredBindingError` — pins site #1 by feeding a binding relation that yields one tuple then defers an error, asserting the error surfaces from the call or from draining the returned relation.

Full `go test -count=1 ./...` green.

Resolves `BUG_NONREUSING_MATCHER_DROPS_ITERATOR_ERRORS` (moved to `docs/bugs/resolved/`).