### PR TITLE
Propagate input-iterator errors in the sequential relation-input path

### DIFF
--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -593,19 +593,37 @@ func (e *Executor) executeRealizedWithRelationInputIterationSequential(
 	// (fallback). The per-tuple inner loop is just prepared.Run(ctx, tuple).
 	prepared := e.prepareIteration(plan, relationInput, inputRelations, iterationIndex)
 
-	// Iterate over each tuple in the relation
+	// Iterate over each tuple in the relation. Close() is explicit (not
+	// deferred) so its error can be inspected before results are combined, and
+	// so a deferred input-iteration failure — which surfaces only through
+	// Error() after Next() returns false — is not laundered into a clean
+	// partial result. This mirrors the parallel path's policy.
 	it := iterationRelation.Iterator()
-	defer it.Close()
 
 	for it.Next() {
 		result, err := prepared.Run(ctx, it.Tuple())
 		if err != nil {
+			// Per-tuple execution error is the most specific cause: close
+			// best-effort and do not let a Close() error mask it.
+			it.Close()
 			return nil, fmt.Errorf("iteration execution failed: %w", err)
 		}
 
 		if result != nil {
 			allResults = append(allResults, result)
 		}
+	}
+
+	// Error priority: a deferred iteration error (the input may have truncated,
+	// so anything past the failure point was never seen) wins over a Close()
+	// error, so cleanup cannot mask the real cause.
+	iterErr := it.Error()
+	closeErr := it.Close()
+	if iterErr != nil {
+		return nil, iterErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
 	}
 
 	// Combine all results

--- a/datalog/executor/relation_input_sequential_error_propagation_test.go
+++ b/datalog/executor/relation_input_sequential_error_propagation_test.go
@@ -1,0 +1,91 @@
+// Reproductions for docs/bugs/BUG_SEQUENTIAL_RELATION_INPUT_DROPS_ITERATOR_ERROR.md
+//
+// The sequential RelationInput path drives the iteration relation directly:
+//
+//	it := iterationRelation.Iterator()
+//	defer it.Close()
+//	for it.Next() { ... }
+//
+// Per the Iterator contract, Error() must be checked after Next() returns false,
+// and Close()'s error must not be discarded. The parallel path already does
+// both; the sequential path is the counterpart that this file pins. These are
+// the sequential analogues of TestRelationInputParallel_PropagatesDeferredIteratorError,
+// but they fail the *input* iteration relation (the actual sequential loss
+// site) rather than a per-tuple result.
+
+package executor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// peopleInputSymbols are the [[?n ?y] ...] relation-input symbols for
+// peopleQueryNoAgg.
+func peopleInputSymbols() []query.Symbol {
+	return []query.Symbol{datalog.NewSymbol("?n"), datalog.NewSymbol("?y")}
+}
+
+// TestRelationInputSequential_PropagatesDeferredInputIteratorError targets the
+// loss site unique to the sequential path: the loop driving the RelationInput
+// iteration relation. If that input relation's iterator yields a prefix and then
+// reports a deferred error (the way a streaming/storage-backed input aborts
+// mid-scan), the sequential path must surface it rather than return the prefix's
+// per-tuple results as a clean success.
+func TestRelationInputSequential_PropagatesDeferredInputIteratorError(t *testing.T) {
+	matcher := NewMemoryPatternMatcher(buildPeopleDatoms())
+	q, err := parser.ParseQuery(peopleQueryNoAgg)
+	require.NoError(t, err)
+
+	// Iteration relation for [[?n ?y] ...]: yields one tuple, then defers
+	// errInjectedIterator via Iterator().Error().
+	base := NewMaterializedRelation(peopleInputSymbols(), []Tuple{
+		{"Alice", int64(2020)},
+		{"Bob", int64(2020)},
+	})
+	inputRel := failingRelation{Relation: base, failAfter: 1}
+
+	exec := NewExecutor(matcher, nil)
+	exec.DisableParallelSubqueries()
+
+	_, err = exec.ExecuteWithRelations(NewContext(nil), q, []Relation{inputRel})
+	require.Error(t, err,
+		"deferred input-iterator error must propagate, not be laundered into clean partial results")
+	require.True(t, errors.Is(err, errInjectedIterator),
+		"error must unwrap to errInjectedIterator; got %v", err)
+}
+
+// TestRelationInputSequential_PropagatesInputCloseError pins the second signal:
+// the iteration relation iterates cleanly to exhaustion but its Close() reports
+// an error. The sequential path defers Close() and discards its return; that
+// error must surface rather than be dropped.
+func TestRelationInputSequential_PropagatesInputCloseError(t *testing.T) {
+	matcher := NewMemoryPatternMatcher(buildPeopleDatoms())
+	q, err := parser.ParseQuery(peopleQueryNoAgg)
+	require.NoError(t, err)
+
+	closeErr := errors.New("injected input Close failure")
+
+	tuples := []Tuple{
+		{"Alice", int64(2020)},
+		{"Bob", int64(2020)},
+	}
+	base := NewMaterializedRelation(peopleInputSymbols(), tuples)
+	// failAfter past the tuple count => no deferred iteration error; Close()
+	// returns closeErr.
+	inputRel := failingRelation{Relation: base, failAfter: len(tuples) + 1, closeErr: closeErr}
+
+	exec := NewExecutor(matcher, nil)
+	exec.DisableParallelSubqueries()
+
+	_, err = exec.ExecuteWithRelations(NewContext(nil), q, []Relation{inputRel})
+	require.Error(t, err,
+		"input Close() error must propagate, not be discarded by a deferred Close()")
+	require.True(t, errors.Is(err, closeErr),
+		"error must unwrap to the injected Close error; got %v", err)
+}

--- a/docs/bugs/resolved/BUG_SEQUENTIAL_RELATION_INPUT_DROPS_ITERATOR_ERROR.md
+++ b/docs/bugs/resolved/BUG_SEQUENTIAL_RELATION_INPUT_DROPS_ITERATOR_ERROR.md
@@ -1,0 +1,144 @@
+# BUG: Sequential Relation-Input Iteration Drops Input Iterator Errors
+
+**Date**: 2026-05-30
+**Severity**: Medium — non-default execution path can report clean partial results
+**Status**: ✅ RESOLVED (2026-05-31)
+**Affected**: `executor.executeRealizedWithRelationInputIterationSequential`
+
+## Resolution
+
+The sequential path now follows the same error-priority policy as the parallel
+path. `Close()` is made explicit instead of deferred, so it can be inspected
+before per-tuple results are combined: after the iteration loop, `it.Error()`
+(deferred iteration failure) is checked first and `it.Close()` second, so a
+cleanup error cannot mask the real cause. On a per-tuple execution error the
+iterator is closed best-effort and that error is returned without consulting
+`Close()`.
+
+Regression coverage in
+`executor/relation_input_sequential_error_propagation_test.go`, both verified to
+fail (`got nil`) before the fix:
+
+- `TestRelationInputSequential_PropagatesDeferredInputIteratorError` — the
+  iteration relation yields one tuple then defers `errInjectedIterator`;
+  `ExecuteWithRelations` (parallel disabled) must surface it, not return the
+  prefix's results as a clean success.
+- `TestRelationInputSequential_PropagatesInputCloseError` — the iteration
+  relation exhausts cleanly but its `Close()` reports an error, which must
+  propagate rather than be discarded by the former deferred `Close()`.
+
+## Summary
+
+The sequential `RelationInput` execution path drains the input relation without
+checking `Iterator.Error()` after iteration completes. If the input iterator
+fails after yielding a prefix of tuples, the executor can return results for the
+prefix and silently ignore the failure.
+
+The parallel `RelationInput` path already handles this correctly: it checks the
+producer iterator's `Error()` and `Close()` before returning. The sequential path
+should follow the same contract.
+
+## Code Evidence
+
+`executeRealizedWithRelationInputIterationSequential` iterates
+`iterationRelation` directly:
+
+```go
+it := iterationRelation.Iterator()
+defer it.Close()
+
+for it.Next() {
+	result, err := prepared.Run(ctx, it.Tuple())
+	if err != nil {
+		return nil, fmt.Errorf("iteration execution failed: %w", err)
+	}
+
+	if result != nil {
+		allResults = append(allResults, result)
+	}
+}
+```
+
+There is no `it.Error()` check after the loop. The deferred `it.Close()` return
+value is also discarded.
+
+By contrast, the parallel path explicitly preserves both signals:
+
+```go
+iterErr := iter.Error()
+closeErr := iter.Close()
+// ...
+if iterErr != nil {
+	return nil, iterErr
+}
+// ...
+if closeErr != nil {
+	return nil, closeErr
+}
+```
+
+## Why This Matters
+
+`RelationInput` queries execute once per input tuple. If the input relation is
+streaming and fails partway through, the sequential path may:
+
+1. execute the query for the tuples before the failure,
+2. combine those per-tuple results,
+3. return success,
+4. never tell the caller the input stream failed.
+
+That produces a plausible but incomplete result set.
+
+This is especially risky because the rest of the codebase treats deferred
+iterator errors as a hard correctness contract. A path that bypasses the
+contract makes behavior depend on the parallel-subquery configuration.
+
+## Expected Behavior
+
+After the input loop finishes, the sequential path should check:
+
+1. `it.Error()`
+2. `it.Close()`, if no iteration error occurred
+
+Any non-nil error should abort the query before combining and returning partial
+per-tuple results.
+
+## Actual Behavior
+
+`Next() == false` is treated as normal exhaustion, and `Close()` is deferred
+with its error ignored.
+
+## Suggested Fix
+
+Use the same priority policy as the parallel path:
+
+```go
+iterErr := it.Error()
+closeErr := it.Close()
+if iterErr != nil {
+	return nil, iterErr
+}
+if closeErr != nil {
+	return nil, closeErr
+}
+```
+
+Because the current code uses `defer it.Close()`, the loop should be reshaped so
+the close error can be inspected before result combination.
+
+Do not let `Close()` mask an earlier per-tuple execution error.
+
+## Tests Needed
+
+Add a sequential counterpart to
+`TestRelationInputParallel_PropagatesDeferredIteratorError`:
+
+1. Build a `RelationInput` query over an input relation whose iterator yields at
+   least one tuple and then reports a deferred error.
+2. Disable parallel subqueries via `exec.DisableParallelSubqueries()`.
+3. Verify `ExecuteWithRelations` returns an error that unwraps to the injected
+   sentinel.
+4. Verify the query does not return clean partial results.
+
+Also add a close-error variant if there is already a reusable close-failing test
+iterator in the executor tests.


### PR DESCRIPTION
## Summary

`executeRealizedWithRelationInputIterationSequential` drained the `RelationInput` iteration relation with `defer it.Close()` and no `it.Error()` check. If that input relation's iterator yields a prefix and then reports a *deferred* error (a streaming/storage-backed input aborting mid-scan — surfacing only through `Error()` after `Next()` returns false), or if its `Close()` errors, the sequential path returned the prefix's per-tuple results as a clean success and dropped the failure.

The parallel path already checks the iteration iterator's `Error()` and `Close()`; this aligns the sequential path with the same contract. Behavior depended on the parallel-subquery configuration, which made it especially easy to miss.

## Fix

`Close()` is now explicit instead of deferred, so it can be inspected before per-tuple results are combined:

- after the loop, `it.Error()` (deferred iteration failure) is checked first and `it.Close()` second, so a cleanup error cannot mask the real cause;
- on a per-tuple `Run` error, the iterator is closed best-effort and that error is returned without consulting `Close()`.

This is the same error-priority shape the parallel path uses.

## Tests

Regression coverage in `executor/relation_input_sequential_error_propagation_test.go`, both written before the fix and **verified to fail (`got nil`)** against the unfixed code. They fail the *input iteration relation* (the actual sequential loss site), distinct from the existing parallel test which fails a per-tuple result:

- `TestRelationInputSequential_PropagatesDeferredInputIteratorError` — iteration relation yields one tuple then defers `errInjectedIterator`; `ExecuteWithRelations` (parallel disabled) must surface it.
- `TestRelationInputSequential_PropagatesInputCloseError` — iteration relation exhausts cleanly but its `Close()` reports an error, which must propagate.

Full `go test -count=1 ./...` green.

Resolves `BUG_SEQUENTIAL_RELATION_INPUT_DROPS_ITERATOR_ERROR` (moved to `docs/bugs/resolved/`).