### PR TITLE
Route PlannerOptions to the matcher through one shared converter

### DIFF
--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -39,7 +39,7 @@ func NewExecutor(matcher PatternMatcher, resolver EntityResolver) *Executor {
 // NewExecutorWithOptions creates a new query executor with custom planner options
 func NewExecutorWithOptions(matcher PatternMatcher, resolver EntityResolver, opts planner.PlannerOptions) *Executor {
 	// Convert to executor options
-	execOpts := convertToExecutorOptions(opts)
+	execOpts := ExecutorOptionsFromPlanner(opts)
 
 	// Configure matcher with executor options if it supports it
 	if indexedMatcher, ok := matcher.(*IndexedMemoryMatcher); ok {
@@ -59,8 +59,15 @@ func NewExecutorWithOptions(matcher PatternMatcher, resolver EntityResolver, opt
 	}
 }
 
-// convertToExecutorOptions extracts executor-specific options from PlannerOptions
-func convertToExecutorOptions(opts planner.PlannerOptions) ExecutorOptions {
+// ExecutorOptionsFromPlanner is the single source of truth for deriving
+// ExecutorOptions from PlannerOptions. Both the executor (NewExecutorWithOptions)
+// and the storage default-source matcher (storage.Database.Matcher) convert
+// through this function so they cannot disagree on which fields cross the
+// boundary — every PlannerOptions field that has an ExecutorOptions counterpart
+// is copied here. Collector is set per-query from the execution context, and
+// DefaultHashTableSize has no PlannerOptions counterpart, so both are left at
+// their zero value.
+func ExecutorOptionsFromPlanner(opts planner.PlannerOptions) ExecutorOptions {
 	return ExecutorOptions{
 		EnableIteratorComposition:       opts.EnableIteratorComposition,
 		EnableTrueStreaming:             opts.EnableTrueStreaming,
@@ -76,6 +83,7 @@ func convertToExecutorOptions(opts planner.PlannerOptions) ExecutorOptions {
 		EnableScanSharing:               opts.EnableScanSharing,
 		EnableEntityPrefetch:            opts.EnableEntityPrefetch,
 		EnableAttributeFetchFusion:      opts.EnableAttributeFetchFusion,
+		IndexNestedLoopThreshold:        opts.IndexNestedLoopThreshold,
 	}
 }
 

--- a/datalog/executor/executor_options_propagation_test.go
+++ b/datalog/executor/executor_options_propagation_test.go
@@ -1,0 +1,33 @@
+// Reproduction for docs/bugs/BUG_PLANNER_OPTIONS_NOT_PROPAGATED_TO_MATCHER.md
+// (executor half).
+//
+// The PlannerOptions -> ExecutorOptions conversion dropped
+// IndexNestedLoopThreshold, so even a custom threshold never reached the
+// executor's effective options. This is the field-set drift the bug report
+// flags: the storage-side and executor-side conversions copied different
+// subsets, and IndexNestedLoopThreshold was absent here.
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog/planner"
+)
+
+// TestNewExecutorWithOptions_HonorsIndexNestedLoopThreshold pins that a custom
+// IndexNestedLoopThreshold survives the PlannerOptions -> ExecutorOptions
+// conversion into the executor's effective options.
+func TestNewExecutorWithOptions_HonorsIndexNestedLoopThreshold(t *testing.T) {
+	opts := planner.PlannerOptions{
+		IndexNestedLoopThreshold: 12345,
+		EnableScanSharing:        true,
+	}
+	exec := NewExecutorWithOptions(nil, nil, opts)
+
+	require.Equal(t, 12345, exec.options.IndexNestedLoopThreshold,
+		"custom IndexNestedLoopThreshold must reach the executor's effective options")
+	require.True(t, exec.options.EnableScanSharing,
+		"sanity: a field the converter already copied must still be honored")
+}

--- a/datalog/storage/convenience.go
+++ b/datalog/storage/convenience.go
@@ -6,7 +6,6 @@ import (
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/executor"
 	"github.com/wbrown/janus-datalog/datalog/parser"
-	"github.com/wbrown/janus-datalog/datalog/planner"
 	"github.com/wbrown/janus-datalog/datalog/query"
 )
 
@@ -48,12 +47,7 @@ func (d *Database) Query(queryInput interface{}, inputs ...interface{}) (executo
 	}
 
 	// Execute with the SourceRouter as the PatternMatcher
-	var planOpts planner.PlannerOptions
-	if d.plannerOptions != nil {
-		planOpts = *d.plannerOptions
-	} else {
-		planOpts = DefaultPlannerOptions()
-	}
+	planOpts := d.effectivePlannerOptions()
 	planOpts.Cache = d.planCache
 	exec := executor.NewExecutorWithOptions(router, d, planOpts)
 	result, err := exec.ExecuteWithRelations(executor.NewContext(d.annotationHandler), q, inputRelations)

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -394,37 +394,25 @@ func (d *Database) NewTransactionAt(t time.Time) *Transaction {
 }
 
 // Matcher returns a PatternMatcher for the current database state
+// effectivePlannerOptions returns the database's planner options: the
+// caller-supplied override (DatabaseOptions.PlannerOptions) when set, otherwise
+// DefaultPlannerOptions(). Every query-construction path (Query, NewExecutor,
+// Matcher) funnels through this accessor so the executor and the default-source
+// matcher always agree on the effective options. See
+// BUG_PLANNER_OPTIONS_NOT_PROPAGATED_TO_MATCHER.
+func (d *Database) effectivePlannerOptions() planner.PlannerOptions {
+	if d.plannerOptions != nil {
+		return *d.plannerOptions
+	}
+	return DefaultPlannerOptions()
+}
+
+// Matcher returns the default-source pattern matcher, configured from the
+// database's effective planner options (override or defaults) so the relations
+// it produces carry the same executor options the query runs with — not a
+// hardcoded default set.
 func (d *Database) Matcher() executor.PatternMatcher {
-	// Convert default planner options to executor options
-	opts := DefaultPlannerOptions()
-	execOpts := executor.ExecutorOptions{
-		EnableIteratorComposition:       opts.EnableIteratorComposition,
-		EnableTrueStreaming:             opts.EnableTrueStreaming,
-		EnableSymmetricHashJoin:         opts.EnableSymmetricHashJoin,
-		EnableParallelSubqueries:        opts.EnableParallelSubqueries,
-		MaxSubqueryWorkers:              opts.MaxSubqueryWorkers,
-		EnableStreamingJoins:            opts.EnableStreamingJoins,
-		EnableStreamingAggregation:      opts.EnableStreamingAggregation,
-		EnableStreamingAggregationDebug: opts.EnableStreamingAggregationDebug,
-		EnableDebugLogging:              opts.EnableDebugLogging,
-		IndexNestedLoopThreshold:        opts.IndexNestedLoopThreshold,
-	}
-	matcher := NewBadgerMatcherWithOptions(d.store, execOpts)
-	// Set annotation handler for storage-level events (index selection, scan details)
-	matcher.SetHandler(d.annotationHandler)
-	// Set schema for CRDT cardinality-aware resolution
-	if d.schema != nil {
-		matcher.SetSchema(d.schema)
-	}
-	// Set cache for CRDT resolution O(1) access
-	if d.cache != nil {
-		matcher.SetCache(d.cache)
-	}
-	// Apply temporal mode if set (AsOf/History)
-	if d.temporalTxID != nil {
-		return matcher.AsOf(*d.temporalTxID)
-	}
-	return matcher
+	return d.matcherWithExecOptions(d.effectivePlannerOptions())
 }
 
 // Match implements executor.PatternMatcher — the Database itself can answer pattern queries.
@@ -516,52 +504,31 @@ func DefaultPlannerOptions() planner.PlannerOptions {
 
 // NewExecutor creates a new query executor that uses the database's plan cache
 func (d *Database) NewExecutor() *executor.Executor {
-	var opts planner.PlannerOptions
-	if d.plannerOptions != nil {
-		opts = *d.plannerOptions
-	} else {
-		opts = DefaultPlannerOptions()
-	}
+	opts := d.effectivePlannerOptions()
 	opts.Cache = d.planCache // Use database's cache
-	return executor.NewExecutorWithOptions(d.Matcher(), d, opts)
+	return executor.NewExecutorWithOptions(d.matcherWithExecOptions(opts), d, opts)
 }
 
 // NewExecutorWithOptions creates a new query executor with custom planner
 // options and the database's plan cache.
 //
-// Uses d.Matcher() to construct the pattern matcher, so schema, cache,
-// annotation handler, and temporal mode (AsOf/History) are all applied.
-// The executor options from the planner options override the matcher's
-// default executor options.
+// Builds the pattern matcher from the same custom options via
+// matcherWithExecOptions, so the executor and the matcher's relations agree on
+// the effective options, and schema, cache, annotation handler, and temporal
+// mode (AsOf/History) are all applied.
 func (d *Database) NewExecutorWithOptions(opts planner.PlannerOptions) *executor.Executor {
 	opts.Cache = d.planCache
-	// Build the matcher via d.Matcher() which applies schema, cache,
-	// annotation handler, and temporal mode. Then override its executor
-	// options with the caller's custom options.
 	matcher := d.matcherWithExecOptions(opts)
 	return executor.NewExecutorWithOptions(matcher, d, opts)
 }
 
 // matcherWithExecOptions builds a fully-configured BadgerMatcher using the
-// caller's executor options (from PlannerOptions) while applying all
+// given planner options (converted through executor.ExecutorOptionsFromPlanner,
+// the single source of truth shared with the executor) while applying all
 // database-level state: schema, cache, annotation handler, temporal mode.
-//
-// This is the same as Matcher() but with custom executor options instead of
-// the defaults.
+// Matcher() funnels through here with the database's effective options.
 func (d *Database) matcherWithExecOptions(opts planner.PlannerOptions) executor.PatternMatcher {
-	execOpts := executor.ExecutorOptions{
-		EnableIteratorComposition:       opts.EnableIteratorComposition,
-		EnableTrueStreaming:             opts.EnableTrueStreaming,
-		EnableSymmetricHashJoin:         opts.EnableSymmetricHashJoin,
-		EnableParallelSubqueries:        opts.EnableParallelSubqueries,
-		MaxSubqueryWorkers:              opts.MaxSubqueryWorkers,
-		EnableStreamingJoins:            opts.EnableStreamingJoins,
-		EnableStreamingAggregation:      opts.EnableStreamingAggregation,
-		EnableStreamingAggregationDebug: opts.EnableStreamingAggregationDebug,
-		EnableDebugLogging:              opts.EnableDebugLogging,
-		IndexNestedLoopThreshold:        opts.IndexNestedLoopThreshold,
-	}
-	matcher := NewBadgerMatcherWithOptions(d.store, execOpts)
+	matcher := NewBadgerMatcherWithOptions(d.store, executor.ExecutorOptionsFromPlanner(opts))
 	matcher.SetHandler(d.annotationHandler)
 	if d.schema != nil {
 		matcher.SetSchema(d.schema)

--- a/datalog/storage/matcher_planner_options_test.go
+++ b/datalog/storage/matcher_planner_options_test.go
@@ -1,0 +1,62 @@
+// Reproduction for docs/bugs/BUG_PLANNER_OPTIONS_NOT_PROPAGATED_TO_MATCHER.md
+//
+// Database.Query builds the executor from the database's effective
+// PlannerOptions, but Database.Matcher() built its BadgerMatcher from
+// DefaultPlannerOptions(). Because a matcher stamps its ExecutorOptions onto
+// every StreamingRelation/MaterializedRelation it returns, a custom-options
+// query ran with the executor seeing the custom options while every
+// storage-produced relation carried defaults — configuration drift inside a
+// single query.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestDatabaseMatcher_HonorsCustomPlannerOptions asserts that relations
+// produced by the default-source matcher carry the database's effective
+// options, not DefaultPlannerOptions(). It exercises both drift directions:
+// fields Matcher() copied but from the wrong source (EnableTrueStreaming,
+// IndexNestedLoopThreshold) and fields Matcher() dropped entirely
+// (EnableScanSharing, EnableEntityPrefetch).
+func TestDatabaseMatcher_HonorsCustomPlannerOptions(t *testing.T) {
+	custom := DefaultPlannerOptions()
+	custom.EnableTrueStreaming = false       // default true
+	custom.EnableScanSharing = true          // default false; dropped by Matcher() pre-fix
+	custom.EnableEntityPrefetch = true       // default false; dropped by Matcher() pre-fix
+	custom.IndexNestedLoopThreshold = 999999 // default 0; built from defaults pre-fix
+
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:           t.TempDir(),
+		ReplicaID:      1,
+		PlannerOptions: &custom,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	m := db.Matcher().(*BadgerMatcher)
+	pattern := &query.DataPattern{
+		Elements: []query.PatternElement{
+			query.Variable{Name: datalog.NewSymbol("?e")},
+			query.Constant{Value: datalog.NewKeyword(":test/attr")},
+			query.Variable{Name: datalog.NewSymbol("?v")},
+		},
+	}
+	rel, err := m.Match(pattern, nil)
+	require.NoError(t, err)
+
+	opts := rel.Options()
+	require.False(t, opts.EnableTrueStreaming,
+		"custom EnableTrueStreaming=false must reach matcher-produced relations")
+	require.True(t, opts.EnableScanSharing,
+		"custom EnableScanSharing=true must reach matcher-produced relations")
+	require.True(t, opts.EnableEntityPrefetch,
+		"custom EnableEntityPrefetch=true must reach matcher-produced relations")
+	require.Equal(t, 999999, opts.IndexNestedLoopThreshold,
+		"custom IndexNestedLoopThreshold must reach matcher-produced relations")
+}

--- a/docs/bugs/resolved/BUG_PLANNER_OPTIONS_NOT_PROPAGATED_TO_MATCHER.md
+++ b/docs/bugs/resolved/BUG_PLANNER_OPTIONS_NOT_PROPAGATED_TO_MATCHER.md
@@ -1,0 +1,175 @@
+# BUG: Custom PlannerOptions Do Not Fully Propagate to BadgerMatcher
+
+**Date**: 2026-05-30
+**Severity**: Medium — custom execution configurations can diverge between planner/executor and storage relations
+**Status**: ✅ RESOLVED (2026-05-31)
+**Affected**: `storage.Database.Query`, `storage.Database.Matcher`
+
+## Resolution
+
+Centralized the `PlannerOptions → ExecutorOptions` conversion and made the
+default-source matcher honor the database's effective options.
+
+The conversion now has one home: `executor.ExecutorOptionsFromPlanner`, which
+copies every `PlannerOptions` field that has an `ExecutorOptions` counterpart —
+including `IndexNestedLoopThreshold`, which the executor's own converter
+previously dropped (so even `NewExecutorWithOptions` lost a custom threshold).
+Three drifting manual copy sites are gone: the executor's
+`convertToExecutorOptions` (renamed to the exported `ExecutorOptionsFromPlanner`)
+and the two in `storage` (`Database.Matcher` and `Database.matcherWithExecOptions`,
+which each omitted `UseStreamingSubqueryUnion`, `UseComponentizedSubquery`,
+`EnableScanSharing`, `EnableEntityPrefetch`, `EnableAttributeFetchFusion`).
+
+A new `Database.effectivePlannerOptions()` returns the caller override or the
+defaults, and every query-construction path funnels through it: `Matcher()`
+delegates to `matcherWithExecOptions(d.effectivePlannerOptions())`, and `Query`,
+`NewExecutor`, and `NewExecutorWithOptions` use the same accessor — so the
+executor and the matcher's relations always agree on the effective options.
+User-supplied `WithSources` matchers are untouched; only the default `$` source
+changed.
+
+Regression coverage, both verified to fail before the fix:
+
+- `storage/matcher_planner_options_test.go`
+  (`TestDatabaseMatcher_HonorsCustomPlannerOptions`) — a relation produced by
+  `db.Matcher()` under custom options carries them (`EnableTrueStreaming`,
+  `EnableScanSharing`, `EnableEntityPrefetch`, `IndexNestedLoopThreshold`), not
+  defaults.
+- `executor/executor_options_propagation_test.go`
+  (`TestNewExecutorWithOptions_HonorsIndexNestedLoopThreshold`) — a custom
+  `IndexNestedLoopThreshold` survives into the executor's effective options.
+
+## Summary
+
+`Database.Query` honors `Database.plannerOptions` when constructing the
+executor, but `Database.Matcher()` always constructs its `BadgerMatcher` from
+`DefaultPlannerOptions()`. Because storage matchers attach `ExecutorOptions` to
+the `StreamingRelation`s they return, custom options can be applied at the
+executor layer while storage-produced relations still carry default options.
+
+This creates configuration drift inside one query.
+
+## Code Evidence
+
+`Database.Query` chooses the query's planner/executor options from
+`d.plannerOptions` when present:
+
+```go
+var planOpts planner.PlannerOptions
+if d.plannerOptions != nil {
+	planOpts = *d.plannerOptions
+} else {
+	planOpts = DefaultPlannerOptions()
+}
+planOpts.Cache = d.planCache
+exec := executor.NewExecutorWithOptions(router, d, planOpts)
+```
+
+But the default database source is built before that through `d.Matcher()`:
+
+```go
+sources := buildSourceMap(opts.sources, d.Matcher())
+```
+
+`d.Matcher()` ignores `d.plannerOptions` and always converts defaults:
+
+```go
+opts := DefaultPlannerOptions()
+execOpts := executor.ExecutorOptions{
+	EnableIteratorComposition:       opts.EnableIteratorComposition,
+	EnableTrueStreaming:             opts.EnableTrueStreaming,
+	EnableSymmetricHashJoin:         opts.EnableSymmetricHashJoin,
+	EnableParallelSubqueries:        opts.EnableParallelSubqueries,
+	MaxSubqueryWorkers:              opts.MaxSubqueryWorkers,
+	EnableStreamingJoins:            opts.EnableStreamingJoins,
+	EnableStreamingAggregation:      opts.EnableStreamingAggregation,
+	EnableStreamingAggregationDebug: opts.EnableStreamingAggregationDebug,
+	EnableDebugLogging:              opts.EnableDebugLogging,
+	IndexNestedLoopThreshold:        opts.IndexNestedLoopThreshold,
+}
+matcher := NewBadgerMatcherWithOptions(d.store, execOpts)
+```
+
+So a query can run with custom `PlannerOptions` in `Executor`, while every
+storage relation produced by the default `$` source carries options derived from
+defaults.
+
+## Why This Matters
+
+Several relation operations read options from their input relations:
+
+- streaming vs materialized relation behavior
+- join strategy flags
+- streaming aggregation flags
+- debug logging flags
+- storage join strategy thresholds
+
+If the executor and matcher disagree about those options, non-default
+configurations become difficult to reason about. A user can disable a feature in
+`PlannerOptions`, but storage-created relations may still carry defaults that
+re-enable or influence downstream behavior.
+
+This is especially suspicious in light of the documented known limitation in
+`active/CONDITIONAL_AGGREGATE_STREAMING_DEPENDENCY.md`: disabling streaming is a
+non-default path that has shown nondeterministic failures. This options drift is
+not proven to be that root cause, but it is the kind of mismatch that makes
+non-default execution modes unreliable.
+
+## Expected Behavior
+
+For a single query, all components that consume execution options should see the
+same effective options:
+
+1. planner
+2. executor
+3. matcher
+4. relations returned by matcher
+5. joins/aggregations/transforms that inherit relation options
+
+If `Database.plannerOptions` is set, the default `$` matcher should be built
+from those options, not from `DefaultPlannerOptions()`.
+
+## Actual Behavior
+
+`Database.Query` uses custom options for the executor but gets the default source
+from `d.Matcher()`, and `d.Matcher()` always uses defaults.
+
+## Suggested Fix
+
+Centralize the conversion from `planner.PlannerOptions` to
+`executor.ExecutorOptions` so `Database.Matcher()` and
+`executor.NewExecutorWithOptions()` cannot drift.
+
+Possible direction:
+
+1. Add a `Database.effectivePlannerOptions()` method that returns
+   `*d.plannerOptions` or `DefaultPlannerOptions()`, with cache set where
+   appropriate.
+2. Add a storage-side conversion function or reuse an exported executor
+   conversion function instead of manually copying fields in `Database.Matcher()`.
+3. Ensure `Database.Query` builds the default matcher using the same effective
+   options passed to `NewExecutorWithOptions`.
+
+Be careful with `WithSources`: user-supplied sources may have their own options
+and should not necessarily be mutated, but the default database source should be
+consistent with the query options.
+
+## Tests Needed
+
+Add tests that force non-default options and assert they reach storage-produced
+relations:
+
+1. Construct a `Database` with `PlannerOptions{EnableIteratorComposition:false,
+   EnableTrueStreaming:false, EnableStreamingAggregation:false}`.
+2. Run a storage-backed query and capture either annotations or relation options
+   from a matcher-created relation.
+3. Verify the matcher relation options match the custom query options, not
+   defaults.
+4. Add a regression test for `IndexNestedLoopThreshold`, since that option is
+   copied in `Database.Matcher()` but not currently included in
+   `executor.convertToExecutorOptions`; this can expose drift in either
+   direction.
+
+If the intended design is that matcher options are always defaults, document that
+explicitly and make sure executor operations do not infer behavior from relation
+options that came from the matcher.


### PR DESCRIPTION
## Summary

`Database.Matcher()` built its `BadgerMatcher` from `DefaultPlannerOptions()`, while `Database.Query` built the executor from the database's *effective* `PlannerOptions`. Since a matcher stamps its `ExecutorOptions` onto every relation it produces (and downstream joins/aggregations read them), a custom-options query ran with the executor seeing custom options and every storage-produced relation carrying defaults — configuration drift inside one query.

Investigation also surfaced that the conversion existed in **three** drifting manual copy sites with different field subsets, so the options that crossed the boundary depended on which path you took.

## Fix

One canonical converter, matcher honors effective options:

- **`executor.ExecutorOptionsFromPlanner`** — exported single source of truth (renamed from the unexported `convertToExecutorOptions`). Copies every `PlannerOptions` field with an `ExecutorOptions` counterpart, **including `IndexNestedLoopThreshold`** — which the old converter dropped, so even `NewExecutorWithOptions` was losing a custom threshold.
- Collapsed the three copy sites into it: the executor converter, `Database.Matcher`, and `Database.matcherWithExecOptions`. The two storage copies also silently dropped `UseStreamingSubqueryUnion`, `UseComponentizedSubquery`, `EnableScanSharing`, `EnableEntityPrefetch`, `EnableAttributeFetchFusion`.
- **`Database.effectivePlannerOptions()`** — returns the caller override or the defaults; `Query`, `NewExecutor`, `NewExecutorWithOptions`, and `Matcher` all funnel through it so the executor and the matcher's relations agree on the effective options.
- User-supplied `WithSources` matchers are untouched; only the default `$` source changed. `database.go` shrinks (three copies → one).

## Tests

Both written before the fix and **verified to fail** against the unfixed code:

- `storage/matcher_planner_options_test.go` (`TestDatabaseMatcher_HonorsCustomPlannerOptions`) — a relation from `db.Matcher()` under custom options carries them (`EnableTrueStreaming`, `EnableScanSharing`, `EnableEntityPrefetch`, `IndexNestedLoopThreshold`), not defaults.
- `executor/executor_options_propagation_test.go` (`TestNewExecutorWithOptions_HonorsIndexNestedLoopThreshold`) — a custom `IndexNestedLoopThreshold` survives into the executor's effective options.

Full `go test -count=1 ./...` green.

Resolves `BUG_PLANNER_OPTIONS_NOT_PROPAGATED_TO_MATCHER` (moved to `docs/bugs/resolved/`).