### PR TITLE
Reconstruct CRDT cardinality from stored ops on schemaless open

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,48 @@ When the user says "revert", do it as your very next action. Do not:
 - **Immediate revert** = recoverable state preserved
 - **Deferred revert** = potentially permanent damage
 
+## Principles Are Upstream, Not a Final Filter
+
+Every rule in this file is a **discipline that generates your actions**, not a
+token or command to suppress at the last checkpoint. When you implement a rule as
+an output filter — scanning for a banned word in identifiers, or catching a
+banned command just before you run it — you leak it everywhere the filter doesn't
+reach, and the leak is proof the upstream thinking already lapsed. If you find
+yourself routing a rule through a checkpoint instead of letting it shape the
+action, stop: you have already lost it. These are the recurring instances:
+
+- **"No helpers" is not "don't type `helper` in a function name."** It is: name
+  every piece of code for what it does. If the word *helper* occurs to you at all
+  — in a name, a comment, or describing your own work out loud — you have not done
+  the naming, and that code needs a second look. The word surfacing IS the
+  violation, wherever it surfaces.
+
+- **Never destroy state you cannot get back.** This is not "avoid these verbs," it
+  is a property of the action. `git clean` and `git stash` are **banned outright,
+  for any reason** — `clean` irrecoverably deletes untracked files (ones git has
+  no record of), `stash` has silently buried work in this repo. Do not `rm`/`rmdir`
+  files. To undo your *own* uncommitted edits when the user asks you to revert,
+  `git restore` on the tracked files you changed this turn is fine; to remove a
+  file you created, leave it in place and ask, or move it — never delete. When in
+  doubt, move, don't delete.
+
+- **Green gates commit-prep.** `git add`, moving a bug doc to `resolved/`, marking
+  something RESOLVED — these are commit-prep, and they come *after* a green
+  `go test -count=1 ./...`, never in the same breath as the run that would tell you
+  whether the work is even correct. A red pre-existing test is the loudest signal
+  the approach is wrong; you must not be anywhere near `git add` when you haven't
+  earned green.
+
+- **Diagnose by reading, not by ritual.** No throwaway `*_test.go` scratch files,
+  no `md5`/`shasum`/`wc -l`/`cat -A` on source files. A failed Edit means your
+  `old_string` was wrong or your context is stale — Read the relevant lines and fix
+  it. The file is not haunted; hashing it tells you nothing about your mistake.
+
+- **One result at a time when actions depend on each other.** Over-parallelizing
+  tool calls so you act on step N before reading step N-1's result is how the
+  destructive and premature mistakes above actually happen. Fan out only truly
+  independent work.
+
 ## Project Overview
 
 This repository contains a Datomic-style Datalog engine implementation in Go, inspired by memories of previous single-node and distributed implementations.

--- a/datalog/storage/cardinality_inference.go
+++ b/datalog/storage/cardinality_inference.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// Schema is optional and is NOT persisted in the store, so a database can be
+// reopened without one (e.g. the `datalog` CLI's storage.NewDatabase). The
+// datoms are self-describing, though: each records its write-time CRDT op
+// atomically with its value — one→OpNone, many→OpCRDTAdd/Remove,
+// vector→OpRGAInsert/Tombstone — so cardinality is recoverable from the data
+// alone. inferSchemaFromStore reconstructs a schema from those ops, which (once
+// installed) makes every existing read path resolve vector/many attributes
+// correctly instead of collapsing them to a single LWW value, with no
+// query-path special-casing.
+
+// cardFromOp maps a CRDT op to the cardinality whose resolver handles it, and
+// reports whether the op is DECISIVE. OpCRDTAdd→many, OpRGAInsert/Tombstone→
+// vector, OpNone→one are decisive. OpCRDTRemove is NOT: it is written for both a
+// cardinality-one tombstone (database.go Remove, CardinalityOne) and a
+// cardinality-many member removal (CardinalityMany), so it cannot classify an
+// attribute by itself — callers skip Remove entries and wait for a decisive op.
+func cardFromOp(op datalog.CRDTOp) (schema.Cardinality, bool) {
+	switch op {
+	case datalog.OpCRDTAdd:
+		return schema.CardinalityMany, true
+	case datalog.OpRGAInsert, datalog.OpRGATombstone:
+		return schema.CardinalityVector, true
+	case datalog.OpNone:
+		return schema.CardinalityOne, true
+	default: // OpCRDTRemove — ambiguous between one and many
+		return schema.CardinalityOne, false
+	}
+}
+
+// valueTypeFromValue maps a decoded datom value to its schema ValueType. Used to
+// populate an inferred attribute's ValueType from a representative stored value
+// (affects typed-vector formatting, not resolution correctness); falls back to
+// TypeString for anything unrecognized.
+func valueTypeFromValue(v interface{}) schema.ValueType {
+	switch v.(type) {
+	case string:
+		return schema.TypeString
+	case int64:
+		return schema.TypeLong
+	case float64:
+		return schema.TypeDouble
+	case bool:
+		return schema.TypeBoolean
+	case time.Time:
+		return schema.TypeInstant
+	case datalog.Identity:
+		return schema.TypeRef
+	case datalog.Keyword:
+		return schema.TypeKeyword
+	case []byte:
+		return schema.TypeBytes
+	default:
+		return schema.TypeString
+	}
+}
+
+// inferSchemaFromStore reconstructs a cardinality/value-type schema by reading
+// the CRDT ops already stored on disk (see the package note above for why this
+// is sound). It performs one keys-only pass over the ATEV index
+// ([A][Tx↓][E][V]), which groups every datom by attribute. Within each
+// attribute it classifies from the first DECISIVE op (see cardFromOp): leading
+// OpCRDTRemove entries are skipped because they are ambiguous, and an attribute
+// whose entries are ALL removes resolves empty under either cardinality, so it
+// defaults to one. Returns a non-nil (possibly empty) schema.
+func inferSchemaFromStore(store *BadgerStore) (*schema.Schema, error) {
+	s := schema.NewSchema()
+	start, end := store.encoder.EncodePrefixRange(ATEV)
+	iter, err := store.ScanKeysOnly(ATEV, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var curA datalog.Keyword
+	var curStr string
+	haveA := false
+	decided := false
+	card := schema.CardinalityOne
+	var vt schema.ValueType
+
+	flush := func() {
+		if haveA {
+			s.Add(&schema.AttributeDefinition{
+				Ident:       curA,
+				Cardinality: card,
+				ValueType:   vt,
+			})
+		}
+	}
+
+	for iter.Next() {
+		d, derr := iter.Datom()
+		if derr != nil {
+			return nil, derr
+		}
+		// Compare by string form rather than relying on Keyword equality
+		// semantics; ATEV groups all entries for an attribute contiguously.
+		if aStr := d.A.String(); !haveA || aStr != curStr {
+			flush()
+			curA = d.A
+			curStr = aStr
+			haveA = true
+			decided = false
+			card = schema.CardinalityOne          // default if only removes appear
+			vt = valueTypeFromValue(d.V)          // sensible default; refined below
+		}
+		if decided {
+			continue // attribute already classified — skip to the next attribute
+		}
+		if c, ok := cardFromOp(d.Op); ok {
+			card = c
+			vt = valueTypeFromValue(d.V)
+			decided = true
+		}
+		// else OpCRDTRemove — keep scanning this attribute for a decisive op
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+	flush()
+	return s, nil
+}

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -170,12 +170,30 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 		cache = NewCache()
 	}
 
+	// When the caller supplies no schema, reconstruct one from the CRDT ops
+	// already stored on disk so vector/many attributes resolve correctly instead
+	// of collapsing to a single LWW value (e.g. the `datalog` CLI opening an
+	// existing database). A supplied schema is authoritative and wins entirely —
+	// no inference. On an empty store this yields an empty schema, equivalent to
+	// the previous nil behavior.
+	effectiveSchema := opts.Schema
+	if effectiveSchema == nil {
+		inferred, ierr := inferSchemaFromStore(store)
+		if ierr != nil {
+			store.Close()
+			return nil, fmt.Errorf("inferring schema from store: %w", ierr)
+		}
+		if inferred.HasSchema() {
+			effectiveSchema = inferred
+		}
+	}
+
 	return &Database{
 		store:             store,
 		activeTx:          make(map[*Transaction]bool),
 		planCache:         planner.NewPlanCache(1000, 0),
 		parseCache:        NewParseCache(1000),
-		schema:            opts.Schema,
+		schema:            effectiveSchema,
 		annotationHandler: annotations.Synchronized(opts.AnnotationHandler),
 		plannerOptions:    opts.PlannerOptions,
 		clock:             clock,

--- a/datalog/storage/schemaless_crdt_read_test.go
+++ b/datalog/storage/schemaless_crdt_read_test.go
@@ -1,0 +1,312 @@
+package storage
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// Regression for BUG_SCHEMALESS_READ_COLLAPSES_CRDT_VECTOR_TO_LWW.
+//
+// A CardinalityVector / CardinalityMany attribute written WITH a schema (so its
+// datoms carry OpRGAInsert / OpCRDTAdd) must read back identically whether or
+// not the reader has a schema: the data is self-describing via its CRDT ops.
+// The bug: a schemaless read collapses a vector to its last element (LWW) and a
+// set to a single member, silently.
+//
+// The invariant asserted here is read-equality — schemaless read == schema-aware
+// read of the same bytes — so it does not hard-code the value representation,
+// only that the schemaless path must not lose data the schema-aware path keeps.
+//
+// NOTE: (count ?v) cannot detect this collapse: a vector binds ?v to one list
+// value, so count is 1 either way. These tests inspect the bound value.
+
+// readVectorAsStrings runs `[:find ?v :where [?e <attr> ?v]]` (E bound via :in
+// when bindE), requires exactly one ?v row, and returns the binding normalized
+// to []string. A correctly-resolved vector binds ?v to one ordered list value
+// ([]string or []interface{}); a collapsed read binds ?v to a single scalar,
+// which fails here — that failure IS the bug.
+func readVectorAsStrings(t *testing.T, db *Database, e datalog.Identity, attrPat string, bindE bool) []string {
+	t.Helper()
+	q := fmt.Sprintf(`[:find ?v :where [?e %s ?v]]`, attrPat)
+	args := []interface{}{}
+	if bindE {
+		q = fmt.Sprintf(`[:find ?v :in $ ?e :where [?e %s ?v]]`, attrPat)
+		args = append(args, e)
+	}
+	rel, err := db.Query(q, args...)
+	require.NoError(t, err)
+	it := rel.Iterator()
+	defer it.Close()
+	require.True(t, it.Next(), "expected one ?v row")
+	v := it.Tuple()[0]
+	require.False(t, it.Next(), "expected exactly one ?v row")
+	require.NoError(t, it.Error())
+	return asStringList(t, v)
+}
+
+// asStringList normalizes a vector ?v binding to []string, failing if v is a
+// scalar (the schemaless collapse) or contains non-strings.
+func asStringList(t *testing.T, v interface{}) []string {
+	t.Helper()
+	switch vv := v.(type) {
+	case []string:
+		return vv
+	case []interface{}:
+		out := make([]string, len(vv))
+		for i, x := range vv {
+			s, ok := x.(string)
+			require.Truef(t, ok, "vector element %d not a string: %T", i, x)
+			out[i] = s
+		}
+		return out
+	default:
+		t.Fatalf("expected a vector value ([]string/[]interface{}), got %T (%v) — "+
+			"this is the schemaless collapse: ?v bound to a single element", v, v)
+		return nil
+	}
+}
+
+// writeVectorDB writes n ordered elements of a CardinalityVector attribute
+// :doc/lines under a schema, then closes. Returns the db path.
+func writeVectorDB(t *testing.T, n int, e datalog.Identity) string {
+	t.Helper()
+	dir := t.TempDir()
+	s := schema.NewBuilder().
+		Attribute(":doc/lines").Type(schema.TypeString).Vector().Add().
+		MustBuild()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir, Schema: s, ReplicaID: 1})
+	require.NoError(t, err)
+	tx := db.NewTransaction()
+	for i := 0; i < n; i++ {
+		require.NoError(t, tx.Add(e, datalog.NewKeyword(":doc/lines"), fmt.Sprintf("line %d", i)))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	return dir
+}
+
+// vectorSchema rebuilds the schema used by writeVectorDB (for schema-aware reopen).
+func vectorSchema() schema.SchemaProvider {
+	return schema.NewBuilder().
+		Attribute(":doc/lines").Type(schema.TypeString).Vector().Add().
+		MustBuild()
+}
+
+// TestSchemalessRead_VectorMatchesSchemaAware is the core regression: reopening
+// a vector-bearing database WITHOUT a schema must return the same ordered list
+// as reopening it WITH the schema. Covered for the unbound-E (streaming
+// CRDTResolvingIterator) and bound-E (cache) query paths, cache enabled and
+// disabled.
+func TestSchemalessRead_VectorMatchesSchemaAware(t *testing.T) {
+	const n = 5
+	e := datalog.NewIdentity("doc-1")
+	dir := writeVectorDB(t, n, e)
+
+	want := make([]string, n)
+	for i := range want {
+		want[i] = fmt.Sprintf("line %d", i)
+	}
+
+	// Establish the schema-aware truth on the same bytes.
+	schemaDB, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir, Schema: vectorSchema(), ReplicaID: 1})
+	require.NoError(t, err)
+	require.Equal(t, want, readVectorAsStrings(t, schemaDB, e, ":doc/lines", false),
+		"schema-aware unbound must see the full ordered vector")
+	require.Equal(t, want, readVectorAsStrings(t, schemaDB, e, ":doc/lines", true),
+		"schema-aware bound must see the full ordered vector")
+	require.NoError(t, schemaDB.Close())
+
+	cases := []struct {
+		name    string
+		opts    DatabaseOptions
+		openDef bool // use NewDatabase(path) (cache on, schemaless)
+	}{
+		{name: "schemaless_cache_on", openDef: true},
+		{name: "schemaless_cache_off", opts: DatabaseOptions{Path: dir, ReplicaID: 1, DisableCache: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var db *Database
+			var err error
+			if tc.openDef {
+				db, err = NewDatabase(dir)
+			} else {
+				db, err = NewDatabaseWithOptions(tc.opts)
+			}
+			require.NoError(t, err)
+			defer db.Close()
+
+			require.Equal(t, want, readVectorAsStrings(t, db, e, ":doc/lines", false),
+				"schemaless unbound-E read must equal schema-aware read, not collapse to the last element")
+			require.Equal(t, want, readVectorAsStrings(t, db, e, ":doc/lines", true),
+				"schemaless bound-E read must equal schema-aware read, not collapse to the last element")
+		})
+	}
+}
+
+// TestSchemalessLookupAttribute_VectorMatchesSchemaAware pins the direct
+// LookupAttribute resolution path (used by Pull). The matcher is obtained via
+// db.Matcher() — the production path — so on a schemaless reopen it carries the
+// schema reconstructed at open from the stored CRDT ops, and must return the
+// full vector rather than collapsing to the last element.
+func TestSchemalessLookupAttribute_VectorMatchesSchemaAware(t *testing.T) {
+	const n = 5
+	e := datalog.NewIdentity("doc-1")
+	dir := writeVectorDB(t, n, e)
+	attr := datalog.NewKeyword(":doc/lines")
+
+	want := make([]string, n)
+	for i := range want {
+		want[i] = fmt.Sprintf("line %d", i)
+	}
+
+	// Schema-aware truth.
+	schemaDB, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir, Schema: vectorSchema(), ReplicaID: 1})
+	require.NoError(t, err)
+	sval, sfound := schemaDB.Matcher().(*BadgerMatcher).LookupAttribute(e, attr)
+	require.True(t, sfound)
+	require.Equal(t, want, asStringList(t, sval), "schema-aware LookupAttribute must return full vector")
+	require.NoError(t, schemaDB.Close())
+
+	// Schemaless reopen: NewDatabase reconstructs the schema from stored ops, so
+	// the production matcher (db.Matcher()) resolves the vector correctly.
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+	val, found := db.Matcher().(*BadgerMatcher).LookupAttribute(e, attr)
+	require.True(t, found)
+	require.Equal(t, want, asStringList(t, val),
+		"schemaless LookupAttribute must reconstruct the vector via the open-time schema, not collapse to the last element")
+}
+
+// TestSchemalessRead_ManyMatchesSchemaAware is the CardinalityMany counterpart:
+// a schemaless read must return the full set, not a single member.
+func TestSchemalessRead_ManyMatchesSchemaAware(t *testing.T) {
+	dir := t.TempDir()
+	e := datalog.NewIdentity("doc-1")
+	attr := datalog.NewKeyword(":doc/tags")
+	members := []string{"alpha", "beta", "gamma", "delta"}
+
+	manySchema := func() schema.SchemaProvider {
+		return schema.NewBuilder().
+			Attribute(":doc/tags").Type(schema.TypeString).Many().Add().
+			MustBuild()
+	}
+
+	dbw, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir, Schema: manySchema(), ReplicaID: 1})
+	require.NoError(t, err)
+	tx := dbw.NewTransaction()
+	for _, m := range members {
+		require.NoError(t, tx.Add(e, attr, m))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+	require.NoError(t, dbw.Close())
+
+	collectSet := func(t *testing.T, db *Database) []string {
+		t.Helper()
+		rel, err := db.Query(`[:find ?v :in $ ?e :where [?e :doc/tags ?v]]`, e)
+		require.NoError(t, err)
+		it := rel.Iterator()
+		defer it.Close()
+		var got []string
+		for it.Next() {
+			s, ok := it.Tuple()[0].(string)
+			require.True(t, ok)
+			got = append(got, s)
+		}
+		require.NoError(t, it.Error())
+		sort.Strings(got)
+		return got
+	}
+
+	want := append([]string(nil), members...)
+	sort.Strings(want)
+
+	schemaDB, err := NewDatabaseWithOptions(DatabaseOptions{Path: dir, Schema: manySchema(), ReplicaID: 1})
+	require.NoError(t, err)
+	require.Equal(t, want, collectSet(t, schemaDB), "schema-aware must see full set")
+	require.NoError(t, schemaDB.Close())
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+	require.Equal(t, want, collectSet(t, db),
+		"schemaless read must return the full add-wins set, not a single member")
+}
+
+// TestSchemalessReopen_WriteUsesInferredCardinality pins the write-path
+// consequence of installing the inferred schema into d.schema: a schemaless
+// reopen of an existing database must write NEW values for an existing
+// vector attribute with RGA semantics (the inferred cardinality), not as an
+// OpNone LWW assertion. The proof is the round trip — appending then reading
+// back the full ordered list. If the write had collapsed to OpNone, that entry
+// would carry the highest Tx and the read would reclassify the group as
+// cardinality-one and return only the new element.
+func TestSchemalessReopen_WriteUsesInferredCardinality(t *testing.T) {
+	const n = 5
+	e := datalog.NewIdentity("doc-1")
+	dir := writeVectorDB(t, n, e) // :doc/lines written as a vector, with schema
+
+	// Reopen WITHOUT a schema; cardinality is reconstructed from stored ops.
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Append a new element through the schemaless handle.
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(e, datalog.NewKeyword(":doc/lines"), fmt.Sprintf("line %d", n)))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	want := make([]string, n+1)
+	for i := range want {
+		want[i] = fmt.Sprintf("line %d", i)
+	}
+	require.Equal(t, want, readVectorAsStrings(t, db, e, ":doc/lines", false),
+		"schemaless append to an inferred vector attribute must extend the vector (RGA), not LWW-overwrite it")
+}
+
+// TestSchemalessPrefetch_VectorNotCollapsed pins the EnableEntityPrefetch path
+// (the 5th cardinality-decision site): PrefetchEntities warms the EA cache by
+// resolving each (E,A) group, and must classify a schemaless vector as Vector
+// from its CRDT ops, not collapse it to a single LWW value. Pre-fix it called
+// GetCardinality (CardinalityOne for schemaless) and cached the last element.
+func TestSchemalessPrefetch_VectorNotCollapsed(t *testing.T) {
+	const n = 5
+	e := datalog.NewIdentity("doc-1")
+	dir := writeVectorDB(t, n, e)
+	attr := datalog.NewKeyword(":doc/lines")
+
+	db, err := NewDatabase(dir) // schemaless, cache enabled
+	require.NoError(t, err)
+	defer db.Close()
+
+	m := db.Matcher().(*BadgerMatcher)
+	// Warm the EA cache the way EnableEntityPrefetch does.
+	m.PrefetchEntities([]datalog.Identity{e})
+
+	// The entry prefetch populated must be a full vector. PopulateFromDatoms set
+	// the entry's version to the group's max ElementID, so GetOrResolve returns
+	// the prefetched entry without rebuilding — i.e. this asserts what prefetch
+	// itself cached.
+	var eEnt Entity
+	copy(eEnt[:], e.Bytes())
+	aStorage := ToStorageDatom(datalog.Datom{A: attr}).A
+	var aAttr Attribute
+	copy(aAttr[:], aStorage[:])
+	key, ok := m.cacheKey(eEnt, aAttr)
+	require.True(t, ok)
+	entry := db.cache.GetOrResolve(key, m)
+	require.NotNil(t, entry)
+	require.Equal(t, schema.CardinalityVector, entry.Cardinality(),
+		"prefetch must classify a schemaless vector as Vector, not collapse to One")
+	require.Len(t, entry.VectorList(), n,
+		"prefetch must cache all vector elements, not just the last")
+}

--- a/docs/bugs/resolved/BUG_SCHEMALESS_READ_COLLAPSES_CRDT_VECTOR_TO_LWW.md
+++ b/docs/bugs/resolved/BUG_SCHEMALESS_READ_COLLAPSES_CRDT_VECTOR_TO_LWW.md
@@ -1,0 +1,199 @@
+# BUG: Schemaless Reads Collapse CRDT Vector/Set Attributes to a Single LWW Value
+
+**Date**: 2026-05-31
+**Severity**: Correctness / silent data loss on read (High)
+**Status**: ✅ RESOLVED (2026-05-31)
+**Affected**: Any reader that opens a database without a schema (`storage.NewDatabase(path)`) and queries a `CardinalityVector` (RGA) or `CardinalityMany` (add-wins set) attribute. Includes the `datalog` CLI and `ednstats`.
+
+## Resolution
+
+Cardinality is **reconstructed from the stored CRDT ops at open** and installed
+as the database's schema. Because every read (and write) path already consults
+`d.schema`, populating it once at open makes them all resolve correctly with **no
+query-path special-casing** — the fix lives entirely at construction time.
+
+### Two corrections to the original report (confirmed during investigation)
+
+1. **The original reproduction was invalid.** `[:find (count ?v) …]` returns 1
+   whether the read is correct or collapsed: a vector binds `?v` to a single
+   *list* value, so `count` is 1 either way. The regression tests instead assert
+   read-equality — schemaless read == schema-aware read of the same bytes —
+   inspecting the bound value's shape.
+
+2. **The collapse had four+ schema-only decision sites, not two.** A schemaless
+   `LookupAttribute` (its own inline schema default), the streaming
+   `CRDTResolvingIterator` (unbound `?e`), the cache `rebuild`/`ResolveEntry`
+   paths, and `PrefetchEntities` each independently defaulted a silent attribute
+   to cardinality-one. Constructing the schema at open fixes all of them at once
+   rather than patching each.
+
+### Why a per-site op-peek does NOT work (a first attempt that was abandoned)
+
+A first attempt added op-inference at each read site by peeking the **first**
+stored datom's op. It broke `TestSchemalessRemove_ThenReAdd` because
+**`OpCRDTRemove` is not unique to cardinality-many**: it is written for both a
+cardinality-one tombstone and a cardinality-many member removal
+(`database.go` `Remove`). Peeking a leading Remove misclassified a removed
+cardinality-one attribute as many, and its re-Add (`OpNone`) then read as absent.
+
+### The shipped fix
+
+`datalog/storage/cardinality_inference.go`:
+
+- `cardFromOp(op)` returns `(cardinality, decisive)`. `OpCRDTAdd`→many,
+  `OpRGAInsert/OpRGATombstone`→vector, `OpNone`→one are **decisive**;
+  `OpCRDTRemove` is **not** (ambiguous one-vs-many).
+- `inferSchemaFromStore` does one keys-only pass over the **ATEV** index
+  (`[A][Tx↓][E][V]`, which groups every datom by attribute) and classifies each
+  attribute by its first **decisive** op — skipping leading `OpCRDTRemove`
+  entries. An attribute whose entries are all removes resolves empty under either
+  cardinality, so it defaults to one. `ValueType` is taken from a representative
+  value (affects typed-vector formatting only).
+
+`database.go` `NewDatabaseWithOptions`: when `opts.Schema == nil`, the effective
+schema is `inferSchemaFromStore(store)`. A supplied schema is authoritative and
+wins entirely (no inference). On an empty store this yields an empty schema,
+equivalent to the prior nil behavior.
+
+This is installed into `d.schema`, so it governs **reads and writes**: a
+schemaless reopen that appends to an existing vector/many attribute now emits the
+correct op (`OpRGAInsert`/`OpCRDTAdd`) instead of corrupting the group with
+`OpNone`. (Cardinality is immutable per attribute in this engine — changing it on
+existing data is unsupported — so a reconstructed cardinality cannot disagree
+with future consistent writes.)
+
+### Regression coverage
+
+`datalog/storage/schemaless_crdt_read_test.go` — all assert schemaless ==
+schema-aware on the same bytes; the read tests were verified to fail before the
+fix:
+
+- `TestSchemalessRead_VectorMatchesSchemaAware` — streaming (unbound `?e`) and
+  cache (bound `?e`) query paths, cache on and off.
+- `TestSchemalessLookupAttribute_VectorMatchesSchemaAware` — the `LookupAttribute`
+  (Pull) path via the production `db.Matcher()`.
+- `TestSchemalessRead_ManyMatchesSchemaAware` — cardinality-many set.
+- `TestSchemalessPrefetch_VectorNotCollapsed` — the `EnableEntityPrefetch` path.
+- `TestSchemalessReopen_WriteUsesInferredCardinality` — schemaless reopen + append
+  extends the vector (RGA) rather than LWW-overwriting it.
+
+## Summary
+
+When a database is opened **without a schema**, querying a cardinality-vector attribute returns only its **last element**, and a cardinality-many attribute returns a single **member** — instead of the full collection. A `count` over a 56-element vector reports `1`.
+
+The storage is intact: every vector datom is persisted as `OpRGAInsert` with its `AfterRef`, and every set datom as `OpCRDTAdd`. A schema-aware open of the same database returns the full collection. The loss is purely in read-resolution on the schemaless path, and it is **silent** — a plausible single value comes back with no error.
+
+This is not "schemaless reads are unsupported." janus already contains an op-inferring resolver (`lookupAllAttributesFallback`) that reconstructs the correct cardinality from the datom ops with no schema. The cache-population path simply doesn't use it: it defaults schemaless attributes to cardinality-one and shadows the correct path.
+
+## Discovery
+
+Found while investigating an apparent `:module/vocabulary` collapse in a downstream scribe import. That attribute is `:db.cardinality/vector`, accumulated across ~50 separate `tx.Add` appends to one entity. Through the CLI it read as a single element:
+
+```
+$ datalog -db curse_of_grimholt.db -query '[:find (count ?v) :where [?e :module/vocabulary ?v]]'
+| (count ?v) | 1 |
+```
+
+…which looked like a last-writer-wins **storage** collapse (the survivor was the last append). But a schema-aware reader showed all 56 entries present and correct, so the discrepancy is the schemaless read, not the data. Probing the raw datom with its Tx component still returns one row — confirming the reader resolves the attribute as cardinality-one (latest), rather than exposing the underlying RGA datoms:
+
+```
+$ datalog -db curse_of_grimholt.db -query '[:find (count ?v) :where [?e :module/vocabulary ?v ?tx]]'
+| (count ?v) | 1 |
+```
+
+## Reproduction
+
+Write a vector attribute with N elements **with a schema** (so the appends are written as `OpRGAInsert`), then reopen the same database **without a schema** (as the CLI does) and query:
+
+```go
+// Writer — schema declares :doc/lines as CardinalityVector.
+dbw, _ := storage.NewDatabaseWithSchema(path, schemaWithVectorAttr)
+e := datalog.NewIdentity("doc-1")
+for i := 0; i < 5; i++ {
+    tx := dbw.Store().NewTransaction()
+    tx.Add(e, linesAttr, fmt.Sprintf("line %d", i)) // OpRGAInsert, AfterRef chained to prior
+    tx.Commit()
+}
+dbw.Close()
+
+// Reader — no schema, exactly how cmd/datalog opens (main.go:103).
+dbr, _ := storage.NewDatabase(path)
+// query: [:find (count ?v) :where [?e :doc/lines ?v]]
+```
+
+**Expected**: 5
+**Actual**: 1 (the last element, `"line 4"`)
+
+The same holds for a `CardinalityMany` attribute: the schemaless reader returns one member instead of the full set.
+
+## Root Cause
+
+Cardinality is resolved from the **schema**, and the schemaless `default` falls back to cardinality-one (LWW) instead of inferring cardinality from the datom ops — even though the data carries the ops needed to do so, and an op-inferring resolver already exists.
+
+### The schemaless default (two sites)
+
+`Cache.rebuild` — populates the cache (`datalog/storage/cache.go:394`):
+
+```go
+func (c *Cache) rebuild(key CacheKey, resolver CacheResolver) *CacheEntry {
+    card := resolver.GetCardinality(key.A)   // schema-derived
+    switch card {
+    case schema.CardinalityOne:    return c.rebuildOne(key, resolver)
+    case schema.CardinalityMany:   return c.rebuildMany(key, resolver)
+    case schema.CardinalityVector: return c.rebuildVector(key, resolver)
+    default:
+        // Default to cardinality-one for schemaless
+        return c.rebuildOne(key, resolver)   // LWW: latest element only
+    }
+}
+```
+
+`ResolveEntry` — the cache-disabled path (`datalog/storage/cache.go:478`) — carries the identical schemaless default (`cache.go:516`), calling `resolver.ResolveLWW`. So the collapse happens whether the EA cache is enabled or not.
+
+`CacheResolver.GetCardinality` (`cache.go:461`) returns the schema cardinality; for an attribute with no schema declaration it yields no match, so both functions hit `default` → cardinality-one → LWW → a single value, which is then cached.
+
+### The correct logic already exists, but is shadowed
+
+`lookupAllAttributesFallback` (`datalog/storage/matcher.go:1019`) resolves an (E, A) **by inferring cardinality from the CRDT ops present in storage**, no schema required:
+
+```
+// - OpNone                       → LWW (cardinality-one): latest value by ElementID
+// - OpCRDTAdd/OpCRDTRemove        → add-wins set (cardinality-many)
+// - OpRGAInsert/OpRGATombstone    → RGA vector (cardinality-vector): reconstruct ordered list
+```
+
+It peeks the first datom's op and dispatches accordingly (`resolveVector` for `OpRGAInsert`). That is exactly the right behavior for a schemaless read. But `matcher.go:1008` reaches it only "when cache is not set" — and `rebuild` *sets* the cache, with the wrong cardinality-one entry. So the cached lookup branch (`matcher.go:996-1004`, `case CardinalityOne: return single value`) wins, and the op-aware fallback never runs.
+
+### The triggering reader
+
+`cmd/datalog/main.go:103` opens the database with `storage.NewDatabase(dbPath)` — no schema. The data is self-describing (every datom carries its op, and `key_encoder_binary.go` persists `AfterRef` for `OpRGAInsert`/`OpRGATombstone`), so cardinality is recoverable; the cache path just doesn't recover it.
+
+## Why this is a bug, not "schema required"
+
+The existence and documented intent of `lookupAllAttributesFallback` — "Infer cardinality from the CRDT ops present in the datoms… rather than returning raw datoms" — establishes that schemaless reads are *meant* to reconstruct CRDT values from the ops. The cache-population paths (`rebuild`, `ResolveEntry`) violate that contract by defaulting to cardinality-one. Two paths disagree on the same input, and the wrong one wins.
+
+## Blast radius
+
+- **Both** `CardinalityVector` and `CardinalityMany` attributes collapse to a single value under any schemaless read.
+- Any consumer on `storage.NewDatabase(path)` without a schema: the `datalog` CLI (`-query`, counts, pulls), `ednstats`, and external tools.
+- **Silent**: returns a plausible last value / single member, no error — easily mistaken for a storage-level LWW collapse (it is not).
+- **Storage is unaffected.** Schema-aware readers, and `lookupAllAttributesFallback` on the no-cache path, return the full collection.
+
+## Proposed Fix
+
+In the schemaless `default` cases of both `Cache.rebuild` (`cache.go:408`) and `ResolveEntry` (`cache.go:516`), infer cardinality from the CRDT ops before resolving — mirror `lookupAllAttributesFallback`: peek the first datom's op for (E, A) and dispatch to the RGA / add-wins / LWW resolver accordingly. Centralizing this in `GetCardinality` (op-inference when the schema has no declaration for the attribute) would fix both sites, and any other `GetCardinality`-gated path, at once.
+
+## Files involved
+
+| File | Issue |
+|------|-------|
+| `datalog/storage/cache.go:394` (`Cache.rebuild`) | schemaless `default` → `rebuildOne` (LWW) collapses vector/many to one value; populates the cache, shadowing the op-aware fallback |
+| `datalog/storage/cache.go:478` (`ResolveEntry`) | identical schemaless `default` → `ResolveLWW` on the cache-disabled path (`cache.go:516`) |
+| `datalog/storage/cache.go:461` (`CacheResolver.GetCardinality`) | returns no cardinality for schemaless attrs → routes both to `default` |
+| `datalog/storage/matcher.go:1019` (`lookupAllAttributesFallback`) | correct op-inference exists but runs only "when cache is not set" (`matcher.go:1008`) |
+| `datalog/storage/matcher.go:996-1004` | cached lookup returns the single value for the (wrong) cardinality-one entry |
+| `cmd/datalog/main.go:103` | CLI opens via `storage.NewDatabase(path)` — the schemaless reader that triggers it |
+
+## Regression test (proposed)
+
+Write a `CardinalityVector` attribute (N≥2 elements) and a `CardinalityMany` attribute with a schema; close; reopen the same path via `storage.NewDatabase(path)` (no schema); assert a query/count returns N (vector) and the full set (many), not 1. A second variant with the EA cache disabled covers the `ResolveEntry` path.


### PR DESCRIPTION
## Summary

A database opened **without a schema** (`storage.NewDatabase`, e.g. the `datalog` CLI) collapsed cardinality-vector attributes to their **last element** and cardinality-many attributes to a **single member**. Every read path defaulted a schema-silent attribute to cardinality-one (LWW), silently losing data that a schema-aware open returns in full. The storage was intact the whole time — only read-resolution was wrong — so it read as a plausible single value with no error.

## Fix

Cardinality is reconstructed from the CRDT ops already on disk and installed as the database's schema **at open**. Every read and write path already consults `d.schema`, so populating it once at construction fixes them all with **no query-path special-casing**.

- `inferSchemaFromStore` (new `cardinality_inference.go`) does one keys-only **ATEV** pass — the index groups datoms by attribute — and classifies each attribute by its first **decisive** op.
- `cardFromOp` maps `OpCRDTAdd`→many, `OpRGAInsert`/`OpRGATombstone`→vector, `OpNone`→one as decisive, and treats `OpCRDTRemove` as **ambiguous** (it's written for both a cardinality-one tombstone and a cardinality-many removal), skipping leading Removes until a decisive op appears. An all-removes attribute resolves empty either way and defaults to one.
- `NewDatabaseWithOptions` installs the inferred schema **only when none is supplied**; a supplied schema wins entirely.

Installed into `d.schema`, this also governs **writes**: a schemaless reopen that appends to an existing vector/many attribute now emits the correct op instead of corrupting the group with `OpNone`. Cardinality is immutable per attribute, so a reconstructed cardinality cannot disagree with future consistent writes.

### Why not a per-site op-peek

A first attempt inferred at each read site by peeking the *first* stored datom's op; it broke `TestSchemalessRemove_ThenReAdd` because a leading `OpCRDTRemove` is ambiguous between one and many. Classifying by the first **decisive** op (skipping Removes), once at open, is the correct form. Detail in the resolved bug doc.

## Tests

`schemaless_crdt_read_test.go` — all assert schemaless == schema-aware on the same bytes; the read tests were verified to **fail before the fix**:

- `TestSchemalessRead_VectorMatchesSchemaAware` — streaming (unbound `?e`) and cache (bound `?e`) query paths, cache on/off
- `TestSchemalessLookupAttribute_VectorMatchesSchemaAware` — the Pull/`LookupAttribute` path via `db.Matcher()`
- `TestSchemalessRead_ManyMatchesSchemaAware` — cardinality-many set
- `TestSchemalessPrefetch_VectorNotCollapsed` — the `EnableEntityPrefetch` path
- `TestSchemalessReopen_WriteUsesInferredCardinality` — schemaless reopen + append extends the vector (RGA), not LWW-overwrite

Full `go test -count=1 ./...` green.

## Also in this PR

A `CLAUDE.md` section, **"Principles Are Upstream, Not a Final Filter,"** capturing that rules must shape actions rather than be suppressed at the last checkpoint (no-helpers; never destroy recoverable state, with `git clean`/`git stash` banned outright; green gates commit-prep; diagnose by reading; one result at a time for dependent steps).

Resolves `BUG_SCHEMALESS_READ_COLLAPSES_CRDT_VECTOR_TO_LWW` (moved to `docs/bugs/resolved/`).