### PR TITLE
Make Analyze() fully execute the query before returning

### DIFF
--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -882,11 +882,30 @@ func (d *Database) Analyze(queryInput interface{}, inputs ...interface{}) (*Anal
 		return nil, fmt.Errorf("query execution failed: %w", err)
 	}
 
+	// Analyze is EXPLAIN ANALYZE-style: it must reflect ACTUAL execution. The
+	// default relation is lazy — storage scans, joins, filters, and deferred
+	// iterator errors happen only when the result is iterated. Drive that work
+	// here via ForEach (which enforces the deferred-error contract) so the
+	// captured events, TotalTime, and any error cover the whole query, not just
+	// plan/pipeline construction. The drained tuples become a materialized,
+	// re-iterable relation for the caller.
+	symbols := result.Symbols()
+	tuples := make([]executor.Tuple, 0)
+	if err := executor.ForEach(result, func(t executor.Tuple) error {
+		cp := make(executor.Tuple, len(t))
+		copy(cp, t)
+		tuples = append(tuples, cp)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("query execution failed: %w", err)
+	}
+	materialized := executor.NewMaterializedRelation(symbols, tuples)
+
 	totalTime := time.Since(startTime)
 
 	return &AnalyzeResult{
 		Plan:      plan,
-		Result:    result,
+		Result:    materialized,
 		Events:    events,
 		TotalTime: totalTime,
 	}, nil

--- a/datalog/storage/explain_test.go
+++ b/datalog/storage/explain_test.go
@@ -269,3 +269,67 @@ func TestAnalyze(t *testing.T) {
 		t.Logf("Join query analysis:\n%s", result.String())
 	})
 }
+
+// TestAnalyze_ConsumesStreamingResults pins that Analyze() fully executes the
+// query before returning, rather than handing back a lazy relation whose work
+// (storage scans, joins, deferred errors) happens only when a caller later
+// iterates it. EXPLAIN ANALYZE-style APIs are expected to measure actual
+// execution; against the unfixed code the storage scan fires during lazy
+// iteration after Analyze has returned, so its events are absent here.
+func TestAnalyze_ConsumesStreamingResults(t *testing.T) {
+	dir, err := os.MkdirTemp("", "analyze-consume-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	db, err := NewDatabase(dir)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	for i, name := range []string{"Task A", "Task B", "Task C"} {
+		e := datalog.NewIdentity(string(rune('a'+i)) + "-task")
+		tx.Add(e, datalog.NewKeyword(":task/name"), name)
+	}
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	result, err := db.Analyze(`[:find ?e :where [?e :task/name ?name]]`)
+	if err != nil {
+		t.Fatalf("Analyze failed: %v", err)
+	}
+
+	// The storage scan is the query's actual work. Analyze must have driven it,
+	// so its event is present without the caller iterating the result.
+	foundScan := false
+	for _, e := range result.Events {
+		if e.Name == annotations.PatternStorageScan {
+			foundScan = true
+			break
+		}
+	}
+	if !foundScan {
+		t.Errorf("Analyze did not capture the storage scan event; query work was deferred past the API boundary. Events: %d", len(result.Events))
+	}
+
+	// The returned result must be fully usable: correct size and re-iterable.
+	if got := result.Result.Size(); got != 3 {
+		t.Errorf("expected 3 result tuples, got %d", got)
+	}
+	count := 0
+	it := result.Result.Iterator()
+	for it.Next() {
+		count++
+	}
+	if err := it.Error(); err != nil {
+		t.Errorf("iterating Analyze result errored: %v", err)
+	}
+	it.Close()
+	if count != 3 {
+		t.Errorf("re-iterating Analyze result yielded %d tuples, want 3", count)
+	}
+}

--- a/datalog/storage/query_boundary_error_test.go
+++ b/datalog/storage/query_boundary_error_test.go
@@ -87,6 +87,17 @@ func TestCollectTuples_SurfacesBlobDecodeError(t *testing.T) {
 	require.ErrorContains(t, err, "blob", "a missing blob must not be reported as an empty result")
 }
 
+// Analyze fully executes the query (EXPLAIN ANALYZE-style), so a deferred
+// blob-decode failure must surface as an error from Analyze itself — not be
+// deferred past the API boundary into a lazy result the caller iterates later.
+func TestAnalyze_SurfacesBlobDecodeError(t *testing.T) {
+	db, e, _ := writeTier3ValueThenCorruptBlob(t)
+	defer db.Close()
+
+	_, err := db.Analyze(`[:find ?v :in $ ?e :where [?e :doc/blob ?v]]`, e)
+	require.ErrorContains(t, err, "blob", "Analyze must surface a deferred decode error, not return a clean lazy result")
+}
+
 func TestQueryInto_SurfacesBlobDecodeError(t *testing.T) {
 	db, e, _ := writeTier3ValueThenCorruptBlob(t)
 	defer db.Close()

--- a/docs/bugs/resolved/BUGS_ANALYZE_DOES_NOT_CONSUME_STREAMING_RESULTS.md
+++ b/docs/bugs/resolved/BUGS_ANALYZE_DOES_NOT_CONSUME_STREAMING_RESULTS.md
@@ -1,0 +1,187 @@
+# BUG: `Analyze()` Returns Before Streaming Query Work Is Fully Executed
+
+**Date**: 2026-05-31
+**Severity**: Observability / Correctness (Medium)
+**Status**: ✅ RESOLVED (2026-05-31)
+**Affected**: `Database.Analyze`, annotation timing, error reporting for lazy query execution
+
+## Resolution
+
+`Analyze()` now fully drives the query before returning (behavior 1 from
+Expected Behavior — the least-surprising option given the `EXPLAIN ANALYZE`
+analogy). After `ExecuteWithRelations`, it consumes the lazy result via
+`executor.ForEach` — which enforces the deferred-iterator-error contract
+(returns the first iteration/close error) — copying each tuple into a slice, then
+builds an `executor.NewMaterializedRelation` from the drained tuples and records
+`TotalTime` *after* consumption. So the captured events, timing, and any error
+now cover the whole query (storage scans, joins, filters, decode/decompression),
+not just plan/pipeline construction, and the returned `Result` is materialized
+and re-iterable for the caller.
+
+Note: `StreamingRelation.Materialize()` was NOT used — on a streaming relation it
+only sets a `shouldCache` flag and defers the actual consumption to the first
+`Iterator()` call, so it would not have driven execution inside `Analyze()`.
+`ForEach` is what forces the work.
+
+Verification (`datalog/storage/`):
+- `explain_test.go::TestAnalyze_ConsumesStreamingResults` — asserts `Analyze()`
+  captures the storage-scan event and returns a correctly-sized (3), re-iterable
+  result. Verified to FAIL against the unfixed code (no scan event; `Size()`
+  returned -1).
+- `query_boundary_error_test.go::TestAnalyze_SurfacesBlobDecodeError` — drives a
+  real deferred Tier-3 blob-decode failure (existing `writeTier3ValueThenCorruptBlob`
+  harness, already proven across nine query boundaries) and asserts `Analyze()`
+  returns the error rather than a clean lazy result.
+- Existing `TestAnalyze` (5 subtests) still pass; full `go test ./...` green.
+
+The `String()` "Result tuples: (streaming...)" branch no longer triggers for
+`Analyze` results, since the result is now materialized — `Size()` returns the
+real count.
+
+## Summary
+
+`Database.Analyze()` is documented as an `EXPLAIN ANALYZE`-style API that
+executes the query and captures execution statistics. In the current streaming
+architecture, however, much of the actual work happens when the returned
+`Relation` is iterated.
+
+`Analyze()` currently returns the lazy relation without consuming it. As a
+result, `TotalTime` and captured events can describe plan construction and lazy
+pipeline construction rather than full query execution. Deferred iterator
+errors can also surface only after `Analyze()` has returned.
+
+## Root Cause
+
+`Analyze()` calls `ExecuteWithRelations`, records elapsed time immediately, and
+returns the relation:
+
+```go
+result, err := exec.ExecuteWithRelations(executor.NewContext(collector.Handler()), q, inputRelations)
+if err != nil {
+    return nil, fmt.Errorf("query execution failed: %w", err)
+}
+
+totalTime := time.Since(startTime)
+
+return &AnalyzeResult{
+    Plan:      plan,
+    Result:    result,
+    Events:    events,
+    TotalTime: totalTime,
+}, nil
+```
+
+But `Relation` is intentionally lazy in the default configuration. A
+`StreamingRelation` reports unknown size instead of consuming its iterator:
+
+```go
+// Streaming behavior: return -1 to indicate unknown size
+// DO NOT call Iterator() here - that would break single-use semantics
+return -1
+```
+
+The execution work, storage decoding, joins, filters, and deferred iterator
+errors may not occur until a caller later iterates `AnalyzeResult.Result`.
+
+## Why This Matters
+
+The API name and documentation imply that `Analyze()` measures actual
+execution. In a lazy engine, returning before the result is consumed means:
+
+1. **Timing can under-report**: `TotalTime` may exclude storage scans, iterator
+   composition work, result materialization, sorting, aggregation finalization,
+   or deferred decode/decompression failures.
+
+2. **Events can be incomplete**: annotation events emitted during iteration can
+   be absent from `AnalyzeResult.Events` at the time the result is returned.
+
+3. **Errors can be delayed past the API boundary**: iterator errors are part of
+   the engine's correctness contract. If they happen during result consumption,
+   `Analyze()` can return nil error even though fully executing the query would
+   fail.
+
+4. **Tests can mask the problem**: a test that checks only that `Analyze()`
+   returns events may pass even if scan/join events have not happened yet.
+
+## Evidence In Existing Tests
+
+`TestAnalyze` already has a soft expectation for storage scan events:
+
+```go
+if !foundScan {
+    t.Log("Note: No storage scan events captured (may depend on executor path)")
+}
+```
+
+That log is consistent with the bug: depending on the lazy path, the storage
+scan may not have occurred during `Analyze()` itself.
+
+## Reproduction Sketch
+
+Use a query whose result is backed by a streaming storage scan, and an
+annotation handler that records storage events.
+
+```go
+result, err := db.Analyze(`[:find ?e :where [?e :person/name ?name]]`)
+require.NoError(t, err)
+
+// At this point, storage scan events may be missing or incomplete.
+eventsBefore := len(result.Events)
+
+_, err = executor.CollectTuples(result.Result, nil)
+require.NoError(t, err)
+
+// Events emitted during iteration happened after Analyze returned.
+eventsAfter := len(result.Events)
+require.Greater(t, eventsAfter, eventsBefore)
+```
+
+A stronger reproducer would use a deferred-error iterator, such as a corrupted
+Tier-3 blob decode path, and verify that `Analyze()` returns nil while
+consuming `AnalyzeResult.Result` returns the actual error.
+
+## Expected Behavior
+
+`Analyze()` should either:
+
+1. fully drive the query and include all execution work, timings, events, and
+   iterator errors in its return value, or
+2. explicitly document that it is a lazy analysis wrapper and that callers must
+   consume `Result` before reading final timing/events.
+
+Given the `EXPLAIN ANALYZE` analogy in the API docs, the first behavior is the
+least surprising.
+
+## Fix Direction
+
+Materialize or otherwise fully consume the result inside `Analyze()` while
+preserving a reusable result relation for the caller.
+
+Possible shape:
+
+```go
+tuples := make([]executor.Tuple, 0)
+if err := executor.ForEach(result, func(t executor.Tuple) error {
+    tuples = append(tuples, copyTuple(t))
+    return nil
+}); err != nil {
+    return nil, fmt.Errorf("query execution failed: %w", err)
+}
+
+materialized := executor.NewMaterializedRelation(result.Symbols(), tuples)
+totalTime := time.Since(startTime)
+```
+
+The actual implementation should use existing relation materialization
+helpers so tuple-copy and deferred-error semantics stay consistent with the
+rest of the executor.
+
+## Verification Plan
+
+1. Add a test where storage scan annotations are only emitted during iteration;
+   verify `Analyze()` captures them.
+2. Add a deferred iterator error test; verify `Analyze()` returns that error
+   instead of returning a successful lazy result.
+3. Verify `AnalyzeResult.TotalTime` includes the forced consumption.
+4. Verify the returned `AnalyzeResult.Result` remains reusable by callers.
+5. Preserve current plan output and event formatting.


### PR DESCRIPTION
## Summary

`Database.Analyze` is documented as EXPLAIN ANALYZE-style — it should measure *actual* execution. But the default relation is lazy: storage scans, joins, filters, and deferred iterator errors happen only when the result is iterated. `Analyze` recorded `TotalTime` and returned the lazy relation **without consuming it**, so captured events and timing described plan/pipeline construction rather than full execution, and a deferred decode error could surface only *after* `Analyze` had already returned nil.

## Fix

`Analyze` now drives the result through `executor.ForEach` (which enforces the deferred-iterator-error contract), materializes the drained tuples into a reusable relation, and records `TotalTime` **after** consumption. Events, timing, and errors now cover the whole query; the returned `Result` is materialized and re-iterable.

`StreamingRelation.Materialize()` was **not** used: on a streaming relation it only sets a `shouldCache` flag and defers consumption to the first `Iterator()` call, so it would not drive execution inside `Analyze`. `ForEach` is what forces the work.

## Tests (storage)

- `TestAnalyze_ConsumesStreamingResults` — asserts `Analyze` captures the storage-scan event and returns a correctly-sized, re-iterable result. **Verified to fail before the fix** (no scan event; `Size()` returned -1).
- `TestAnalyze_SurfacesBlobDecodeError` — drives a real deferred Tier-3 blob-decode failure through the existing `writeTier3ValueThenCorruptBlob` harness (already proven across nine query boundaries) and asserts `Analyze` returns the error rather than a clean lazy result.
- Existing `TestAnalyze` (5 subtests) still pass; full `go test ./...` green.

Resolves `BUGS_ANALYZE_DOES_NOT_CONSUME_STREAMING_RESULTS` (moved to `docs/bugs/resolved/`).