### PR TITLE
Give CompareValues a type-ranked total ordering

### DIFF
--- a/datalog/compare.go
+++ b/datalog/compare.go
@@ -9,13 +9,63 @@ import (
 	"time"
 )
 
+// typeRank assigns each value an ordering class so CompareValues is a total,
+// antisymmetric order even across types. Values of different types are ordered
+// by rank; same-rank values compare by value. int and float share rank 1 so
+// they continue to compare by numeric magnitude (not split into separate
+// classes) — the engine's existing, correct numeric cross-comparison. The rank
+// order is internal to in-memory comparison; it is deliberately NOT the on-disk
+// ValueType tag order (which separates int and float and would break numeric
+// cross-compare). Unknown types share the top rank and fall back to string form.
+func typeRank(v interface{}) int {
+	switch v.(type) {
+	case nil:
+		return 0
+	case int, int8, int16, int32, int64, uint64, *uint64, float64:
+		return 1
+	case bool:
+		return 2
+	case time.Time:
+		return 3
+	case string:
+		return 4
+	case []byte:
+		return 5
+	case Keyword:
+		return 6
+	case Symbol:
+		return 7
+	case Identity:
+		return 8
+	case ElementID, *ElementID:
+		return 9
+	default:
+		return 10
+	}
+}
+
+// compareByRank orders two values of different types by their type rank. It is
+// only called once same-type comparison has been ruled out; equal ranks at this
+// point mean an unknown/unhandled type pair, which falls back to string form so
+// the result is still deterministic and antisymmetric.
+func compareByRank(left, right interface{}) int {
+	lr, rr := typeRank(left), typeRank(right)
+	if lr != rr {
+		return compareInt64s(int64(lr), int64(rr))
+	}
+	return strings.Compare(stringValue(left), stringValue(right))
+}
+
 // CompareValues compares two values and returns:
 //
 //	-1 if left < right
 //	 0 if left == right
 //	 1 if left > right
 //
-// This function handles all Datalog value types including:
+// Across different types it applies a stable type rank (see typeRank), so the
+// result is a total antisymmetric order usable by sort/min/max/order-by. int and
+// float still compare by numeric magnitude. This function handles all Datalog
+// value types including:
 // - Basic types: int, int64, float64, string, bool, time.Time
 // - Datalog types: Identity, Keyword
 // - Nil values (nil is less than any non-nil value)
@@ -45,8 +95,8 @@ func CompareValues(left, right interface{}) int {
 		if id2, ok := right.(Identity); ok {
 			return id1.Compare(id2)
 		}
-		// Identity vs non-Identity: type mismatch
-		return -1
+		// Identity vs non-Identity: order by type rank.
+		return compareByRank(left, right)
 	}
 
 	// Handle Keyword comparison - use the Compare method which handles nil
@@ -54,8 +104,8 @@ func CompareValues(left, right interface{}) int {
 		if kw2, ok := right.(Keyword); ok {
 			return kw1.Compare(kw2)
 		}
-		// Keyword vs non-Keyword: type mismatch
-		return -1
+		// Keyword vs non-Keyword: order by type rank.
+		return compareByRank(left, right)
 	}
 
 	// Handle Symbol comparison - use the Compare method which handles nil
@@ -63,8 +113,8 @@ func CompareValues(left, right interface{}) int {
 		if sym2, ok := right.(Symbol); ok {
 			return sym1.Compare(sym2)
 		}
-		// Symbol vs non-Symbol: type mismatch
-		return -1
+		// Symbol vs non-Symbol: order by type rank.
+		return compareByRank(left, right)
 	}
 
 	// Handle ElementID comparison — dereference pointers, then compare by value
@@ -72,7 +122,8 @@ func CompareValues(left, right interface{}) int {
 		if eid2, ok := DerefElementID(right); ok {
 			return eid1.Compare(eid2)
 		}
-		return -1
+		// ElementID vs non-ElementID: order by type rank.
+		return compareByRank(left, right)
 	}
 
 	// Integer widths normalize to int64 (the canonical representation) so
@@ -91,8 +142,14 @@ func CompareValues(left, right interface{}) int {
 		if r, ok := right.(string); ok {
 			return strings.Compare(l, r)
 		}
-		// String vs non-string: type mismatch
-		return -1
+		// String vs non-string: order by type rank.
+		return compareByRank(left, right)
+	case []byte:
+		if r, ok := right.([]byte); ok {
+			return bytes.Compare(l, r)
+		}
+		// []byte vs non-[]byte: order by type rank.
+		return compareByRank(left, right)
 	case bool:
 		if r, ok := right.(bool); ok {
 			if !l && r {
@@ -102,8 +159,8 @@ func CompareValues(left, right interface{}) int {
 			}
 			return 0
 		}
-		// Bool vs non-bool: type mismatch
-		return -1
+		// Bool vs non-bool: order by type rank.
+		return compareByRank(left, right)
 	case time.Time:
 		if r, ok := right.(time.Time); ok {
 			if l.Before(r) {
@@ -113,12 +170,13 @@ func CompareValues(left, right interface{}) int {
 			}
 			return 0
 		}
-		// Time vs non-time: type mismatch
-		return -1
+		// Time vs non-time: order by type rank.
+		return compareByRank(left, right)
 	}
 
-	// Fall back to string comparison for unknown types
-	return strings.Compare(stringValue(left), stringValue(right))
+	// Unknown types: order by type rank (falls back to string form for
+	// same-rank unknowns), keeping the comparator total and antisymmetric.
+	return compareByRank(left, right)
 }
 
 // compareNumeric compares an int64 with another numeric value
@@ -129,7 +187,9 @@ func compareNumeric(left int64, right interface{}) int {
 	if r, ok := right.(float64); ok {
 		return compareFloats(float64(left), r)
 	}
-	// Non-numeric: type mismatch
+	// Numeric (rank 1) vs non-numeric (higher rank): numeric sorts first. The
+	// reverse direction (non-numeric left vs numeric right) reaches
+	// compareByRank and yields +1, so this is antisymmetric.
 	return -1
 }
 
@@ -141,7 +201,7 @@ func compareFloat(left float64, right interface{}) int {
 	if r, ok := right.(float64); ok {
 		return compareFloats(left, r)
 	}
-	// Non-numeric: type mismatch
+	// Numeric (rank 1) vs non-numeric: numeric sorts first (see compareNumeric).
 	return -1
 }
 
@@ -215,7 +275,7 @@ func compareUint64(left uint64, right interface{}) int {
 	case float64:
 		return compareFloats(float64(left), r)
 	}
-	// Non-numeric: type mismatch
+	// Numeric (rank 1) vs non-numeric: numeric sorts first (see compareNumeric).
 	return -1
 }
 

--- a/datalog/compare_ordering_laws_test.go
+++ b/datalog/compare_ordering_laws_test.go
@@ -1,0 +1,146 @@
+package datalog
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Reproducer for BUGS_MIXED_TYPE_COMPARISON_ORDERING: CompareValues returned -1
+// for every type mismatch, so for mixed-type pairs BOTH CompareValues(a,b) < 0
+// and CompareValues(b,a) < 0 could be true — non-antisymmetric, which violates
+// the strict-weak-ordering contract sort.Slice/min/max/order-by depend on.
+//
+// The fix gives CompareValues a custom type-rank total ordering: numeric
+// (int/float together) < bool < time < string < bytes < keyword < symbol <
+// identity < elementID; same-rank values compare by value, different-rank by
+// rank. These tests pin the comparator laws (antisymmetry, sort-safety,
+// predicate consistency) rather than any single direction outcome.
+
+// mixedTypeValues spans every rank class, for the antisymmetry matrix.
+func mixedTypeValues() []Value {
+	return []Value{
+		nil,
+		int64(-5),
+		int64(42),
+		3.14,
+		true,
+		false,
+		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		"apple",
+		"zzz",
+		[]byte{0x01, 0x02},
+		NewKeyword(":k/one"),
+		NewSymbol("sym"),
+		NewIdentity("ent-1"),
+		ElementID{Lamport: 1, ReplicaID: 1},
+	}
+}
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// TestCompareValues_Antisymmetric pins cmp(a,b) == -cmp(b,a) across every
+// ordered pair of mixed types. This is the core defect: previously many pairs
+// had cmp(a,b) == cmp(b,a) == -1.
+func TestCompareValues_Antisymmetric(t *testing.T) {
+	vals := mixedTypeValues()
+	for i, a := range vals {
+		for j, b := range vals {
+			ab := sign(CompareValues(a, b))
+			ba := sign(CompareValues(b, a))
+			require.Equalf(t, ab, -ba,
+				"antisymmetry violated: CompareValues(vals[%d]=%v, vals[%d]=%v)=%d but reverse=%d",
+				i, a, j, b, ab, ba)
+		}
+	}
+}
+
+// TestCompareValues_EqualOnlyWithinSameValue pins that cmp(a,b)==0 implies the
+// values are equal under ValuesEqual (so distinct-type pairs never compare equal
+// by accident).
+func TestCompareValues_ZeroIsEquality(t *testing.T) {
+	vals := mixedTypeValues()
+	for _, a := range vals {
+		for _, b := range vals {
+			if CompareValues(a, b) == 0 {
+				require.Truef(t, ValuesEqual(a, b),
+					"cmp(%v,%v)==0 but ValuesEqual is false", a, b)
+			}
+		}
+	}
+}
+
+// TestCompareValues_Transitive samples transitivity: for any a<b and b<c, a<c.
+func TestCompareValues_Transitive(t *testing.T) {
+	vals := mixedTypeValues()
+	for _, a := range vals {
+		for _, b := range vals {
+			if sign(CompareValues(a, b)) >= 0 {
+				continue
+			}
+			for _, c := range vals {
+				if sign(CompareValues(b, c)) < 0 {
+					require.Truef(t, sign(CompareValues(a, c)) < 0,
+						"transitivity violated: %v < %v < %v but not %v < %v", a, b, c, a, c)
+				}
+			}
+		}
+	}
+}
+
+// TestCompareValues_SortStable confirms a heterogeneous slice sorts without
+// violating Go's strict-weak-ordering contract (a non-antisymmetric comparator
+// produces an unstable / order-dependent result; modern Go can even panic).
+// Sorting twice from different initial orders must yield the same sequence.
+func TestCompareValues_SortStable(t *testing.T) {
+	base := mixedTypeValues()
+
+	a := append([]Value(nil), base...)
+	sort.SliceStable(a, func(i, j int) bool { return CompareValues(a[i], a[j]) < 0 })
+
+	b := append([]Value(nil), base...)
+	// Reverse b first so it starts from a different order.
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	sort.SliceStable(b, func(i, j int) bool { return CompareValues(b[i], b[j]) < 0 })
+
+	require.Equal(t, len(a), len(b))
+	for i := range a {
+		require.Truef(t, ValuesEqual(a[i], b[i]) || (a[i] == nil && b[i] == nil),
+			"sort order differs at %d: %v vs %v", i, a[i], b[i])
+	}
+}
+
+// TestCompareValues_PredicateNotBothDirections is the direct user-visible
+// reproducer from the bug report: a mixed-type pair must not satisfy `<` in both
+// directions.
+func TestCompareValues_PredicateNotBothDirections(t *testing.T) {
+	less := func(x, y Value) bool { return CompareValues(x, y) < 0 }
+	require.Falsef(t, less("zzz", int64(1)) && less(int64(1), "zzz"),
+		"string<int and int<string both passed")
+	require.Falsef(t, less(NewSymbol("s"), "a") && less("a", NewSymbol("s")),
+		"symbol<string and string<symbol both passed")
+}
+
+// TestCompareValues_NumericCrossTypeUnchanged pins that int and float still
+// compare by numeric value (not separated by rank) — the existing, correct
+// behavior the custom rank must preserve.
+func TestCompareValues_NumericCrossTypeUnchanged(t *testing.T) {
+	require.Equal(t, -1, sign(CompareValues(int64(1), 2.5)))
+	require.Equal(t, 1, sign(CompareValues(3.0, int64(2))))
+	require.Equal(t, 0, sign(CompareValues(int64(2), 2.0)))
+	// Int-width normalization unchanged.
+	require.Equal(t, 0, sign(CompareValues(int32(5), int64(5))))
+}

--- a/datalog/compare_test.go
+++ b/datalog/compare_test.go
@@ -243,9 +243,13 @@ func TestSymbolCompareValues(t *testing.T) {
 		t.Errorf("CompareValues(beta, alpha) = %d, want > 0", cmp)
 	}
 
-	// Symbol vs non-Symbol
-	if cmp := CompareValues(a, "alpha"); cmp >= 0 {
-		t.Errorf("CompareValues(symbol, string) = %d, want < 0 (type mismatch)", cmp)
+	// Symbol vs non-Symbol: ordered by type rank. Symbol (rank 7) sorts after
+	// string (rank 4), so the result is > 0. (Antisymmetric: the reverse is < 0.)
+	if cmp := CompareValues(a, "alpha"); cmp <= 0 {
+		t.Errorf("CompareValues(symbol, string) = %d, want > 0 (symbol rank > string rank)", cmp)
+	}
+	if cmp := CompareValues("alpha", a); cmp >= 0 {
+		t.Errorf("CompareValues(string, symbol) = %d, want < 0 (string rank < symbol rank)", cmp)
 	}
 }
 
@@ -293,9 +297,13 @@ func TestElementIDCompareValues(t *testing.T) {
 		t.Errorf("CompareValues(higher ReplicaID, lower ReplicaID) = %d, want > 0", cmp)
 	}
 
-	// ElementID vs non-ElementID
-	if cmp := CompareValues(a, int64(100)); cmp >= 0 {
-		t.Errorf("CompareValues(ElementID, int64) = %d, want < 0 (type mismatch)", cmp)
+	// ElementID vs non-ElementID: ordered by type rank. ElementID (rank 9) sorts
+	// after numeric (rank 1), so the result is > 0. (Antisymmetric: reverse < 0.)
+	if cmp := CompareValues(a, int64(100)); cmp <= 0 {
+		t.Errorf("CompareValues(ElementID, int64) = %d, want > 0 (ElementID rank > numeric rank)", cmp)
+	}
+	if cmp := CompareValues(int64(100), a); cmp >= 0 {
+		t.Errorf("CompareValues(int64, ElementID) = %d, want < 0 (numeric rank < ElementID rank)", cmp)
 	}
 }
 

--- a/datalog/executor/filter_test.go
+++ b/datalog/executor/filter_test.go
@@ -240,9 +240,9 @@ func TestCompareValues(t *testing.T) {
 		{"int64 to float", int64(10), 20.5, -1},
 		{"float to int", 10.5, int(10), 1},
 
-		// Type mismatch
-		{"string vs int", "test", 123, -1},
-		{"bool vs string", true, "test", -1},
+		// Mixed types order by type rank (numeric=1 < bool=2 < string=4).
+		{"string vs int", "test", 123, 1},  // string rank > numeric rank
+		{"bool vs string", true, "test", -1}, // bool rank < string rank
 	}
 
 	for _, tt := range tests {

--- a/docs/bugs/resolved/BUGS_MIXED_TYPE_COMPARISON_ORDERING.md
+++ b/docs/bugs/resolved/BUGS_MIXED_TYPE_COMPARISON_ORDERING.md
@@ -1,0 +1,221 @@
+# BUG: Mixed-Type `CompareValues` Ordering Is Not Antisymmetric
+
+**Date**: 2026-05-31
+**Severity**: Correctness (Medium)
+**Status**: ✅ RESOLVED (2026-05-31)
+**Affected**: Comparison predicates (`<`, `<=`, `>`, `>=`), chained comparisons, ordering, min/max over mixed-type values
+
+## Resolution
+
+Fixed via **Option A (type-ranked total ordering)**. `CompareValues` is now
+antisymmetric and total across types: when two values are not the same
+comparable type, it orders them by a stable type rank (`typeRank`) instead of
+returning `-1` in both directions.
+
+The rank is a **custom** order, deliberately NOT the on-disk `ValueType` tag
+order. Investigation found the tag order is not a valid rank for `CompareValues`:
+it separates `TypeInt` (1) and `TypeFloat` (2), but the comparator correctly
+compares int and float *numerically* across that boundary. So int and float
+share a single numeric rank here:
+
+```
+nil(0) < numeric:int/uint/float(1) < bool(2) < time(3) < string(4) <
+bytes(5) < keyword(6) < symbol(7) < identity(8) < elementID(9) < unknown(10)
+```
+
+Same-rank values compare by value (numerics by magnitude, including int↔float);
+different ranks compare by rank. Every former `return -1` type-mismatch site in
+`compare.go` now returns `compareByRank(left, right)`. The numeric helpers
+(`compareNumeric`/`compareFloat`/`compareUint64`) keep their direct `return -1`
+for the numeric-vs-non-numeric case — that is now *correct and antisymmetric* by
+construction (numeric is rank 1, so it sorts before every higher rank; the
+reverse direction reaches `compareByRank` and yields +1). A missing `[]byte`
+same-type branch was added (compares via `bytes.Compare`).
+
+`compareByRank`/`typeRank` are on the type-mismatch cold path only; the hot path
+(same-type Identity/int64/string compares) returns before any rank logic, so
+performance is unchanged.
+
+This fixes all caller categories with no call-site changes: the `sort.Slice`
+order-by comparators (which a non-antisymmetric comparator left in undefined
+behavior), the `<,<=,>,>=` predicates (which previously passed in both
+directions for mixed types), and `min`/`max` aggregation.
+
+`ValuesEqual` is untouched — equality semantics for mixed types were already
+correct (different types are unequal).
+
+### Tests
+
+- `datalog/compare_ordering_laws_test.go` (new) — pins the comparator laws:
+  antisymmetry across a full mixed-type matrix, transitivity, `cmp==0 ⇒ equal`,
+  sort-stability of a heterogeneous slice, the both-directions predicate
+  reproducer, and a guard that int↔float still compare numerically. The
+  antisymmetry/transitivity/sort/predicate tests were verified to FAIL against
+  the unfixed comparator.
+- Three existing assertions that pinned the broken `-1` behavior were updated to
+  the documented rank direction (and strengthened with the reverse-direction
+  check): `compare_test.go` symbol-vs-string and elementID-vs-int64, and
+  `executor/filter_test.go` string-vs-int.
+
+Full `go test ./...` green.
+
+## Summary
+
+`datalog.CompareValues` uses `-1` as the fallback result for many type
+mismatches. That makes the comparator non-antisymmetric: for some mixed-type
+pairs, both `CompareValues(a, b) < 0` and `CompareValues(b, a) < 0` are true.
+
+The immediate user-visible consequence is that relational predicates can accept
+both directions of an invalid comparison. For example, string-vs-int and
+int-vs-string both compare as "left is less than right" through different
+branches.
+
+This is fine for `=`/`!=` as a rough "different types are unequal" signal, but
+it is not valid ordering semantics.
+
+## Root Cause
+
+`CompareValues` treats type mismatch as an ordering result instead of either:
+
+1. applying a total type-rank ordering consistently in both directions, or
+2. reporting that values are not order-comparable.
+
+Examples from `datalog/compare.go`:
+
+```go
+if id1, ok := left.(Identity); ok {
+    if id2, ok := right.(Identity); ok {
+        return id1.Compare(id2)
+    }
+    // Identity vs non-Identity: type mismatch
+    return -1
+}
+
+if kw1, ok := left.(Keyword); ok {
+    if kw2, ok := right.(Keyword); ok {
+        return kw1.Compare(kw2)
+    }
+    // Keyword vs non-Keyword: type mismatch
+    return -1
+}
+```
+
+The same shape exists for strings, bools, times, numeric-vs-nonnumeric, and
+other branches.
+
+Predicates then interpret the comparator result directly:
+
+```go
+cmp := datalog.CompareValues(leftVal, rightVal)
+
+switch c.Op {
+case OpLT:
+    return cmp < 0, nil
+case OpLTE:
+    return cmp <= 0, nil
+case OpGT:
+    return cmp > 0, nil
+case OpGTE:
+    return cmp >= 0, nil
+}
+```
+
+## Reproduction Sketch
+
+Any query path that evaluates a comparison over mixed types can exhibit the
+problem:
+
+```clojure
+[:find ?e
+ :where [?e :thing/value ?v]
+        [(< ?v "zzz")]]
+```
+
+If `?v` is an integer, `CompareValues(int64(...), "zzz")` returns `-1`, so the
+predicate passes.
+
+The reverse direction can also pass:
+
+```clojure
+[:find ?e
+ :where [?e :thing/value ?v]
+        [(< "zzz" ?v)]]
+```
+
+If `?v` is an integer, `CompareValues("zzz", int64(...))` also returns `-1`, so
+this predicate can pass too.
+
+## Impact
+
+1. **Incorrect predicate results**: Range predicates can include rows whose
+   value type is not actually order-comparable with the constant.
+
+2. **Invalid chained comparisons**: A chained comparison can succeed due to
+   arbitrary type-mismatch ordering rather than meaningful value order.
+
+3. **Unstable sorting assumptions**: `sort.Slice` expects a strict weak
+   ordering. A comparator where both `a < b` and `b < a` can be true violates
+   that contract for mixed-type result sets.
+
+4. **Potential min/max surprises**: Aggregations over heterogeneous values can
+   select winners based on type-branch accident rather than a defined ordering.
+
+## Why This Is Subtle
+
+The current behavior is partially tested as "type mismatch returns -1" in some
+unit tests. That pins a behavior, but not a valid ordering invariant. The tests
+check individual direction outcomes; they do not check comparator laws:
+
+- antisymmetry: `cmp(a,b) == -cmp(b,a)`
+- equality consistency: `cmp(a,b)==0` iff values are equal under the comparator
+- transitivity: if `a < b` and `b < c`, then `a < c`
+
+The bug is not that mismatched types are unequal. The bug is that mismatched
+types are treated as ordered in a direction that is not consistent.
+
+## Fix Direction
+
+There are two plausible fixes; choose the semantics explicitly:
+
+### Option A: Type-Ranked Total Ordering
+
+Define a stable type rank:
+
+```go
+nil < bool < int/float < time < string < keyword < symbol < identity < elementID < bytes < vector
+```
+
+Then mixed-type comparisons use rank order before same-type value comparison.
+This keeps `CompareValues` total and usable for sorting/min/max.
+
+### Option B: Separate Equality From Ordering
+
+Keep `ValuesEqual` for equality, and add an ordered comparison API that can
+return an error for non-orderable type pairs:
+
+```go
+CompareOrdered(left, right any) (int, error)
+```
+
+Then `<`, `<=`, `>`, `>=`, `min`, `max`, and order-by can decide whether to
+error or apply a documented type rank.
+
+This is semantically cleaner but touches more call sites.
+
+## Verification Plan
+
+Add comparator-law tests:
+
+1. Mixed-type pair matrix verifies antisymmetry.
+2. Sorting a heterogeneous slice does not violate strict weak ordering.
+3. Relational predicates over mismatched types either error or follow documented
+   type rank consistently.
+4. `=` and `!=` remain correct for mixed types.
+5. Existing int-width normalization behavior remains unchanged.
+
+Example regression cases:
+
+```go
+require.Equal(t, -CompareValues("x", int64(1)), CompareValues(int64(1), "x"))
+require.False(t, less("x", int64(1)) && less(int64(1), "x"))
+```


### PR DESCRIPTION
## Summary

`datalog.CompareValues` returned `-1` for every type mismatch, so for mixed-type pairs **both** `CompareValues(a,b) < 0` and `CompareValues(b,a) < 0` could be true. That non-antisymmetric comparator broke the strict-weak-ordering contract that `sort.Slice` (order-by), `min`/`max`, and the `<,<=,>,>=` predicates depend on: order-by over heterogeneous values was undefined (modern Go can panic), and a mixed-type predicate passed in **both** directions.

## Fix (Option A: type-ranked total ordering)

`CompareValues` now orders different-typed values by a stable type rank, then same-rank values by value:

```
nil(0) < numeric:int/uint/float(1) < bool(2) < time(3) < string(4) <
bytes(5) < keyword(6) < symbol(7) < identity(8) < elementID(9) < unknown(10)
```

The rank is **custom**, deliberately not the on-disk `ValueType` tag order: investigation found the tag order separates `TypeInt` and `TypeFloat`, but the comparator correctly compares int and float *numerically* across that boundary — so they share one numeric rank here. Every former `return -1` type-mismatch site returns `compareByRank(left, right)`; the numeric helpers keep a direct `-1` for numeric-vs-non-numeric, which is antisymmetric **by construction** (numeric is the lowest non-nil rank; the reverse direction reaches `compareByRank` and yields +1). A missing `[]byte` same-type branch was added.

`typeRank`/`compareByRank` are on the type-mismatch **cold path** only — the hot path (same-type Identity/int64/string compares) returns before any rank logic, so performance is unchanged. Fixes all caller categories (order-by, predicates, min/max) with **no call-site changes**. `ValuesEqual` is untouched (mixed-type equality was already correct).

## Tests

- `datalog/compare_ordering_laws_test.go` (new) — pins antisymmetry across a full mixed-type matrix, transitivity, `cmp==0 ⇒ equal`, sort-stability of a heterogeneous slice, the both-directions predicate reproducer, and int↔float numeric cross-compare. **The law tests were verified to fail before the fix.**
- Three existing assertions that pinned the broken `-1` behavior were updated to the documented rank direction (and strengthened with the reverse-direction check): `compare_test.go` symbol-vs-string and elementID-vs-int64, `executor/filter_test.go` string-vs-int.

Full `go test ./...` green.

Resolves `BUGS_MIXED_TYPE_COMPARISON_ORDERING` (moved to `docs/bugs/resolved/`).