### PR TITLE
Add linear snapshots and destructive rollback (TruncateTo)

### DIFF
--- a/datalog/db/snapshot.go
+++ b/datalog/db/snapshot.go
@@ -1,0 +1,18 @@
+package db
+
+import "github.com/wbrown/janus-datalog/datalog/storage"
+
+// SnapshotInfo re-exports storage.SnapshotInfo so db-package users can name the type
+// returned by (*DB).Snapshot without importing the storage package directly. The Snapshot,
+// AsOfSnapshot, Snapshots, DeleteSnapshot, and TruncateTo methods are defined on
+// storage.Database (aliased as DB), so they are available on *DB automatically.
+type SnapshotInfo = storage.SnapshotInfo
+
+var (
+	// ErrSnapshotExists is returned by Snapshot when the name is already taken.
+	ErrSnapshotExists = storage.ErrSnapshotExists
+	// ErrSnapshotNotFound is returned when a named snapshot does not exist.
+	ErrSnapshotNotFound = storage.ErrSnapshotNotFound
+	// ErrRollbackInProgress is returned by a write started while a TruncateTo is running.
+	ErrRollbackInProgress = storage.ErrRollbackInProgress
+)

--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -163,6 +163,91 @@ func (s *BadgerStore) retractDatom(txn *badger.Txn, d *datalog.Datom) error {
 	return nil
 }
 
+// MaxTxForEntity returns the highest Tx among a single entity's datoms. The bool is
+// false when the entity has no datoms. TruncateTo uses it to find the floor below which
+// a snapshot marker must be preserved.
+func (s *BadgerStore) MaxTxForEntity(e datalog.Identity) (datalog.ElementID, bool, error) {
+	prefix := concatBytes([]byte{byte(EAVT)}, e.Bytes())
+	var maxID datalog.ElementID
+	found := false
+	err := s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			datom, err := DatomFromKey(EAVT, it.Item().KeyCopy(nil), s.encoder, s.db)
+			if err != nil {
+				return fmt.Errorf("decode EAVT key: %w", err)
+			}
+			if !found || maxID.Less(datom.Tx) {
+				maxID = datom.Tx
+				found = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return datalog.ElementID{}, false, err
+	}
+	return maxID, found, nil
+}
+
+// DatomsAfter returns every datom whose Tx is strictly greater than eid. It scans TAEV,
+// whose Tx-descending order puts the affected datoms first, and stops at the first datom
+// with Tx <= eid. Read-only; the caller removes them with DeleteDatoms, doing whatever
+// cache/clock coordination it needs in between.
+func (s *BadgerStore) DatomsAfter(eid datalog.ElementID) ([]datalog.Datom, error) {
+	taevPrefix := []byte{byte(TAEV)}
+	var datoms []datalog.Datom
+	err := s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(taevPrefix); it.ValidForPrefix(taevPrefix); it.Next() {
+			datom, err := DatomFromKey(TAEV, it.Item().KeyCopy(nil), s.encoder, s.db)
+			if err != nil {
+				return fmt.Errorf("decode TAEV key: %w", err)
+			}
+			if !eid.Less(datom.Tx) {
+				// Tx <= eid; TAEV is Tx-descending, so nothing later exceeds eid either.
+				break
+			}
+			datoms = append(datoms, datom)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return datoms, nil
+}
+
+// DeleteDatoms physically removes each given datom from all eight indices in a single
+// transaction, returning the count removed. Unlike Retract (which appends a tombstone at a
+// higher Tx), this is a true rewind: the keys are gone, so the datoms vanish from
+// History() too.
+func (s *BadgerStore) DeleteDatoms(datoms []datalog.Datom) (int, error) {
+	deleted := 0
+	err := s.db.Update(func(txn *badger.Txn) error {
+		for i := range datoms {
+			for _, idx := range Indices {
+				key := s.encoder.EncodeKey(idx, &datoms[i])
+				if err := txn.Delete(key); err != nil && err != badger.ErrKeyNotFound {
+					return fmt.Errorf("delete from %v index: %w", idx, err)
+				}
+			}
+			deleted++
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return deleted, nil
+}
+
 // Scan returns an iterator for a range of keys
 func (s *BadgerStore) Scan(index IndexType, start, end []byte) (Iterator, error) {
 	txn := s.db.NewTransaction(false)

--- a/datalog/storage/cache.go
+++ b/datalog/storage/cache.go
@@ -223,6 +223,25 @@ func (c *Cache) Invalidate(touched []CacheKey) {
 	// next IsAttributeFresh() call will fetch current max from store
 }
 
+// InvalidateRewind drops cached state for keys whose datoms a rollback physically removed.
+// Unlike Invalidate (forward commits, where maxVersions was just advanced and must be
+// kept), a rewind RETREATS the version high-water, and UpdateMaxVersion is monotonic — so
+// the per-(E,A) max and the per-attribute version must be dropped too, or a rebuilt
+// lower-version entry would compare unequal to the stranded max forever and never cache-hit
+// again. Pairs with BeginInFlight: that opens the uncached window before the delete, this
+// closes it after.
+func (c *Cache) InvalidateRewind(touched []CacheKey) {
+	seenAttr := make(map[Attribute]struct{}, len(touched))
+	for _, key := range touched {
+		c.entries.Delete(key)
+		c.maxVersions.Delete(key)
+		if _, ok := seenAttr[key.A]; !ok {
+			seenAttr[key.A] = struct{}{}
+			c.attrVersions.Delete(key.A)
+		}
+	}
+}
+
 // InvalidateAttribute removes all cached entries for the given attribute,
 // regardless of entity. Used when a write to a unique attribute may have
 // silently staled other entities' cached values under the walk-based

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -61,6 +61,13 @@ type Database struct {
 	// read was once possible. Test-only (nil in production); lets a test run a
 	// reader deterministically in that window. See the cache stale-read tests.
 	onCommitWindow func()
+
+	// Rollback (TruncateTo) coordination: rollbackInProgress and drainCond are guarded by
+	// mu (drainCond signals the rollback's drain as activeTx shrinks); rollbackMu
+	// serializes one rollback against another.
+	rollbackInProgress bool
+	drainCond          *sync.Cond
+	rollbackMu         sync.Mutex
 }
 
 // NewDatabase creates a new database with BadgerDB storage
@@ -188,7 +195,7 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 		}
 	}
 
-	return &Database{
+	d := &Database{
 		store:             store,
 		activeTx:          make(map[*Transaction]bool),
 		planCache:         planner.NewPlanCache(1000, 0),
@@ -199,7 +206,9 @@ func NewDatabaseWithOptions(opts DatabaseOptions) (*Database, error) {
 		clock:             clock,
 		replicaID:         replicaID,
 		cache:             cache,
-	}, nil
+	}
+	d.drainCond = sync.NewCond(&d.mu)
+	return d, nil
 }
 
 // Schema returns the current schema (may be nil)
@@ -415,9 +424,14 @@ func (d *Database) NewTransaction() *Transaction {
 		datoms:            make([]datalog.Datom, 0),
 		retracts:          make([]datalog.Datom, 0),
 		lastVectorElement: make(map[entityAttrKey]datalog.ElementID),
+		doomed:            d.rollbackInProgress,
 	}
 
-	d.activeTx[tx] = true
+	// A transaction born during a rollback is dropped (its writes return
+	// ErrRollbackInProgress) and is not registered, so it never holds up the drain.
+	if !tx.doomed {
+		d.activeTx[tx] = true
+	}
 	return tx
 }
 
@@ -1308,6 +1322,7 @@ type Transaction struct {
 	closed            bool
 	txTime            *time.Time                          // Optional custom transaction time
 	lastVectorElement map[entityAttrKey]datalog.ElementID // Track last appended element per (E,A) for RGA chaining
+	doomed            bool                                // born during a rollback; its writes return ErrRollbackInProgress
 }
 
 // SetTime sets a custom transaction time for this transaction
@@ -1334,6 +1349,9 @@ func (t *Transaction) Add(e datalog.Identity, a datalog.Keyword, v interface{}) 
 
 	if t.closed {
 		return fmt.Errorf("transaction is closed")
+	}
+	if t.doomed {
+		return ErrRollbackInProgress
 	}
 
 	if err := validateAttributeStorable(a); err != nil {
@@ -1984,6 +2002,9 @@ func (t *Transaction) Retract(e datalog.Identity, a datalog.Keyword, v interface
 	if t.closed {
 		return fmt.Errorf("transaction is closed")
 	}
+	if t.doomed {
+		return ErrRollbackInProgress
+	}
 
 	if err := validateAttributeStorable(a); err != nil {
 		return err
@@ -2063,6 +2084,9 @@ func (t *Transaction) Commit() (datalog.ElementID, error) {
 
 	if t.closed {
 		return datalog.ElementID{}, fmt.Errorf("transaction is closed")
+	}
+	if t.doomed {
+		return datalog.ElementID{}, ErrRollbackInProgress
 	}
 
 	// Uniqueness is a read-time CRDT resolution rule, not a write-time gate.
@@ -2220,6 +2244,9 @@ func (t *Transaction) Commit() (datalog.ElementID, error) {
 	t.closed = true
 	t.db.mu.Lock()
 	delete(t.db.activeTx, t)
+	if t.db.rollbackInProgress {
+		t.db.drainCond.Broadcast()
+	}
 	t.db.mu.Unlock()
 
 	// Return the metadata ElementID - it has the highest Lamport in this tx,
@@ -2266,6 +2293,9 @@ func (t *Transaction) Rollback() error {
 
 	t.db.mu.Lock()
 	delete(t.db.activeTx, t)
+	if t.db.rollbackInProgress {
+		t.db.drainCond.Broadcast()
+	}
 	t.db.mu.Unlock()
 
 	return nil

--- a/datalog/storage/snapshot.go
+++ b/datalog/storage/snapshot.go
@@ -1,0 +1,251 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// Snapshots are recorded as ordinary entities in a reserved :db.snapshot/* namespace,
+// not in a side table. Listing snapshots is therefore a Datalog query, and causal
+// ordering is intrinsic to each marker's Tx and to the captured point it stores. See
+// docs/proposals/BRANCHING_AND_SNAPSHOTS.md §12.1 (Slice A).
+
+// snapshotEntityPrefix derives a snapshot marker's entity id from its name, so a name
+// maps to exactly one marker entity.
+const snapshotEntityPrefix = "db.snapshot/"
+
+var (
+	snapshotNameAttr      = datalog.NewKeyword(":db.snapshot/name")
+	snapshotAtLamportAttr = datalog.NewKeyword(":db.snapshot/at-lamport")
+	snapshotAtReplicaAttr = datalog.NewKeyword(":db.snapshot/at-replica")
+	snapshotCreatedAttr   = datalog.NewKeyword(":db.snapshot/created")
+)
+
+var (
+	// ErrSnapshotExists is returned by Snapshot when the name is already taken.
+	ErrSnapshotExists = errors.New("snapshot already exists")
+	// ErrSnapshotNotFound is returned when a named snapshot does not exist.
+	ErrSnapshotNotFound = errors.New("snapshot not found")
+	// ErrRollbackInProgress is returned by a write (Add/Retract/Commit) started while a
+	// TruncateTo rollback is running on the same handle. The write is dropped, not queued;
+	// retry on a fresh transaction once the rollback completes.
+	ErrRollbackInProgress = errors.New("write rejected: a rollback (TruncateTo) is in progress")
+)
+
+// SnapshotInfo is the decoded snapshot marker. Fields are additive: the branching round
+// adds Path/Parent without changing existing callers (their absence ⇒ root).
+type SnapshotInfo struct {
+	Name    string
+	At      datalog.ElementID // captured high-water point (the AsOf read point)
+	Created time.Time
+}
+
+// snapshotEntity returns the marker entity identity for a snapshot name.
+func snapshotEntity(name string) datalog.Identity {
+	return datalog.NewIdentity(snapshotEntityPrefix + name)
+}
+
+// Snapshot names the current state of this handle as a :db.snapshot/* entity. It captures
+// store.MaxElementID() as the snapshot point and writes the marker in a single
+// transaction. Returns ErrSnapshotExists if the name is already in use.
+func (d *Database) Snapshot(name string) (SnapshotInfo, error) {
+	if d.temporalTxID != nil {
+		return SnapshotInfo{}, fmt.Errorf("Snapshot: cannot snapshot a read-only temporal handle (AsOf/History)")
+	}
+	if name == "" {
+		return SnapshotInfo{}, fmt.Errorf("Snapshot: name must not be empty")
+	}
+
+	existing, err := d.lookupSnapshot(name)
+	if err != nil {
+		return SnapshotInfo{}, err
+	}
+	if existing != nil {
+		return SnapshotInfo{}, fmt.Errorf("Snapshot %q: %w", name, ErrSnapshotExists)
+	}
+
+	before, err := d.store.MaxElementID()
+	if err != nil {
+		return SnapshotInfo{}, fmt.Errorf("Snapshot %q: capture high-water: %w", name, err)
+	}
+
+	created := time.Now()
+	e := snapshotEntity(name)
+
+	tx := d.NewTransaction()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := tx.Add(e, snapshotNameAttr, name); err != nil {
+		return SnapshotInfo{}, fmt.Errorf("Snapshot %q: %w", name, err)
+	}
+	if err := tx.Add(e, snapshotAtLamportAttr, int64(before.Lamport)); err != nil {
+		return SnapshotInfo{}, fmt.Errorf("Snapshot %q: %w", name, err)
+	}
+	if err := tx.Add(e, snapshotAtReplicaAttr, int64(before.ReplicaID)); err != nil {
+		return SnapshotInfo{}, fmt.Errorf("Snapshot %q: %w", name, err)
+	}
+	if err := tx.Add(e, snapshotCreatedAttr, created); err != nil {
+		return SnapshotInfo{}, fmt.Errorf("Snapshot %q: %w", name, err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		return SnapshotInfo{}, fmt.Errorf("Snapshot %q: commit: %w", name, err)
+	}
+	committed = true
+
+	return SnapshotInfo{Name: name, At: before, Created: created}, nil
+}
+
+// AsOfSnapshot returns a read-only handle viewing the database as of the named snapshot.
+// The returned handle rejects writes (NewTransaction panics on a temporal handle).
+//
+// It reads at the marker's own high-water (snapshotMarkerMax), which is domain-equivalent
+// to the captured point At — the marker datoms it adds are reserved-namespace and filtered
+// from domain queries — and, unlike At, is always non-zero. That matters for an
+// empty-database snapshot (At == zero ElementID): AsOf of the zero ElementID would collide
+// with the matcher's History sentinel and show everything instead of nothing.
+func (d *Database) AsOfSnapshot(name string) (*Database, error) {
+	info, err := d.lookupSnapshot(name)
+	if err != nil {
+		return nil, err
+	}
+	if info == nil {
+		return nil, fmt.Errorf("AsOfSnapshot %q: %w", name, ErrSnapshotNotFound)
+	}
+	point, err := d.snapshotMarkerMax(name)
+	if err != nil {
+		return nil, err
+	}
+	return d.AsOf(point), nil
+}
+
+// Snapshots lists every snapshot, in causal order (by captured point, then name).
+func (d *Database) Snapshots() ([]SnapshotInfo, error) {
+	type row struct {
+		Name    string    `datalog:"?name"`
+		Lamport int64     `datalog:"?lamport"`
+		Replica int64     `datalog:"?replica"`
+		Created time.Time `datalog:"?created"`
+	}
+	var rows []row
+	err := d.QueryInto(&rows, `[:find ?name ?lamport ?replica ?created
+		:where [?s :db.snapshot/name ?name]
+		       [?s :db.snapshot/at-lamport ?lamport]
+		       [?s :db.snapshot/at-replica ?replica]
+		       [?s :db.snapshot/created ?created]]`)
+	if err != nil {
+		return nil, fmt.Errorf("Snapshots: %w", err)
+	}
+
+	out := make([]SnapshotInfo, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, SnapshotInfo{
+			Name:    r.Name,
+			At:      datalog.ElementID{Lamport: uint64(r.Lamport), ReplicaID: uint64(r.Replica)},
+			Created: r.Created,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if c := out[i].At.Compare(out[j].At); c != 0 {
+			return c < 0
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+// DeleteSnapshot removes the named snapshot from the registry by retracting its marker.
+// The rewindable timeline is untouched; only the registry entry goes away.
+func (d *Database) DeleteSnapshot(name string) error {
+	if d.temporalTxID != nil {
+		return fmt.Errorf("DeleteSnapshot: cannot modify a read-only temporal handle (AsOf/History)")
+	}
+	info, err := d.lookupSnapshot(name)
+	if err != nil {
+		return err
+	}
+	if info == nil {
+		return fmt.Errorf("DeleteSnapshot %q: %w", name, ErrSnapshotNotFound)
+	}
+
+	e := snapshotEntity(name)
+	tx := d.NewTransaction()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Retracting the name attribute is what removes the snapshot from the registry (it
+	// breaks the join in Snapshots/lookupSnapshot). The remaining retracts are cleanup.
+	if err := tx.Retract(e, snapshotNameAttr, name); err != nil {
+		return fmt.Errorf("DeleteSnapshot %q: %w", name, err)
+	}
+	if err := tx.Retract(e, snapshotAtLamportAttr, int64(info.At.Lamport)); err != nil {
+		return fmt.Errorf("DeleteSnapshot %q: %w", name, err)
+	}
+	if err := tx.Retract(e, snapshotAtReplicaAttr, int64(info.At.ReplicaID)); err != nil {
+		return fmt.Errorf("DeleteSnapshot %q: %w", name, err)
+	}
+	if err := tx.Retract(e, snapshotCreatedAttr, info.Created); err != nil {
+		return fmt.Errorf("DeleteSnapshot %q: %w", name, err)
+	}
+	if _, err := tx.Commit(); err != nil {
+		return fmt.Errorf("DeleteSnapshot %q: commit: %w", name, err)
+	}
+	committed = true
+	return nil
+}
+
+// lookupSnapshot resolves a snapshot by name via a Datalog query. Returns nil if no such
+// snapshot exists.
+func (d *Database) lookupSnapshot(name string) (*SnapshotInfo, error) {
+	type row struct {
+		Lamport int64     `datalog:"?lamport"`
+		Replica int64     `datalog:"?replica"`
+		Created time.Time `datalog:"?created"`
+	}
+	var rows []row
+	err := d.QueryInto(&rows, `[:find ?lamport ?replica ?created
+		:in $ ?name
+		:where [?s :db.snapshot/name ?name]
+		       [?s :db.snapshot/at-lamport ?lamport]
+		       [?s :db.snapshot/at-replica ?replica]
+		       [?s :db.snapshot/created ?created]]`, name)
+	if err != nil {
+		return nil, fmt.Errorf("lookup snapshot %q: %w", name, err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	r := rows[0]
+	return &SnapshotInfo{
+		Name:    name,
+		At:      datalog.ElementID{Lamport: uint64(r.Lamport), ReplicaID: uint64(r.Replica)},
+		Created: r.Created,
+	}, nil
+}
+
+// snapshotMarkerMax returns the highest Tx of a snapshot's marker entity — the snapshot's
+// effective point. AsOfSnapshot reads there and TruncateTo truncates there. It is always
+// non-zero (a marker always has datoms), which keeps an empty-database snapshot from
+// resolving to the zero ElementID the matcher reserves for History mode.
+func (d *Database) snapshotMarkerMax(name string) (datalog.ElementID, error) {
+	mm, ok, err := d.store.MaxTxForEntity(snapshotEntity(name))
+	if err != nil {
+		return datalog.ElementID{}, fmt.Errorf("snapshot %q: locate marker: %w", name, err)
+	}
+	if !ok {
+		return datalog.ElementID{}, fmt.Errorf("snapshot %q: marker entity has no datoms", name)
+	}
+	return mm, nil
+}

--- a/datalog/storage/snapshot_test.go
+++ b/datalog/storage/snapshot_test.go
@@ -1,0 +1,302 @@
+package storage
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// snapTestAddName writes a single :person/name fact in its own transaction.
+func snapTestAddName(t *testing.T, d *Database, idStr, name string) {
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(datalog.NewIdentity(idStr), datalog.NewKeyword(":person/name"), name))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+}
+
+// snapTestNames returns the sorted set of :person/name values visible through a handle.
+func snapTestNames(t *testing.T, d *Database) []string {
+	var ns []string
+	require.NoError(t, d.QueryInto(&ns, `[:find ?n :where [?e :person/name ?n]]`))
+	sort.Strings(ns)
+	return ns
+}
+
+// snapTestHistoryNames returns the :person/name values physically present, via History.
+func snapTestHistoryNames(t *testing.T, d *Database) []string {
+	var ns []string
+	require.NoError(t, d.History().QueryInto(&ns, `[:find ?n :where [?e :person/name ?n]]`))
+	sort.Strings(ns)
+	return ns
+}
+
+func TestSnapshotCaptureAndAsOf(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+
+	snap, err := d.Snapshot("cp1")
+	require.NoError(t, err)
+	assert.Equal(t, "cp1", snap.Name)
+	assert.False(t, snap.At.IsZero(), "captured point should be non-zero after a write")
+
+	// Write after the snapshot.
+	snapTestAddName(t, d, "bob", "Bob")
+
+	// Live DB sees both; the snapshot handle sees only the pre-snapshot state.
+	assert.Equal(t, []string{"Alice", "Bob"}, snapTestNames(t, d))
+
+	asof, err := d.AsOfSnapshot("cp1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Alice"}, snapTestNames(t, asof))
+}
+
+func TestSnapshotEmptyDatabase(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snap, err := d.Snapshot("empty")
+	require.NoError(t, err)
+	assert.True(t, snap.At.IsZero(), "snapshot of an empty DB captures the zero point")
+
+	asof, err := d.AsOfSnapshot("empty")
+	require.NoError(t, err)
+	assert.Empty(t, snapTestNames(t, asof))
+
+	// Writing after the empty snapshot is visible live; the AsOf view stays empty.
+	snapTestAddName(t, d, "alice", "Alice")
+	assert.Equal(t, []string{"Alice"}, snapTestNames(t, d))
+
+	asof2, err := d.AsOfSnapshot("empty")
+	require.NoError(t, err)
+	assert.Empty(t, snapTestNames(t, asof2))
+}
+
+func TestSnapshotListCausalOrder(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	_, err = d.Snapshot("a")
+	require.NoError(t, err)
+	snapTestAddName(t, d, "bob", "Bob")
+	_, err = d.Snapshot("b")
+	require.NoError(t, err)
+
+	snaps, err := d.Snapshots()
+	require.NoError(t, err)
+	require.Len(t, snaps, 2)
+	assert.Equal(t, "a", snaps[0].Name)
+	assert.Equal(t, "b", snaps[1].Name)
+	assert.True(t, snaps[0].At.Less(snaps[1].At), "snapshot a captured before b")
+}
+
+func TestSnapshotDuplicateName(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	_, err = d.Snapshot("x")
+	require.NoError(t, err)
+	_, err = d.Snapshot("x")
+	require.ErrorIs(t, err, ErrSnapshotExists)
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	_, err = d.Snapshot("x")
+	require.NoError(t, err)
+
+	require.NoError(t, d.DeleteSnapshot("x"))
+
+	snaps, err := d.Snapshots()
+	require.NoError(t, err)
+	assert.Empty(t, snaps)
+
+	_, err = d.AsOfSnapshot("x")
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+
+	require.ErrorIs(t, d.DeleteSnapshot("nope"), ErrSnapshotNotFound)
+}
+
+func TestTruncateToRemovesLaterWrites(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	_, err = d.Snapshot("cp1")
+	require.NoError(t, err)
+	snapTestAddName(t, d, "bob", "Bob")
+	snapTestAddName(t, d, "carol", "Carol")
+
+	require.Equal(t, []string{"Alice", "Bob", "Carol"}, snapTestNames(t, d))
+
+	require.NoError(t, d.TruncateTo("cp1"))
+
+	// Live reads equal the snapshot exactly.
+	assert.Equal(t, []string{"Alice"}, snapTestNames(t, d))
+
+	// Physically gone, not just hidden: History no longer shows Bob/Carol.
+	assert.Equal(t, []string{"Alice"}, snapTestHistoryNames(t, d))
+
+	// The target snapshot survives.
+	snaps, err := d.Snapshots()
+	require.NoError(t, err)
+	require.Len(t, snaps, 1)
+	assert.Equal(t, "cp1", snaps[0].Name)
+}
+
+func TestTruncateToResumesClockWithoutCollision(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	_, err = d.Snapshot("cp1")
+	require.NoError(t, err)
+	snapTestAddName(t, d, "bob", "Bob")
+
+	require.NoError(t, d.TruncateTo("cp1"))
+
+	// The next write must succeed and read back, with no collision against rewound datoms.
+	snapTestAddName(t, d, "dave", "Dave")
+	assert.Equal(t, []string{"Alice", "Dave"}, snapTestNames(t, d))
+	assert.Equal(t, []string{"Alice", "Dave"}, snapTestHistoryNames(t, d))
+}
+
+func TestTruncateToPrunesLaterSnapshots(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	_, err = d.Snapshot("cp1")
+	require.NoError(t, err)
+	snapTestAddName(t, d, "bob", "Bob")
+	_, err = d.Snapshot("cp2")
+	require.NoError(t, err)
+
+	// Truncating to cp1 erases everything after cp1's marker, cp2 included.
+	require.NoError(t, d.TruncateTo("cp1"))
+
+	snaps, err := d.Snapshots()
+	require.NoError(t, err)
+	require.Len(t, snaps, 1)
+	assert.Equal(t, "cp1", snaps[0].Name)
+
+	_, err = d.AsOfSnapshot("cp2")
+	assert.ErrorIs(t, err, ErrSnapshotNotFound)
+}
+
+func TestTruncateToLatestIsNoop(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	_, err = d.Snapshot("cp1")
+	require.NoError(t, err)
+
+	// No writes after the snapshot: truncate keeps everything up to and including it.
+	require.NoError(t, d.TruncateTo("cp1"))
+	assert.Equal(t, []string{"Alice"}, snapTestNames(t, d))
+
+	// Still writable afterward.
+	snapTestAddName(t, d, "bob", "Bob")
+	assert.Equal(t, []string{"Alice", "Bob"}, snapTestNames(t, d))
+}
+
+func TestTruncateThenSnapshotRewoundTimeline(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	_, err = d.Snapshot("cp1")
+	require.NoError(t, err)
+	snapTestAddName(t, d, "bob", "Bob")
+
+	require.NoError(t, d.TruncateTo("cp1"))
+
+	// Snapshot the rewound timeline and read it back.
+	_, err = d.Snapshot("cp2")
+	require.NoError(t, err)
+	snapTestAddName(t, d, "carol", "Carol")
+
+	asof, err := d.AsOfSnapshot("cp2")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Alice"}, snapTestNames(t, asof))
+	assert.Equal(t, []string{"Alice", "Carol"}, snapTestNames(t, d))
+
+	// truncate -> write -> truncate is stable.
+	require.NoError(t, d.TruncateTo("cp2"))
+	assert.Equal(t, []string{"Alice"}, snapTestNames(t, d))
+}
+
+func TestTruncateToUnknownSnapshot(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+	assert.ErrorIs(t, d.TruncateTo("nope"), ErrSnapshotNotFound)
+}
+
+func TestAsOfSnapshotRejectsWrites(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	_, err = d.Snapshot("cp1")
+	require.NoError(t, err)
+	asof, err := d.AsOfSnapshot("cp1")
+	require.NoError(t, err)
+
+	assert.Panics(t, func() {
+		asof.NewTransaction()
+	}, "AsOfSnapshot handle must reject writes")
+}
+
+// TestStoreTruncateAfterAndMaxTxForEntity exercises the two BadgerStore primitives
+// directly, independent of the snapshot machinery layered on top.
+func TestStoreDatomsAfterDeleteAndMaxTxForEntity(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	mid, err := d.store.MaxElementID()
+	require.NoError(t, err)
+
+	snapTestAddName(t, d, "bob", "Bob")
+
+	// Alice's entity max Tx does not exceed the high-water captured before Bob.
+	maxAlice, ok, err := d.store.MaxTxForEntity(datalog.NewIdentity("alice"))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.False(t, mid.Less(maxAlice), "alice's max Tx should not exceed the pre-bob high-water")
+
+	// Removing everything after mid takes Bob's datoms (and their tx metadata) with it.
+	datoms, err := d.store.DatomsAfter(mid)
+	require.NoError(t, err)
+	n, err := d.store.DeleteDatoms(datoms)
+	require.NoError(t, err)
+	assert.Greater(t, n, 0, "should have deleted Bob's datoms")
+	assert.Equal(t, []string{"Alice"}, snapTestHistoryNames(t, d))
+
+	// An entity with no datoms reports not-found.
+	_, ok, err = d.store.MaxTxForEntity(datalog.NewIdentity("ghost"))
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/datalog/storage/truncate.go
+++ b/datalog/storage/truncate.go
@@ -1,0 +1,110 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// TruncateTo destructively rewinds this handle's writable timeline to the named snapshot.
+// Every datom written after the snapshot's own marker is PHYSICALLY removed (not
+// tombstoned), so it disappears from History() as well as from current reads; the clock
+// resumes from the snapshot point so the next write does not collide. Snapshots taken after
+// the target are pruned along with the timeline they indexed; the target snapshot and
+// earlier ones survive. See docs/proposals/BRANCHING_AND_SNAPSHOTS.md §12.1 (Slice B).
+//
+// Concurrency (§12.1, "Rollback safety"): TruncateTo serializes against other rollbacks
+// (rollbackMu), drains in-flight write transactions, and drops writes started while it runs
+// (they return ErrRollbackInProgress). An in-flight write opened before the rollback is
+// allowed to commit; its post-snapshot datoms are then erased like any other Tx > markerMax.
+// Reads are never locked — BadgerDB MVCC keeps them consistent, and the cache in-flight
+// window (BeginInFlight → delete → InvalidateRewind) keeps them from caching a soon-to-be-
+// stale value while the rewind is visible mid-flight.
+func (d *Database) TruncateTo(name string) error {
+	if d.temporalTxID != nil {
+		return fmt.Errorf("TruncateTo: cannot rewind a read-only temporal handle (AsOf/History)")
+	}
+
+	// Serialize this whole operation against other rollbacks.
+	d.rollbackMu.Lock()
+	defer d.rollbackMu.Unlock()
+
+	info, err := d.lookupSnapshot(name)
+	if err != nil {
+		return err
+	}
+	if info == nil {
+		return fmt.Errorf("TruncateTo %q: %w", name, ErrSnapshotNotFound)
+	}
+
+	// The deletion floor is the marker entity's own highest Tx, not the captured point:
+	// the marker was written just after the capture, so deleting strictly above it keeps
+	// the marker itself while erasing everything written later (including snapshots taken
+	// after this one, whose markers sit above the floor).
+	markerMax, err := d.snapshotMarkerMax(name)
+	if err != nil {
+		return err
+	}
+
+	// Gate new writers and drain in-flight ones so the clock rewind below cannot collide
+	// with a concurrent commit. drainCond.Wait releases d.mu while blocked, letting a
+	// draining commit reacquire it to deregister and signal; holding d.mu across the wait
+	// would deadlock against the very commits being waited on.
+	d.mu.Lock()
+	d.rollbackInProgress = true
+	for len(d.activeTx) > 0 {
+		d.drainCond.Wait()
+	}
+	d.mu.Unlock()
+
+	// Reopen the gate on every exit path below so writers resume.
+	defer func() {
+		d.mu.Lock()
+		d.rollbackInProgress = false
+		d.mu.Unlock()
+	}()
+
+	// Collect the datoms to remove and their touched (E,A) keys BEFORE deleting, so the
+	// cache window opens before the delete is visible. The set is stable: writers are
+	// drained and new ones dropped.
+	datoms, err := d.store.DatomsAfter(markerMax)
+	if err != nil {
+		return fmt.Errorf("TruncateTo %q: scan: %w", name, err)
+	}
+	keys := touchedCacheKeys(datoms)
+
+	if d.cache != nil {
+		d.cache.BeginInFlight(keys)
+	}
+
+	if _, err := d.store.DeleteDatoms(datoms); err != nil {
+		if d.cache != nil {
+			d.cache.InvalidateRewind(keys) // close the window even on failure
+		}
+		return fmt.Errorf("TruncateTo %q: delete: %w", name, err)
+	}
+
+	// No writer holds a Lamport above markerMax now; the rewind is collision-free.
+	d.clock.Restore(markerMax)
+
+	if d.cache != nil {
+		d.cache.InvalidateRewind(keys)
+	}
+	return nil
+}
+
+// touchedCacheKeys returns the deduplicated (E,A) cache keys for a set of datoms.
+func touchedCacheKeys(datoms []datalog.Datom) []CacheKey {
+	seen := make(map[CacheKey]struct{}, len(datoms))
+	keys := make([]CacheKey, 0, len(datoms))
+	for i := range datoms {
+		sd := ToStorageDatom(datoms[i])
+		k := CacheKey{E: sd.E, A: sd.A}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/datalog/storage/truncate_concurrency_test.go
+++ b/datalog/storage/truncate_concurrency_test.go
@@ -1,0 +1,183 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// cacheKeyFor builds the cache key for an (entity, attribute) pair the way the storage
+// layer does, for inspecting cache state in tests.
+func cacheKeyFor(e datalog.Identity, a datalog.Keyword) CacheKey {
+	sd := ToStorageDatom(datalog.Datom{E: e, A: a})
+	return CacheKey{E: sd.E, A: sd.A}
+}
+
+// TestTruncateToInvalidatesCache verifies the rewind drops the cached view AND resets the
+// monotonic freshness tracking for a rewound (E, A) — not just the entry. If maxVersions
+// were left stranded at the pre-rollback high-water, the rebuilt lower-version entry would
+// never compare fresh again.
+func TestTruncateToInvalidatesCache(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	_, err = d.Snapshot("cp1")
+	require.NoError(t, err)
+
+	e := datalog.NewIdentity("alice")
+	ageAttr := datalog.NewKeyword(":person/age")
+	tx := d.NewTransaction()
+	require.NoError(t, tx.Add(e, ageAttr, int64(30)))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	// Read the age so the cache holds a resolved view for (alice, :person/age).
+	var ages []int64
+	require.NoError(t, d.QueryInto(&ages, `[:find ?a :in $ ?e :where [?e :person/age ?a]]`, e))
+	require.Equal(t, []int64{30}, ages)
+
+	key := cacheKeyFor(e, ageAttr)
+	_, hadEntry := d.cache.entries.Load(key)
+	require.True(t, hadEntry, "the read should have populated the cache")
+
+	// Rewind past the age write.
+	require.NoError(t, d.TruncateTo("cp1"))
+
+	if _, ok := d.cache.entries.Load(key); ok {
+		t.Error("rewound cache entry must be dropped")
+	}
+	if _, ok := d.cache.maxVersions.Load(key); ok {
+		t.Error("rewound maxVersions must be reset, not left at the pre-rollback high-water")
+	}
+
+	// The read now reflects the erasure, not a stale-cached 30.
+	ages = nil
+	require.NoError(t, d.QueryInto(&ages, `[:find ?a :in $ ?e :where [?e :person/age ?a]]`, e))
+	assert.Empty(t, ages, "age must read as absent after rollback, not stale-cached")
+}
+
+// TestTruncateToDropsWritesStartedDuringRollback covers both writer semantics: an in-flight
+// transaction (opened before the rollback) is allowed to clear, while a transaction opened
+// while the rollback is in progress is dropped with ErrRollbackInProgress. It is made
+// deterministic by holding the in-flight transaction open, which parks the rollback in its
+// drain.
+func TestTruncateToDropsWritesStartedDuringRollback(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "alice", "Alice")
+	_, err = d.Snapshot("cp1")
+	require.NoError(t, err)
+
+	// Created BEFORE the rollback → in activeTx → the drain waits for it (allowed to clear).
+	blocker := d.NewTransaction()
+	require.NoError(t, blocker.Add(datalog.NewIdentity("bob"), datalog.NewKeyword(":person/name"), "Bob"))
+
+	done := make(chan error, 1)
+	go func() { done <- d.TruncateTo("cp1") }()
+
+	// Wait until the rollback has entered its drain.
+	require.Eventually(t, func() bool {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		return d.rollbackInProgress
+	}, 2*time.Second, time.Millisecond, "rollback should enter its drain")
+
+	// Created DURING the rollback → dropped.
+	doomed := d.NewTransaction()
+	addErr := doomed.Add(datalog.NewIdentity("carol"), datalog.NewKeyword(":person/name"), "Carol")
+	require.ErrorIs(t, addErr, ErrRollbackInProgress, "a write started during a rollback must be dropped")
+	_, commitErr := doomed.Commit()
+	require.ErrorIs(t, commitErr, ErrRollbackInProgress, "committing a dropped tx must report the rollback")
+
+	// Releasing the in-flight write lets it clear and the rollback complete.
+	_, blockErr := blocker.Commit()
+	require.NoError(t, blockErr, "an in-flight write opened before the rollback must be allowed to clear")
+	require.NoError(t, <-done)
+
+	// Exactly the snapshot: Bob (cleared, but post-snapshot) was erased; Carol never landed.
+	assert.Equal(t, []string{"Alice"}, snapTestNames(t, d))
+	assert.Equal(t, []string{"Alice"}, snapTestHistoryNames(t, d))
+}
+
+// TestTruncateToConcurrentWritersNoCollision stresses concurrent writers against repeated
+// rollbacks and asserts the core safety invariant: no two datoms share a Tx. A botched
+// rewind (restoring the clock while a writer holds a Lamport above the floor) would produce
+// a duplicate (Lamport, ReplicaID). Run under -race to also catch unsynchronized access to
+// the drain state.
+func TestTruncateToConcurrentWritersNoCollision(t *testing.T) {
+	d, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer d.Close()
+
+	snapTestAddName(t, d, "seed", "Seed")
+	_, err = d.Snapshot("cp1")
+	require.NoError(t, err)
+
+	const writers = 8
+	const perWriter = 25
+	var wg sync.WaitGroup
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				tx := d.NewTransaction()
+				e := datalog.NewIdentity(fmt.Sprintf("w%d-i%d", w, i))
+				if err := tx.Add(e, datalog.NewKeyword(":person/name"), fmt.Sprintf("n%d-%d", w, i)); err != nil {
+					if errors.Is(err, ErrRollbackInProgress) {
+						_ = tx.Rollback()
+						continue
+					}
+					t.Errorf("unexpected Add error: %v", err)
+					return
+				}
+				if _, err := tx.Commit(); err != nil && !errors.Is(err, ErrRollbackInProgress) {
+					t.Errorf("unexpected Commit error: %v", err)
+					return
+				}
+			}
+		}(w)
+	}
+
+	for r := 0; r < 3; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := d.TruncateTo("cp1"); err != nil {
+				t.Errorf("TruncateTo error: %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// No two datoms may share a Tx.
+	all, err := d.store.DatomsAfter(datalog.ElementID{})
+	require.NoError(t, err)
+	seen := make(map[datalog.ElementID]struct{}, len(all))
+	for i := range all {
+		if _, dup := seen[all[i].Tx]; dup {
+			t.Fatalf("duplicate Tx %v — clock collision from a rewind", all[i].Tx)
+		}
+		seen[all[i].Tx] = struct{}{}
+	}
+
+	// Still consistent and queryable; the pre-snapshot seed always survives a rollback to cp1.
+	var names []string
+	require.NoError(t, d.QueryInto(&names, `[:find ?n :where [?e :person/name ?n]]`))
+	sort.Strings(names)
+	assert.Contains(t, names, "Seed", "the pre-snapshot datom must survive every rollback to cp1")
+}

--- a/docs/proposals/BRANCHING_AND_SNAPSHOTS.md
+++ b/docs/proposals/BRANCHING_AND_SNAPSHOTS.md
@@ -738,9 +738,18 @@ cited sections.
   a possible future opt-in.
 - **`History()` across the chain (§10.11): merged lineage, fork-ceilings applied** — the
   raw datoms the session could have seen (own + ancestors up to fork), unresolved.
-- **Branch/snapshot metadata storage: reserved Badger `refs/` keyspace** (`name → path,
-  parent, forkLamport`) via `GetMetadataUint64`/`SetMetadataUint64`; dogfooding as
-  system-attribute datoms deferred.
+- **Branch/snapshot metadata storage: system-attribute datoms** (`:db.snapshot/*`),
+  listed and resolved via Datalog queries. *Reversed 2026-06-26 from the earlier
+  "reserved Badger `refs/` keyspace via `GetMetadataUint64`/`SetMetadataUint64`" plan;
+  full reasoning in §12.1 Slice A.* The operations the linear slice must support — list
+  snapshots, see their causal ordering — are exactly what datoms give for free: a snapshot
+  is a first-class entity, so `Snapshots()` is a query, causal order is intrinsic to each
+  marker's Tx, name-uniqueness rides the existing read-time `(A,V)`-LWW (§7), and the
+  registry adds no new store surface. Rollback is **timeline-coupled** (semantics (i),
+  §12.1): a snapshot's point is its own marker's Tx, so `TruncateTo` keeps the target
+  snapshot and prunes any taken later, leaving no dangling refs. The `refs/` keyspace and
+  content-addressed metadata remain available for the branching/distribution rounds;
+  dogfooding does not preclude them.
 - **Clock model (§4.1): one shared counter**, stamped per-arena — globally monotonic,
   tie-free on a single node.
 - **Deferred (axis A only):** cache validity-stamp granularity (§8.4) — relevant only if
@@ -1210,7 +1219,7 @@ The three flavors differ in what (if anything) they destroy:
 > when the rollback variants were first sketched, a gap in the reasoning, not just the
 > writeup.) **Decided (2026-06-26): forbid.** Hard-truncate errors if any descendant's
 > fork-point exceeds `T`; the caller must drop or re-base those children first. This is
-> cheap to enforce: the `refs/` keyspace records each branch's parent and `forkLamport`
+> cheap to enforce: the snapshot/branch registry (`:db.snapshot/*` datoms, §9.6) records each branch's parent and `forkLamport`
 > (§11.2), so descendants past `T` are a direct lookup. Cascade (auto-invalidating
 > descendants) is a possible future opt-in, not the default. Soft rollback and
 > branch-on-rollback carry no such hazard: they delete nothing.
@@ -1376,7 +1385,7 @@ func (d *Database) Fork(name string) (*Database, error) {
     forkAt, _ := d.store.MaxElementID()     // committed high-water (not Peek; §10.3): ceiling for d.arena
 
     if err := d.store.putBranchRef(name, child, d.arena, forkAt); err != nil {
-        return nil, err                     // refs keyspace (§9.6): name → (path, parent, forkLamport)
+        return nil, err                     // branch registry (§9.6): a :db.snapshot/* marker — name → (path, parent, forkLamport)
     }
 
     // The child's chain = d's chain, but d.arena flips from leaf (unbounded) to a
@@ -1550,8 +1559,8 @@ otherwise untouched.
    R5 split; §11.5).
 2. **One `Iterator`-interface addition:** `Key() []byte` — the merge needs raw-key
    ordering; trivial on `BadgerIterator`, which already holds the key.
-3. **Branch metadata in a `refs/` keyspace** (`name → path, parent, forkLamport`), per
-   §9.6.
+3. **Branch metadata as `:db.snapshot/*` datoms** (`name → path, parent, forkLamport`),
+   per §9.6 — listed and resolved by query, not a side keyspace.
 4. **Session handle is a writable `Database` clone** — unlike `AsOf`/`History`, which
    panic on write.
 
@@ -1596,30 +1605,66 @@ coordinate for the new writes, i.e. the branch axis, which is what the tree-path
 adds and why branch-on-rollback is deferred. So linear rollback is one of two things
 only: a read-only view (Slice A) or a destructive rewind (Slice B).
 
-**Slice A — snapshots + read-only views.** Almost pure metadata over existing
-machinery; reuses `store.MaxElementID()` (capture) and `d.AsOf(eid)` (read), so there is
-no new read code.
+**Slice A — snapshots + read-only views, recorded as system-attribute datoms.** A
+snapshot is an ordinary entity in a reserved `:db.snapshot/*` namespace, not a row in a
+side table. This *reverses* the earlier "reserved `refs/` keyspace" plan (§9.6), and the
+reason is the slice's own requirements: the operations it must support are *list the
+snapshots* and *see their causal ordering*, and for those, datoms are the natural
+representation while a side table is a second, weaker API bolted alongside the engine.
+Recording snapshots as datoms gives, in order of why it won:
+
+- **`Snapshots()` is a Datalog query, not new storage code.** For example
+  `[:find ?name ?lamport ?created :where [?s :db.snapshot/name ?name]
+  [?s :db.snapshot/at-lamport ?lamport] [?s :db.snapshot/created ?created]]`, ordered by
+  `?lamport` (the captured point) or `?created` (wall clock).
+- **Causal ordering is inherent and real.** Each marker is itself a datom with a Lamport
+  Tx, so the order snapshots were *created* is intrinsic to the log, and the point each
+  one *captures* is a queryable, sortable attribute. A `refs/` side table would have
+  carried only a wall-clock field unless it separately recorded the creating Tx — i.e. it
+  would have had to *reconstruct* what datoms already are.
+- **No new store surface.** Capture reuses `store.MaxElementID()`; the marker write reuses
+  the ordinary transaction path; name-uniqueness rides the existing read-time `(A,V)`-LWW
+  (§7); `AsOfSnapshot` is a query plus the existing `d.AsOf(eid)`; `DeleteSnapshot` is a
+  retract. This is *more* faithful to the slice's "zero storage-core change" goal than the
+  bytes-metadata side API the `refs/` plan implied — it adds none.
+- **It is how Datomic models its own metadata** (`:db/*` system attributes), so it is
+  idiomatic, not a novel mechanism.
 
 ```go
-// Snapshot names the current state of THIS handle. Internally records the handle's
-// high-water point (ElementID today via store.MaxElementID(); (arena, frontier) under
-// tree-path) — the signature does not change. Errors if name exists.
+// Snapshot names the current state of THIS handle as a :db.snapshot/* entity. Captures
+// store.MaxElementID() as the point and writes the marker in one transaction. Errors if
+// the name already exists (a read-time uniqueness check, not write-time enforcement).
 func (d *Database) Snapshot(name string) (SnapshotInfo, error)
 
 // AsOfSnapshot returns a READ-ONLY handle viewing the DB as of the named snapshot.
-// Internally d.AsOf(ref); AsOf handles already reject writes (NewTransaction panics).
+// Reads at the marker's own high-water (always non-zero, so it dodges the zero-ElementID
+// History sentinel; domain-equivalent to the captured point); AsOf handles already reject
+// writes (NewTransaction panics on a temporal handle), so the read-only guarantee is free.
 func (d *Database) AsOfSnapshot(name string) (*Database, error)
 
+// Snapshots lists every snapshot — a query over :db.snapshot/* — in causal order.
 func (d *Database) Snapshots() ([]SnapshotInfo, error)
+
+// DeleteSnapshot retracts the named marker entity. The rewindable timeline is untouched;
+// only the registry entry goes away.
 func (d *Database) DeleteSnapshot(name string) error
 
-// SnapshotInfo is opaque beyond Name. Its internal ref widens (ElementID → arena+frontier)
-// without changing this type's contract; metadata fields can be added additively.
+// SnapshotInfo is the decoded marker. Fields are additive: the branching round adds
+// Path/Parent without changing existing callers (their absence ⇒ root).
 type SnapshotInfo struct {
-    Name string
-    // unexported: ref, created — internal, free to grow
+    Name    string
+    At      datalog.ElementID // captured high-water point
+    Created time.Time
 }
 ```
+
+**Reserved namespace.** `:db.snapshot/name` (the unique key); `:db.snapshot/at-lamport`
+and `:db.snapshot/at-replica` (the captured `ElementID`, stored as two `int64`s so the
+point is itself queryable and comparable — that is what makes causal ordering a query
+rather than a decode); `:db.snapshot/created` (`time.Time`, for human listing). These
+markers are visible in `History()` and raw scans — by design: the registry is itself
+auditable and time-travelable — and are filtered out of domain queries by their reserved
+namespace, exactly as Datomic's `:db/*` datoms are.
 
 `AsOfSnapshot` returns a read-only handle: an `AsOf`/`History` handle rejects writes
 (`NewTransaction` panics on a temporal handle). So Slice A is "name a checkpoint;
@@ -1636,17 +1681,144 @@ query/operate as of it"; it does not change the live, writable DB.
 func (d *Database) TruncateTo(name string) error
 ```
 
-- **Mechanics:** scan TAEV (the Tx-leading index) for `Tx > eid` — a bounded range
-  from the index start to `encode(eid)`; for each affected datom, physically delete its
-  key from all eight indices in one `BadgerTx`; then `clock.Restore(eid)` so the next
-  write resumes at `eid.Lamport+1`; invalidate the cache.
+- **Mechanics (semantics (i), timeline-coupled).** Resolve the target's captured point
+  `at` and its marker entity by query. The marker was written *just after* it captured
+  `at`, so its own datoms occupy the Tx range immediately above `at`; let `markerMax` be
+  the marker entity's highest Tx. The deletion floor is `markerMax`, not `at`: deleting
+  `Tx > markerMax` keeps the target marker itself, prunes every snapshot taken later (each
+  indexed a now-erased future, so removing them is exactly what *prevents* dangling refs),
+  and erases all post-snapshot game writes — and there are none in `(at, markerMax]`
+  because the marker is written contiguously, right after the capture. Concretely: scan
+  TAEV (the Tx-leading index) for `Tx > markerMax` — a bounded range from the index start
+  to `encode(markerMax)` — and physically delete each affected datom's key from all eight
+  indices in one `BadgerTx`; then `clock.Restore(markerMax)` so the next write resumes at
+  `markerMax.Lamport+1` with no collision against the surviving marker; invalidate the
+  cache. (`AsOfSnapshot` reads at `markerMax` too, not at the stored `at`: it is
+  domain-equivalent — the marker datoms it includes are reserved-namespace, filtered from
+  domain queries — and, unlike `at`, always non-zero, so an empty-database snapshot whose
+  `at` is the zero ElementID does not collide with the matcher's History sentinel and read
+  back as the whole database.)
 - **The new primitive — physical delete-by-Tx.** Today the store has only `Retract`,
   which appends a tombstone at a higher Tx (forward, the opposite of a rewind), so true
   truncation is new code: scan + 8 key deletes per affected datom.
 - **Destructive, by design:** the rolled-back datoms are gone; `History()` will not show
-  them either. Safe in the linear case because there are no branches, hence no
-  descendants to orphan; the §10.7 guard is vacuous now and becomes active only under
+  them either. The target snapshot and every snapshot taken at or before it survive (their
+  markers sit at or below `markerMax`); snapshots taken *after* it are pruned along with
+  the timeline they indexed. Safe in the linear case because there are no branches, hence
+  no descendants to orphan; the §10.7 guard is vacuous now and becomes active only under
   tree-path.
+
+**Rollback safety under concurrency.** The single-threaded mechanics above are not safe
+against concurrent readers and writers; `TruncateTo` is a destructive control-plane
+operation and must be made safe explicitly. There are two hazards, of different severity:
+
+- **Clock collision — real corruption.** `clock.Restore(markerMax)` rewinds the Lamport
+  counter while `TruncateAfter` deletes `Tx > markerMax`. If a writer is mid-commit with
+  Lamports already assigned above `markerMax`, either its datoms are deleted out from under
+  a commit the caller was told succeeded, or after the restore the next writer is handed a
+  Lamport the concurrent writer already used — an identical `(Lamport, ReplicaID)`, which
+  is duplicate-key corruption of the CRDT order, not merely a stale read. This is the
+  hazard that forces serialization against writers.
+- **Cache incoherence on a rewind.** Storage reads are already safe: BadgerDB MVCC gives
+  every iterator a consistent snapshot, so a reader overlapping the delete sees its own pre-
+  or post-delete snapshot. The cache is the gap. It holds resolved CRDT views keyed by
+  `(E, A)`, and a rewind makes any entry over a deleted datom stale. The freshness counter
+  compounds it: `UpdateMaxVersion` only ever raises the per-`(E,A)` high-water (cache.go),
+  because a forward commit only ever advances it. A rewind lowers the true high-water,
+  which the freshness path cannot represent — left alone, a rebuilt lower-version entry
+  compares unequal to the stranded high recorded max forever, so it never cache-hits again:
+  a silent permanent slowdown for every rewound key, on top of the staleness.
+
+So reads need no lock for storage correctness; only the clock and the cache do. That
+shapes the design.
+
+**Why write-drain, not a read lock.** `TruncateTo` is rare; reads are the hot path. Gating
+every read behind a shared lock so a rare operation can exclude them is the wrong trade for
+a high-performance store, and `sync.RWMutex` punishes it specifically: the read side
+contends on one `readerCount` cacheline at high core counts, and Go gives a waiting writer
+priority, so the instant `TruncateTo` called `Lock()` it would stall all new reads until it
+finished and the slowest in-flight query drained. Streaming makes it worse: a `Query`
+iterator outlives the call, so a read lock would have to be held across iteration, turning
+a leaked iterator into a hung rollback. Reads therefore take no new lock. The clock hazard
+is closed by draining writers; the cache hazard by the existing in-flight mechanism plus a
+freshness reset. (A full read/write `RWMutex` gate and a caller-quiesce contract were both
+weighed and rejected — the first for the per-read cost, the second for pushing correctness
+onto the caller.)
+
+**Writer semantics: drain in-flight, drop new.** A rollback lets the writes already in
+flight finish and rejects writes that start while it runs:
+
+- A transaction created *before* the rollback (already in `activeTx`) is allowed to commit;
+  the drain waits for it. Its post-snapshot datoms are then erased by the delete like any
+  other `Tx > markerMax` — "clearing" means committing cleanly, not surviving.
+- A transaction created *while* a rollback is in progress is dropped: its writes return
+  `ErrRollbackInProgress`.
+
+Dropping rather than blocking-then-applying is what makes the result deterministic. A
+blocked-then-resumed write would land at `markerMax+1` after the restore and survive, so a
+write that merely raced the rollback would leak onto the rewound timeline and the
+post-rollback state would be "the snapshot plus whatever happened to race," not the
+snapshot. Dropping also keeps any writer from hanging for the rollback's duration. The drop
+is a retryable sentinel error, never a silent no-op: the caller learns its write did not
+land and can retry after the rollback or abandon it. Silent write loss is exactly the
+failure that stays invisible until it has corrupted downstream state.
+
+**The cache half is the existing in-flight pattern.** No new "uncached window" mechanism is
+needed: `Commit` already implements precisely this (cache.go `BeginInFlight` /
+`storeIfNotInFlight` / `Invalidate`). Before its storage mutation it stores an in-flight
+sentinel for each touched `(E, A)`; while the sentinel is present `GetOrResolve` resolves
+straight from storage without caching and writers refuse to cache, so those keys are
+uncached for the duration; after the mutation `Invalidate` drops the sentinels and reads
+rebuild fresh. The rollback reuses this verbatim, with one extension. `Invalidate`
+deliberately keeps `maxVersions` (a forward commit just advanced it, and the next read
+should see the entry as current); a rewind must instead drop `maxVersions` for the touched
+keys and `attrVersions` for the touched attributes, so the monotonic high-water above is
+cleared rather than stranded over the rebuilt value. That is the one new cache method,
+`InvalidateRewind(touched)`: drop entries and `maxVersions` per key, and `attrVersions` per
+touched attribute.
+
+**Choreography.** `TruncateTo` holds a dedicated `rollbackMu` for its whole duration, which
+serializes rollback against rollback. Inside it:
+
+1. `db.mu.Lock()`; set `rollbackInProgress = true`; `for len(activeTx) > 0 { cond.Wait() }`;
+   `db.mu.Unlock()`. `Cond.Wait` releases `db.mu` while blocked, which is what lets an
+   in-flight commit reacquire `db.mu` to deregister from `activeTx` and signal the drain;
+   holding `db.mu` across the wait would deadlock against the very commits being waited on.
+   When the loop returns, in-flight writers have cleared and `rollbackInProgress` gates new
+   ones.
+2. Scan TAEV for `Tx > markerMax`, collecting the affected datoms and their touched
+   `(E, A)` keys. The set is stable because writers are drained and new ones dropped.
+3. `cache.BeginInFlight(keys)` — open the uncached window before the delete is visible, so
+   no reader can cache-hit a soon-to-be-stale entry.
+4. Physically delete the collected datoms from all eight indices in one `BadgerTx`.
+5. `clock.Restore(markerMax)` — safe now, since no writer holds a Lamport above `markerMax`.
+6. `cache.InvalidateRewind(keys)` — close the window and reset freshness.
+7. `db.mu.Lock()`; `rollbackInProgress = false`; `db.mu.Unlock()`; release `rollbackMu`.
+
+Steps 2–6 run without `db.mu` held, so a rollback never blocks the brief `db.mu` sections
+`NewTransaction` and `Commit` take; `rollbackInProgress`, not the lock, gates writers across
+the storage work.
+
+**Concurrency surface.** The entire addition: a `doomed bool` per `Transaction`, stamped
+from `rollbackInProgress` at `NewTransaction` time, with `Add`/`Retract`/`Commit` returning
+`ErrRollbackInProgress` when it is set; a `rollbackInProgress bool` and a `sync.Cond` over
+the existing `db.mu`, used only for the drain; and a `rollbackMu` serializing rollbacks. The
+read path is untouched — no new lock, no atomic. The write path gains, per operation, one
+bool check and (in commit/rollback cleanup, only while a rollback is draining) one
+`cond.Broadcast`, both inside a `db.mu` section those paths already take.
+
+**Consequences and contract.**
+- An in-flight commit can succeed and then have its data erased by the rollback that was
+  draining it. That is inherent to destructively rewinding past a point the commit wrote,
+  not a bug.
+- A write attempted during a rollback fails with `ErrRollbackInProgress` (retryable),
+  rather than blocking or silently vanishing.
+- Reads never block on a rollback and never see a torn or stale-cached value: they run on
+  MVCC snapshots and bypass the cache for touched keys across the window.
+- The drain waits on in-flight write transactions only, so a write transaction the caller
+  holds open stalls the rollback for as long as it stays open; the contract is that write
+  transactions are short-lived. A future drain deadline could bound this; it is out of
+  scope for the linear slice.
 
 **Forward-compatibility.** The public surface expresses only what generalizes;
 everything that changes stays behind it. Five rules, each tied to the breakage it
@@ -1657,14 +1829,15 @@ prevents:
 | **Name-based API** — snapshots/rollback by `string`; the ref never appears in a signature | Snapshot identity widening `ElementID → (arena, frontier)` would change a return/param type |
 | **Methods on `*Database`, returning `*Database`** | A session handle (tree-path) would otherwise need a new type; instead the same methods work on root and session handles |
 | **All mutators return `error`** | The future descendant-guard (§10.7) is a new error case, not a new signature (vacuous linearly) |
-| **Opaque, version-tagged stored ref** | The record grows `[v1][ElementID:16] → [v2][arena:32][frontier…]` with no migration of old snapshots |
+| **Marker stored as additive datoms** | The branching round adds `:db.snapshot/path` (etc.) attributes; old snapshots stay valid (no path ⇒ root) with no record migration — additivity is what datoms give natively |
 | **`RollbackTo`/`Fork` reserved; destructive op named `TruncateTo`** | No verb ever flips meaning from destructive → non-destructive when branching lands |
 
 **What generalizes underneath the stable surface** (none of it visible in the API):
 - `Snapshot` capture: `store.MaxElementID()` → the handle's `(arena, frontier)`.
-- Stored ref: version-tagged — `v1 = [ElementID:16]` → `v2 = [arena:32][frontier…]`. Old
-  `v1` snapshots stay valid: a linear snapshot is `(rootArena, eid)`, which the §10
-  ancestor-chain read path already handles (root is the base of every chain).
+- Stored marker: today `:db.snapshot/at-{lamport,replica}`; under tree-path the same
+  entity gains `:db.snapshot/path` (and parent/fork attributes). Datoms are additive, so
+  old markers stay valid with no migration: a linear snapshot has no path, which the §10
+  ancestor-chain read path already treats as the root — the base of every chain.
 - `AsOfSnapshot` read path: `d.AsOf(eid)` → the §10 ancestor-chain merge; same handle
   type and signature.
 - `TruncateTo` scope: the whole linear timeline → the current branch's subtree, plus the
@@ -1683,6 +1856,13 @@ so the friendly "rollback" name never has to flip from destructive to non-destru
   next write gets `T+1` with no collision; truncate → write → truncate is stable.
 - Edges: snapshot of an empty DB; truncate to the latest snapshot (no-op); snapshot the
   rewound timeline and read it back.
+- Concurrency (run under `-race`): a write transaction opened *before* `TruncateTo` commits
+  cleanly and the rollback drains it; a write *started during* the rollback returns
+  `ErrRollbackInProgress`; a writer racing a rollback never produces a duplicate
+  `(Lamport, ReplicaID)` and the post-rollback clock is collision-free; a reader running
+  across the rollback never observes a stale-cached value for a truncated `(E, A)`; two
+  concurrent `TruncateTo` calls serialize. Any race the detector surfaces in this new
+  concurrency code is mine to resolve before the slice ships.
 
 ### 12.2 Full staged arc
 


### PR DESCRIPTION
## Summary

Implements the minimum linear slice of the branching/snapshots proposal (`docs/proposals/BRANCHING_AND_SNAPSHOTS.md` §12.1): named **snapshots**, read-only **`AsOfSnapshot`** views, and a destructive **`TruncateTo`** rollback. The proposal doc is updated in the same change (the datom-native reversal and the rollback-safety design).

## Design

- **Snapshots are `:db.snapshot/*` datoms**, not a side table — so `Snapshots()` is a Datalog query and causal ordering is intrinsic to each marker's Tx. Name uniqueness rides the existing read-time `(A,V)`-LWW; `AsOfSnapshot` wraps the existing `AsOf`.
- **`AsOfSnapshot` reads at the marker's own high-water** (always non-zero), which dodges the zero-ElementID `History` sentinel for an empty-database snapshot.
- **`TruncateTo`, semantics (i)**: physically deletes `Tx > markerMax`; the target snapshot and earlier ones survive, later ones are pruned along with the timeline they indexed — no dangling refs.

## Rollback safety (the part to review closely)

`TruncateTo` is made concurrency-safe without taxing the read path:

- Serializes against other rollbacks (`rollbackMu`).
- **Drains** in-flight write transactions and **drops** writes started while it runs (`ErrRollbackInProgress`) — this prevents a Lamport-clock collision when `clock.Restore` rewinds the counter.
- **Reads take no new lock** — BadgerDB MVCC plus the existing cache in-flight window (`BeginInFlight` → delete → `InvalidateRewind`) keep them coherent.
- `InvalidateRewind` resets the monotonic cache freshness high-water that a rewind *retreats* (the plain `Invalidate` deliberately keeps it, for forward commits).

The full reasoning, hazards, and the 7-step choreography (including the `drainCond.Wait` deadlock-avoidance) are in the "Rollback safety under concurrency" subsection of §12.1.

## Storage primitives

`DatomsAfter` + `DeleteDatoms` (split so the cache in-flight window can open between the scan and the delete) and `MaxTxForEntity`.

## Testing

- Snapshot capture / list (causal order) / delete, duplicate-name error, empty-DB edge.
- `TruncateTo` semantics, physical absence verified via `History()` (not just resolved reads), clock-resume without collision, prune-later-snapshots, rewind-then-re-snapshot.
- Cache coherence and `maxVersions` reset across a rewind.
- Concurrent writers vs. rollbacks asserting no duplicate `(Lamport, ReplicaID)`, run under `-race`.

`go test -count=1 ./...` is green; the three concurrency tests additionally pass under `-race` (scoped to the new concurrent code).
