### PR TITLE
Add top-level :limit clause with unified order-by/limit finalization

### DIFF
--- a/.claude/skills/datalog/SKILL.md
+++ b/.claude/skills/datalog/SKILL.md
@@ -86,6 +86,10 @@ Queries are EDN vectors. The basic form:
 [:find ?dept (sum ?salary) (count ?e) :where ...]
 
 ;; Available: sum, count, avg, min, max
+
+;; Scalar find-spec — trailing "." means "return a single value" (the first
+;; result), not a set. Requires exactly one find element.
+[:find ?name . :where [?p :person/name ?name]]
 ```
 
 ### Where Clauses
@@ -191,6 +195,8 @@ Important: `enumerate` produces **multiple output tuples** from a single input t
 
 The subquery `(q [...] $ ?var1 ?var2)` takes a full query, then lists the inputs to pass (matching the subquery's `:in` clause). The binding after `)` determines how results are captured: `[[?x]]` for a single tuple, `[[?x ?y] ...]` for multiple tuples.
 
+`:limit` is **not** supported inside a subquery (it parse-errors). For "top-1 per group", use the `(max ?x)`/`(min ?x)` aggregate idiom in the subquery instead.
+
 **Tagged literals** — use typed constants directly in patterns and predicates:
 ```clojure
 [#identity "L85hash..." :person/name ?name]   ;; match specific entity
@@ -246,6 +252,61 @@ Each `-in` value is parsed as EDN, so tagged literals work too: `-in '#inst "202
  :where [?p :person/name ?name]
         [?p :person/age ?age]]
 ```
+
+### Limiting Results and Pagination
+
+**`:limit N`** caps the number of result rows — for *bounding* a result (top-N,
+latest-1, "does any row match"), not for pagination. `:order-by` is optional and
+independent: `:limit N` alone returns the first N rows the engine produces
+(arbitrary but valid, like SQL `LIMIT` without `ORDER BY`) and stops the scan
+early. Add `:order-by` only when N must be chosen by a sort key — e.g. with
+`:order-by … :desc`, `:limit 1` is the canonical "latest record" query:
+
+```clojure
+;; "give me any one matching entity" — no :order-by needed
+[:find ?e :where [?e :entity/type :entity.type/telemetry] :limit 1]
+```
+
+When ordering matters, the cap is applied after `:order-by` (and after
+aggregation):
+
+```clojure
+[:find ?e ?tx
+ :where [?e :entity/type :entity.type/telemetry ?tx]
+ :order-by [[?tx :desc]]
+ :limit 1]
+```
+
+Scalar rule: with a scalar find-spec (`:find … .`), `:limit 0` and `:limit 1` are
+allowed; `:limit N>1` is an error — it contradicts "return a single value".
+
+```bash
+~/go/bin/datalog -db <path> -query \
+  '[:find ?e ?seq
+    :where [?e :event/kind "telemetry"] [?e :event/seq ?seq]
+    :order-by [[?seq :desc]] :limit 1]'
+```
+
+**There is no `:offset` / pagination clause, by design.** A query result is a
+streaming relation, so "the next page" is just *keep pulling from the same
+iterator* — which reads one consistent snapshot and gives stable, gap-free paging
+for free. An offset would re-scan and discard rows every page and is unstable
+across writes. For stateless/cross-process paging, use **keyset (cursor)
+pagination** instead: pin a snapshot with `d.AsOf(tx)` and carry the last-seen
+sort key forward as a `:where` bound —
+
+```clojure
+;; page 2+: continue past the last tx already seen
+[:find ?e ?tx
+ :in $ ?last-tx
+ :where [?e :entity/type :entity.type/telemetry ?tx]
+        [(> ?tx ?last-tx)]
+ :order-by [[?tx :asc]]
+ :limit 100]
+```
+
+This is O(N) per page (no discard), uses the index directly, and is stable under
+`d.AsOf`.
 
 ### Time-Travel
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,7 @@
 - **LZ77+FSE compression codec** (3.6× on prose, 10-13× on structured/repetitive; 2.1-2.4 GB/s decompression; deterministic; Tier-3 blob store for large values)
 - **Iterator-error contract enforced across executor + storage**: deferred storage errors (Tier-3 blob decode, etc.) ride through every materialization, join, sort, projection, union, and subquery boundary instead of being laundered into clean partial results
 - **Collection binding `[?x ...]`** for set inputs (parser + executor wired through subqueries, OR fallback, and input handling)
+- **Top-level `:limit`** (bounded results / top-N / latest-1) with streaming early-termination when unordered; finalization (`:order-by` then `:limit`) unified at the `ExecuteRealized` boundary so it composes correctly with aggregation and `RelationInput` (also corrected a latent `:order-by`+`RelationInput` global-ordering bug)
 
 ### Production Readiness: ✅ Ready
 
@@ -92,11 +93,13 @@ These items have been completed and are preserved for historical context:
 
 ### Query Engine Enhancements
 1. **Distinct Aggregation**: `(count-distinct ?x)` and a `distinct` modifier on existing aggregates
+2. **Subquery `:limit` (per-invocation)**: top-level `:limit` is done; inside a subquery it is currently a **parse error** (would otherwise be silently ignored). Supporting it requires per-invocation finalization, disabling batching when a cap is present, and guarding decorrelation. Forward-compatible tests already assert correctness once the parse rejection is removed (`datalog/executor/limit_edge_test.go`). Full design: [docs/bugs/resolved/BUG_QUERY_LIMIT_CLAUSE_UNSUPPORTED.md](docs/bugs/resolved/BUG_QUERY_LIMIT_CLAUSE_UNSUPPORTED.md).
 
 ### Performance Optimizations
 1. **Parallel Pattern Execution**: For independent patterns (complex dependency analysis)
 2. **Statistics Collection**: For better query planning (requires architecture changes)
 3. **Adaptive Streaming Strategy**: Automatically choose streaming vs materialized based on data
+4. **Index-order pushdown for `:order-by … :limit`**: turn `:order-by [[?tx :desc]] :limit 1` into a true point read (the EATV/ATEV indices already store Tx descending) instead of materialize-and-sort. Staged design + soundness preconditions (joins, aggregation, CRDT, ordering totality) in [docs/bugs/resolved/BUG_QUERY_LIMIT_CLAUSE_UNSUPPORTED.md](docs/bugs/resolved/BUG_QUERY_LIMIT_CLAUSE_UNSUPPORTED.md).
 
 ## Long Term (3-6 Months)
 

--- a/datalog/db/limit_test.go
+++ b/datalog/db/limit_test.go
@@ -1,0 +1,127 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+)
+
+// collectFirstCol drains a relation and returns the first column of each row.
+func collectFirstCol(t *testing.T, rel executor.Relation) []interface{} {
+	t.Helper()
+	var out []interface{}
+	it := rel.Iterator()
+	defer it.Close()
+	for it.Next() {
+		out = append(out, it.Tuple()[0])
+	}
+	require.NoError(t, it.Error())
+	return out
+}
+
+// TestQueryLimitThroughStorage exercises :limit end-to-end against real
+// BadgerDB storage (the streaming-matcher path the feature targets), not a
+// synthetic in-memory relation.
+func TestQueryLimitThroughStorage(t *testing.T) {
+	d := tempDB(t)
+
+	kind := datalog.NewKeyword(":event/kind")
+	seq := datalog.NewKeyword(":event/seq")
+
+	tx := d.NewTransaction()
+	for i := int64(1); i <= 5; i++ {
+		e := datalog.NewIdentity("event:" + string(rune('a'+i-1)))
+		require.NoError(t, tx.Add(e, kind, "telemetry"))
+		require.NoError(t, tx.Add(e, seq, i))
+	}
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	t.Run("limit caps rows without order-by", func(t *testing.T) {
+		rel, err := d.Query(`[:find ?seq
+		                      :where [?e :event/kind "telemetry"]
+		                             [?e :event/seq ?seq]
+		                      :limit 2]`)
+		require.NoError(t, err)
+		got := collectFirstCol(t, rel)
+		require.Len(t, got, 2)
+	})
+
+	t.Run("latest record via order-by desc + limit 1", func(t *testing.T) {
+		rel, err := d.Query(`[:find ?seq
+		                      :where [?e :event/kind "telemetry"]
+		                             [?e :event/seq ?seq]
+		                      :order-by [[?seq :desc]]
+		                      :limit 1]`)
+		require.NoError(t, err)
+		got := collectFirstCol(t, rel)
+		require.Len(t, got, 1)
+		require.Equal(t, int64(5), got[0])
+	})
+
+	t.Run("limit zero yields no rows", func(t *testing.T) {
+		rel, err := d.Query(`[:find ?seq
+		                      :where [?e :event/kind "telemetry"]
+		                             [?e :event/seq ?seq]
+		                      :limit 0]`)
+		require.NoError(t, err)
+		got := collectFirstCol(t, rel)
+		require.Len(t, got, 0)
+	})
+
+	t.Run("limit above match count returns all", func(t *testing.T) {
+		rel, err := d.Query(`[:find ?seq
+		                      :where [?e :event/kind "telemetry"]
+		                             [?e :event/seq ?seq]
+		                      :limit 100]`)
+		require.NoError(t, err)
+		got := collectFirstCol(t, rel)
+		require.Len(t, got, 5)
+	})
+}
+
+// TestLimitComposesWithAsOf is the production pattern: "latest snapshot as of a
+// point in time" — :order-by desc + :limit 1 against an AsOf view must return
+// the latest row visible at that transaction, not the absolute latest.
+func TestLimitComposesWithAsOf(t *testing.T) {
+	d := tempDB(t)
+
+	kind := datalog.NewKeyword(":snap/kind")
+	seq := datalog.NewKeyword(":snap/seq")
+
+	latestQuery := `[:find ?seq
+	                 :where [?e :snap/kind "turn"]
+	                        [?e :snap/seq ?seq]
+	                 :order-by [[?seq :desc]]
+	                 :limit 1]`
+
+	// One snapshot entity per turn, each in its own transaction.
+	var tx2ID datalog.ElementID
+	for i := int64(1); i <= 3; i++ {
+		e := datalog.NewIdentity("snap:" + string(rune('a'+i-1)))
+		tx := d.NewTransaction()
+		require.NoError(t, tx.Add(e, kind, "turn"))
+		require.NoError(t, tx.Add(e, seq, i))
+		id, err := tx.Commit()
+		require.NoError(t, err)
+		if i == 2 {
+			tx2ID = id
+		}
+	}
+
+	// Live view: latest snapshot is seq 3.
+	rel, err := d.Query(latestQuery)
+	require.NoError(t, err)
+	live := collectFirstCol(t, rel)
+	require.Len(t, live, 1)
+	require.Equal(t, int64(3), live[0])
+
+	// As-of tx2: snap3 is not yet visible, so the latest is seq 2.
+	rel, err = d.AsOf(tx2ID).Query(latestQuery)
+	require.NoError(t, err)
+	asOf := collectFirstCol(t, rel)
+	require.Len(t, asOf, 1)
+	require.Equal(t, int64(2), asOf[0])
+}

--- a/datalog/executor/executor.go
+++ b/datalog/executor/executor.go
@@ -216,7 +216,30 @@ func (e *Executor) ExecuteWithRelations(ctx Context, q *query.Query, inputRelati
 // - Each phase executes as independent Query returning []Relation (disjoint groups)
 // - Groups are projected to Keep symbols and passed to next phase
 // - Final phase must collapse to single relation or error on Cartesian product
+//
+// Finalization (:order-by then :limit) is applied here, at the single outer
+// boundary, on the fully-assembled result. This is what makes the inline path
+// and the per-tuple RelationInput-iteration path behave identically: the result
+// of a RelationInput query is the union of its per-tuple executions, so ordering
+// and capping must run over that whole union — not per iteration. Sorting before
+// limiting yields a correct global top-N.
 func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inputRelations []Relation) (Relation, error) {
+	result, err := e.executeRealizedPlan(ctx, plan, inputRelations)
+	if err != nil {
+		return nil, err
+	}
+	if len(plan.Query.OrderBy) > 0 {
+		result = result.Sort(plan.Query.OrderBy)
+	}
+	if plan.Query.Limit != nil {
+		result = NewLimitRelation(result, *plan.Query.Limit)
+	}
+	return result, nil
+}
+
+// executeRealizedPlan runs the phase pipeline and returns the assembled result
+// (un-ordered, un-limited). ExecuteRealized applies :order-by and :limit to it.
+func (e *Executor) executeRealizedPlan(ctx Context, plan *planner.RealizedPlan, inputRelations []Relation) (Relation, error) {
 	// Check if we need to iterate over a RelationInput
 	// RelationInput (e.g., :in [[?a ?b]]) requires executing the query once per tuple
 	if hasRelationInput(plan.Query) && len(inputRelations) > 0 {
@@ -422,14 +445,8 @@ func (e *Executor) ExecuteRealized(ctx Context, plan *planner.RealizedPlan, inpu
 		return emptyRelationForQuery(plan.Query), nil
 	}
 
-	finalResult := currentGroups[0]
-
-	// Apply ordering if specified
-	if len(plan.Query.OrderBy) > 0 {
-		finalResult = finalResult.Sort(plan.Query.OrderBy)
-	}
-
-	return finalResult, nil
+	// :order-by and :limit are applied by ExecuteRealized on the final result.
+	return currentGroups[0], nil
 }
 
 // executeRealizedWithRelationInputIteration handles RelationInput iteration for QueryExecutor path
@@ -1114,13 +1131,11 @@ func (p *preparedIteration) Run(ctx Context, iterationTuple Tuple) (Relation, er
 		return emptyRelationForQuery(p.plan.Query), nil
 	}
 
-	finalResult := currentGroups[0]
-
-	if len(p.plan.Query.OrderBy) > 0 {
-		finalResult = finalResult.Sort(p.plan.Query.OrderBy)
-	}
-
-	return finalResult, nil
+	// Per-tuple results are returned un-ordered: the RelationInput result is the
+	// union of all per-tuple executions, and :order-by/:limit are applied once by
+	// ExecuteRealized over that whole union (a per-tuple sort here would be
+	// discarded by the union and would not produce a global ordering).
+	return currentGroups[0], nil
 }
 
 // SetPlanCache sets the plan cache for this executor

--- a/datalog/executor/limit_edge_test.go
+++ b/datalog/executor/limit_edge_test.go
@@ -1,0 +1,179 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/planner"
+)
+
+// catItemDatoms: two categories; A has 5 items, B has 2. Used to distinguish
+// per-invocation vs global vs dropped limit semantics for subqueries.
+func catItemDatoms() []datalog.Datom {
+	d := []datalog.Datom{
+		{E: datalog.NewIdentity("catA"), A: datalog.NewKeyword(":cat/name"), V: "A", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: datalog.NewIdentity("catB"), A: datalog.NewKeyword(":cat/name"), V: "B", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+	}
+	add := func(seed, cat string, val int64) {
+		e := datalog.NewIdentity(seed)
+		d = append(d,
+			datalog.Datom{E: e, A: datalog.NewKeyword(":item/cat"), V: cat, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+			datalog.Datom{E: e, A: datalog.NewKeyword(":item/val"), V: val, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		)
+	}
+	add("a1", "A", 1)
+	add("a2", "A", 2)
+	add("a3", "A", 3)
+	add("a4", "A", 4)
+	add("a5", "A", 5)
+	add("b1", "B", 6)
+	add("b2", "B", 7)
+	return d
+}
+
+// TestSubqueryLimitIsPerInvocation pins the contract for :limit inside a
+// subquery. Two end states are acceptable; silently-ignored caps (wrong
+// results) are not:
+//   - Interim: parsing rejects the subquery :limit (no silent wrong results).
+//   - Future: parsing succeeds AND the cap is applied per invocation —
+//     A=5 items -> 2, B=2 items -> 2, total 4 rows.
+//
+// A global cap (2) or a dropped limit (7) must fail this test. When per-
+// invocation support lands, simply removing the parse rejection makes the
+// correctness assertion below the active gate — no test edit required.
+func TestSubqueryLimitIsPerInvocation(t *testing.T) {
+	matcher := NewMemoryPatternMatcher(catItemDatoms())
+	exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{})
+
+	q, err := parser.ParseQuery(`[:find ?c ?v
+	                              :where [?cat :cat/name ?c]
+	                                     [(q [:find ?val
+	                                          :in $ ?c
+	                                          :where [?i :item/cat ?c]
+	                                                 [?i :item/val ?val]
+	                                          :limit 2]
+	                                         $ ?c) [[?v] ...]]]`)
+	if err != nil {
+		// Interim behavior: :limit inside a subquery is rejected at parse time.
+		t.Logf("subquery :limit rejected at parse (interim): %v", err)
+		return
+	}
+	// Rejection removed => execution must honor the per-invocation cap.
+	result, err := exec.Execute(q)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if result.Size() != 4 {
+		t.Errorf("expected 4 rows (per-invocation limit 2: A->2, B->2), got %d", result.Size())
+		dumpRelationTest(t, result)
+	}
+}
+
+// TestSubqueryLimitTopPerGroup pins the "top per group" idiom — order-by desc +
+// limit 1 in a correlated subquery bound as a tuple. Acceptable end states:
+//   - Interim: parsing rejects the subquery :limit.
+//   - Future: parsing succeeds AND it yields the max val per category:
+//     (A,5), (B,7).
+//
+// When per-invocation support lands, removing the parse rejection makes the
+// correctness assertion below the active gate — no test edit required.
+func TestSubqueryLimitTopPerGroup(t *testing.T) {
+	matcher := NewMemoryPatternMatcher(catItemDatoms())
+	exec := NewExecutorWithOptions(matcher, nil, planner.PlannerOptions{})
+
+	q, err := parser.ParseQuery(`[:find ?c ?v
+	                              :where [?cat :cat/name ?c]
+	                                     [(q [:find ?val
+	                                          :in $ ?c
+	                                          :where [?i :item/cat ?c]
+	                                                 [?i :item/val ?val]
+	                                          :order-by [[?val :desc]]
+	                                          :limit 1]
+	                                         $ ?c) [[?v]]]]`)
+	if err != nil {
+		// Interim behavior: :limit inside a subquery is rejected at parse time.
+		t.Logf("subquery :limit rejected at parse (interim): %v", err)
+		return
+	}
+	// Rejection removed => execution must honor order-by + limit per invocation.
+	result, err := exec.Execute(q)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if result.Size() != 2 {
+		t.Fatalf("expected 2 rows (top-1 per group), got %d", result.Size())
+	}
+	got := map[string]int64{}
+	it := result.Iterator()
+	defer it.Close()
+	for it.Next() {
+		tup := it.Tuple()
+		got[tup[0].(string)] = tup[1].(int64)
+	}
+	if got["A"] != 5 || got["B"] != 7 {
+		t.Errorf("expected A->5, B->7, got %v", got)
+	}
+}
+
+// TestPureAggregateWithLimit: a pure (ungrouped) aggregate yields one row;
+// limit 1 keeps it, limit 0 yields none.
+func TestPureAggregateWithLimit(t *testing.T) {
+	matcher := NewMemoryPatternMatcher(catItemDatoms())
+	exec := NewExecutor(matcher, nil)
+
+	t.Run("limit 1 keeps the single aggregate row", func(t *testing.T) {
+		q, err := parser.ParseQuery(`[:find (count ?e) .
+		                              :where [?e :item/val ?v]
+		                              :limit 1]`)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		result, err := exec.Execute(q)
+		if err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if result.Size() != 1 {
+			t.Fatalf("expected 1 row, got %d", result.Size())
+		}
+		if result.Get(0)[0].(int64) != 7 {
+			t.Errorf("expected count 7, got %v", result.Get(0)[0])
+		}
+	})
+
+	t.Run("limit 0 drops the aggregate row", func(t *testing.T) {
+		q, err := parser.ParseQuery(`[:find (count ?e)
+		                              :where [?e :item/val ?v]
+		                              :limit 0]`)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		result, err := exec.Execute(q)
+		if err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if result.Size() != 0 {
+			t.Errorf("expected 0 rows, got %d", result.Size())
+		}
+	})
+}
+
+// TestPullWithLimit: :limit caps the number of pulled entities (rows).
+func TestPullWithLimit(t *testing.T) {
+	matcher := NewMemoryPatternMatcher(catItemDatoms())
+	exec := NewExecutor(matcher, nil)
+
+	q, err := parser.ParseQuery(`[:find (pull ?e [:item/val])
+	                              :where [?e :item/val ?v]
+	                              :limit 1]`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	result, err := exec.Execute(q)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if result.Size() != 1 {
+		t.Errorf("expected 1 pulled row, got %d", result.Size())
+	}
+}

--- a/datalog/executor/limit_relation.go
+++ b/datalog/executor/limit_relation.go
@@ -1,0 +1,106 @@
+package executor
+
+import (
+	"sync"
+
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// LimitRelation caps a relation to at most N tuples. It materializes lazily,
+// pulling the source iterator no more than N times — so a :limit with no
+// :order-by stops the underlying scan early instead of draining it. When the
+// source is already materialized (e.g. after :order-by sorts), the cap is a
+// cheap truncation of the first N tuples.
+//
+// All relational operations delegate to the bounded materialization, so the
+// source iterator is consumed exactly once regardless of access pattern.
+type LimitRelation struct {
+	source Relation
+	limit  int
+
+	once sync.Once
+	mat  *MaterializedRelation
+}
+
+// NewLimitRelation wraps source so that at most limit tuples are produced.
+// A negative limit is treated as zero (empty result).
+func NewLimitRelation(source Relation, limit int) *LimitRelation {
+	if limit < 0 {
+		limit = 0
+	}
+	return &LimitRelation{source: source, limit: limit}
+}
+
+// ensure materializes at most limit tuples from the source exactly once.
+func (r *LimitRelation) ensure() *MaterializedRelation {
+	r.once.Do(func() {
+		tuples := make([]Tuple, 0, r.limit)
+		var err error
+
+		if r.limit > 0 {
+			needsCopy := r.source.RequiresCopy()
+			it := r.source.Iterator()
+			// Pull no more than limit tuples — this is the early termination:
+			// once we have N, we stop advancing the source.
+			for len(tuples) < r.limit && it.Next() {
+				tuple := it.Tuple()
+				if needsCopy {
+					tuple = copyTuple(tuple)
+				}
+				tuples = append(tuples, tuple)
+			}
+			err = it.Error()
+			if cerr := it.Close(); err == nil {
+				err = cerr
+			}
+		}
+
+		r.mat = NewMaterializedRelationWithOptions(r.source.Symbols(), tuples, r.source.Options())
+		// Carry any deferred source error so it isn't laundered by materialization.
+		r.mat.err = err
+	})
+	return r.mat
+}
+
+func (r *LimitRelation) Symbols() []query.Symbol { return r.source.Symbols() }
+func (r *LimitRelation) Iterator() Iterator       { return r.ensure().Iterator() }
+func (r *LimitRelation) Size() int                { return r.ensure().Size() }
+func (r *LimitRelation) IsEmpty() bool            { return r.ensure().IsEmpty() }
+func (r *LimitRelation) Get(i int) Tuple          { return r.ensure().Get(i) }
+func (r *LimitRelation) String() string           { return r.ensure().String() }
+func (r *LimitRelation) Table() string            { return r.ensure().Table() }
+
+func (r *LimitRelation) ProjectFromPattern(pattern *query.DataPattern) Relation {
+	return r.ensure().ProjectFromPattern(pattern)
+}
+func (r *LimitRelation) Sorted() ([]Tuple, error) { return r.ensure().Sorted() }
+func (r *LimitRelation) Project(symbols []query.Symbol) (Relation, error) {
+	return r.ensure().Project(symbols)
+}
+func (r *LimitRelation) Materialize() Relation { return r.ensure() }
+func (r *LimitRelation) Sort(orderBy []query.OrderByClause) Relation {
+	return r.ensure().Sort(orderBy)
+}
+func (r *LimitRelation) Filter(filter Filter) Relation { return r.ensure().Filter(filter) }
+func (r *LimitRelation) FilterWithPredicate(pred query.Predicate) Relation {
+	return r.ensure().FilterWithPredicate(pred)
+}
+func (r *LimitRelation) EvaluateFunction(fn query.Function, outputSymbol query.Symbol) Relation {
+	return r.ensure().EvaluateFunction(fn, outputSymbol)
+}
+func (r *LimitRelation) Select(pred func(Tuple) bool) Relation { return r.ensure().Select(pred) }
+func (r *LimitRelation) Join(other Relation) Relation          { return r.ensure().Join(other) }
+func (r *LimitRelation) HashJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return r.ensure().HashJoin(other, joinSyms)
+}
+func (r *LimitRelation) SemiJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return r.ensure().SemiJoin(other, joinSyms)
+}
+func (r *LimitRelation) AntiJoin(other Relation, joinSyms []query.Symbol) Relation {
+	return r.ensure().AntiJoin(other, joinSyms)
+}
+func (r *LimitRelation) Aggregate(findElements []query.FindElement) Relation {
+	return r.ensure().Aggregate(findElements)
+}
+func (r *LimitRelation) Options() ExecutorOptions { return r.source.Options() }
+func (r *LimitRelation) RequiresCopy() bool       { return false }

--- a/datalog/executor/limit_test.go
+++ b/datalog/executor/limit_test.go
@@ -1,0 +1,288 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/parser"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// countingSliceIterator (defined in lazy_seq_relation_test.go) tracks how many
+// tuples the source produced via its nextCalls pointer, which lets these tests
+// prove that a limit stops pulling from the source instead of draining it.
+
+// TestLimitRelationStopsScanAfterN is the core streaming-early-termination
+// contract: wrapping a streaming relation of 1000 tuples in a limit of 5 must
+// pull the source iterator at most 5 times, not drain it.
+func TestLimitRelationStopsScanAfterN(t *testing.T) {
+	const total = 1000
+
+	build := func(calls *int) *countingSliceIterator {
+		tuples := make([]Tuple, total)
+		for i := range tuples {
+			tuples[i] = Tuple{int64(i)}
+		}
+		return &countingSliceIterator{tuples: tuples, nextCalls: calls}
+	}
+
+	t.Run("limit below size stops the scan early", func(t *testing.T) {
+		calls := 0
+		sr := NewStreamingRelation([]query.Symbol{datalog.NewSymbol("?x")}, build(&calls))
+		lr := NewLimitRelation(sr, 5)
+
+		if got := lr.Size(); got != 5 {
+			t.Errorf("expected Size 5, got %d", got)
+		}
+		if calls != 5 {
+			t.Errorf("expected source pulled exactly 5 times (early termination), got %d", calls)
+		}
+	})
+
+	t.Run("limit zero pulls nothing", func(t *testing.T) {
+		calls := 0
+		sr := NewStreamingRelation([]query.Symbol{datalog.NewSymbol("?x")}, build(&calls))
+		lr := NewLimitRelation(sr, 0)
+
+		if got := lr.Size(); got != 0 {
+			t.Errorf("expected Size 0, got %d", got)
+		}
+		if calls != 0 {
+			t.Errorf("expected source pulled 0 times, got %d", calls)
+		}
+	})
+
+	t.Run("limit above size returns all without error", func(t *testing.T) {
+		calls := 0
+		small := &countingSliceIterator{tuples: []Tuple{{int64(1)}, {int64(2)}, {int64(3)}}, nextCalls: &calls}
+		sr := NewStreamingRelation([]query.Symbol{datalog.NewSymbol("?x")}, small)
+		lr := NewLimitRelation(sr, 10)
+
+		if got := lr.Size(); got != 3 {
+			t.Errorf("expected Size 3, got %d", got)
+		}
+	})
+
+	t.Run("iterator yields exactly the limit", func(t *testing.T) {
+		calls := 0
+		sr := NewStreamingRelation([]query.Symbol{datalog.NewSymbol("?x")}, build(&calls))
+		lr := NewLimitRelation(sr, 7)
+
+		it := lr.Iterator()
+		defer it.Close()
+		count := 0
+		for it.Next() {
+			count++
+		}
+		if count != 7 {
+			t.Errorf("expected iterator to yield 7 tuples, got %d", count)
+		}
+	})
+}
+
+// telemetryDatoms builds a small dataset: 5 entities, each with a value and a
+// monotonically increasing tx-like ordinal, for top-N / limit testing.
+func telemetryDatoms() []datalog.Datom {
+	mk := func(seed string, ord int64) []datalog.Datom {
+		e := datalog.NewIdentity(seed)
+		return []datalog.Datom{
+			{E: e, A: datalog.NewKeyword(":n/ord"), V: ord, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+			{E: e, A: datalog.NewKeyword(":n/kind"), V: "telemetry", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		}
+	}
+	var datoms []datalog.Datom
+	datoms = append(datoms, mk("e1", 10)...)
+	datoms = append(datoms, mk("e2", 20)...)
+	datoms = append(datoms, mk("e3", 30)...)
+	datoms = append(datoms, mk("e4", 40)...)
+	datoms = append(datoms, mk("e5", 50)...)
+	return datoms
+}
+
+func TestQueryLimitNoOrderBy(t *testing.T) {
+	matcher := NewMemoryPatternMatcher(telemetryDatoms())
+	exec := NewExecutor(matcher, nil)
+
+	cases := []struct {
+		name  string
+		limit string
+		want  int
+	}{
+		{"limit below size", "1", 1},
+		{"limit equal size", "5", 5},
+		{"limit above size", "100", 5},
+		{"limit zero", "0", 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q, err := parser.ParseQuery(`[:find ?e ?ord
+			                              :where [?e :n/kind "telemetry"]
+			                                     [?e :n/ord ?ord]
+			                              :limit ` + tc.limit + `]`)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			result, err := exec.Execute(q)
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if result.Size() != tc.want {
+				t.Errorf("expected %d rows, got %d", tc.want, result.Size())
+			}
+		})
+	}
+}
+
+func TestQueryLimitWithOrderByTopN(t *testing.T) {
+	matcher := NewMemoryPatternMatcher(telemetryDatoms())
+	exec := NewExecutor(matcher, nil)
+
+	// Latest-2 by ord descending: should be 50, 40 in that order.
+	q, err := parser.ParseQuery(`[:find ?ord
+	                              :where [?e :n/kind "telemetry"]
+	                                     [?e :n/ord ?ord]
+	                              :order-by [[?ord :desc]]
+	                              :limit 2]`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	result, err := exec.Execute(q)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if result.Size() != 2 {
+		t.Fatalf("expected 2 rows, got %d", result.Size())
+	}
+	want := []int64{50, 40}
+	for i := 0; i < result.Size(); i++ {
+		got := result.Get(i)[0].(int64)
+		if got != want[i] {
+			t.Errorf("row %d: expected %d, got %d", i, want[i], got)
+		}
+	}
+}
+
+func TestQueryLimitAfterAggregationCapsGroups(t *testing.T) {
+	// Four cities; limit 2 must cap the number of grouped rows to 2.
+	datoms := []datalog.Datom{
+		{E: datalog.NewIdentity("p1"), A: datalog.NewKeyword(":person/city"), V: "NYC", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: datalog.NewIdentity("p2"), A: datalog.NewKeyword(":person/city"), V: "LA", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: datalog.NewIdentity("p3"), A: datalog.NewKeyword(":person/city"), V: "SF", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		{E: datalog.NewIdentity("p4"), A: datalog.NewKeyword(":person/city"), V: "BOS", Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+	}
+	matcher := NewMemoryPatternMatcher(datoms)
+	exec := NewExecutor(matcher, nil)
+
+	q, err := parser.ParseQuery(`[:find ?city (count ?p)
+	                              :where [?p :person/city ?city]
+	                              :limit 2]`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	result, err := exec.Execute(q)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if result.Size() != 2 {
+		t.Errorf("expected 2 grouped rows, got %d", result.Size())
+	}
+}
+
+// TestQueryLimitWithRelationInputIsGlobal verifies the cap is applied to the
+// combined output across all RelationInput tuples, not per input tuple.
+func TestQueryLimitWithRelationInputIsGlobal(t *testing.T) {
+	// Two keys, each with 3 values: 6 rows total without a limit.
+	datoms := []datalog.Datom{}
+	add := func(seed, key string, val int64) {
+		e := datalog.NewIdentity(seed)
+		datoms = append(datoms,
+			datalog.Datom{E: e, A: datalog.NewKeyword(":item/key"), V: key, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+			datalog.Datom{E: e, A: datalog.NewKeyword(":item/val"), V: val, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		)
+	}
+	add("a1", "k1", 1)
+	add("a2", "k1", 2)
+	add("a3", "k1", 3)
+	add("b1", "k2", 4)
+	add("b2", "k2", 5)
+	add("b3", "k2", 6)
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	exec := NewExecutor(matcher, nil)
+
+	q, err := parser.ParseQuery(`[:find ?v
+	                              :in $ [[?k] ...]
+	                              :where [?e :item/key ?k]
+	                                     [?e :item/val ?v]
+	                              :limit 2]`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	keySym := datalog.NewSymbol("?k")
+	inputRel := NewMaterializedRelation([]query.Symbol{keySym}, []Tuple{{"k1"}, {"k2"}})
+
+	result, err := exec.ExecuteWithRelations(NewContext(nil), q, []Relation{inputRel})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	// Global cap of 2; a per-tuple cap would yield up to 4 (2 per key).
+	if result.Size() != 2 {
+		t.Errorf("expected global limit of 2 rows, got %d", result.Size())
+	}
+}
+
+// TestOrderByAndLimitWithRelationInputIsGlobal verifies finalization runs over
+// the UNION of per-tuple executions: :order-by sorts the whole result and
+// :limit takes a global top-N. The old per-tuple-sort-then-concatenate behavior
+// would return an order-dependent (wrong) slice here.
+func TestOrderByAndLimitWithRelationInputIsGlobal(t *testing.T) {
+	// keyA -> vals {1,2,3}, keyB -> vals {4,5,6,7}. Global top-3 desc = 7,6,5.
+	datoms := []datalog.Datom{}
+	add := func(seed, key string, val int64) {
+		e := datalog.NewIdentity(seed)
+		datoms = append(datoms,
+			datalog.Datom{E: e, A: datalog.NewKeyword(":item/key"), V: key, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+			datalog.Datom{E: e, A: datalog.NewKeyword(":item/val"), V: val, Tx: datalog.ElementID{Lamport: 1, ReplicaID: 1}},
+		)
+	}
+	add("a1", "A", 1)
+	add("a2", "A", 2)
+	add("a3", "A", 3)
+	add("b1", "B", 4)
+	add("b2", "B", 5)
+	add("b3", "B", 6)
+	add("b4", "B", 7)
+
+	matcher := NewMemoryPatternMatcher(datoms)
+	exec := NewExecutor(matcher, nil)
+
+	q, err := parser.ParseQuery(`[:find ?v
+	                              :in $ [[?k] ...]
+	                              :where [?e :item/key ?k]
+	                                     [?e :item/val ?v]
+	                              :order-by [[?v :desc]]
+	                              :limit 3]`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	keySym := datalog.NewSymbol("?k")
+	inputRel := NewMaterializedRelation([]query.Symbol{keySym}, []Tuple{{"A"}, {"B"}})
+
+	result, err := exec.ExecuteWithRelations(NewContext(nil), q, []Relation{inputRel})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if result.Size() != 3 {
+		t.Fatalf("expected 3 rows, got %d", result.Size())
+	}
+	want := []int64{7, 6, 5}
+	for i := 0; i < 3; i++ {
+		got := result.Get(i)[0].(int64)
+		if got != want[i] {
+			t.Errorf("row %d: expected %d, got %d (global top-3 desc)", i, want[i], got)
+		}
+	}
+}

--- a/datalog/parser/limit_test.go
+++ b/datalog/parser/limit_test.go
@@ -1,0 +1,237 @@
+package parser
+
+import (
+	"testing"
+)
+
+// TestLimitParsing covers the :limit clause grammar: it reads a single
+// non-negative integer, rejects negatives/non-integers loudly, and is
+// independent of :order-by (a bare :limit with no ordering is valid).
+func TestLimitParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		wantErr bool
+		want    int // expected *Limit when no error and Limit set
+		wantNil bool
+	}{
+		{
+			name: "limit with order-by (latest record)",
+			query: `[:find ?e ?tx
+			         :where [?e :event/crawl ?tx]
+			         :order-by [[?tx :desc]]
+			         :limit 1]`,
+			want: 1,
+		},
+		{
+			name: "limit without order-by is valid",
+			query: `[:find ?e
+			         :where [?e :entity/type :entity.type/telemetry]
+			         :limit 1]`,
+			want: 1,
+		},
+		{
+			name: "limit larger than one",
+			query: `[:find ?e
+			         :where [?e :person/name ?n]
+			         :limit 10]`,
+			want: 10,
+		},
+		{
+			name: "limit zero is valid",
+			query: `[:find ?e
+			         :where [?e :person/name ?n]
+			         :limit 0]`,
+			want: 0,
+		},
+		{
+			name: "no limit leaves Limit nil",
+			query: `[:find ?e
+			         :where [?e :person/name ?n]]`,
+			wantNil: true,
+		},
+		{
+			name: "negative limit is an error",
+			query: `[:find ?e
+			         :where [?e :person/name ?n]
+			         :limit -1]`,
+			wantErr: true,
+		},
+		{
+			name: "non-integer (float) limit is an error",
+			query: `[:find ?e
+			         :where [?e :person/name ?n]
+			         :limit 3.5]`,
+			wantErr: true,
+		},
+		{
+			name: "string limit is an error",
+			query: `[:find ?e
+			         :where [?e :person/name ?n]
+			         :limit "x"]`,
+			wantErr: true,
+		},
+		{
+			name: "missing limit value is an error",
+			query: `[:find ?e
+			         :where [?e :person/name ?n]
+			         :limit]`,
+			wantErr: true,
+		},
+		{
+			name: "two limit values is an error",
+			query: `[:find ?e
+			         :where [?e :person/name ?n]
+			         :limit 5 7]`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, err := ParseQuery(tt.query)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseQuery() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if tt.wantNil {
+				if q.Limit != nil {
+					t.Fatalf("expected Limit nil, got %d", *q.Limit)
+				}
+				return
+			}
+			if q.Limit == nil {
+				t.Fatalf("expected Limit %d, got nil", tt.want)
+			}
+			if *q.Limit != tt.want {
+				t.Errorf("expected Limit %d, got %d", tt.want, *q.Limit)
+			}
+		})
+	}
+}
+
+// TestLimitScalarInteraction covers the janus convention for :limit combined
+// with the scalar find-spec (:find ... .): limit 0 and 1 are coherent, limit
+// N>1 contradicts "return a single value" and is a parse error.
+func TestLimitScalarInteraction(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		wantErr bool
+	}{
+		{
+			name: "scalar with limit 1 is valid",
+			query: `[:find ?name .
+			         :where [?p :person/name ?name]
+			         :limit 1]`,
+		},
+		{
+			name: "scalar with limit 0 is valid",
+			query: `[:find ?name .
+			         :where [?p :person/name ?name]
+			         :limit 0]`,
+		},
+		{
+			name: "scalar with limit 2 is an error",
+			query: `[:find ?name .
+			         :where [?p :person/name ?name]
+			         :limit 2]`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseQuery(tt.query)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseQuery() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestLimitRejectedInSubquery: :limit inside a subquery is rejected at parse
+// time (the subquery execution path does not apply it, so allowing it would
+// silently ignore the cap). A subquery without :limit must still parse, and a
+// top-level :limit on a query that contains a subquery is fine.
+func TestLimitRejectedInSubquery(t *testing.T) {
+	t.Run("subquery with :limit is rejected", func(t *testing.T) {
+		_, err := ParseQuery(`[:find ?c ?v
+		                       :where [?cat :cat/name ?c]
+		                              [(q [:find ?val
+		                                   :in $ ?c
+		                                   :where [?i :item/cat ?c] [?i :item/val ?val]
+		                                   :limit 2]
+		                                  $ ?c) [[?v] ...]]]`)
+		if err == nil {
+			t.Error("expected parse error for :limit inside a subquery, got nil")
+		}
+	})
+
+	t.Run("subquery without :limit still parses", func(t *testing.T) {
+		_, err := ParseQuery(`[:find ?c ?v
+		                       :where [?cat :cat/name ?c]
+		                              [(q [:find ?val
+		                                   :in $ ?c
+		                                   :where [?i :item/cat ?c] [?i :item/val ?val]]
+		                                  $ ?c) [[?v] ...]]]`)
+		if err != nil {
+			t.Errorf("subquery without :limit should parse, got %v", err)
+		}
+	})
+
+	t.Run("top-level :limit with a subquery is fine", func(t *testing.T) {
+		q, err := ParseQuery(`[:find ?c ?v
+		                       :where [?cat :cat/name ?c]
+		                              [(q [:find ?val
+		                                   :in $ ?c
+		                                   :where [?i :item/cat ?c] [?i :item/val ?val]]
+		                                  $ ?c) [[?v] ...]]
+		                       :limit 5]`)
+		if err != nil {
+			t.Fatalf("top-level :limit with subquery should parse, got %v", err)
+		}
+		if q.Limit == nil || *q.Limit != 5 {
+			t.Errorf("expected top-level Limit 5, got %v", q.Limit)
+		}
+	})
+}
+
+// TestLimitRoundTrip verifies that a query carrying :limit round-trips through
+// both formatters (parser.FormatQuery and query.Query.String()).
+func TestLimitRoundTrip(t *testing.T) {
+	queries := []string{
+		`[:find ?e ?tx
+		  :where [?e :event/crawl ?tx]
+		  :order-by [[?tx :desc]]
+		  :limit 1]`,
+		`[:find ?e
+		  :where [?e :person/name ?n]
+		  :limit 25]`,
+		`[:find ?e
+		  :where [?e :person/name ?n]
+		  :limit 0]`,
+	}
+
+	for _, qs := range queries {
+		q, err := ParseQuery(qs)
+		if err != nil {
+			t.Fatalf("ParseQuery() error = %v", err)
+		}
+
+		for _, formatted := range []string{FormatQuery(q), q.String()} {
+			q2, err := ParseQuery(formatted)
+			if err != nil {
+				t.Fatalf("re-parse of %q error = %v", formatted, err)
+			}
+			if q2.Limit == nil {
+				t.Fatalf("re-parse dropped :limit from %q", formatted)
+			}
+			if *q2.Limit != *q.Limit {
+				t.Errorf("limit mismatch after round-trip: got %d want %d (formatted: %q)", *q2.Limit, *q.Limit, formatted)
+			}
+		}
+	}
+}

--- a/datalog/parser/parser.go
+++ b/datalog/parser/parser.go
@@ -122,6 +122,25 @@ func parseQueryVector(node *edn.Node) (*query.Query, error) {
 			}
 			i++
 
+		case ":limit":
+			// :limit expects exactly one non-negative integer.
+			if i >= len(node.Nodes) {
+				return nil, fmt.Errorf(":limit requires a non-negative integer")
+			}
+			if node.Nodes[i].Type != edn.NodeInt {
+				return nil, fmt.Errorf(":limit must be a non-negative integer, got %v", node.Nodes[i].Type)
+			}
+			n, err := strconv.ParseInt(node.Nodes[i].Value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf(":limit must be a valid integer: %w", err)
+			}
+			if n < 0 {
+				return nil, fmt.Errorf(":limit must be non-negative, got %d", n)
+			}
+			limit := int(n)
+			q.Limit = &limit
+			i++
+
 		default:
 			return nil, fmt.Errorf("unknown query clause: %s", keyword)
 		}
@@ -133,6 +152,12 @@ func parseQueryVector(node *edn.Node) (*query.Query, error) {
 	}
 	if len(q.Where) == 0 {
 		return nil, fmt.Errorf("query must have at least one where pattern")
+	}
+
+	// Scalar find spec (.) returns a single value, so a :limit above 1 is
+	// contradictory. :limit 0 (no result) and :limit 1 are coherent.
+	if q.ScalarReturn && q.Limit != nil && *q.Limit > 1 {
+		return nil, fmt.Errorf("scalar find spec (.) is incompatible with :limit %d (limit must be 0 or 1)", *q.Limit)
 	}
 
 	return q, nil
@@ -493,6 +518,16 @@ func parseSubqueryPattern(list *edn.Node, bindingNode *edn.Node) (*query.Subquer
 	nestedQuery, err := parseQueryVector(&list.Nodes[1])
 	if err != nil {
 		return nil, fmt.Errorf("error parsing nested query: %w", err)
+	}
+
+	// :limit inside a subquery is not yet supported. The subquery execution path
+	// applies neither :order-by nor :limit (both are top-level finalization
+	// steps), so honoring it would require per-invocation finalization plus
+	// disabling batching/decorrelation when a cap is present. Rejecting here
+	// prevents silently-ignored caps (wrong results). Tracked in
+	// docs/bugs/resolved/BUG_QUERY_LIMIT_CLAUSE_UNSUPPORTED.md.
+	if nestedQuery.Limit != nil {
+		return nil, fmt.Errorf(":limit is not supported inside a subquery; cap rows in the enclosing query, or use the (max ?x)/(min ?x) aggregate idiom for top-1-per-group")
 	}
 
 	// Parse inputs (everything between query and end)
@@ -1316,6 +1351,14 @@ func formatQueryWithIndent(q *query.Query, indent string) string {
 			}
 		}
 		sb.WriteString("]")
+	}
+
+	// Add :limit clause if present
+	if q.Limit != nil {
+		sb.WriteString("\n")
+		sb.WriteString(indent)
+		sb.WriteString(" :limit ")
+		sb.WriteString(strconv.Itoa(*q.Limit))
 	}
 
 	sb.WriteString("]")

--- a/datalog/planner/cache.go
+++ b/datalog/planner/cache.go
@@ -171,6 +171,13 @@ func (c *PlanCache) computeKeyWithOptions(q *query.Query, opts PlannerOptions) s
 		}
 	}
 
+	// Hash limit clause. The realized plan carries the query and the executor
+	// reads the limit from it, so two queries differing only by :limit must not
+	// share a cache entry (else the wrong limit would be applied).
+	if q.Limit != nil {
+		fmt.Fprintf(h, "LIMIT:%d;", *q.Limit)
+	}
+
 	// Hash planner options that affect the plan
 	fmt.Fprintf(h, "OPTIONS:")
 	fmt.Fprintf(h, "AlgebraOptimizer:%v;", opts.EnableAlgebraOptimizer)

--- a/datalog/planner/cache_limit_test.go
+++ b/datalog/planner/cache_limit_test.go
@@ -1,0 +1,59 @@
+package planner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+// TestPlanCacheDistinguishesLimit guards a correctness trap: the realized plan
+// carries the query (RealizedPlan.Query), and the executor reads the limit from
+// that cached query. If :limit is not part of the cache key, two queries that
+// differ only by limit collide and the wrong limit is applied. The cache must
+// treat different limits as different keys.
+func TestPlanCacheDistinguishesLimit(t *testing.T) {
+	cache := NewPlanCache(10, 1*time.Minute)
+	opts := PlannerOptions{}
+
+	mkQuery := func(limit *int) *query.Query {
+		return &query.Query{
+			Find: []query.FindElement{
+				query.FindVariable{Symbol: datalog.NewSymbol("?e")},
+			},
+			Where: []query.Clause{
+				&query.DataPattern{
+					Elements: []query.PatternElement{
+						query.Variable{Name: datalog.NewSymbol("?e")},
+						query.Constant{Value: datalog.NewKeyword(":person/name")},
+						query.Variable{Name: datalog.NewSymbol("?n")},
+					},
+				},
+			},
+			Limit: limit,
+		}
+	}
+
+	one, five := 1, 5
+	q1 := mkQuery(&one)
+	q5 := mkQuery(&five)
+
+	plan1 := &RealizedPlan{Query: q1}
+	cache.SetWithOptions(q1, plan1, opts)
+
+	// A query differing only by limit must NOT hit the cached plan.
+	if _, ok := cache.GetWithOptions(q5, opts); ok {
+		t.Error("queries differing only by :limit must not share a cache entry")
+	}
+
+	// The same limit must still hit.
+	if _, ok := cache.GetWithOptions(mkQuery(&one), opts); !ok {
+		t.Error("identical query (same :limit) should hit the cache")
+	}
+
+	// No-limit must also be distinct from a limited query.
+	if _, ok := cache.GetWithOptions(mkQuery(nil), opts); ok {
+		t.Error("unlimited query must not share a cache entry with a limited one")
+	}
+}

--- a/datalog/qb/builder.go
+++ b/datalog/qb/builder.go
@@ -14,6 +14,7 @@ type QueryBuilder struct {
 	in      []query.InputSpec
 	where   []query.Clause
 	orderBy []query.OrderByClause
+	limit   *int
 	errors  []error
 }
 
@@ -134,6 +135,26 @@ func (b *QueryBuilder) OrderBy(specs ...interface{}) *QueryBuilder {
 	return b
 }
 
+// Limit caps the number of result rows. The cap is applied after OrderBy (and
+// after aggregation), so OrderBy(Desc(...)) + Limit(1) is the "latest record"
+// query. A negative limit is a build error.
+//
+// Example:
+//
+//	qb.Query().
+//	    Find(e, tx).
+//	    Where(...).
+//	    OrderBy(qb.Desc(tx)).
+//	    Limit(1)
+func (b *QueryBuilder) Limit(n int) *QueryBuilder {
+	if n < 0 {
+		b.errors = append(b.errors, fmt.Errorf("limit must be non-negative, got %d", n))
+		return b
+	}
+	b.limit = &n
+	return b
+}
+
 // Build finalizes and validates the query, returning the built *query.Query.
 // Returns an error if the query is invalid or if any errors occurred during construction.
 func (b *QueryBuilder) Build() (*query.Query, error) {
@@ -152,6 +173,7 @@ func (b *QueryBuilder) Build() (*query.Query, error) {
 		In:      b.in,
 		Where:   b.where,
 		OrderBy: b.orderBy,
+		Limit:   b.limit,
 	}, nil
 }
 

--- a/datalog/qb/limit_test.go
+++ b/datalog/qb/limit_test.go
@@ -1,0 +1,72 @@
+package qb
+
+import (
+	"testing"
+)
+
+func TestBuilderLimit(t *testing.T) {
+	e := NewVar("e")
+	name := NewVar("name")
+
+	q, err := Query().
+		Find(e).
+		Where(Pat(e, Kw(":person/name"), name)).
+		Limit(10).
+		Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if q.Limit == nil {
+		t.Fatalf("expected Limit to be set, got nil")
+	}
+	if *q.Limit != 10 {
+		t.Errorf("expected Limit 10, got %d", *q.Limit)
+	}
+}
+
+func TestBuilderLimitZero(t *testing.T) {
+	e := NewVar("e")
+	name := NewVar("name")
+
+	q, err := Query().
+		Find(e).
+		Where(Pat(e, Kw(":person/name"), name)).
+		Limit(0).
+		Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if q.Limit == nil || *q.Limit != 0 {
+		t.Fatalf("expected Limit 0, got %v", q.Limit)
+	}
+}
+
+func TestBuilderNoLimit(t *testing.T) {
+	e := NewVar("e")
+	name := NewVar("name")
+
+	q, err := Query().
+		Find(e).
+		Where(Pat(e, Kw(":person/name"), name)).
+		Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if q.Limit != nil {
+		t.Errorf("expected Limit nil when not set, got %d", *q.Limit)
+	}
+}
+
+func TestBuilderNegativeLimitErrors(t *testing.T) {
+	e := NewVar("e")
+	name := NewVar("name")
+
+	_, err := Query().
+		Find(e).
+		Where(Pat(e, Kw(":person/name"), name)).
+		Limit(-1).
+		Build()
+	if err == nil {
+		t.Error("expected Build() error for negative limit, got nil")
+	}
+}

--- a/datalog/query/types.go
+++ b/datalog/query/types.go
@@ -354,6 +354,7 @@ type Query struct {
 	In           []InputSpec     // Input specifications (database and parameters)
 	Where        []Clause        // Clauses in WHERE (DataPattern, Predicate, Expression, Subquery)
 	OrderBy      []OrderByClause // Optional ordering of results
+	Limit        *int            // Optional cap on result rows (nil = unbounded); applied after OrderBy and aggregation
 	ScalarReturn bool            // If true, return scalar value (find spec ends with .)
 }
 
@@ -517,6 +518,11 @@ func (q Query) formatWithIndent(indent string) string {
 			result += clause.String()
 		}
 		result += "]"
+	}
+
+	// Add :limit clause if present
+	if q.Limit != nil {
+		result += "\n" + indent + " :limit " + strconv.Itoa(*q.Limit)
 	}
 
 	result += "]"

--- a/docs/bugs/resolved/BUG_QUERY_LIMIT_CLAUSE_UNSUPPORTED.md
+++ b/docs/bugs/resolved/BUG_QUERY_LIMIT_CLAUSE_UNSUPPORTED.md
@@ -1,0 +1,316 @@
+# BUG: No Top-Level `:limit` Clause — Top-N / Latest Queries Must Over-Fetch
+
+**Date**: 2026-06-29
+**Severity**: Low–Medium — feature gap, not wrong results or a crash. Queries that want "the latest row" or "top N" parse-error if they try `:limit`, forcing callers to fetch the entire ordered result set and slice in Go.
+**Status**: RESOLVED (2026-06-30) — top-level `:limit` implemented with streaming early-termination per the plan below. `:offset` intentionally not provided. Index-order pushdown remains a documented roadmap item (not yet implemented).
+**Affected**: top-level query result limiting. `:order-by` (asc/desc) is supported; capping the number of returned rows is not.
+
+## Summary
+
+A query cannot ask for a bounded number of result rows. There is no `:limit`
+clause in the grammar: the `Query` struct has no `Limit` field, and the query
+parser rejects `:limit` as an unknown clause. `:order-by` exists and supports
+both `:asc` and `:desc`, so the ordering half of "give me the most recent row"
+is available — but without a row cap, the only way to get the latest (or top N)
+is to run the ordered query, materialize *all* matching rows, and discard all
+but the tail in application code.
+
+This is the natural pairing the grammar is missing: `:order-by [[?tx :desc]]`
+plus `:limit 1` is the canonical "current value / latest record" query, and
+`:order-by [[?score :desc]]` plus `:limit 10` is "top 10". Today neither can be
+expressed.
+
+## Reproducer
+
+Any query carrying `:limit` fails at parse time:
+
+```clojure
+[:find ?e ?tx
+ :where [?e :entity/type :entity.type/telemetry ?tx]
+        [?e :event/crawl ?crawl]
+ :order-by [[?tx :desc]]
+ :limit 1]
+```
+
+```
+EDN parse error: unknown query clause: :limit
+```
+
+(The error comes from `parseQueryVector`'s `default` arm — see below.)
+
+## Expected Behavior
+
+A `:limit N` clause caps the number of result rows to the first `N` after
+`:order-by` is applied (and after aggregation, if any). Composed with
+`:order-by … :desc`, `:limit 1` returns the single latest row in one round trip,
+without transferring or allocating the rest of the result set.
+
+A natural extension (not required for the core feature) is `:offset M` for
+pagination, but `:limit` alone covers the latest/top-N cases that motivate this.
+
+## Actual Behavior
+
+`datalog/parser/parser.go::parseQueryVector` (the clause switch at lines 44–127)
+handles exactly `:find`, `:in`, `:where`, and `:order-by`. Any other top-level
+keyword hits the `default` arm at line 126:
+
+```go
+default:
+    return nil, fmt.Errorf("unknown query clause: %s", keyword)
+```
+
+so `:limit` is a hard parse error. Correspondingly, `query.Query`
+(`datalog/query/types.go`) has no `Limit` field — only `Find`, `In`, `Where`,
+`OrderBy`, `ScalarReturn`.
+
+## Not To Be Confused With Pull `:limit`
+
+The query package already has `PullLimitExpr` / `ResolvedPullLimitExpr`. That is
+a **pull-pattern** limit — it caps how many values of a cardinality-many
+attribute a `pull` returns (e.g. `[(:some/attr :limit 5)]`), operating *within*
+one entity's attribute. It does **not** limit the number of result *rows* of the
+enclosing query, and cannot serve the top-N / latest-row case. This feature is a
+distinct, top-level clause.
+
+## Motivating Use Case
+
+Consumers that want "the current/latest record of kind K" have no choice but to
+load the full per-key history and take the last element. For example, a
+telemetry reader that records one snapshot row per turn and then wants the most
+recent one ends up loading every row for the entity/crawl just to return
+`rows[len(rows)-1]` — an unbounded read that grows linearly with history length,
+on what should be an O(1) point read. The documented workaround is the
+`(max ?tx)` subquery idiom (find the max transaction, then match on it), which
+works for "latest single" but is more ceremony than `:order-by :desc :limit 1`
+and does not generalize to top-N.
+
+## Where To Investigate
+
+1. **Grammar/AST** — add a `Limit *int` (and optionally `Offset *int`) field to
+   `query.Query` in `datalog/query/types.go`; reflect it in `Query.String()` so
+   it round-trips through the parser.
+2. **Parser** — add a `:limit` case to the `parseQueryVector` switch
+   (`datalog/parser/parser.go`, alongside `:order-by` at line 104) that reads a
+   single non-negative integer node; reject negatives and non-integers loudly.
+3. **Executor** — apply the cap after ordering (and after aggregation) in the
+   result-assembly path, so it composes with `:order-by`. Truncating the
+   ordered relation before materializing the tail is where the actual savings
+   come from; a limit applied only after full materialization fixes correctness
+   but not the over-fetch cost.
+4. **Scalar interaction** — define behavior with `ScalarReturn` (`:find … .`):
+   `:limit 1` + scalar should be coherent; `:limit N>1` + scalar should error or
+   be disallowed.
+
+---
+
+## Implementation Plan (2026-06-30)
+
+Decisions recorded after a design discussion. Scope: ship a top-level `:limit`
+with streaming early-termination; document index-order pushdown as a roadmap
+item; **deliberately do not** add `:offset`.
+
+### Decision register
+
+| Decision | Resolution |
+|----------|------------|
+| `:limit N` | Implement now. Caps result rows **after** `:order-by` and **after** aggregation. |
+| Streaming early-termination | When there is **no** `:order-by`, stop pulling from the underlying iterator after N tuples (real scan + transfer savings). When `:order-by` **is** present, the sort already materializes the whole set, so the limit truncates post-sort (savings on transfer/tail only — *not* the scan). Closing that gap for the ordered case is the index-pushdown roadmap item below. |
+| `:offset M` | **Deliberately NOT provided.** Rationale below. |
+| Scalar `:find … .` | `:limit 0` and `:limit 1` allowed; `:limit N>1` combined with `.` is a **parse error** (it contradicts "return a single value"). |
+| `:limit` inside a subquery | **Parse error** (interim). Subqueries execute via `DefaultQueryExecutor.Execute`, which applies neither `:order-by` nor `:limit` (both are top-level finalization steps in `ExecuteRealized`), so a subquery cap would be *silently ignored* — wrong results. Rejecting at parse prevents that. Per-invocation support is a follow-up (see below). |
+
+### Subquery `:limit` — rejected at parse (interim), per-invocation support deferred
+
+Discovered during edge-case testing: a subquery carrying `:limit` had its cap
+**silently dropped** (a correlated subquery with `:limit 2` returned all rows,
+not 2 per invocation). Root cause: subqueries run their inner query through
+`DefaultQueryExecutor.Execute(subq.Query, inputs)` (`executor/query_executor.go`),
+which runs clauses + find-projection but performs no finalization. `:order-by`
+and `:limit` are applied only at the top-level `ExecuteRealized` boundary, which
+subqueries bypass. (The same path means `:order-by` inside a subquery is *also*
+silently ignored — pre-existing, untouched by this work.)
+
+To avoid silent wrong results, `:limit` inside a subquery is now a **parse
+error**. Proper per-invocation support is deferred because it is an architectural
+change with three coupled parts:
+
+1. **Per-invocation finalization** — apply `:order-by` + `:limit` to each
+   subquery invocation's result (so the cap is per correlation group, e.g.
+   top-1-per-group).
+2. **Disable batching when a cap is present** — `canBatchSubquery` runs the
+   subquery once with all correlation tuples as a `RelationInput`; a per-invocation
+   cap cannot be expressed in that single batched execution.
+3. **Guard decorrelation** — with the algebra optimizer on, a correlated subquery
+   is rewritten into a join, which drops the cap (the rewrite is unsafe under a
+   row limit — the same class as the documented "decorrelation inside Union"
+   guard). Skip decorrelation when the inner query has a `:limit`.
+
+The forward-compatible tests (`executor/limit_edge_test.go`) accept the parse
+rejection today and assert per-invocation correctness automatically once the
+rejection is removed — so implementing the above and deleting the parser check is
+all that is needed to land support.
+
+`:order-by` is **optional** with `:limit` — they are independent clauses. `:limit
+N` with no `:order-by` is valid and is the streaming-early-termination case (stop
+the scan after N); the returned rows are simply the first N the engine produces,
+which is *arbitrary but valid* (no ordering guarantee, same as SQL `LIMIT` without
+`ORDER BY`). "after `:order-by`" in the table means *operation order when an
+`:order-by` is present* (cap applied after the sort), not a requirement that one
+be present. Add `:order-by … :desc` only when you need the *latest*/top-N
+specifically rather than *any* N.
+
+There is **no Datomic precedent** for any of this: Datomic's datalog has no
+top-level `:limit`/`:offset` and no `:order-by` at all — its only `:limit` is the
+pull-pattern cap (the "Not To Be Confused With" case above), and result sorting
+and pagination are expected to happen in caller code (`take`/`drop`). janus is
+already ahead by having `:order-by`; a top-level `:limit` and the scalar rule
+above are janus conventions, not inherited ones.
+(Sources: [Datomic Query Reference](https://docs.datomic.com/query/query-data-reference.html),
+[Datomic pagination thread](https://datomic.narkive.com/ehWHxXQZ/pagination).)
+
+### Why `:offset` is deliberately omitted — pagination is an anti-pattern in a streaming engine
+
+A query result is a streaming `Relation`: the caller drives it through
+`rel.Iterator()` / `it.Next()` and pulls exactly as many tuples as it wants.
+"The next page" is just **keep pulling from the same iterator**. That iterator
+reads from a single consistent storage snapshot for its lifetime, so an
+in-process consumer that pauses and resumes gets stable, gap-free, duplicate-free
+paging *for free* — no `:offset`, no AsOf pinning, no re-scan.
+
+`:offset M` would be strictly worse on every axis:
+
+- **Cost** — it re-runs the query and *discards* the first M rows every page
+  (O(M+N) per page) instead of O(N).
+- **Stability** — across a mutating database it is unstable: an assert/retract
+  between page fetches shifts the window, causing skipped or duplicated rows.
+  Making it stable requires pinning a snapshot (`d.AsOf(tx)`) **and** a total
+  order (`:order-by` plus a tie-breaker) — at which point offset is doing nothing
+  the snapshot + order don't already give you.
+
+Offset/limit pagination exists in other systems only to serve **stateless,
+cross-process** consumers (e.g. an HTTP endpoint) that cannot hold an iterator
+open between requests. Even there, the correct serializable encoding of "where I
+paused" is **keyset / cursor pagination**, not offset: carry the last-seen sort
+key forward as a `:where` bound. This is expressible **today** and is naturally
+snapshot-stable under `d.AsOf`:
+
+```clojure
+;; page 2+: pin a snapshot via d.AsOf(tx), continue past the last key seen
+[:find ?e ?tx
+ :in $ ?last-tx
+ :where [?e :entity/type :entity.type/telemetry ?tx]
+        [(> ?tx ?last-tx)]
+ :order-by [[?tx :asc]]
+ :limit 100]
+```
+
+This is O(N) per page (no discard), uses the index directly, and is exactly the
+shape the index-order pushdown roadmap item below turns into a range-scan-then-stop.
+
+**What `:limit` is for (and why it still earns its place):** not pagination, but
+*bounding* — "at most N", top-N, latest-1. Crucially, `:limit` is **declarative
+and pushdownable**: because the bound lives in the query, the planner/storage can
+stop the scan at the source. A consumer pausing its own iterator cannot achieve
+that — by the time it pauses, the query has already committed to a plan that may
+have over-produced (an unordered scan yields *a* tuple, not the *latest*; only
+the engine, knowing `:order-by :desc :limit 1`, can use index order to make it a
+point read). `:limit` + pushdown is the streaming-native primitive; `:offset` is
+not.
+
+### Mechanical changes (limit: correctness + streaming early-termination)
+
+1. **AST** — add `Limit *int` to `query.Query` (`datalog/query/types.go`). Pointer
+   so "unset" is distinguishable from `:limit 0`. Emit `:limit N` in
+   `Query.formatWithIndent` so `String()` round-trips through the parser (same
+   obligation `:order-by` already has).
+2. **Parser** — add a `:limit` case to the `parseQueryVector` switch
+   (`datalog/parser/parser.go`, alongside `:order-by`). Read exactly one integer
+   node; reject negatives and non-integers loudly. Enforce the scalar rule:
+   `ScalarReturn && *Limit > 1` → parse error.
+3. **Plan cache** — hash `Limit` into the plan-cache key
+   (`datalog/planner/cache.go`, next to the existing `ORDERBY:` hashing).
+   **This is a correctness trap, not an optimization:** `RealizedPlan.Query = q`
+   (`planner_clause_based.go`), the cache stores that plan, and the executor reads
+   the limit from `plan.Query` — the *cached* query. If `Limit` is not in the key,
+   two queries differing only by limit collide and the wrong limit is applied.
+4. **Executor — unified finalization** (`datalog/executor/executor.go`). Both
+   `:order-by` and `:limit` are applied **once**, at the single `ExecuteRealized`
+   boundary, on the fully-assembled result: `Sort` then `Limit`.
+   `executeRealizedPlan` now returns the raw, un-ordered, un-limited relation; the
+   per-path sorts that used to live in the inline path and (per-tuple) in the
+   RelationInput-iteration path were removed.
+   - **Why unified, not per-path**: a `RelationInput` query's result is the
+     *union* of its per-tuple executions. The old code sorted *inside each
+     iteration* and concatenated, so `:order-by` over a `RelationInput` query was
+     already silently wrong (the per-tuple sort is discarded by the union), and
+     `:limit` over it returned an order-dependent slice. Finalizing over the whole
+     union makes the inline and RelationInput paths behave identically and yields
+     a correct global top-N. This corrected a pre-existing `:order-by` bug as a
+     side effect. (Verified contained to top-level queries: the live subquery path
+     runs through `DefaultQueryExecutor.Execute`, never `ExecuteRealized`; the
+     `subquery.go` `ExecuteRealized` caller is dead — `NestedPlan` is never
+     assigned.)
+   - **`:limit`** is a small `LimitRelation` wrapper implementing `Relation`
+     (delegates `Symbols()`; lazily materializes at most N, pulling the source
+     iterator no more than N times; delegates the rest to that bounded result).
+     - No `:order-by`: wrapping the (possibly streaming) result stops the
+       underlying scan after N — the real saving.
+     - With `:order-by`: `Sort` already returned a `MaterializedRelation`, so the
+       wrapper just truncates the first N tuples.
+5. **qb builder** — add `Limit(n int) *QueryBuilder` (`datalog/qb/builder.go`),
+   store it, and wire it into `Build()` alongside `OrderBy`.
+6. **Tests** —
+   - Parser: `:limit 5` parses; `:limit -1`, `:limit 3.5`, `:limit "x"` error;
+     `String()` round-trips a query carrying `:limit`.
+   - Scalar: `:find ?x . … :limit 1` ok; `… :limit 2` is a parse error.
+   - Executor: limit < / = / > result size; `:limit 0` → empty; limit composes
+     with `:order-by` (top-N by sort key); limit **after aggregation** caps the
+     number of groups; limit + RelationInput applies globally (not per-tuple).
+   - Streaming: with no `:order-by`, assert the underlying scan stops early
+     (e.g. via an annotation/scan-count handler) rather than draining the source.
+   - Plan cache: two queries identical except for `:limit` do not share a cached
+     limit (the L3 trap).
+
+### Roadmap: index-order pushdown ("latest" / top-N as a true point read)
+
+The mechanical plan above makes `:limit` correct and makes the *unordered* case
+cheap, but it does **not** make the motivating query — `:order-by [[?tx :desc]]
+:limit 1` — a point read: the sort still materializes the full matching set
+first. Eliminating that over-fetch is a separate, larger optimization tracked
+here as a roadmap item, not part of the initial feature.
+
+**Idea.** When the planner sees `:order-by [[?k <dir>]] :limit N` where `?k` is
+bound by a single data pattern and aligns with an index's physical key order,
+push the ordering + bound into the index scan: scan in index order and stop after
+N, skipping the materialize-and-sort entirely. The cheapest, highest-value
+special case is "latest by transaction": the EATV / ATEV indices already store Tx
+in **descending** order (bitwise-NOT encoding — see `key_encoder_binary.go` and
+the CRDT notes in `CLAUDE.md`), so `:order-by [[?tx :desc]] :limit 1` is literally
+"take the first key the index yields." This dovetails with the keyset-pagination
+idiom above: `[(> ?tx ?last-tx)] :order-by [[?tx :asc]] :limit N` becomes a bounded
+range scan that stops after N.
+
+**Why it is staged, not done now.** Pushdown is only sound under structural
+preconditions, and getting them wrong silently returns wrong results (cf. the
+decorrelation-inside-Union learning in `CLAUDE.md`):
+
+- **Joins** — the limit may only be pushed onto the *driving* relation, and only
+  when the join preserves that relation's order and cannot drop the top-N rows. A
+  pushdown that limits a pattern before a join that then filters those rows away
+  is wrong. Safe cases (single-pattern queries; the limited/ordered variable comes
+  from the relation that survives the join unfiltered) must be detected explicitly.
+- **Aggregation** — `:limit` applies *after* aggregation, so it caps groups, not
+  scanned rows; it cannot be pushed to the scan when an aggregate sits between.
+- **CRDT resolution** — the resolving iterator already consumes the index in Tx
+  order; "latest by tx" aligns with the existing physical order (the easy win),
+  but pushdown on other keys must compose with resolution, not bypass it.
+- **Ordering totality** — index order is a total physical order; if the requested
+  `:order-by` key has ties, the pushed result must match the materialize-and-sort
+  result (or the optimization must be declined).
+
+Suggested staging: (1) recognize and push the `:order-by [[?tx :desc/:asc]]
+:limit N` single-pattern case down to a bounded index scan (covers "latest" and
+keyset pagination); (2) extend to other index-aligned sort keys on single
+patterns; (3) consider join-driving-side pushdown with explicit order-preservation
+checks. Each stage must carry semantic-preservation tests comparing pushed vs.
+materialize-and-sort results on realistic data sizes.


### PR DESCRIPTION
## Summary

Adds a top-level `:limit N` clause — bounded results / top-N / latest-1 — which the grammar previously lacked (it was a hard parse error). Resolves `docs/bugs/resolved/BUG_QUERY_LIMIT_CLAUSE_UNSUPPORTED.md`.

`:limit` caps result rows **after** `:order-by` and aggregation:
- **No `:order-by`** → streaming early-termination: `LimitRelation` pulls the source iterator at most N times, stopping the scan rather than draining it.
- **With `:order-by`** → the sorted result is truncated to N (correct global top-N).

```clojure
;; latest record in one round trip
[:find ?e ?tx
 :where [?e :event/crawl ?tx]
 :order-by [[?tx :desc]]
 :limit 1]
```

## Unified finalization (and a latent bug fixed)

`:order-by` and `:limit` are now applied **once**, at the single `ExecuteRealized` boundary, over the fully-assembled result. The per-path sorts (inline path + per-tuple in the `RelationInput`-iteration path) were removed.

This corrected a pre-existing bug: `:order-by` over a `RelationInput` query previously sorted *within each iteration* and concatenated, so the global ordering was never applied. Finalizing over the union of per-tuple executions makes the inline and `RelationInput` paths behave identically. Verified contained to top-level queries — the live subquery path runs through `DefaultQueryExecutor.Execute`, never `ExecuteRealized`.

## Conventions / decisions

- **Scalar `:find … .`**: `:limit 0`/`1` allowed; `:limit N>1` is a parse error (contradicts "return a single value"). No Datomic precedent — Datomic has no top-level `:limit`/`:offset` or `:order-by`; this is a janus convention.
- **No `:offset`**, by design: a result is a streaming relation, so pagination is "keep pulling the same iterator"; for stateless callers, keyset pagination (`d.AsOf` + a `:where` range bound + `:limit`) is the recommended idiom. Rationale in the resolved bug doc.
- **`:limit` inside a subquery** is rejected at parse time. The subquery execution path applies no finalization, so honoring it would silently ignore the cap (wrong results). Per-invocation support is deferred (requires per-invocation finalization, disabling batching under a cap, and a decorrelation guard) and tracked in `TODO.md`.

## Changes

- **AST**: `query.Query.Limit *int`; rendered by `String()`/`FormatQuery` for round-trip.
- **Parser**: `:limit` clause; scalar + subquery validation.
- **Planner**: `:limit` hashed into the plan-cache key (the realized plan carries the query, so differing limits must not share an entry).
- **Executor**: `LimitRelation` wrapper; unified `Sort`-then-`Limit` finalization.
- **qb**: `Limit(n)` builder method.

## Tests

Parser (valid/negative/non-int/round-trip, scalar, subquery rejection), executor (streaming early-termination, sizes, `:limit 0`, top-N, aggregation, pull, global order-by+limit over `RelationInput`, forward-compatible subquery edge cases), planner cache key, qb, and db end-to-end against real BadgerDB including an `AsOf` "latest snapshot as of tx" case. Full suite green (`go test -count=1 ./...`).

## Follow-ups (tracked in TODO.md)

- Subquery `:limit` (per-invocation) — forward-compatible tests already assert correctness once the parse rejection is removed.
- Index-order pushdown for `:order-by … :limit` — turn `:order-by [[?tx :desc]] :limit 1` into a true point read instead of materialize-and-sort.