### PR TITLE
Add -stats flag and direct EDN dump querying to the datalog CLI

### DIFF
--- a/.claude/skills/datalog/SKILL.md
+++ b/.claude/skills/datalog/SKILL.md
@@ -9,7 +9,7 @@ description: >
   subqueries (tuple + relation binding), enumerate and vector fns, :in bindings,
   order-by/limit, and time-travel (History/AsOf). Also use it to inspect/explore a
   .db, check entity attributes, debug query results, or examine CRDT storage state.
-argument-hint: <database-path>
+argument-hint: <database-or-edn-dump-path>
 allowed-tools: Bash(~/go/bin/datalog *)
 ---
 
@@ -17,7 +17,7 @@ allowed-tools: Bash(~/go/bin/datalog *)
 
 Query janus-datalog databases for debugging and data exploration.
 
-The user will provide a database path and describe what they want to know. Use the `datalog` CLI to run queries against the database.
+The user will provide a database path — a BadgerDB directory or an `.edn` dump — and describe what they want to know. Use the `datalog` CLI to run queries against the database. A path ending in `.edn` is loaded into a temporary database automatically (writes are discarded on exit).
 
 ## Data Model
 
@@ -46,6 +46,8 @@ go install github.com/wbrown/janus-datalog/cmd/datalog@latest
 
 ## Invocation
 
+`-db <path>` accepts either a BadgerDB database directory or an `.edn` dump file.
+
 ```bash
 # Run a query
 ~/go/bin/datalog -db <path> -query '<EDN query>'
@@ -58,6 +60,9 @@ go install github.com/wbrown/janus-datalog/cmd/datalog@latest
 
 # Export entire database to readable EDN (useful for small DBs)
 ~/go/bin/datalog -db <path> -export <output.edn>
+
+# Per-attribute statistics: cardinality, value sizes, duplication, CRDT ops
+~/go/bin/datalog -db <path> -stats
 ```
 
 Output is a markdown table. Errors go to stderr.
@@ -69,6 +74,7 @@ If the user says `/datalog <path>`, treat `$ARGUMENTS` as the database path. Sta
 - Prebuilt benchmark DB: `datalog/storage/testdata/ohlc_benchmark.db`
 - Default path when unspecified: `datalog.db` in current directory
 - Test databases are created in temp directories by tests (look for `t.TempDir()` calls)
+- EDN dumps (from `-export`) work directly: `-db dump.edn`
 - Ask the user if the path is unclear
 
 ## EDN Query Syntax
@@ -358,7 +364,15 @@ asOf.Query(`[:find ?name :where [?p :person/name ?name]]`)
 
 ### 1. Explore an unknown database
 
-Start by discovering the schema shape:
+Start with the statistics report — one command that shows every attribute with
+its datom count, distinct entities, distinct values, value types, size
+distribution, and duplication:
+
+```bash
+~/go/bin/datalog -db <path> -stats
+```
+
+Or discover the schema shape with queries:
 
 ```bash
 # What attributes exist?

--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -29,10 +30,11 @@ func main() {
 	var exportPath string
 	var importPath string
 	var compressedExport bool
+	var showStats bool
 
 	var inputValues ednSliceFlag
 
-	flag.StringVar(&dbPath, "db", "", "database path")
+	flag.StringVar(&dbPath, "db", "", "database or EDN dump path (.edn dumps load into a temporary database)")
 	flag.BoolVar(&interactive, "i", false, "interactive mode")
 	flag.BoolVar(&help, "h", false, "show help")
 	flag.BoolVar(&verbose, "verbose", false, "verbose mode (show query annotations)")
@@ -41,15 +43,14 @@ func main() {
 	flag.StringVar(&exportPath, "export", "", "export database to EDN file")
 	flag.BoolVar(&compressedExport, "compressed", false, "use #lzj compressed tagged literals in export")
 	flag.StringVar(&importPath, "import", "", "import database from EDN file")
+	flag.BoolVar(&showStats, "stats", false, "print per-attribute cardinality, value size, and duplication statistics")
 	flag.Var(&inputValues, "in", "input parameter as EDN value (repeatable, one per :in binding)")
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [options] [database_path]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [options] [database_or_edn_dump_path]\n\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "A Datalog query engine with persistent storage.\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
-		fmt.Fprintf(os.Stderr, "  %s                    # Run demo with default database\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "  %s mydata.db          # Run demo with specific database\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -i                 # Interactive mode with default database\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -i mydata.db      # Interactive mode with specific database\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -db /path/to/db   # Using -db flag\n", os.Args[0])
@@ -59,6 +60,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  %s -query '[:find ?n :in $ ?age :where [?p :person/age ?age] [?p :person/name ?n]]' -in 30  # With input binding\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -db mydata.db -export data.edn  # Export database to EDN file\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -db newdata.db -import data.edn # Import EDN file into database\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -db mydata.db -stats            # Print cardinality and value statistics\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -db dump.edn -query '...'       # Query an EDN dump directly (temporary database)\n", os.Args[0])
 	}
 	flag.Parse()
 
@@ -76,10 +79,19 @@ func main() {
 	if exportPath != "" && importPath != "" {
 		log.Fatalf("Cannot specify both -export and -import")
 	}
+	if showStats && (exportPath != "" || importPath != "") {
+		log.Fatalf("Cannot combine -stats with -export or -import")
+	}
 
 	// Default to datalog.db if no path specified
 	if dbPath == "" {
 		dbPath = "datalog.db"
+	}
+
+	// Handle stats mode
+	if showStats {
+		runStats(dbPath)
+		return
 	}
 
 	// Handle export mode
@@ -94,17 +106,12 @@ func main() {
 		return
 	}
 
-	// Check if database exists
-	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		log.Fatalf("Database does not exist: %s", dbPath)
-	}
-
-	// Open database
-	db, err := storage.NewDatabase(dbPath)
+	// Open database (BadgerDB directory or .edn dump)
+	db, cleanup, err := openDatabaseOrEDN(dbPath)
 	if err != nil {
-		log.Fatalf("Failed to open database: %v", err)
+		log.Fatalf("%v", err)
 	}
-	defer db.Close()
+	defer cleanup()
 
 	// Create annotation handler if verbose mode
 	var handler annotations.Handler
@@ -119,118 +126,7 @@ func main() {
 	} else if interactive {
 		runInteractive(db, handler, enableDecorrelation)
 	} else {
-		// Check if database is empty before running demo
-		if isDatabaseEmpty(db) {
-			fmt.Println("Database is empty, loading demo data...")
-			runDemo(db, handler, enableDecorrelation)
-		} else {
-			fmt.Println("Database contains data. Use -i for interactive mode or -query to run a query.")
-		}
-	}
-}
-
-func runDemo(db *storage.Database, handler annotations.Handler, enableDecorrelation bool) {
-	fmt.Println("=== Janus Datalog Demo ===")
-
-	// Create a transaction
-	tx := db.NewTransaction()
-
-	// Add some test data
-	fmt.Println("\nAdding test data...")
-
-	// Add people
-	alice, _ := tx.AddMap(map[string]interface{}{
-		":person/name": "Alice",
-		":person/age":  int64(30),
-		":person/city": "New York",
-	})
-
-	bob, _ := tx.AddMap(map[string]interface{}{
-		":person/name": "Bob",
-		":person/age":  int64(25),
-		":person/city": "Boston",
-	})
-
-	charlie, _ := tx.AddMap(map[string]interface{}{
-		":person/name": "Charlie",
-		":person/age":  int64(35),
-		":person/city": "New York",
-	})
-
-	// Add friendships
-	tx.Add(alice, datalog.NewKeyword(":person/friend"), bob)
-	tx.Add(alice, datalog.NewKeyword(":person/friend"), charlie)
-	tx.Add(bob, datalog.NewKeyword(":person/friend"), charlie)
-
-	// Commit transaction
-	txID, err := tx.Commit()
-	if err != nil {
-		log.Fatalf("Failed to commit: %v", err)
-	}
-	fmt.Printf("Committed transaction %v\n", txID)
-
-	// Run some queries
-	fmt.Println("\n=== Running Queries ===")
-
-	queries := []string{
-		// Find all people
-		`[:find ?name ?age
-		  :where [?p :person/name ?name]
-		         [?p :person/age ?age]]`,
-
-		// Find people in New York
-		`[:find ?name
-		  :where [?p :person/name ?name]
-		         [?p :person/city "New York"]]`,
-
-		// Find Alice's friends
-		`[:find ?friend-name
-		  :where [?alice :person/name "Alice"]
-		         [?alice :person/friend ?friend]
-		         [?friend :person/name ?friend-name]]`,
-
-		// Find people over 25
-		`[:find ?name ?age
-		  :where [?p :person/name ?name]
-		         [?p :person/age ?age]
-		         [(> ?age 25)]]`,
-
-		// Calculate age in 5 years
-		`[:find ?name ?age ?future-age
-		  :where [?p :person/name ?name]
-		         [?p :person/age ?age]
-		         [(+ ?age 5) ?future-age]]`,
-	}
-
-	// Create executor with optimizations
-	opts := storage.DefaultPlannerOptions()
-	exec := db.NewExecutorWithOptions(opts)
-
-	for _, queryStr := range queries {
-		fmt.Printf("\nQuery: %s\n", queryStr)
-
-		// Parse query
-		q, err := parser.ParseQuery(queryStr)
-		if err != nil {
-			fmt.Printf("Parse error: %v\n", err)
-			continue
-		}
-
-		// Execute query
-		var result executor.Relation
-		if handler != nil {
-			ctx := executor.NewContext(handler)
-			result, err = exec.ExecuteWithContext(ctx, q)
-		} else {
-			result, err = exec.Execute(q)
-		}
-		if err != nil {
-			fmt.Printf("Execution error: %v\n", err)
-			continue
-		}
-
-		// Display results as markdown table
-		fmt.Println(result.Table())
+		fmt.Println("Use -i for interactive mode or -query to run a query.")
 	}
 }
 
@@ -378,38 +274,62 @@ func parseValue(s string) interface{} {
 	return s
 }
 
-// isDatabaseEmpty checks if the database contains any data
-func isDatabaseEmpty(db *storage.Database) bool {
-	// Try a simple query to see if there's any data
-	query := `[:find ?e :where [?e _ _]]`
-
-	exec := db.NewExecutor()
-	q, err := parser.ParseQuery(query)
-	if err != nil {
-		return true // Assume empty on error
+// openDatabaseOrEDN opens dbPath as a BadgerDB database, or — when the path
+// ends in .edn — imports the EDN dump into a database in a temporary
+// directory. The returned cleanup function closes the database and removes
+// the temporary directory; callers must invoke it. Writes to an EDN-backed
+// database are discarded when the process exits.
+func openDatabaseOrEDN(dbPath string) (*storage.Database, func(), error) {
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil, nil, fmt.Errorf("database does not exist: %s", dbPath)
 	}
 
-	result, err := exec.Execute(q)
-	if err != nil {
-		return true // Assume empty on error
+	if !strings.HasSuffix(dbPath, ".edn") {
+		db, err := storage.NewDatabase(dbPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to open database: %w", err)
+		}
+		return db, func() { db.Close() }, nil
 	}
 
-	return result.Size() == 0
+	tmpDir, err := os.MkdirTemp("", "datalog-dump-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	db, err := storage.NewDatabase(filepath.Join(tmpDir, "temp.db"))
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		return nil, nil, fmt.Errorf("failed to create temp database: %w", err)
+	}
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	}
+
+	f, err := os.Open(dbPath)
+	if err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to open EDN file: %w", err)
+	}
+	defer f.Close()
+
+	if err := db.Import(f); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to import EDN dump: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Loaded EDN dump %s into a temporary database (changes will be discarded)\n", dbPath)
+	return db, cleanup, nil
 }
 
-// runExport exports the database to an EDN file
+// runExport exports the database to an EDN file. The source may itself be an
+// EDN dump, which supports re-encoding (e.g. plain dump -> -compressed dump).
 func runExport(dbPath, exportPath string, compressed bool) {
-	// Check if database exists
-	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		log.Fatalf("Database does not exist: %s", dbPath)
-	}
-
-	// Open database
-	db, err := storage.NewDatabase(dbPath)
+	db, cleanup, err := openDatabaseOrEDN(dbPath)
 	if err != nil {
-		log.Fatalf("Failed to open database: %v", err)
+		log.Fatalf("%v", err)
 	}
-	defer db.Close()
+	defer cleanup()
 
 	// Create export file
 	f, err := os.Create(exportPath)
@@ -428,6 +348,12 @@ func runExport(dbPath, exportPath string, compressed bool) {
 
 // runImport imports an EDN file into the database
 func runImport(dbPath, importPath string) {
+	// Importing into an .edn path would load into a discarded temp database;
+	// the target must be a real database directory.
+	if strings.HasSuffix(dbPath, ".edn") {
+		log.Fatalf("Cannot import into %s: -db must be a database directory, not an EDN dump", dbPath)
+	}
+
 	// Check if import file exists
 	if _, err := os.Stat(importPath); os.IsNotExist(err) {
 		log.Fatalf("Import file does not exist: %s", importPath)

--- a/cmd/datalog/main_test.go
+++ b/cmd/datalog/main_test.go
@@ -411,3 +411,47 @@ func TestCLI_ImportNonexistentFile(t *testing.T) {
 		t.Errorf("Expected 'does not exist' error, got: %s", out)
 	}
 }
+
+// TestCLI_BareInvocationDoesNotWrite is the regression test for demo-mode
+// removal: invoking the CLI with no mode flags must never commit data.
+// (Demo mode used to auto-populate an empty database with sample datoms.)
+func TestCLI_BareInvocationDoesNotWrite(t *testing.T) {
+	binPath := buildCLI(t)
+
+	// Create an EMPTY database (directory exists, no datoms).
+	dbPath := filepath.Join(t.TempDir(), "empty.db")
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	db.Close()
+
+	cmd := exec.Command(binPath, "-db", dbPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Bare invocation failed: %v\n%s", err, out)
+	}
+
+	// Should print the usage hint, not load demo data.
+	if strings.Contains(string(out), "demo") || strings.Contains(string(out), "Demo") {
+		t.Errorf("Bare invocation mentions demo mode:\n%s", out)
+	}
+	if !strings.Contains(string(out), "-query") {
+		t.Errorf("Expected usage hint mentioning -query, got:\n%s", out)
+	}
+
+	// The database must still be empty.
+	db, err = storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to reopen database: %v", err)
+	}
+	defer db.Close()
+
+	results, err := executor.CollectTuples(db.Query(`[:find ?e :where [?e _ _]]`))
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Bare invocation wrote %d entities into an empty database", len(results))
+	}
+}

--- a/cmd/datalog/open_database_test.go
+++ b/cmd/datalog/open_database_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// createTestEDNDump exports the standard two-person test database to an EDN file.
+func createTestEDNDump(t *testing.T) string {
+	t.Helper()
+	dbPath := createTestDatabase(t)
+
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	ednPath := filepath.Join(t.TempDir(), "dump.edn")
+	f, err := os.Create(ednPath)
+	if err != nil {
+		t.Fatalf("Failed to create EDN file: %v", err)
+	}
+	defer f.Close()
+
+	if err := db.Export(f); err != nil {
+		t.Fatalf("Failed to export: %v", err)
+	}
+	return ednPath
+}
+
+func TestOpenDatabaseOrEDN_BadgerPath(t *testing.T) {
+	dbPath := createTestDatabase(t)
+
+	db, cleanup, err := openDatabaseOrEDN(dbPath)
+	if err != nil {
+		t.Fatalf("openDatabaseOrEDN(badger path) failed: %v", err)
+	}
+	defer cleanup()
+
+	results, err := executor.CollectTuples(db.Query(`[:find ?name :where [_ :person/name ?name]]`))
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("Expected 2 names, got %d", len(results))
+	}
+}
+
+func TestOpenDatabaseOrEDN_EDNDump(t *testing.T) {
+	ednPath := createTestEDNDump(t)
+
+	db, cleanup, err := openDatabaseOrEDN(ednPath)
+	if err != nil {
+		t.Fatalf("openDatabaseOrEDN(edn dump) failed: %v", err)
+	}
+	defer cleanup()
+
+	results, err := executor.CollectTuples(db.Query(`[:find ?name :where [_ :person/name ?name]]`))
+	if err != nil {
+		t.Fatalf("Query against EDN-backed database failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("Expected 2 names from EDN dump, got %d", len(results))
+	}
+}
+
+func TestOpenDatabaseOrEDN_MissingPath(t *testing.T) {
+	for _, path := range []string{
+		"/nonexistent/path/db",
+		"/nonexistent/path/dump.edn",
+	} {
+		_, _, err := openDatabaseOrEDN(path)
+		if err == nil {
+			t.Errorf("openDatabaseOrEDN(%q) succeeded, want error", path)
+			continue
+		}
+		if !strings.Contains(err.Error(), "does not exist") {
+			t.Errorf("openDatabaseOrEDN(%q) error = %q, want mention of 'does not exist'", path, err)
+		}
+	}
+}
+
+func TestCLI_QueryFromEDNDump(t *testing.T) {
+	binPath := buildCLI(t)
+	ednPath := createTestEDNDump(t)
+
+	cmd := exec.Command(binPath, "-db", ednPath,
+		"-query", `[:find ?name :where [_ :person/name ?name]]`)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Query against EDN dump failed: %v\n%s", err, out)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, "Alice") || !strings.Contains(output, "Bob") {
+		t.Errorf("Expected Alice and Bob in output:\n%s", output)
+	}
+}
+
+func TestCLI_StatsFromEDNDump(t *testing.T) {
+	binPath := buildCLI(t)
+	ednPath := createTestEDNDump(t)
+
+	cmd := exec.Command(binPath, "-db", ednPath, "-stats")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Stats against EDN dump failed: %v\n%s", err, out)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, "Total datoms") {
+		t.Errorf("Expected stats summary in output:\n%s", output)
+	}
+	if !strings.Contains(output, ":person/name") {
+		t.Errorf("Expected :person/name attribute row in output:\n%s", output)
+	}
+}
+
+func TestCLI_ExportFromEDNDump(t *testing.T) {
+	binPath := buildCLI(t)
+	ednPath := createTestEDNDump(t)
+	exportPath := filepath.Join(t.TempDir(), "reexport.edn")
+
+	cmd := exec.Command(binPath, "-db", ednPath, "-export", exportPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Export from EDN dump failed: %v\n%s", err, out)
+	}
+
+	reexported, err := os.ReadFile(exportPath)
+	if err != nil {
+		t.Fatalf("Failed to read re-exported file: %v", err)
+	}
+	if !strings.Contains(string(reexported), ":person/name") {
+		t.Errorf("Re-exported EDN missing expected datoms:\n%s", reexported)
+	}
+}
+
+func TestCLI_ImportIntoEDNPathRejected(t *testing.T) {
+	binPath := buildCLI(t)
+	ednPath := createTestEDNDump(t)
+
+	// Importing INTO an .edn path is nonsense (the temp database would be
+	// discarded); it must be rejected, not silently accepted.
+	cmd := exec.Command(binPath, "-db", filepath.Join(t.TempDir(), "target.edn"), "-import", ednPath)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Error("Expected error when importing into an .edn path")
+	}
+	if !strings.Contains(string(out), "database directory") {
+		t.Errorf("Expected error to explain -db must be a database directory, got: %s", out)
+	}
+}

--- a/cmd/datalog/stats.go
+++ b/cmd/datalog/stats.go
@@ -1,0 +1,428 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+// runStats scans the full database (EAVT index, all history) and reports
+// per-attribute cardinality, value size distribution, and value duplication.
+// The source may be a BadgerDB directory or an .edn dump.
+func runStats(dbPath string) {
+	db, cleanup, err := openDatabaseOrEDN(dbPath)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	defer cleanup()
+
+	report, err := collectStats(db)
+	if err != nil {
+		log.Fatalf("Failed to collect statistics: %v", err)
+	}
+	report.print(os.Stdout, dbPath)
+}
+
+// valueInfo tracks one distinct value: how often it occurs, its encoded size,
+// and a short preview for the duplication report.
+type valueInfo struct {
+	count   int
+	size    int
+	typ     string
+	preview string
+}
+
+// attrAccum accumulates statistics for a single attribute.
+type attrAccum struct {
+	name       string
+	count      int
+	totalBytes int
+	entities   map[[20]byte]struct{}
+	values     map[[32]byte]*valueInfo
+	sizes      []int
+	types      map[string]int
+}
+
+func newAttrAccum(name string) *attrAccum {
+	return &attrAccum{
+		name:     name,
+		entities: make(map[[20]byte]struct{}),
+		values:   make(map[[32]byte]*valueInfo),
+		types:    make(map[string]int),
+	}
+}
+
+// dbStats holds the full scan result.
+type dbStats struct {
+	totalDatoms  int
+	attrs        map[string]*attrAccum
+	entities     map[[20]byte]struct{}
+	globalValues map[[32]byte]*valueInfo
+	typeCounts   map[string]int
+	typeBytes    map[string]int
+	opCounts     map[datalog.CRDTOp]int
+}
+
+func newDBStats() *dbStats {
+	return &dbStats{
+		attrs:        make(map[string]*attrAccum),
+		entities:     make(map[[20]byte]struct{}),
+		globalValues: make(map[[32]byte]*valueInfo),
+		typeCounts:   make(map[string]int),
+		typeBytes:    make(map[string]int),
+		opCounts:     make(map[datalog.CRDTOp]int),
+	}
+}
+
+// collectStats scans the EAVT index and accumulates statistics over every
+// datom in the database, including full CRDT history (removes, RGA ops).
+func collectStats(db *storage.Database) (*dbStats, error) {
+	// Scan the entire EAVT index, same bounds as Database.Export.
+	start := []byte{byte(storage.EAVT)}
+	end := []byte{byte(storage.EATV)}
+	iter, err := db.Store().Scan(storage.EAVT, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan database: %w", err)
+	}
+	defer iter.Close()
+
+	s := newDBStats()
+	for iter.Next() {
+		d, err := iter.Datom()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read datom: %w", err)
+		}
+		s.record(d)
+	}
+	return s, nil
+}
+
+func (s *dbStats) record(d *datalog.Datom) {
+	s.totalDatoms++
+	s.opCounts[d.Op]++
+
+	if d.E != nil {
+		s.entities[d.E.Hash()] = struct{}{}
+	}
+
+	attrName := d.A.String()
+	aa, ok := s.attrs[attrName]
+	if !ok {
+		aa = newAttrAccum(attrName)
+		s.attrs[attrName] = aa
+	}
+	aa.count++
+	if d.E != nil {
+		aa.entities[d.E.Hash()] = struct{}{}
+	}
+
+	typ, encoded := encodeValueForStats(d.V)
+	size := len(encoded)
+
+	s.typeCounts[typ]++
+	s.typeBytes[typ] += size
+	aa.types[typ]++
+	aa.totalBytes += size
+	aa.sizes = append(aa.sizes, size)
+
+	key := hashValue(typ, encoded)
+	recordValue(aa.values, key, typ, size, d.V)
+	recordValue(s.globalValues, key, typ, size, d.V)
+}
+
+// encodeValueForStats returns the value's type name and encoded bytes as they
+// would appear in index keys (uncompressed). Nil values (which should not
+// occur in storage) are reported under their own type rather than panicking.
+func encodeValueForStats(v interface{}) (string, []byte) {
+	if v == nil {
+		return "nil", nil
+	}
+	return valueTypeName(v), datalog.ValueBytes(v)
+}
+
+func valueTypeName(v interface{}) string {
+	switch v.(type) {
+	case string:
+		return "string"
+	case int64, int:
+		return "int64"
+	case float64:
+		return "float64"
+	case bool:
+		return "bool"
+	case []byte:
+		return "bytes"
+	case datalog.Identity:
+		return "ref"
+	case datalog.Keyword:
+		return "keyword"
+	case datalog.Symbol:
+		return "symbol"
+	case datalog.ElementID:
+		return "elementid"
+	case time.Time:
+		return "time"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}
+
+func hashValue(typ string, encoded []byte) [32]byte {
+	h := sha256.New()
+	h.Write([]byte(typ))
+	h.Write([]byte{0})
+	h.Write(encoded)
+	var key [32]byte
+	copy(key[:], h.Sum(nil))
+	return key
+}
+
+func recordValue(m map[[32]byte]*valueInfo, key [32]byte, typ string, size int, v interface{}) {
+	vi, ok := m[key]
+	if !ok {
+		vi = &valueInfo{size: size, typ: typ, preview: valuePreview(v)}
+		m[key] = vi
+	}
+	vi.count++
+}
+
+// valuePreview renders a short, quoted preview of a value for the duplication
+// report. Long values are truncated; binary values show only their size.
+func valuePreview(v interface{}) string {
+	const maxLen = 40
+	switch val := v.(type) {
+	case string:
+		if len(val) > maxLen {
+			return strconv.Quote(val[:maxLen]) + "…"
+		}
+		return strconv.Quote(val)
+	case []byte:
+		return fmt.Sprintf("<%d bytes>", len(val))
+	case datalog.Identity:
+		return "#identity " + val.L85()
+	case nil:
+		return "nil"
+	default:
+		s := fmt.Sprintf("%v", val)
+		if len(s) > maxLen {
+			s = s[:maxLen] + "…"
+		}
+		return s
+	}
+}
+
+// uniqueBytes sums the encoded size of each distinct value once.
+func uniqueBytes(m map[[32]byte]*valueInfo) int {
+	total := 0
+	for _, vi := range m {
+		total += vi.size
+	}
+	return total
+}
+
+func percentile(sorted []int, p float64) int {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(p*float64(len(sorted))+0.5) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func humanBytes(n int) string {
+	switch {
+	case n >= 1<<30:
+		return fmt.Sprintf("%.2f GiB", float64(n)/(1<<30))
+	case n >= 1<<20:
+		return fmt.Sprintf("%.2f MiB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.2f KiB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+func (s *dbStats) print(w io.Writer, dbPath string) {
+	totalValueBytes := 0
+	for _, b := range s.typeBytes {
+		totalValueBytes += b
+	}
+	globalUnique := uniqueBytes(s.globalValues)
+
+	fmt.Fprintf(w, "# Database Statistics: %s\n\n", dbPath)
+	fmt.Fprintf(w, "Total datoms (all CRDT history): %d\n", s.totalDatoms)
+	fmt.Fprintf(w, "Distinct entities:               %d\n", len(s.entities))
+	fmt.Fprintf(w, "Distinct attributes:             %d\n", len(s.attrs))
+	fmt.Fprintf(w, "Distinct values (global):        %d\n", len(s.globalValues))
+	fmt.Fprintf(w, "Encoded value bytes (total):     %s\n", humanBytes(totalValueBytes))
+	fmt.Fprintf(w, "Encoded value bytes (deduped):   %s", humanBytes(globalUnique))
+	if totalValueBytes > 0 {
+		fmt.Fprintf(w, "  (%.1f%% duplicated)", 100*float64(totalValueBytes-globalUnique)/float64(totalValueBytes))
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "\nNote: sizes are uncompressed encoded value bytes; each value is embedded\nin all 8 index keys, so on-disk value bytes are ~8x the totals above.\n")
+
+	s.printTypeDistribution(w)
+	s.printAttrTable(w)
+	s.printSizeDistribution(w)
+	s.printTopDuplicated(w)
+	s.printOpDistribution(w)
+}
+
+func (s *dbStats) printTypeDistribution(w io.Writer) {
+	fmt.Fprintf(w, "\n## Value Type Distribution\n\n")
+	fmt.Fprintln(w, "| Type | Count | Total Bytes | Avg Size |")
+	fmt.Fprintln(w, "|------|------:|------------:|---------:|")
+
+	names := make([]string, 0, len(s.typeCounts))
+	for t := range s.typeCounts {
+		names = append(names, t)
+	}
+	sort.Slice(names, func(i, j int) bool { return s.typeBytes[names[i]] > s.typeBytes[names[j]] })
+	for _, t := range names {
+		count := s.typeCounts[t]
+		avg := 0.0
+		if count > 0 {
+			avg = float64(s.typeBytes[t]) / float64(count)
+		}
+		fmt.Fprintf(w, "| %s | %d | %s | %.1f |\n", t, count, humanBytes(s.typeBytes[t]), avg)
+	}
+}
+
+// sortedAttrs returns attribute accumulators ordered by total value bytes descending.
+func (s *dbStats) sortedAttrs() []*attrAccum {
+	attrs := make([]*attrAccum, 0, len(s.attrs))
+	for _, aa := range s.attrs {
+		attrs = append(attrs, aa)
+	}
+	sort.Slice(attrs, func(i, j int) bool {
+		if attrs[i].totalBytes != attrs[j].totalBytes {
+			return attrs[i].totalBytes > attrs[j].totalBytes
+		}
+		return attrs[i].name < attrs[j].name
+	})
+	return attrs
+}
+
+func (aa *attrAccum) typeList() string {
+	names := make([]string, 0, len(aa.types))
+	for t := range aa.types {
+		names = append(names, t)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+func (s *dbStats) printAttrTable(w io.Writer) {
+	fmt.Fprintf(w, "\n## Per-Attribute Cardinality and Duplication\n\n")
+	fmt.Fprintln(w, "| Attribute | Datoms | Entities | Distinct V | Dup x | Datoms/E | Types | V Bytes | Unique V Bytes | Saved |")
+	fmt.Fprintln(w, "|-----------|-------:|---------:|-----------:|------:|---------:|-------|--------:|---------------:|------:|")
+
+	for _, aa := range s.sortedAttrs() {
+		distinct := len(aa.values)
+		dup := 0.0
+		if distinct > 0 {
+			dup = float64(aa.count) / float64(distinct)
+		}
+		perEntity := 0.0
+		if len(aa.entities) > 0 {
+			perEntity = float64(aa.count) / float64(len(aa.entities))
+		}
+		unique := uniqueBytes(aa.values)
+		saved := 0.0
+		if aa.totalBytes > 0 {
+			saved = 100 * float64(aa.totalBytes-unique) / float64(aa.totalBytes)
+		}
+		fmt.Fprintf(w, "| %s | %d | %d | %d | %.1f | %.1f | %s | %s | %s | %.1f%% |\n",
+			aa.name, aa.count, len(aa.entities), distinct, dup, perEntity,
+			aa.typeList(), humanBytes(aa.totalBytes), humanBytes(unique), saved)
+	}
+}
+
+func (s *dbStats) printSizeDistribution(w io.Writer) {
+	// Percentiles only make sense for variable-size value types.
+	variable := make([]*attrAccum, 0)
+	for _, aa := range s.sortedAttrs() {
+		if aa.types["string"] > 0 || aa.types["bytes"] > 0 || aa.types["keyword"] > 0 || aa.types["symbol"] > 0 {
+			variable = append(variable, aa)
+		}
+	}
+	if len(variable) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "\n## Value Size Distribution (variable-size attributes)\n\n")
+	fmt.Fprintln(w, "| Attribute | Count | Avg | P50 | P90 | P99 | Max | Total |")
+	fmt.Fprintln(w, "|-----------|------:|----:|----:|----:|----:|----:|------:|")
+
+	for _, aa := range variable {
+		sorted := make([]int, len(aa.sizes))
+		copy(sorted, aa.sizes)
+		sort.Ints(sorted)
+		avg := 0.0
+		if aa.count > 0 {
+			avg = float64(aa.totalBytes) / float64(aa.count)
+		}
+		fmt.Fprintf(w, "| %s | %d | %.1f | %d | %d | %d | %d | %s |\n",
+			aa.name, aa.count, avg,
+			percentile(sorted, 0.50), percentile(sorted, 0.90), percentile(sorted, 0.99),
+			sorted[len(sorted)-1], humanBytes(aa.totalBytes))
+	}
+}
+
+func (s *dbStats) printTopDuplicated(w io.Writer) {
+	type dupEntry struct {
+		vi     *valueInfo
+		wasted int
+	}
+	dups := make([]dupEntry, 0)
+	for _, vi := range s.globalValues {
+		if vi.count > 1 {
+			dups = append(dups, dupEntry{vi: vi, wasted: (vi.count - 1) * vi.size})
+		}
+	}
+	if len(dups) == 0 {
+		return
+	}
+	sort.Slice(dups, func(i, j int) bool { return dups[i].wasted > dups[j].wasted })
+	if len(dups) > 10 {
+		dups = dups[:10]
+	}
+
+	fmt.Fprintf(w, "\n## Top Duplicated Values (by wasted bytes)\n\n")
+	fmt.Fprintln(w, "| Type | Size | Count | Wasted | Preview |")
+	fmt.Fprintln(w, "|------|-----:|------:|-------:|---------|")
+	for _, d := range dups {
+		fmt.Fprintf(w, "| %s | %s | %d | %s | %s |\n",
+			d.vi.typ, humanBytes(d.vi.size), d.vi.count, humanBytes(d.wasted), d.vi.preview)
+	}
+}
+
+func (s *dbStats) printOpDistribution(w io.Writer) {
+	fmt.Fprintf(w, "\n## CRDT Op Distribution\n\n")
+	fmt.Fprintln(w, "| Op | Count |")
+	fmt.Fprintln(w, "|----|------:|")
+
+	ops := make([]datalog.CRDTOp, 0, len(s.opCounts))
+	for op := range s.opCounts {
+		ops = append(ops, op)
+	}
+	sort.Slice(ops, func(i, j int) bool { return ops[i] < ops[j] })
+	for _, op := range ops {
+		fmt.Fprintf(w, "| %s | %d |\n", storage.FormatCRDTOpEDN(op), s.opCounts[op])
+	}
+}

--- a/cmd/datalog/stats_test.go
+++ b/cmd/datalog/stats_test.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/storage"
+)
+
+func TestPercentile(t *testing.T) {
+	tests := []struct {
+		name   string
+		sorted []int
+		p      float64
+		want   int
+	}{
+		{"empty", nil, 0.50, 0},
+		{"single p50", []int{7}, 0.50, 7},
+		{"single p99", []int{7}, 0.99, 7},
+		{"ten values p50", []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 0.50, 5},
+		{"ten values p90", []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 0.90, 9},
+		{"ten values p99", []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 0.99, 10},
+		{"two values p50", []int{3, 9}, 0.50, 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := percentile(tt.sorted, tt.p); got != tt.want {
+				t.Errorf("percentile(%v, %v) = %d, want %d", tt.sorted, tt.p, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.00 KiB"},
+		{1536, "1.50 KiB"},
+		{1 << 20, "1.00 MiB"},
+		{1 << 30, "1.00 GiB"},
+	}
+	for _, tt := range tests {
+		if got := humanBytes(tt.n); got != tt.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestValueTypeName(t *testing.T) {
+	tests := []struct {
+		v    interface{}
+		want string
+	}{
+		{"hello", "string"},
+		{int64(42), "int64"},
+		{3.14, "float64"},
+		{true, "bool"},
+		{[]byte{1, 2}, "bytes"},
+		{datalog.NewIdentity("x"), "ref"},
+		{datalog.NewKeyword(":status/active"), "keyword"},
+	}
+	for _, tt := range tests {
+		if got := valueTypeName(tt.v); got != tt.want {
+			t.Errorf("valueTypeName(%T) = %q, want %q", tt.v, got, tt.want)
+		}
+	}
+}
+
+func TestHashValueDistinguishesTypeAndContent(t *testing.T) {
+	// Same bytes, different type must hash differently: the int64 5 and an
+	// 8-byte string with identical encoded bytes are distinct values.
+	enc := datalog.ValueBytes(int64(5))
+	if hashValue("int64", enc) == hashValue("string", enc) {
+		t.Error("hashValue must distinguish values of different types with identical encodings")
+	}
+	if hashValue("int64", enc) != hashValue("int64", enc) {
+		t.Error("hashValue must be deterministic")
+	}
+	if hashValue("int64", datalog.ValueBytes(int64(5))) == hashValue("int64", datalog.ValueBytes(int64(6))) {
+		t.Error("hashValue must distinguish different values of the same type")
+	}
+}
+
+func TestValuePreviewTruncation(t *testing.T) {
+	long := strings.Repeat("a", 100)
+	got := valuePreview(long)
+	if len(got) > 50 {
+		t.Errorf("valuePreview did not truncate long string: %q (len %d)", got, len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated preview should end with ellipsis: %q", got)
+	}
+	if valuePreview("hi") != `"hi"` {
+		t.Errorf("short string preview = %q, want %q", valuePreview("hi"), `"hi"`)
+	}
+	if valuePreview([]byte{1, 2, 3}) != "<3 bytes>" {
+		t.Errorf("bytes preview = %q, want %q", valuePreview([]byte{1, 2, 3}), "<3 bytes>")
+	}
+}
+
+// createStatsTestDatabase builds a database with known cardinality and
+// duplication structure:
+//   - 3 person entities
+//   - :person/name  → 3 datoms, 3 distinct values (no duplication)
+//   - :person/city  → 3 datoms, 1 distinct value  ("Springfield" x3)
+//   - :person/age   → 2 datoms, 2 distinct values
+//   - :person/bio   → 1 datom, one 100-byte string
+//
+// The single commit also writes transaction metadata: one :db/txInstant
+// datom on a transaction entity. Storage therefore holds 10 datoms,
+// 4 entities, 5 attributes, and 8 distinct values.
+func createStatsTestDatabase(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "stats-test.db")
+
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
+	defer db.Close()
+
+	tx := db.NewTransaction()
+	name := datalog.NewKeyword(":person/name")
+	city := datalog.NewKeyword(":person/city")
+	age := datalog.NewKeyword(":person/age")
+	bio := datalog.NewKeyword(":person/bio")
+
+	alice := datalog.NewIdentity("alice")
+	bob := datalog.NewIdentity("bob")
+	carol := datalog.NewIdentity("carol")
+
+	tx.Add(alice, name, "Alice")
+	tx.Add(bob, name, "Bob")
+	tx.Add(carol, name, "Carol")
+
+	tx.Add(alice, city, "Springfield")
+	tx.Add(bob, city, "Springfield")
+	tx.Add(carol, city, "Springfield")
+
+	tx.Add(alice, age, int64(30))
+	tx.Add(bob, age, int64(25))
+
+	tx.Add(alice, bio, strings.Repeat("x", 100))
+
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	return dbPath
+}
+
+func TestCollectStats(t *testing.T) {
+	dbPath := createStatsTestDatabase(t)
+
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	s, err := collectStats(db)
+	if err != nil {
+		t.Fatalf("collectStats failed: %v", err)
+	}
+
+	// 9 person datoms + 1 :db/txInstant transaction-metadata datom.
+	if s.totalDatoms != 10 {
+		t.Errorf("totalDatoms = %d, want 10", s.totalDatoms)
+	}
+	// 3 person entities + 1 transaction entity.
+	if len(s.entities) != 4 {
+		t.Errorf("distinct entities = %d, want 4", len(s.entities))
+	}
+	// 4 person attributes + :db/txInstant.
+	if len(s.attrs) != 5 {
+		t.Errorf("distinct attributes = %d, want 5", len(s.attrs))
+	}
+
+	city, ok := s.attrs[":person/city"]
+	if !ok {
+		t.Fatal("missing :person/city stats")
+	}
+	if city.count != 3 {
+		t.Errorf(":person/city count = %d, want 3", city.count)
+	}
+	if len(city.values) != 1 {
+		t.Errorf(":person/city distinct values = %d, want 1 (all Springfield)", len(city.values))
+	}
+	if len(city.entities) != 3 {
+		t.Errorf(":person/city entities = %d, want 3", len(city.entities))
+	}
+	// Total bytes = 3 x len("Springfield"); unique bytes = 1 x len("Springfield").
+	wantTotal := 3 * len("Springfield")
+	if city.totalBytes != wantTotal {
+		t.Errorf(":person/city totalBytes = %d, want %d", city.totalBytes, wantTotal)
+	}
+	if got := uniqueBytes(city.values); got != len("Springfield") {
+		t.Errorf(":person/city unique bytes = %d, want %d", got, len("Springfield"))
+	}
+
+	name, ok := s.attrs[":person/name"]
+	if !ok {
+		t.Fatal("missing :person/name stats")
+	}
+	if len(name.values) != 3 {
+		t.Errorf(":person/name distinct values = %d, want 3", len(name.values))
+	}
+
+	age, ok := s.attrs[":person/age"]
+	if !ok {
+		t.Fatal("missing :person/age stats")
+	}
+	if age.count != 2 || len(age.values) != 2 {
+		t.Errorf(":person/age count/distinct = %d/%d, want 2/2", age.count, len(age.values))
+	}
+	if age.types["int64"] != 2 {
+		t.Errorf(":person/age int64 type count = %d, want 2", age.types["int64"])
+	}
+
+	bio, ok := s.attrs[":person/bio"]
+	if !ok {
+		t.Fatal("missing :person/bio stats")
+	}
+	if bio.totalBytes != 100 {
+		t.Errorf(":person/bio totalBytes = %d, want 100", bio.totalBytes)
+	}
+
+	// Global distinct values: 3 names + 1 city + 2 ages + 1 bio + 1 txInstant = 8.
+	if len(s.globalValues) != 8 {
+		t.Errorf("global distinct values = %d, want 8", len(s.globalValues))
+	}
+
+	// The duplicated Springfield value should be tracked with count 3.
+	found := false
+	for _, vi := range s.globalValues {
+		if vi.count == 3 && vi.typ == "string" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a string value with count 3 (Springfield) in global values")
+	}
+}
+
+func TestStatsReportOutput(t *testing.T) {
+	dbPath := createStatsTestDatabase(t)
+
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	s, err := collectStats(db)
+	if err != nil {
+		t.Fatalf("collectStats failed: %v", err)
+	}
+
+	var buf strings.Builder
+	s.print(&buf, dbPath)
+	out := buf.String()
+
+	for _, want := range []string{
+		"Total datoms (all CRDT history): 10",
+		"Distinct entities:               4",
+		":person/city",
+		":person/name",
+		"## Per-Attribute Cardinality and Duplication",
+		"## Value Size Distribution",
+		"## Top Duplicated Values",
+		"Springfield",
+		"## CRDT Op Distribution",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestStatsFlagCLI(t *testing.T) {
+	binPath := buildCLI(t)
+	dbPath := createStatsTestDatabase(t)
+
+	cmd := exec.Command(binPath, "-db", dbPath, "-stats")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("CLI -stats failed: %v\n%s", err, out)
+	}
+	output := string(out)
+	if !strings.Contains(output, "Total datoms") {
+		t.Errorf("-stats output missing summary header:\n%s", output)
+	}
+	if !strings.Contains(output, ":person/city") {
+		t.Errorf("-stats output missing attribute row:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary
- New `-stats` mode scans the full EAVT index (all CRDT history) and reports per-attribute datom/entity/value counts, duplication, value size percentiles, top duplicated values, and CRDT op distribution — useful for exploring unfamiliar databases.
- `-db` now also accepts an `.edn` dump path directly: it's loaded into a temporary database (writes discarded on exit) so `-query`, `-export`, and `-stats` can all run against exported data without a separate import step. Implemented via a shared `openDatabaseOrEDN` helper.
- Removes demo mode: bare CLI invocation against an empty database used to auto-populate sample data; it now just prints a usage hint. Guarded by a new regression test.
- `.claude/skills/datalog/SKILL.md` updated to document both features.

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./...` (full suite, including new `cmd/datalog` tests for stats collection/report/CLI flag, EDN-dump-backed query/export/stats, and the demo-mode-removal regression test)