### PR TITLE
Batch wildcard Pull entity resolution

### DIFF
--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -32,7 +32,7 @@ The Janus Datalog engine delivers production-ready performance through architect
 - ✅ **Correlated OR outer replacement**: OR/fallback relations already contain their selected outer tuples, so QueryExecutor replaces consumed relation groups instead of appending the result and joining it back to the same outer data. Removing five redundant joins improves the complex checkpoint **11.3% time, 8.3% memory, and 10.6% allocations**. Outer, branch-cache, and close errors now propagate rather than falling through to defaults (n=10; verified 2026-07-13, darwin/arm64).
 - ✅ **Correlated-subquery product streaming**: replayable source relations feed their single-use product directly into typed input-combination deduplication instead of materializing and deduplicating the complete product first. Valid 10K/100K set products improve **39.6–44.2% time**, **37.0–38.7% memory**, and **14.3% allocations**. The complex checkpoint does not exercise this multi-group shape and remains unchanged (n=10; verified 2026-07-13, darwin/arm64).
 - ✅ **Relation set-invariant construction**: operators that already prove duplicate-free output now construct Relations without repeating typed deduplication. Grouped aggregation publishes its group key; union/fallback realization, join-key extraction, selection, deterministic extension, sorting, limits, phase realization, and lazy replay preserve the set proof. The complex checkpoint improves **5.1% time, 15.6% memory, and 8.6% allocations** (n=10; verified 2026-07-13, darwin/arm64).
-- ✅ **Batch wildcard Pull resolution**: `(pull ?e [*])` finalization collects matched entities and resolves them through one Badger read transaction and iterator instead of opening/discarding one transaction per entity. Focused 230/3,899-entity runs are **14.4×/10.8× faster**, use **90.9% less memory**, and perform **89.7% fewer allocations**. Latest and AsOf preserve CRDT semantics; unique attributes retain walk-based ownership resolution and History retains its raw-mode path (10 iterations; verified 2026-07-13, darwin/arm64).
+- ✅ **Batch wildcard Pull resolution**: `(pull ?e [*])` finalization collects matched entities and resolves their non-unique EATV ranges through one Badger read transaction and iterator instead of opening/discarding one transaction per entity. Focused 230/3,899-entity runs are **14.4×/10.8× faster**, use **90.9% less memory**, and perform **89.7% fewer allocations**. Latest and AsOf preserve CRDT semantics; unique-ownership walks and Tier-3 blob dereferences may open additional reads, and History retains its raw-mode path (10 iterations; verified 2026-07-13, darwin/arm64).
 - ✅ **Iterator contract hardening**: early-close materialization reports an incomplete-cache error, predicate evaluation failures propagate, streaming transforms use relation-owned iterators, hash joins retain build/probe close errors, unknown-size inputs bind correctly, and `StreamingRelation.Get` performs real random-access realization. Correctness-only; no performance claim.
 - ✅ **Typed aggregation keys**: batch and streaming grouped aggregation now key groups with `TupleKeyMap` instead of delimiter-joined formatted strings. This fixes silent collisions between distinct values and makes grouped aggregation **47.5% faster**, with **25.8% less memory** and **71.3% fewer allocations** (n=10 geomean; verified 2026-07-11, darwin/arm64).
 - ✅ **Single-lookup dedup insertion**: eight set-insertion paths now use `TupleKeyMap.PutIfAbsent` instead of `Exists` followed by `Put`. Materialized and streaming deduplication improve **5.4–9.0%** (**7.3% geomean**) with unchanged memory and allocations (n=10; verified 2026-07-11, darwin/arm64).
@@ -320,7 +320,7 @@ See `docs/archive/2025-10/CSE_FINDINGS.md` for historical analysis.
 
 **Wildcard find-pull batching** (5 attributes/entity, cache disabled):
 
-| Entities | Per-entity transactions | One batch transaction | Time | Memory | Allocations |
+| Entities | Per-entity transactions | Batched EATV scan | Time | Memory | Allocations |
 |---------:|------------------------:|----------------------:|-----:|-------:|------------:|
 | 230 | 4.829 ms | 335.4 µs | **14.4× faster** | **90.9% less** | **89.7% fewer** |
 | 3,899 | 64.19 ms | 5.917 ms | **10.8× faster** | **90.9% less** | **89.7% fewer** |
@@ -328,10 +328,11 @@ See `docs/archive/2025-10/CSE_FINDINGS.md` for historical analysis.
 `applyFindPulls` now collects the result entities and calls `PullMany` once per
 pull expression. Exact wildcard patterns use `BatchEntityResolver`;
 `Database.ResolveAllAttributesMany` deduplicates and sorts entities by EATV
-order, then seeks every entity range through one Badger transaction and one
-iterator. `pull/batch.begin` and `pull/batch.complete` annotations make the
-result-boundary work visible. Explicit-attribute and nested pull patterns retain
-their existing per-entity execution.
+order, then seeks every non-unique entity range through one Badger transaction
+and iterator. Unique-attribute ownership walks and Tier-3 blob dereferences retain
+their specialized reads. `pull/batch.begin` and `pull/batch.complete` annotations
+make the result-boundary work visible. Explicit-attribute and nested pull patterns
+retain their existing per-entity execution.
 
 **Scaling Characteristics**:
 - **Per-attribute cost**: ~1.2µs (BadgerDB), ~470ns (in-memory)

--- a/PERFORMANCE_STATUS.md
+++ b/PERFORMANCE_STATUS.md
@@ -32,6 +32,7 @@ The Janus Datalog engine delivers production-ready performance through architect
 - ✅ **Correlated OR outer replacement**: OR/fallback relations already contain their selected outer tuples, so QueryExecutor replaces consumed relation groups instead of appending the result and joining it back to the same outer data. Removing five redundant joins improves the complex checkpoint **11.3% time, 8.3% memory, and 10.6% allocations**. Outer, branch-cache, and close errors now propagate rather than falling through to defaults (n=10; verified 2026-07-13, darwin/arm64).
 - ✅ **Correlated-subquery product streaming**: replayable source relations feed their single-use product directly into typed input-combination deduplication instead of materializing and deduplicating the complete product first. Valid 10K/100K set products improve **39.6–44.2% time**, **37.0–38.7% memory**, and **14.3% allocations**. The complex checkpoint does not exercise this multi-group shape and remains unchanged (n=10; verified 2026-07-13, darwin/arm64).
 - ✅ **Relation set-invariant construction**: operators that already prove duplicate-free output now construct Relations without repeating typed deduplication. Grouped aggregation publishes its group key; union/fallback realization, join-key extraction, selection, deterministic extension, sorting, limits, phase realization, and lazy replay preserve the set proof. The complex checkpoint improves **5.1% time, 15.6% memory, and 8.6% allocations** (n=10; verified 2026-07-13, darwin/arm64).
+- ✅ **Batch wildcard Pull resolution**: `(pull ?e [*])` finalization collects matched entities and resolves them through one Badger read transaction and iterator instead of opening/discarding one transaction per entity. Focused 230/3,899-entity runs are **14.4×/10.8× faster**, use **90.9% less memory**, and perform **89.7% fewer allocations**. Latest and AsOf preserve CRDT semantics; unique attributes retain walk-based ownership resolution and History retains its raw-mode path (10 iterations; verified 2026-07-13, darwin/arm64).
 - ✅ **Iterator contract hardening**: early-close materialization reports an incomplete-cache error, predicate evaluation failures propagate, streaming transforms use relation-owned iterators, hash joins retain build/probe close errors, unknown-size inputs bind correctly, and `StreamingRelation.Get` performs real random-access realization. Correctness-only; no performance claim.
 - ✅ **Typed aggregation keys**: batch and streaming grouped aggregation now key groups with `TupleKeyMap` instead of delimiter-joined formatted strings. This fixes silent collisions between distinct values and makes grouped aggregation **47.5% faster**, with **25.8% less memory** and **71.3% fewer allocations** (n=10 geomean; verified 2026-07-11, darwin/arm64).
 - ✅ **Single-lookup dedup insertion**: eight set-insertion paths now use `TupleKeyMap.PutIfAbsent` instead of `Exists` followed by `Put`. Materialized and streaming deduplication improve **5.4–9.0%** (**7.3% geomean**) with unchanged memory and allocations (n=10; verified 2026-07-11, darwin/arm64).
@@ -316,6 +317,21 @@ See `docs/archive/2025-10/CSE_FINDINGS.md` for historical analysis.
 |--------|------|---------|
 | Pull | 3.5µs | **9.2×** |
 | Query | 32.7µs | baseline |
+
+**Wildcard find-pull batching** (5 attributes/entity, cache disabled):
+
+| Entities | Per-entity transactions | One batch transaction | Time | Memory | Allocations |
+|---------:|------------------------:|----------------------:|-----:|-------:|------------:|
+| 230 | 4.829 ms | 335.4 µs | **14.4× faster** | **90.9% less** | **89.7% fewer** |
+| 3,899 | 64.19 ms | 5.917 ms | **10.8× faster** | **90.9% less** | **89.7% fewer** |
+
+`applyFindPulls` now collects the result entities and calls `PullMany` once per
+pull expression. Exact wildcard patterns use `BatchEntityResolver`;
+`Database.ResolveAllAttributesMany` deduplicates and sorts entities by EATV
+order, then seeks every entity range through one Badger transaction and one
+iterator. `pull/batch.begin` and `pull/batch.complete` annotations make the
+result-boundary work visible. Explicit-attribute and nested pull patterns retain
+their existing per-entity execution.
 
 **Scaling Characteristics**:
 - **Per-attribute cost**: ~1.2µs (BadgerDB), ~470ns (in-memory)

--- a/datalog/annotations/types.go
+++ b/datalog/annotations/types.go
@@ -68,6 +68,8 @@ const (
 	// Pull API operations
 	PullBegin           = "pull/begin"
 	PullComplete        = "pull/complete"
+	PullBatchBegin      = "pull/batch.begin"
+	PullBatchComplete   = "pull/batch.complete"
 	PullEntityBegin     = "pull/entity.begin"
 	PullEntityComplete  = "pull/entity.complete"
 	PullAttributeLookup = "pull/attr.lookup"

--- a/datalog/executor/batch_wildcard_pull_test.go
+++ b/datalog/executor/batch_wildcard_pull_test.go
@@ -107,6 +107,34 @@ func TestApplyFindPullsPropagatesBatchWildcardError(t *testing.T) {
 	require.ErrorIs(t, err, batchErr)
 }
 
+func TestPullManyDoesNotBatchMixedWildcardPattern(t *testing.T) {
+	name := datalog.NewKeyword(":entity/name")
+	first := datalog.NewIdentity("mixed-pull-first")
+	second := datalog.NewIdentity("mixed-pull-second")
+	resolver := &recordingBatchEntityResolver{
+		values: map[[20]byte]map[datalog.Keyword]interface{}{
+			first.Hash():  {name: "First"},
+			second.Hash(): {name: "Second"},
+		},
+	}
+	matcher := NewIndexedMemoryMatcher([]datalog.Datom{
+		{E: first, A: name, V: "First"},
+		{E: second, A: name, V: "Second"},
+	})
+	puller := NewPullExecutor(matcher, resolver)
+	pattern := &query.PullPattern{Specs: []query.PullAttrSpec{
+		&query.PullWildcard{},
+		&query.PullAttribute{Attr: name},
+	}}
+
+	results, err := puller.PullMany([]datalog.Identity{first, second}, pattern)
+	require.NoError(t, err)
+	require.Zero(t, resolver.batchCalls)
+	require.Equal(t, 2, resolver.singleCalls)
+	require.Equal(t, "First", results[0]["entity/name"])
+	require.Equal(t, "Second", results[1]["entity/name"])
+}
+
 func TestApplyFindPullsPropagatesInputIteratorAndCloseErrors(t *testing.T) {
 	entitySymbol := datalog.NewSymbol("?entity")
 	entity := datalog.NewIdentity("batch-pull-input-error")

--- a/datalog/executor/batch_wildcard_pull_test.go
+++ b/datalog/executor/batch_wildcard_pull_test.go
@@ -1,0 +1,143 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/query"
+)
+
+type recordingBatchEntityResolver struct {
+	values      map[[20]byte]map[datalog.Keyword]interface{}
+	singleCalls int
+	batchCalls  int
+	batchErr    error
+}
+
+func (r *recordingBatchEntityResolver) ResolveAllAttributes(
+	entity datalog.Identity,
+) (map[datalog.Keyword]interface{}, error) {
+	r.singleCalls++
+	return r.values[entity.Hash()], nil
+}
+
+func (r *recordingBatchEntityResolver) ResolveAllAttributesMany(
+	entities []datalog.Identity,
+) ([]map[datalog.Keyword]interface{}, error) {
+	r.batchCalls++
+	if r.batchErr != nil {
+		return nil, r.batchErr
+	}
+	results := make([]map[datalog.Keyword]interface{}, len(entities))
+	for i, entity := range entities {
+		results[i] = r.values[entity.Hash()]
+	}
+	return results, nil
+}
+
+func TestApplyFindPullsBatchesWildcardEntities(t *testing.T) {
+	entitySymbol := datalog.NewSymbol("?entity")
+	indexSymbol := datalog.NewSymbol("?index")
+	name := datalog.NewKeyword(":entity/name")
+	first := datalog.NewIdentity("batch-pull-first")
+	second := datalog.NewIdentity("batch-pull-second")
+	var events []annotations.Event
+	collector := annotations.NewCollector(func(event annotations.Event) {
+		events = append(events, event)
+	})
+	input := NewMaterializedRelationWithOptions(
+		[]query.Symbol{entitySymbol, indexSymbol},
+		[]Tuple{{first, int64(0)}, {second, int64(1)}, {first, int64(2)}},
+		ExecutorOptions{Collector: collector},
+	)
+	resolver := &recordingBatchEntityResolver{
+		values: map[[20]byte]map[datalog.Keyword]interface{}{
+			first.Hash():  {name: "First"},
+			second.Hash(): {name: "Second"},
+		},
+	}
+	find := []query.FindElement{query.FindPull{
+		Variable: entitySymbol,
+		Pattern: &query.PullPattern{
+			Specs: []query.PullAttrSpec{&query.PullWildcard{}},
+		},
+	}}
+
+	result, err := applyFindPulls(nil, resolver, input, find)
+	require.NoError(t, err)
+	require.Equal(t, 1, resolver.batchCalls)
+	require.Zero(t, resolver.singleCalls)
+
+	rows, err := CollectTuples(result, nil)
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+	require.Equal(t, "First", rows[0][0].(map[string]interface{})["entity/name"])
+	require.Equal(t, first, rows[0][0].(map[string]interface{})[query.DBIDKey])
+	require.Equal(t, "Second", rows[1][0].(map[string]interface{})["entity/name"])
+	require.Equal(t, second, rows[1][0].(map[string]interface{})[query.DBIDKey])
+	require.Equal(t, "First", rows[2][0].(map[string]interface{})["entity/name"])
+	require.Equal(t, first, rows[2][0].(map[string]interface{})[query.DBIDKey])
+	require.Len(t, events, 2)
+	require.Equal(t, annotations.PullBatchBegin, events[0].Name)
+	require.Equal(t, 3, events[0].Data["entity_count"])
+	require.Equal(t, annotations.PullBatchComplete, events[1].Name)
+	require.Equal(t, true, events[1].Data["success"])
+}
+
+func TestApplyFindPullsPropagatesBatchWildcardError(t *testing.T) {
+	entitySymbol := datalog.NewSymbol("?entity")
+	entity := datalog.NewIdentity("batch-pull-error")
+	input := NewMaterializedRelation(
+		[]query.Symbol{entitySymbol},
+		[]Tuple{{entity}},
+	)
+	batchErr := errors.New("batch wildcard failure")
+	resolver := &recordingBatchEntityResolver{batchErr: batchErr}
+	find := []query.FindElement{query.FindPull{
+		Variable: entitySymbol,
+		Pattern: &query.PullPattern{
+			Specs: []query.PullAttrSpec{&query.PullWildcard{}},
+		},
+	}}
+
+	_, err := applyFindPulls(nil, resolver, input, find)
+	require.ErrorIs(t, err, batchErr)
+}
+
+func TestApplyFindPullsPropagatesInputIteratorAndCloseErrors(t *testing.T) {
+	entitySymbol := datalog.NewSymbol("?entity")
+	entity := datalog.NewIdentity("batch-pull-input-error")
+	base := NewMaterializedRelation(
+		[]query.Symbol{entitySymbol},
+		[]Tuple{{entity}},
+	)
+	resolver := &recordingBatchEntityResolver{}
+	find := []query.FindElement{query.FindPull{
+		Variable: entitySymbol,
+		Pattern: &query.PullPattern{
+			Specs: []query.PullAttrSpec{&query.PullWildcard{}},
+		},
+	}}
+
+	_, err := applyFindPulls(
+		nil,
+		resolver,
+		failingRelation{Relation: base, failAfter: 0},
+		find,
+	)
+	require.ErrorIs(t, err, errInjectedIterator)
+	require.Zero(t, resolver.batchCalls)
+
+	closeErr := errors.New("pull input close failure")
+	_, err = applyFindPulls(
+		nil,
+		resolver,
+		failingRelation{Relation: base, failAfter: 100, closeErr: closeErr},
+		find,
+	)
+	require.ErrorIs(t, err, closeErr)
+	require.Zero(t, resolver.batchCalls)
+}

--- a/datalog/executor/interfaces.go
+++ b/datalog/executor/interfaces.go
@@ -77,3 +77,13 @@ type EntityResolver interface {
 	// - CardinalityVector: []interface{} (RGA ordered list)
 	ResolveAllAttributes(entity datalog.Identity) (map[datalog.Keyword]interface{}, error)
 }
+
+// BatchEntityResolver extends EntityResolver with wildcard resolution for a
+// complete entity set. Implementations may share storage traversal state across
+// entities while preserving input order in the returned slice.
+type BatchEntityResolver interface {
+	EntityResolver
+	ResolveAllAttributesMany(
+		entities []datalog.Identity,
+	) ([]map[datalog.Keyword]interface{}, error)
+}

--- a/datalog/executor/pull.go
+++ b/datalog/executor/pull.go
@@ -15,6 +15,11 @@ type PullExecutor struct {
 	entityResolver EntityResolver
 }
 
+type pullBatchContext interface {
+	PullBatchBegin(entityCount, specCount int, resolved bool)
+	PullBatchComplete(entityCount, attrCount int, resolved bool, err error)
+}
+
 // NewPullExecutor creates a new pull executor
 func NewPullExecutor(matcher PatternMatcher, resolver EntityResolver) *PullExecutor {
 	return &PullExecutor{
@@ -345,6 +350,20 @@ func (pe *PullExecutor) getAllAttributesInternal(entity datalog.Identity) ([]dat
 
 // PullMany executes a pull pattern for multiple entities
 func (pe *PullExecutor) PullMany(entities []datalog.Identity, pattern *query.PullPattern) ([]map[string]interface{}, error) {
+	if resolver, ok := pe.entityResolver.(BatchEntityResolver); ok &&
+		isWildcardPullPattern(pattern) &&
+		len(entities) > 0 {
+		pe.pullBatchBegin(len(entities), len(pattern.Specs), false)
+		resolved, err := resolver.ResolveAllAttributesMany(entities)
+		if err != nil {
+			pe.pullBatchComplete(len(entities), 0, false, err)
+			return nil, fmt.Errorf("batch wildcard pull failed: %w", err)
+		}
+		results, attrCount, err := renderBatchWildcardResults(resolved, len(entities))
+		pe.pullBatchComplete(len(entities), attrCount, false, err)
+		return results, err
+	}
+
 	results := make([]map[string]interface{}, len(entities))
 	for i, entity := range entities {
 		result, err := pe.Pull(entity, pattern)
@@ -354,6 +373,41 @@ func (pe *PullExecutor) PullMany(entities []datalog.Identity, pattern *query.Pul
 		results[i] = result
 	}
 	return results, nil
+}
+
+func isWildcardPullPattern(pattern *query.PullPattern) bool {
+	if pattern == nil || len(pattern.Specs) != 1 {
+		return false
+	}
+	_, ok := pattern.Specs[0].(*query.PullWildcard)
+	return ok
+}
+
+func renderBatchWildcardResults(
+	resolved []map[datalog.Keyword]interface{},
+	entityCount int,
+) ([]map[string]interface{}, int, error) {
+	if len(resolved) != entityCount {
+		return nil, 0, fmt.Errorf(
+			"batch wildcard resolver returned %d results for %d entities",
+			len(resolved),
+			entityCount,
+		)
+	}
+	results := make([]map[string]interface{}, len(resolved))
+	attrCount := 0
+	for i, attrs := range resolved {
+		if len(attrs) == 0 {
+			continue
+		}
+		result := make(map[string]interface{}, len(attrs))
+		for attr, value := range attrs {
+			result[query.KeyName(attr)] = value
+		}
+		results[i] = result
+		attrCount += len(result)
+	}
+	return results, attrCount, nil
 }
 
 // ============================================================================
@@ -611,6 +665,20 @@ func (pe *PullExecutor) lookupAllValuesInternal(entity datalog.Identity, attr da
 
 // PullResolvedMany executes a resolved pull pattern for multiple entities
 func (pe *PullExecutor) PullResolvedMany(entities []datalog.Identity, pattern *query.ResolvedPullPattern) ([]map[string]interface{}, error) {
+	if resolver, ok := pe.entityResolver.(BatchEntityResolver); ok &&
+		isResolvedWildcardPullPattern(pattern) &&
+		len(entities) > 0 {
+		pe.pullBatchBegin(len(entities), len(pattern.Specs), true)
+		resolved, err := resolver.ResolveAllAttributesMany(entities)
+		if err != nil {
+			pe.pullBatchComplete(len(entities), 0, true, err)
+			return nil, fmt.Errorf("batch resolved wildcard pull failed: %w", err)
+		}
+		results, attrCount, err := renderBatchWildcardResults(resolved, len(entities))
+		pe.pullBatchComplete(len(entities), attrCount, true, err)
+		return results, err
+	}
+
 	results := make([]map[string]interface{}, len(entities))
 	for i, entity := range entities {
 		result, err := pe.PullResolved(entity, pattern)
@@ -620,6 +688,30 @@ func (pe *PullExecutor) PullResolvedMany(entities []datalog.Identity, pattern *q
 		results[i] = result
 	}
 	return results, nil
+}
+
+func isResolvedWildcardPullPattern(pattern *query.ResolvedPullPattern) bool {
+	if pattern == nil || len(pattern.Specs) != 1 {
+		return false
+	}
+	_, ok := pattern.Specs[0].(*query.ResolvedPullWildcard)
+	return ok
+}
+
+func (pe *PullExecutor) pullBatchBegin(entityCount, specCount int, resolved bool) {
+	if ctx, ok := pe.ctx.(pullBatchContext); ok {
+		ctx.PullBatchBegin(entityCount, specCount, resolved)
+	}
+}
+
+func (pe *PullExecutor) pullBatchComplete(
+	entityCount, attrCount int,
+	resolved bool,
+	err error,
+) {
+	if ctx, ok := pe.ctx.(pullBatchContext); ok {
+		ctx.PullBatchComplete(entityCount, attrCount, resolved, err)
+	}
 }
 
 // getIdentity extracts an Identity from a value

--- a/datalog/executor/pull_context.go
+++ b/datalog/executor/pull_context.go
@@ -60,8 +60,9 @@ func (c *BasePullContext) NestedComplete(parentEntity datalog.Identity, attr dat
 
 // AnnotatedPullContext wraps operations with timing and event emission.
 type AnnotatedPullContext struct {
-	handler   annotations.Handler
-	pullStart time.Time
+	handler    annotations.Handler
+	pullStart  time.Time
+	batchStart time.Time
 }
 
 // NewPullContext creates an appropriate context based on whether annotations are needed.
@@ -97,6 +98,35 @@ func (c *AnnotatedPullContext) PullComplete(entity datalog.Identity, attrCount i
 			"attr_count": attrCount,
 			"resolved":   resolved,
 			"success":    err == nil,
+		},
+	})
+}
+
+func (c *AnnotatedPullContext) PullBatchBegin(entityCount, specCount int, resolved bool) {
+	c.batchStart = time.Now()
+	c.handler(annotations.Event{
+		Name:  annotations.PullBatchBegin,
+		Start: c.batchStart,
+		Data: map[string]interface{}{
+			"entity_count": entityCount,
+			"spec_count":   specCount,
+			"resolved":     resolved,
+		},
+	})
+}
+
+func (c *AnnotatedPullContext) PullBatchComplete(entityCount, attrCount int, resolved bool, err error) {
+	end := time.Now()
+	c.handler(annotations.Event{
+		Name:    annotations.PullBatchComplete,
+		Start:   c.batchStart,
+		End:     end,
+		Latency: end.Sub(c.batchStart),
+		Data: map[string]interface{}{
+			"entity_count": entityCount,
+			"attr_count":   attrCount,
+			"resolved":     resolved,
+			"success":      err == nil,
 		},
 	})
 }

--- a/datalog/executor/query_executor.go
+++ b/datalog/executor/query_executor.go
@@ -1266,70 +1266,76 @@ func hasPulls(find []query.FindElement) bool {
 // design (docs/bugs/resolved/BUG_PULL_WITH_ORDER_BY_PANICS.md) runs this only at the
 // result boundary, after sort/strip/limit.
 func applyFindPulls(matcher PatternMatcher, entityResolver EntityResolver, rel Relation, find []query.FindElement) (Relation, error) {
-	// Build mapping: symbol index -> pull pattern
 	symbols := rel.Symbols()
-	pullSpecs := make(map[int]query.FindPull)
-
+	type pullRequest struct {
+		symbolIndex int
+		pull        query.FindPull
+	}
+	var requests []pullRequest
 	for _, elem := range find {
 		if pull, ok := elem.(query.FindPull); ok {
-			// Find the symbol index for this pull variable
 			for i, sym := range symbols {
 				if sym == pull.Variable {
-					pullSpecs[i] = pull
+					requests = append(requests, pullRequest{
+						symbolIndex: i,
+						pull:        pull,
+					})
 					break
 				}
 			}
 		}
 	}
-
-	if len(pullSpecs) == 0 {
-		return rel, nil // No pulls to execute
+	if len(requests) == 0 {
+		return rel, nil
 	}
 
-	// Create pull executor
 	puller := NewPullExecutor(matcher, entityResolver)
+	if collector := rel.Options().Collector; collector != nil {
+		puller = NewPullExecutorWithHandler(matcher, entityResolver, collector.Handler())
+	}
 
-	// Process tuples and execute pulls
 	var resultTuples []Tuple
 	it := rel.Iterator()
-	defer it.Close()
-
 	for it.Next() {
 		tuple := it.Tuple()
-		// Make a copy to modify
 		newTuple := make(Tuple, len(tuple))
 		copy(newTuple, tuple)
+		resultTuples = append(resultTuples, newTuple)
+	}
+	iterErr := it.Error()
+	closeErr := it.Close()
+	if iterErr != nil {
+		return nil, iterErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
 
-		// Execute pulls for each pull symbol
-		for symIdx, pull := range pullSpecs {
-			if symIdx >= len(tuple) {
+	for _, request := range requests {
+		var entities []datalog.Identity
+		var tupleIndexes []int
+		for tupleIndex, tuple := range resultTuples {
+			if request.symbolIndex >= len(tuple) {
 				continue
 			}
-
-			// Get the entity value
-			entity, ok := tuple[symIdx].(datalog.Identity)
+			entity, ok := tuple[request.symbolIndex].(datalog.Identity)
 			if !ok || entity == nil {
-				// Value is not an entity - keep it as is
 				continue
 			}
-
-			// Execute pull
-			pulled, err := puller.Pull(entity, pull.Pattern)
-			if err != nil {
-				return nil, fmt.Errorf("pull failed for %s: %w", pull.Variable, err)
-			}
-
-			// Add the entity ID to the pull result so it can be mapped to struct fields
-			// tagged with datalog:"db/id" or datalog:":db/id"
+			entities = append(entities, entity)
+			tupleIndexes = append(tupleIndexes, tupleIndex)
+		}
+		pulledResults, err := puller.PullMany(entities, request.pull.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("pull failed for %s: %w", request.pull.Variable, err)
+		}
+		for i, pulled := range pulledResults {
+			entity := entities[i]
 			if pulled != nil {
 				pulled[query.DBIDKey] = entity
 			}
-
-			// Replace entity with pulled map (nil if entity not found)
-			newTuple[symIdx] = pulled
+			resultTuples[tupleIndexes[i]][request.symbolIndex] = pulled
 		}
-
-		resultTuples = append(resultTuples, newTuple)
 	}
 
 	// Return relation without deduplication - pulled maps (map[string]interface{})

--- a/datalog/storage/crdt_resolving_iterator.go
+++ b/datalog/storage/crdt_resolving_iterator.go
@@ -419,8 +419,16 @@ func (it *CRDTResolvingIterator) resolveRGAGroup() []*datalog.Datom {
 	// DFS from HEAD, collect values into a single resolved list.
 	// Recursion depth ≈ vector length for sequentially-appended vectors; see
 	// the stack-depth note in storage/rga_reconstruct.go (ReconstructRGA).
-	var values []any
+	values := make([]any, 0)
 	var maxTx datalog.ElementID
+	for _, element := range elemByID {
+		if maxTx.Less(element.id) {
+			maxTx = element.id
+		}
+		if element.tombstoneID != nil && maxTx.Less(*element.tombstoneID) {
+			maxTx = *element.tombstoneID
+		}
+	}
 	visited := make(map[datalog.ElementID]bool)
 	var walk func(id datalog.ElementID)
 	walk = func(id datalog.ElementID) {
@@ -432,18 +440,11 @@ func (it *CRDTResolvingIterator) resolveRGAGroup() []*datalog.Datom {
 		for _, child := range children[id] {
 			if child.tombstoneID == nil && child.value != nil {
 				values = append(values, child.value)
-				if maxTx.Less(child.id) {
-					maxTx = child.id
-				}
 			}
 			walk(child.id)
 		}
 	}
 	walk(HEAD)
-
-	if len(values) == 0 {
-		return nil
-	}
 
 	return []*datalog.Datom{{
 		E:  it.currentE,

--- a/datalog/storage/database.go
+++ b/datalog/storage/database.go
@@ -2643,6 +2643,14 @@ func (d *Database) ResolveEntityAttributes(entity datalog.Identity, attrs []data
 // vector) via CRDTResolvingIterator. Returns nil if the entity has no
 // current value for the attribute.
 func (d *Database) resolveAttributeViaMatcher(entity datalog.Identity, attr datalog.Keyword, matcher *BadgerMatcher, card schema.Cardinality, valueType schema.ValueType) (interface{}, error) {
+	if card == schema.CardinalityVector && d.cache == nil {
+		value, found, err := matcher.LookupAttribute(entity, attr)
+		if err != nil || !found {
+			return nil, err
+		}
+		return value, nil
+	}
+
 	pattern := &query.DataPattern{
 		Elements: []query.PatternElement{
 			query.Constant{Value: entity},
@@ -2680,9 +2688,6 @@ func (d *Database) resolveAttributeViaMatcher(entity datalog.Identity, attr data
 			tuple := iter.Tuple()
 			if len(tuple) > 0 && tuple[0] != nil {
 				if vec, ok := tuple[0].([]interface{}); ok {
-					if len(vec) == 0 {
-						return nil, nil
-					}
 					if valueType != "" {
 						return typedVector(vec, valueType), nil
 					}
@@ -2725,7 +2730,11 @@ func entryToValue(entry *CacheEntry, valueType schema.ValueType) interface{} {
 		}
 		return values
 	case schema.CardinalityVector:
-		return typedVector(entry.VectorList(), valueType)
+		values := entry.VectorList()
+		if values == nil {
+			return nil
+		}
+		return typedVector(values, valueType)
 	default:
 		return entry.OneValue()
 	}

--- a/datalog/storage/pull_batch.go
+++ b/datalog/storage/pull_batch.go
@@ -1,0 +1,251 @@
+package storage
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+type wildcardUniqueLookup struct {
+	entity datalog.Identity
+	attr   datalog.Keyword
+}
+
+// ResolveAllAttributesMany resolves wildcard pulls for a complete entity set
+// through one Badger read transaction and one iterator. Results preserve input
+// order. Duplicate entities are scanned once.
+func (d *Database) ResolveAllAttributesMany(
+	entities []datalog.Identity,
+) ([]map[datalog.Keyword]interface{}, error) {
+	results := make([]map[datalog.Keyword]interface{}, len(entities))
+	if len(entities) == 0 {
+		return results, nil
+	}
+
+	matcher := d.Matcher().(*BadgerMatcher)
+	if matcher.isHistoryMode() {
+		for i, entity := range entities {
+			result, err := d.ResolveAllAttributes(entity)
+			if err != nil {
+				return nil, err
+			}
+			results[i] = result
+		}
+		return results, nil
+	}
+
+	uniqueEntities := make(map[[20]byte]datalog.Identity, len(entities))
+	for _, entity := range entities {
+		if entity != nil {
+			uniqueEntities[entity.Hash()] = entity
+		}
+	}
+	sortedEntities := make([]datalog.Identity, 0, len(uniqueEntities))
+	for _, entity := range uniqueEntities {
+		sortedEntities = append(sortedEntities, entity)
+	}
+	sort.Slice(sortedEntities, func(i, j int) bool {
+		return bytes.Compare(sortedEntities[i].Bytes(), sortedEntities[j].Bytes()) < 0
+	})
+
+	resolved := make(map[[20]byte]map[datalog.Keyword]interface{}, len(sortedEntities))
+	var uniqueLookups []wildcardUniqueLookup
+	err := d.store.db.View(func(txn *badger.Txn) error {
+		options := badger.DefaultIteratorOptions
+		options.PrefetchValues = false
+		iterator := txn.NewIterator(options)
+		defer iterator.Close()
+
+		for _, entity := range sortedEntities {
+			entityResult, pending, err := d.resolveWildcardEntity(
+				matcher,
+				iterator,
+				entity,
+			)
+			if err != nil {
+				return err
+			}
+			resolved[entity.Hash()] = entityResult
+			uniqueLookups = append(uniqueLookups, pending...)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("batch wildcard scan failed: %w", err)
+	}
+
+	for _, lookup := range uniqueLookups {
+		value, err := d.ResolveEntityAttributes(
+			lookup.entity,
+			[]datalog.Keyword{lookup.attr},
+		)
+		if err != nil {
+			return nil, err
+		}
+		if resolvedValue, ok := value[lookup.attr]; ok {
+			resolved[lookup.entity.Hash()][lookup.attr] = resolvedValue
+		}
+	}
+
+	for i, entity := range entities {
+		if entity == nil {
+			continue
+		}
+		results[i] = cloneResolvedAttributes(resolved[entity.Hash()])
+	}
+	return results, nil
+}
+
+func (d *Database) resolveWildcardEntity(
+	matcher *BadgerMatcher,
+	iterator *badger.Iterator,
+	entity datalog.Identity,
+) (map[datalog.Keyword]interface{}, []wildcardUniqueLookup, error) {
+	entityBytes := entity.Bytes()
+	start, end := d.store.encoder.EncodePrefixRange(EATV, entityBytes[:])
+	result := make(map[datalog.Keyword]interface{})
+	var pending []wildcardUniqueLookup
+	var currentAttr datalog.Keyword
+	var currentDatoms []datalog.Datom
+
+	flush := func() {
+		if currentAttr == nil || len(currentDatoms) == 0 {
+			return
+		}
+		if d.isUniqueAttribute(currentAttr) {
+			pending = append(pending, wildcardUniqueLookup{
+				entity: entity,
+				attr:   currentAttr,
+			})
+		} else if value, present := d.resolveWildcardDatoms(
+			matcher,
+			entity,
+			currentAttr,
+			currentDatoms,
+		); present {
+			result[currentAttr] = value
+		}
+		currentDatoms = currentDatoms[:0]
+	}
+
+	for iterator.Seek(start); iterator.Valid(); iterator.Next() {
+		key := iterator.Item().Key()
+		if bytes.Compare(key, end) >= 0 {
+			break
+		}
+		keyCopy := iterator.Item().KeyCopy(nil)
+		datom, err := DatomFromKey(EATV, keyCopy, d.store.encoder, d.store.db)
+		if err != nil {
+			return nil, nil, err
+		}
+		if matcher.shouldFilterTx(datom.Tx) {
+			continue
+		}
+		if currentAttr != nil && datom.A != currentAttr {
+			flush()
+		}
+		currentAttr = datom.A
+		currentDatoms = append(currentDatoms, datom)
+	}
+	flush()
+	return result, pending, nil
+}
+
+func (d *Database) resolveWildcardDatoms(
+	matcher *BadgerMatcher,
+	entity datalog.Identity,
+	attr datalog.Keyword,
+	datoms []datalog.Datom,
+) (interface{}, bool) {
+	storageDatom := ToStorageDatom(datalog.Datom{E: entity, A: attr})
+	cardinality := matcher.GetCardinality(storageDatom.A)
+	if d.cache != nil {
+		if key, ok := matcher.cacheKey(storageDatom.E, storageDatom.A); ok {
+			d.cache.PopulateFromDatoms(key, cardinality, datoms)
+		}
+	}
+
+	switch cardinality {
+	case schema.CardinalityMany:
+		members, _ := ResolveAddWinsFromDatoms(datoms)
+		if len(members) == 0 {
+			return nil, false
+		}
+		values := make([]interface{}, 0, len(members))
+		for _, value := range members {
+			values = append(values, value)
+		}
+		return values, true
+	case schema.CardinalityVector:
+		values, _, maxID := ResolveRGAFromDatoms(datoms)
+		if maxID.IsZero() {
+			return nil, false
+		}
+		return typedVector(values, d.attributeValueType(attr)), true
+	default:
+		value, _ := ResolveLWWFromDatoms(datoms)
+		if value == nil {
+			return nil, false
+		}
+		return value, true
+	}
+}
+
+func (d *Database) isUniqueAttribute(attr datalog.Keyword) bool {
+	if d.schema == nil {
+		return false
+	}
+	definition := d.schema.GetAttribute(attr)
+	return definition != nil && definition.Unique != ""
+}
+
+func (d *Database) attributeValueType(attr datalog.Keyword) schema.ValueType {
+	if d.schema == nil {
+		return ""
+	}
+	definition := d.schema.GetAttribute(attr)
+	if definition == nil {
+		return ""
+	}
+	return definition.ValueType
+}
+
+func cloneResolvedAttributes(
+	attrs map[datalog.Keyword]interface{},
+) map[datalog.Keyword]interface{} {
+	if len(attrs) == 0 {
+		return nil
+	}
+	cloned := make(map[datalog.Keyword]interface{}, len(attrs))
+	for attr, value := range attrs {
+		cloned[attr] = cloneResolvedAttributeValue(value)
+	}
+	return cloned
+}
+
+func cloneResolvedAttributeValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case []byte:
+		return append([]byte(nil), typed...)
+	case []interface{}:
+		cloned := make([]interface{}, len(typed))
+		for i, element := range typed {
+			cloned[i] = cloneResolvedAttributeValue(element)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), typed...)
+	case []int64:
+		return append([]int64(nil), typed...)
+	case []float64:
+		return append([]float64(nil), typed...)
+	case []bool:
+		return append([]bool(nil), typed...)
+	default:
+		return value
+	}
+}

--- a/datalog/storage/pull_batch.go
+++ b/datalog/storage/pull_batch.go
@@ -15,9 +15,10 @@ type wildcardUniqueLookup struct {
 	attr   datalog.Keyword
 }
 
-// ResolveAllAttributesMany resolves wildcard pulls for a complete entity set
-// through one Badger read transaction and one iterator. Results preserve input
-// order. Duplicate entities are scanned once.
+// ResolveAllAttributesMany resolves wildcard pulls for a complete entity set.
+// The dominant non-unique EATV traversal shares one Badger read transaction and
+// iterator; unique-ownership walks and blob dereferences retain their specialized
+// reads. Results preserve input order. Duplicate entities are scanned once.
 func (d *Database) ResolveAllAttributesMany(
 	entities []datalog.Identity,
 ) ([]map[datalog.Keyword]interface{}, error) {
@@ -53,6 +54,7 @@ func (d *Database) ResolveAllAttributesMany(
 	})
 
 	resolved := make(map[[20]byte]map[datalog.Keyword]interface{}, len(sortedEntities))
+	declaredAttrs := d.declaredWildcardAttributes()
 	var uniqueLookups []wildcardUniqueLookup
 	err := d.store.db.View(func(txn *badger.Txn) error {
 		options := badger.DefaultIteratorOptions
@@ -65,6 +67,7 @@ func (d *Database) ResolveAllAttributesMany(
 				matcher,
 				iterator,
 				entity,
+				declaredAttrs,
 			)
 			if err != nil {
 				return err
@@ -104,6 +107,7 @@ func (d *Database) resolveWildcardEntity(
 	matcher *BadgerMatcher,
 	iterator *badger.Iterator,
 	entity datalog.Identity,
+	declaredAttrs map[datalog.Keyword]struct{},
 ) (map[datalog.Keyword]interface{}, []wildcardUniqueLookup, error) {
 	entityBytes := entity.Bytes()
 	start, end := d.store.encoder.EncodePrefixRange(EATV, entityBytes[:])
@@ -115,6 +119,12 @@ func (d *Database) resolveWildcardEntity(
 	flush := func() {
 		if currentAttr == nil || len(currentDatoms) == 0 {
 			return
+		}
+		if declaredAttrs != nil {
+			if _, declared := declaredAttrs[currentAttr]; !declared {
+				currentDatoms = currentDatoms[:0]
+				return
+			}
 		}
 		if d.isUniqueAttribute(currentAttr) {
 			pending = append(pending, wildcardUniqueLookup{
@@ -153,6 +163,19 @@ func (d *Database) resolveWildcardEntity(
 	}
 	flush()
 	return result, pending, nil
+}
+
+func (d *Database) declaredWildcardAttributes() map[datalog.Keyword]struct{} {
+	s, ok := d.schema.(*schema.Schema)
+	if !ok || !s.HasSchema() {
+		return nil
+	}
+	attrs := s.Attributes()
+	declared := make(map[datalog.Keyword]struct{}, len(attrs))
+	for _, definition := range attrs {
+		declared[definition.Ident] = struct{}{}
+	}
+	return declared
 }
 
 func (d *Database) resolveWildcardDatoms(
@@ -218,7 +241,7 @@ func cloneResolvedAttributes(
 	attrs map[datalog.Keyword]interface{},
 ) map[datalog.Keyword]interface{} {
 	if len(attrs) == 0 {
-		return nil
+		return make(map[datalog.Keyword]interface{})
 	}
 	cloned := make(map[datalog.Keyword]interface{}, len(attrs))
 	for attr, value := range attrs {
@@ -230,7 +253,9 @@ func cloneResolvedAttributes(
 func cloneResolvedAttributeValue(value interface{}) interface{} {
 	switch typed := value.(type) {
 	case []byte:
-		return append([]byte(nil), typed...)
+		cloned := make([]byte, len(typed))
+		copy(cloned, typed)
+		return cloned
 	case []interface{}:
 		cloned := make([]interface{}, len(typed))
 		for i, element := range typed {
@@ -238,13 +263,21 @@ func cloneResolvedAttributeValue(value interface{}) interface{} {
 		}
 		return cloned
 	case []string:
-		return append([]string(nil), typed...)
+		cloned := make([]string, len(typed))
+		copy(cloned, typed)
+		return cloned
 	case []int64:
-		return append([]int64(nil), typed...)
+		cloned := make([]int64, len(typed))
+		copy(cloned, typed)
+		return cloned
 	case []float64:
-		return append([]float64(nil), typed...)
+		cloned := make([]float64, len(typed))
+		copy(cloned, typed)
+		return cloned
 	case []bool:
-		return append([]bool(nil), typed...)
+		cloned := make([]bool, len(typed))
+		copy(cloned, typed)
+		return cloned
 	default:
 		return value
 	}

--- a/datalog/storage/pull_batch_test.go
+++ b/datalog/storage/pull_batch_test.go
@@ -1,0 +1,242 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/annotations"
+	"github.com/wbrown/janus-datalog/datalog/executor"
+	"github.com/wbrown/janus-datalog/datalog/query"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+func TestResolveAllAttributesManyPreservesWildcardSemantics(t *testing.T) {
+	for _, disableCache := range []bool{false, true} {
+		t.Run(fmt.Sprintf("disable_cache=%t", disableCache), func(t *testing.T) {
+			s, err := schema.NewBuilder().
+				Attribute(":person/name").Type(schema.TypeString).One().Add().
+				Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+				Attribute(":person/skills").Type(schema.TypeString).Vector().Add().
+				Attribute(":person/blobs").Type(schema.TypeBytes).Many().Add().
+				Attribute(":person/missing").Type(schema.TypeString).One().Add().
+				Build()
+			require.NoError(t, err)
+			db, err := NewDatabaseWithOptions(DatabaseOptions{
+				Path:         t.TempDir(),
+				Schema:       s,
+				DisableCache: disableCache,
+			})
+			require.NoError(t, err)
+			defer db.Close()
+
+			name := datalog.NewKeyword(":person/name")
+			tags := datalog.NewKeyword(":person/tags")
+			skills := datalog.NewKeyword(":person/skills")
+			blobs := datalog.NewKeyword(":person/blobs")
+			first := datalog.NewIdentity("batch-resolve-first")
+			second := datalog.NewIdentity("batch-resolve-second")
+			absent := datalog.NewIdentity("batch-resolve-absent")
+
+			tx := db.NewTransaction()
+			require.NoError(t, tx.Set(first, name, "First"))
+			require.NoError(t, tx.Add(first, tags, "admin"))
+			require.NoError(t, tx.Add(first, tags, "author"))
+			require.NoError(t, tx.Add(first, skills, "Go"))
+			require.NoError(t, tx.Add(first, skills, "Rust"))
+			require.NoError(t, tx.Add(first, blobs, []byte("blob")))
+			require.NoError(t, tx.Set(second, name, "Second"))
+			require.NoError(t, tx.Remove(second, name, "Second"))
+			_, err = tx.Commit()
+			require.NoError(t, err)
+
+			results, err := db.ResolveAllAttributesMany(
+				[]datalog.Identity{second, first, absent, first},
+			)
+			require.NoError(t, err)
+			require.Len(t, results, 4)
+			require.Empty(t, results[0], "the latest name operation is a tombstone")
+			require.Equal(t, "First", results[1][name])
+			require.ElementsMatch(t, []interface{}{"admin", "author"}, results[1][tags])
+			require.Equal(t, []string{"Go", "Rust"}, results[1][skills])
+			require.Empty(t, results[2])
+			require.Equal(t, results[1], results[3])
+			results[1][skills].([]string)[0] = "Changed"
+			require.Equal(t, []string{"Go", "Rust"}, results[3][skills],
+				"duplicate entities must receive independent vector values")
+			results[1][blobs].([]interface{})[0].([]byte)[0] = 'X'
+			require.Equal(t, []byte("blob"), results[3][blobs].([]interface{})[0],
+				"duplicate entities must receive independent byte values")
+		})
+	}
+}
+
+func TestResolveAllAttributesManyHonorsAsOf(t *testing.T) {
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Build()
+	require.NoError(t, err)
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: t.TempDir(), Schema: s})
+	require.NoError(t, err)
+	defer db.Close()
+
+	name := datalog.NewKeyword(":person/name")
+	first := datalog.NewIdentity("batch-asof-first")
+	second := datalog.NewIdentity("batch-asof-second")
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(first, name, "First v1"))
+	require.NoError(t, tx.Set(second, name, "Second v1"))
+	asOfID, err := tx.Commit()
+	require.NoError(t, err)
+
+	tx = db.NewTransaction()
+	require.NoError(t, tx.Set(first, name, "First v2"))
+	require.NoError(t, tx.Set(second, name, "Second v2"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	results, err := db.AsOf(asOfID).ResolveAllAttributesMany(
+		[]datalog.Identity{first, second},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "First v1", results[0][name])
+	require.Equal(t, "Second v1", results[1][name])
+}
+
+func TestResolveAllAttributesManyPreservesUniqueFallback(t *testing.T) {
+	s, err := schema.NewBuilder().
+		Attribute(":person/email").Type(schema.TypeString).Unique(schema.UniqueValue).Add().
+		Build()
+	require.NoError(t, err)
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: t.TempDir(), Schema: s})
+	require.NoError(t, err)
+	defer db.Close()
+
+	email := datalog.NewKeyword(":person/email")
+	first := datalog.NewIdentity("batch-unique-first")
+	second := datalog.NewIdentity("batch-unique-second")
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(first, email, "first@example.com"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+	tx = db.NewTransaction()
+	require.NoError(t, tx.Set(first, email, "shared@example.com"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+	tx = db.NewTransaction()
+	require.NoError(t, tx.Set(second, email, "shared@example.com"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	results, err := db.ResolveAllAttributesMany([]datalog.Identity{first, second})
+	require.NoError(t, err)
+	require.Equal(t, "first@example.com", results[0][email])
+	require.Equal(t, "shared@example.com", results[1][email])
+}
+
+func TestWildcardPullQueryUsesOneBatch(t *testing.T) {
+	var batchBegins, batchCompletes int
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path: t.TempDir(),
+		AnnotationHandler: func(event annotations.Event) {
+			switch event.Name {
+			case annotations.PullBatchBegin:
+				batchBegins++
+				require.Equal(t, 230, event.Data["entity_count"])
+			case annotations.PullBatchComplete:
+				batchCompletes++
+				require.Equal(t, true, event.Data["success"])
+			}
+		},
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	entityType := datalog.NewKeyword(":entity/type")
+	name := datalog.NewKeyword(":entity/name")
+	tx := db.NewTransaction()
+	for i := 0; i < 230; i++ {
+		entity := datalog.NewIdentity(fmt.Sprintf("scenario:%d", i))
+		require.NoError(t, tx.Set(entity, entityType, "scenario"))
+		require.NoError(t, tx.Set(entity, name, fmt.Sprintf("Scenario %d", i)))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	result, queryErr := db.Query(`[:find (pull ?entity [*])
+		:where [?entity :entity/type "scenario"]]`)
+	rows, err := executor.CollectTuples(result, queryErr)
+	require.NoError(t, err)
+	require.Len(t, rows, 230)
+	require.Equal(t, 1, batchBegins)
+	require.Equal(t, 1, batchCompletes)
+	for _, row := range rows {
+		pulled, ok := row[0].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "scenario", pulled["entity/type"])
+		require.NotNil(t, pulled[query.DBIDKey])
+	}
+}
+
+func BenchmarkResolveAllAttributesMany(b *testing.B) {
+	for _, entityCount := range []int{230, 3_899} {
+		b.Run(fmt.Sprintf("entities=%d", entityCount), func(b *testing.B) {
+			db, entities := setupBatchWildcardBenchmarkDB(b, entityCount, 5)
+
+			b.Run("per-entity", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					for _, entity := range entities {
+						if _, err := db.ResolveAllAttributes(entity); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+			})
+			b.Run("batch", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					if _, err := db.ResolveAllAttributesMany(entities); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func setupBatchWildcardBenchmarkDB(
+	b *testing.B,
+	entityCount, attrsPerEntity int,
+) (*Database, []datalog.Identity) {
+	b.Helper()
+	db, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:         b.TempDir(),
+		DisableCache: true,
+	})
+	require.NoError(b, err)
+	b.Cleanup(func() {
+		require.NoError(b, db.Close())
+	})
+
+	attrs := make([]datalog.Keyword, attrsPerEntity)
+	for i := range attrs {
+		attrs[i] = datalog.NewKeyword(fmt.Sprintf(":entity/attr%d", i))
+	}
+	entities := make([]datalog.Identity, entityCount)
+	tx := db.NewTransaction()
+	for i := range entities {
+		entities[i] = datalog.NewIdentity(fmt.Sprintf("batch-entity:%d", i))
+		for attrIndex, attr := range attrs {
+			require.NoError(b, tx.Set(
+				entities[i],
+				attr,
+				fmt.Sprintf("value-%d-%d", i, attrIndex),
+			))
+		}
+	}
+	_, err = tx.Commit()
+	require.NoError(b, err)
+	return db, entities
+}

--- a/datalog/storage/pull_batch_test.go
+++ b/datalog/storage/pull_batch_test.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"fmt"
+	"math/rand"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -135,6 +137,180 @@ func TestResolveAllAttributesManyPreservesUniqueFallback(t *testing.T) {
 	require.Equal(t, "shared@example.com", results[1][email])
 }
 
+func TestResolveAllAttributesManyMatchesDeclaredSchema(t *testing.T) {
+	s, err := schema.NewBuilder().
+		Attribute(":person/name").Type(schema.TypeString).One().Add().
+		Build()
+	require.NoError(t, err)
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: t.TempDir(), Schema: s})
+	require.NoError(t, err)
+	defer db.Close()
+
+	entity := datalog.NewIdentity("batch-declared-schema")
+	name := datalog.NewKeyword(":person/name")
+	nickname := datalog.NewKeyword(":person/nickname")
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(entity, name, "Declared"))
+	require.NoError(t, tx.Set(entity, nickname, "Stored but undeclared"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	perEntity, err := db.ResolveAllAttributes(entity)
+	require.NoError(t, err)
+	batch, err := db.ResolveAllAttributesMany([]datalog.Identity{entity})
+	require.NoError(t, err)
+	require.Equal(t, perEntity, batch[0])
+	require.NotContains(t, batch[0], nickname)
+}
+
+func TestResolveAllAttributesManyKeepsExplicitlyClearedVector(t *testing.T) {
+	for _, disableCache := range []bool{false, true} {
+		t.Run(fmt.Sprintf("disable_cache=%t", disableCache), func(t *testing.T) {
+			s, err := schema.NewBuilder().
+				Attribute(":person/skills").Type(schema.TypeString).Vector().Add().
+				Build()
+			require.NoError(t, err)
+			db, err := NewDatabaseWithOptions(DatabaseOptions{
+				Path:         t.TempDir(),
+				Schema:       s,
+				DisableCache: disableCache,
+			})
+			require.NoError(t, err)
+			defer db.Close()
+
+			entity := datalog.NewIdentity("batch-cleared-vector")
+			neverSet := datalog.NewIdentity("batch-never-set-vector")
+			skills := datalog.NewKeyword(":person/skills")
+			tx := db.NewTransaction()
+			require.NoError(t, tx.Add(entity, skills, "Go"))
+			_, err = tx.Commit()
+			require.NoError(t, err)
+			tx = db.NewTransaction()
+			require.NoError(t, tx.Remove(entity, skills, "Go"))
+			_, err = tx.Commit()
+			require.NoError(t, err)
+
+			perEntity, err := db.ResolveAllAttributes(entity)
+			require.NoError(t, err)
+			batch, err := db.ResolveAllAttributesMany([]datalog.Identity{entity})
+			require.NoError(t, err)
+			require.Equal(t, perEntity, batch[0])
+			require.Equal(t, []string{}, batch[0][skills])
+
+			neverSetPerEntity, err := db.ResolveAllAttributes(neverSet)
+			require.NoError(t, err)
+			neverSetBatch, err := db.ResolveAllAttributesMany([]datalog.Identity{neverSet})
+			require.NoError(t, err)
+			require.NotContains(t, neverSetPerEntity, skills)
+			require.Equal(t, neverSetPerEntity, neverSetBatch[0])
+		})
+	}
+}
+
+func TestResolveAllAttributesManyDifferential(t *testing.T) {
+	for _, disableCache := range []bool{false, true} {
+		t.Run(fmt.Sprintf("disable_cache=%t", disableCache), func(t *testing.T) {
+			random := rand.New(rand.NewSource(0x381))
+			s, err := schema.NewBuilder().
+				Attribute(":person/name").Type(schema.TypeString).One().Add().
+				Attribute(":person/tags").Type(schema.TypeString).Many().Add().
+				Attribute(":person/steps").Type(schema.TypeString).Vector().Add().
+				Attribute(":person/missing").Type(schema.TypeString).One().Add().
+				Build()
+			require.NoError(t, err)
+			db, err := NewDatabaseWithOptions(DatabaseOptions{
+				Path:         t.TempDir(),
+				Schema:       s,
+				DisableCache: disableCache,
+			})
+			require.NoError(t, err)
+			defer db.Close()
+
+			name := datalog.NewKeyword(":person/name")
+			tags := datalog.NewKeyword(":person/tags")
+			steps := datalog.NewKeyword(":person/steps")
+			undeclared := datalog.NewKeyword(":person/nickname")
+			entities := make([]datalog.Identity, 64)
+			addedSteps := make(map[[20]byte][]string)
+			tx := db.NewTransaction()
+			for i := range entities {
+				entity := datalog.NewIdentity(fmt.Sprintf("batch-differential-%d", i))
+				entities[i] = entity
+				if random.Intn(4) != 0 {
+					require.NoError(t, tx.Set(entity, name, fmt.Sprintf("Name %d", i)))
+				}
+				if random.Intn(3) == 0 {
+					require.NoError(t, tx.Set(entity, undeclared, fmt.Sprintf("Nick %d", i)))
+				}
+				for tag := 0; tag < random.Intn(4); tag++ {
+					require.NoError(t, tx.Add(entity, tags, fmt.Sprintf("tag-%d", tag)))
+				}
+				for step := 0; step < random.Intn(4); step++ {
+					value := fmt.Sprintf("step-%d", step)
+					require.NoError(t, tx.Add(entity, steps, value))
+					addedSteps[entity.Hash()] = append(addedSteps[entity.Hash()], value)
+				}
+			}
+			_, err = tx.Commit()
+			require.NoError(t, err)
+
+			tx = db.NewTransaction()
+			for i, entity := range entities {
+				if i%5 == 0 {
+					for _, value := range addedSteps[entity.Hash()] {
+						require.NoError(t, tx.Remove(entity, steps, value))
+					}
+				}
+				if i%7 == 0 {
+					require.NoError(t, tx.Remove(entity, name, fmt.Sprintf("Name %d", i)))
+				}
+			}
+			_, err = tx.Commit()
+			require.NoError(t, err)
+
+			expected := make([]map[datalog.Keyword]interface{}, len(entities))
+			for i, entity := range entities {
+				expected[i], err = db.ResolveAllAttributes(entity)
+				require.NoError(t, err)
+			}
+			actual, err := db.ResolveAllAttributesMany(entities)
+			require.NoError(t, err)
+			require.Len(t, actual, len(expected))
+			for i := range expected {
+				require.Equal(t,
+					normalizeWildcardAttributes(expected[i]),
+					normalizeWildcardAttributes(actual[i]),
+					"entity %d", i,
+				)
+			}
+		})
+	}
+}
+
+func TestResolveAllAttributesManyHistoryMatchesPerEntity(t *testing.T) {
+	db, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	defer db.Close()
+
+	entity := datalog.NewIdentity("batch-history")
+	name := datalog.NewKeyword(":person/name")
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Set(entity, name, "First"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+	tx = db.NewTransaction()
+	require.NoError(t, tx.Set(entity, name, "Second"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	history := db.History()
+	perEntity, err := history.ResolveAllAttributes(entity)
+	require.NoError(t, err)
+	batch, err := history.ResolveAllAttributesMany([]datalog.Identity{entity})
+	require.NoError(t, err)
+	require.Equal(t, perEntity, batch[0])
+}
+
 func TestWildcardPullQueryUsesOneBatch(t *testing.T) {
 	var batchBegins, batchCompletes int
 	db, err := NewDatabaseWithOptions(DatabaseOptions{
@@ -177,6 +353,63 @@ func TestWildcardPullQueryUsesOneBatch(t *testing.T) {
 		require.Equal(t, "scenario", pulled["entity/type"])
 		require.NotNil(t, pulled[query.DBIDKey])
 	}
+}
+
+func TestWildcardPullQueryRendersMultiValuedAttributes(t *testing.T) {
+	s, err := schema.NewBuilder().
+		Attribute(":entity/type").Type(schema.TypeString).One().Add().
+		Attribute(":entity/tags").Type(schema.TypeString).Many().Add().
+		Attribute(":entity/steps").Type(schema.TypeString).Vector().Add().
+		Build()
+	require.NoError(t, err)
+	db, err := NewDatabaseWithOptions(DatabaseOptions{Path: t.TempDir(), Schema: s})
+	require.NoError(t, err)
+	defer db.Close()
+
+	entityType := datalog.NewKeyword(":entity/type")
+	tags := datalog.NewKeyword(":entity/tags")
+	steps := datalog.NewKeyword(":entity/steps")
+	tx := db.NewTransaction()
+	for i := 0; i < 3; i++ {
+		entity := datalog.NewIdentity(fmt.Sprintf("multi:%d", i))
+		require.NoError(t, tx.Set(entity, entityType, "multi"))
+		require.NoError(t, tx.Add(entity, tags, "one"))
+		require.NoError(t, tx.Add(entity, tags, "two"))
+		require.NoError(t, tx.Add(entity, steps, "first"))
+		require.NoError(t, tx.Add(entity, steps, "second"))
+	}
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	result, queryErr := db.Query(`[:find (pull ?entity [*])
+		:where [?entity :entity/type "multi"]]`)
+	rows, err := executor.CollectTuples(result, queryErr)
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+	for _, row := range rows {
+		pulled := row[0].(map[string]interface{})
+		require.ElementsMatch(t, []interface{}{"one", "two"}, pulled["entity/tags"])
+		require.Equal(t, []string{"first", "second"}, pulled["entity/steps"])
+	}
+}
+
+func normalizeWildcardAttributes(
+	attrs map[datalog.Keyword]interface{},
+) map[datalog.Keyword]interface{} {
+	normalized := make(map[datalog.Keyword]interface{}, len(attrs))
+	for attr, value := range attrs {
+		if values, ok := value.([]interface{}); ok {
+			items := make([]string, len(values))
+			for i, item := range values {
+				items[i] = fmt.Sprintf("%T:%v", item, item)
+			}
+			sort.Strings(items)
+			normalized[attr] = items
+		} else {
+			normalized[attr] = value
+		}
+	}
+	return normalized
 }
 
 func BenchmarkResolveAllAttributesMany(b *testing.B) {

--- a/docs/bugs/resolved/BUG_WILDCARD_PULL_PER_ENTITY_TRANSACTIONS.md
+++ b/docs/bugs/resolved/BUG_WILDCARD_PULL_PER_ENTITY_TRANSACTIONS.md
@@ -1,0 +1,100 @@
+# Wildcard Pull Opened One Badger Transaction Per Entity
+
+**Status:** Resolved (2026-07-13)
+
+## Summary
+
+A find expression such as:
+
+```clojure
+[:find (pull ?entity [*])
+ :where [?entity :entity/type "scenario"]]
+```
+
+rendered the pull once per result tuple. Each wildcard called
+`Database.ResolveAllAttributes`, whose entity scan owned a fresh Badger read
+transaction and iterator. N matched entities therefore created and discarded N
+transactions after relational query execution had already completed.
+
+The per-entity loop predates v0.14.0. Moving Pull rendering to the final result
+boundary in v0.14.0 made its cost fall outside the `query/completed` annotation,
+which exposed the transaction churn as a large traced-time gap. Downstream issue
+TTR-381 supplied the decisive scheduler trace:
+
+- 71.07% under `badger.(*Txn).Discard`.
+- Approximately 19–21% under iterator seek/block loading.
+- 7.73% under `badger.(*DB).NewTransaction`.
+
+## Root Cause
+
+`applyFindPulls` called `PullExecutor.Pull` inside its tuple loop.
+`PullExecutor.PullMany` also looped over `Pull`. The wildcard resolver interface
+only accepted one entity:
+
+```go
+ResolveAllAttributes(entity datalog.Identity)
+```
+
+At the storage boundary, `BadgerStore.Scan` correctly gave each independent scan
+its own transaction. The defect was issuing independent scans for a result set
+whose entity IDs were already known together.
+
+There was no existing query-wide Badger transaction to reuse. Adding one would
+have changed lazy Relation lifetimes, cache/snapshot semantics, subqueries,
+multi-source execution, and concurrency. The fix is deliberately scoped to
+wildcard Pull finalization.
+
+## Fix
+
+`BatchEntityResolver` adds ordered multi-entity wildcard resolution.
+`applyFindPulls` first collects the result tuples, then calls `PullMany` once per
+pull expression. Exact `[*]` patterns use the batch resolver; explicit,
+defaulted, limited, and nested patterns retain their existing behavior.
+
+`Database.ResolveAllAttributesMany`:
+
+1. Deduplicates entities and sorts them by identity bytes, matching EATV order.
+2. Opens one Badger read transaction and one iterator.
+3. Seeks each entity's EATV range through that iterator.
+4. Groups datoms by attribute and applies the canonical LWW, add-wins, or RGA
+   resolution functions.
+5. Populates the EA cache when enabled.
+6. Preserves input order in returned results.
+
+Latest and AsOf modes filter transactions exactly as their matcher does.
+Unique attributes retain walk-based ownership/fallback resolution. History mode
+retains its prior raw-mode path. Duplicate input entities are scanned once but
+receive independent result maps.
+
+`pull/batch.begin` and `pull/batch.complete` annotations expose entity count,
+attribute count, latency, mode, and success at the result boundary.
+
+## Verification
+
+Tests cover:
+
+- Query-level `(pull ?entity [*])` over 230 matched entities and exact batch
+  annotation counts.
+- Cache-enabled and cache-disabled resolution.
+- CardinalityOne tombstones, CardinalityMany sets, CardinalityVector ordering,
+  missing entities/attributes, duplicate entities, and input-order preservation.
+- AsOf visibility.
+- Unique-attribute ownership fallback.
+- Batch resolver and input iterator/close error propagation.
+
+Focused storage benchmark, five attributes per entity with cache disabled:
+
+| Entities | Per-entity | Batch | Time | Memory | Allocations |
+|---------:|-----------:|------:|-----:|-------:|------------:|
+| 230 | 4.829 ms | 335.4 µs | 14.4× faster | 90.9% less | 89.7% fewer |
+| 3,899 | 64.19 ms | 5.917 ms | 10.8× faster | 90.9% less | 89.7% fewer |
+
+The full repository suite passes.
+
+## Architectural Lesson
+
+When a complete binding set is already available, a storage operation should
+accept that set as one execution unit. Repeating a correctly isolated
+single-entity API can still create pathological transaction and iterator
+lifecycle costs. A targeted batch boundary avoids that cost without forcing
+query-wide snapshot ownership into every lazy Relation.

--- a/docs/bugs/resolved/BUG_WILDCARD_PULL_PER_ENTITY_TRANSACTIONS.md
+++ b/docs/bugs/resolved/BUG_WILDCARD_PULL_PER_ENTITY_TRANSACTIONS.md
@@ -54,7 +54,8 @@ defaulted, limited, and nested patterns retain their existing behavior.
 `Database.ResolveAllAttributesMany`:
 
 1. Deduplicates entities and sorts them by identity bytes, matching EATV order.
-2. Opens one Badger read transaction and one iterator.
+2. Opens one Badger read transaction and one iterator for the non-unique EATV
+   ranges that dominate wildcard resolution.
 3. Seeks each entity's EATV range through that iterator.
 4. Groups datoms by attribute and applies the canonical LWW, add-wins, or RGA
    resolution functions.
@@ -65,6 +66,16 @@ Latest and AsOf modes filter transactions exactly as their matcher does.
 Unique attributes retain walk-based ownership/fallback resolution. History mode
 retains its prior raw-mode path. Duplicate input entities are scanned once but
 receive independent result maps.
+
+When a schema is present, the batch path applies the same declared-attribute set
+as single-entity `ResolveAllAttributes`; stored undeclared attributes remain
+excluded from wildcard results. Fully tombstoned CardinalityVector attributes
+are present as typed empty vectors, while never-set vectors remain absent. The
+cache-enabled and cache-disabled single-entity paths now share that distinction.
+
+Unique-attribute ownership walks and Tier-3 blob dereferences may open additional
+specialized reads; the single transaction claim applies to the dominant batched
+EATV traversal, not every possible storage access.
 
 `pull/batch.begin` and `pull/batch.complete` annotations expose entity count,
 attribute count, latency, mode, and success at the result boundary.
@@ -80,6 +91,11 @@ Tests cover:
   missing entities/attributes, duplicate entities, and input-order preservation.
 - AsOf visibility.
 - Unique-attribute ownership fallback.
+- Declared-schema filtering of stored undeclared attributes.
+- Differential batch-versus-single resolution over randomized schema-backed data.
+- Fully tombstoned versus never-set vector semantics in both cache modes.
+- History-mode fallback and exact-wildcard gate decline for mixed patterns.
+- Multi-valued attributes through the end-to-end rendered Pull boundary.
 - Batch resolver and input iterator/close error propagation.
 
 Focused storage benchmark, five attributes per entity with cache disabled:


### PR DESCRIPTION
## Summary

Exact wildcard find pulls now resolve the complete matched entity set through one batched EATV traversal instead of opening and discarding one transaction per entity.

The triggering downstream query was:

```clojure
[:find (pull ?entity [*])
 :where [?entity :entity/type "scenario"]]
```

At 230 matched entities, scheduler tracing attributed 71.07% of delay to `Txn.Discard`, approximately 19–21% to iterator seek/block loading, and 7.73% to `NewTransaction`. Relational query execution itself completed in milliseconds while wildcard result rendering dominated wall time.

The per-entity loop predates v0.14.0. Moving Pull rendering to the final result boundary in v0.14.0 made this work fall after `query/completed`, exposing both the transaction churn and the annotation gap. There is no existing query-wide Badger transaction to reuse, so this PR introduces a targeted batch boundary rather than changing snapshot ownership for every lazy Relation.

Resolves downstream issue TTR-381.

## Execution change

`applyFindPulls` now:

1. Drains and copies the finalized result tuples while preserving iterator and close errors.
2. Collects the entity values for each pull expression.
3. Calls `PullMany` once per pull expression.
4. Restores pulled maps at their original tuple positions with `db/id` retained for `QueryInto` decoding.

`PullMany` and `PullResolvedMany` use the new optional `BatchEntityResolver` only for exact `[*]` patterns. Explicit attributes, defaults, limits, nested references, mixed wildcard patterns, non-entity values, and resolvers without batch support retain the existing per-entity path.

The exported `PullContext` interface is unchanged.

## Storage batching

`Database.ResolveAllAttributesMany` performs the dominant wildcard resolution as one storage operation:

- Deduplicates input identities while preserving output multiplicity and order.
- Sorts unique entities by raw identity bytes to follow EATV disk order.
- Opens one Badger read transaction and one iterator for non-unique EATV ranges.
- Seeks each entity's range through that iterator.
- Groups datoms by attribute.
- Applies the canonical LWW, add-wins, and RGA resolution functions.
- Populates the EA cache when enabled.
- Returns independent maps, vectors, sets, and byte values for duplicate entities.

Unique-attribute ownership walks and Tier-3 blob dereferences retain their specialized reads and may open additional transactions. This avoids introducing query-scoped transaction lifetime into matchers, subqueries, multi-source execution, and lazy Relation ownership.

## Semantic boundaries

The batch path now has direct differential coverage against per-entity `ResolveAllAttributes` and preserves its behavior:

- With a schema, wildcard results contain only declared attributes; additive stored undeclared attributes remain excluded.
- Schemaless wildcard results contain all stored attributes.
- Latest and AsOf use the matcher's transaction visibility filter.
- CardinalityOne tombstones omit the attribute.
- CardinalityMany returns the resolved add-wins members.
- A fully tombstoned CardinalityVector is present as a typed empty vector.
- A never-set CardinalityVector is absent.
- Unique attributes continue through walk-based ownership/fallback resolution.
- History retains its existing raw-mode path.
- Missing entities and attributes remain absent.
- Cache-enabled and cache-disabled databases produce equivalent results.
- Duplicate input identities are scanned once but receive independently mutable results.

The fully-cleared-vector distinction also fixes the prior cache-on/cache-off disagreement in single-entity wildcard resolution.

## Structured observability

Adds:

- `pull/batch.begin`
- `pull/batch.complete`

The events report entity count, specification count, resolved mode, total attribute count, latency, and success. Result-boundary Pull receives the query collector's handler, so work occurring after `query/completed` is visible directly rather than inferred from wall time.

## Performance

Focused benchmark: five attributes per entity, cache disabled, 10 iterations, darwin/arm64.

| Entities | Per-entity transactions | Batched EATV scan | Speedup | Memory | Allocations |
|---------:|------------------------:|------------------:|--------:|-------:|------------:|
| 230 | 4.829 ms | 335.4 µs | 14.4× | 90.9% less | 89.7% fewer |
| 3,899 | 64.19 ms | 5.917 ms | 10.8× | 90.9% less | 89.7% fewer |

These are focused storage-resolution measurements, not a claim that every full application query improves by the same ratio. Explicit and nested pull patterns are unchanged.

## Tests

New coverage includes:

- The exact 230-entity `(pull ?entity [*])` query shape from TTR-381.
- Exactly one batch begin/complete event for that result set.
- `QueryInto`-compatible `db/id` rendering.
- Cache-enabled and cache-disabled resolution.
- CardinalityOne, CardinalityMany, and CardinalityVector behavior.
- Tombstones, missing attributes, missing entities, and duplicate entities.
- Declared-schema filtering of stored undeclared attributes.
- Fully tombstoned versus never-set vectors in both cache modes.
- Latest, AsOf, and History behavior.
- Unique-attribute ownership fallback.
- Independent vector/set/byte results for duplicate identities.
- Mixed wildcard patterns declining the batch path.
- Multi-valued attributes through the end-to-end rendered query boundary.
- Batch resolver errors and input iterator/close errors.
- A deterministic randomized differential across 64 schema-backed entities in both cache modes, covering undeclared attributes, missing values, sets, vectors, tombstones, and explicit clears.
- Focused per-entity versus batch benchmarks at 230 and 3,899 entities.

## Test plan

- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./datalog/executor ./datalog/storage`
- [x] Shuffled executor/storage package suite
- [x] Focused wildcard batching and exact query integration tests
- [x] Randomized batch-versus-per-entity differential in cache-on/off modes
- [x] `BenchmarkResolveAllAttributesMany` with 10 iterations and allocation reporting

## Documentation

Updates `PERFORMANCE_STATUS.md` with the measured result and qualified transaction scope. `docs/bugs/resolved/BUG_WILDCARD_PULL_PER_ENTITY_TRANSACTIONS.md` records the downstream evidence, actual version history, schema/vector semantics, scoped design, measurements, and verification.
