### PR TITLE
Support predicate-correlated not-join headers

### DIFF
--- a/.claude/skills/datalog/SKILL.md
+++ b/.claude/skills/datalog/SKILL.md
@@ -149,6 +149,18 @@ Queries are EDN vectors. The basic form:
   [?p :person/status "inactive"])
 ```
 
+`not-join` headers must include every outer variable consumed by the body,
+including predicate/expression-only inputs:
+```clojure
+[?goal :goal/set-type ?goalSet]
+(not-join [?goal ?goalSet]
+  [?event :event/goal ?goal]
+  [?event :event/type ?eventType]
+  [(!= ?eventType ?goalSet)])
+```
+Variables produced by both sides are equality keys; outer variables consumed
+only by body predicates are correlation inputs. Plain `not` infers both.
+
 **OR clauses** — alternative patterns:
 ```clojure
 (or [?p :person/city "New York"]
@@ -156,6 +168,14 @@ Queries are EDN vectors. The basic form:
 (or-join [?p]
   [?p :role/admin true]
   [?p :role/superuser true])
+```
+
+Every `or-join` branch must bind every header variable. Keep branch-specific
+filter inputs out of the header:
+```clojure
+(or-join [?e]
+  [?e :entity/crawl ?crawl]
+  [?e :entity/world ?world])
 ```
 
 **Vector functions** — operate on cardinality-vector attributes:

--- a/DATOMIC_COMPATIBILITY.md
+++ b/DATOMIC_COMPATIBILITY.md
@@ -235,6 +235,24 @@ Logical negation and disjunction for complex query patterns:
                   [?e :deleted true])]
 ```
 
+The header must include every outer variable consumed by the body, including
+variables used only by predicates or expressions:
+
+```clojure
+[:find ?goal
+ :where
+ [?goal :goal/set-type ?goalSet]
+ (not-join [?goal ?goalSet]
+   [?event :event/goal ?goal]
+   [?event :event/type ?eventType]
+   [(!= ?eventType ?goalSet)])]
+```
+
+Here `?goal` is produced by both sides and acts as an equality key.
+`?goalSet` is supplied by the outer tuple and consumed only by the body
+predicate. Omitting it from the header is invalid. Plain `not` infers both
+right-produced equality keys and predicate/expression correlation inputs.
+
 **OR - Union of branches:**
 ```clojure
 [:find ?name
@@ -250,6 +268,16 @@ Logical negation and disjunction for complex query patterns:
         (or-join [?e]
                  [?e :user/status "active"]
                  [?e :admin/status "enabled"])]
+```
+
+Every `or-join` branch must bind every header variable. The header is the shared
+branch output interface, not a list of branch-specific filter inputs:
+
+```clojure
+;; Valid: both branches bind ?e.
+(or-join [?e]
+  [?e :entity/crawl ?crawl]
+  [?e :entity/world ?world])
 ```
 
 **OR semantics (Datomic-compatible):**

--- a/datalog/algebra/analysis.go
+++ b/datalog/algebra/analysis.go
@@ -82,6 +82,7 @@ func RefreshSchemas(root *Node) (*Node, error) {
 			}
 			copy := *data
 			copy.JoinSymbols = cloneSymbols(data.JoinSymbols)
+			copy.Required = cloneSymbols(data.Required)
 			copy.Output = cloneSymbols(children[0].Symbols())
 			refreshed.Data = &copy
 		case *Union:
@@ -342,9 +343,40 @@ func analyzeAntiJoin(node *Node, children []Analysis) (Analysis, error) {
 	if !ok {
 		return Analysis{}, dataTypeError(node, "*algebra.AntiJoin")
 	}
+	for _, symbol := range data.Required {
+		if !containsSymbol(data.JoinSymbols, symbol) {
+			return Analysis{}, fmt.Errorf("correlation requirement %s is not declared as an anti-join symbol", symbol)
+		}
+		if !containsSymbol(children[0].Output, symbol) {
+			return Analysis{}, fmt.Errorf("correlation requirement %s is not produced by the left child", symbol)
+		}
+		if containsSymbol(children[1].Output, symbol) {
+			return Analysis{}, fmt.Errorf("correlation requirement %s is already produced by the right child", symbol)
+		}
+		if !containsSymbol(children[1].Required, symbol) {
+			return Analysis{}, fmt.Errorf("correlation requirement %s is not a free requirement of the right child", symbol)
+		}
+	}
 	for _, symbol := range data.JoinSymbols {
-		if !containsSymbol(children[0].Output, symbol) || !containsSymbol(children[1].Output, symbol) {
-			return Analysis{}, fmt.Errorf("anti-join symbol %s must be produced by both children", symbol)
+		if !containsSymbol(children[0].Output, symbol) {
+			return Analysis{}, fmt.Errorf("anti-join symbol %s must be produced by the left child", symbol)
+		}
+		if !containsSymbol(children[1].Output, symbol) && !containsSymbol(data.Required, symbol) {
+			return Analysis{}, fmt.Errorf(
+				"anti-join symbol %s must be produced by the right child or declared as a correlation requirement",
+				symbol,
+			)
+		}
+	}
+	for _, symbol := range children[1].Required {
+		if symbol.IsSource() || containsSymbol(children[1].Output, symbol) {
+			continue
+		}
+		if containsSymbol(children[0].Output, symbol) && !containsSymbol(data.Required, symbol) {
+			return Analysis{}, fmt.Errorf(
+				"right child requires outer symbol %s but the anti-join does not declare it as a correlation requirement",
+				symbol,
+			)
 		}
 	}
 	if !sameSymbolsInOrder(data.Output, children[0].Output) {
@@ -383,6 +415,15 @@ func analyzeUnionBranches(output, joinVars, outerRequired []query.Symbol, childr
 				continue
 			}
 			if !containsSymbol(child.Output, symbol) {
+				if len(joinVars) > 0 && containsSymbol(joinVars, symbol) {
+					return Analysis{}, fmt.Errorf(
+						"or-join header declares %s, but branch %d schema %v does not bind it; every branch must bind every header variable; if %s is an input filter rather than an output, remove it from the header",
+						symbol,
+						i,
+						child.Output,
+						symbol,
+					)
+				}
 				return Analysis{}, fmt.Errorf("union branch %d schema %v does not provide output symbol %s", i, child.Output, symbol)
 			}
 		}

--- a/datalog/algebra/analysis_test.go
+++ b/datalog/algebra/analysis_test.go
@@ -289,6 +289,49 @@ func TestAnalyzeAntiJoinDoesNotTreatRightOutputAsLeftEnvironment(t *testing.T) {
 		"the right side of an anti-join filters left tuples but cannot satisfy the left environment")
 }
 
+func TestAnalyzeCorrelatedAntiJoinRequirements(t *testing.T) {
+	goal := datalog.NewSymbol("?goal")
+	goalSet := datalog.NewSymbol("?goalSet")
+	termType := datalog.NewSymbol("?termType")
+	left := algebraTestScan(goal, goalSet)
+	rightScan := algebraTestScan(goal, termType)
+	right := &Node{
+		Op:       RuleSelect,
+		Children: []*Node{rightScan},
+		Data: &Select{
+			Required: []query.Symbol{termType, goalSet},
+			Output:   []query.Symbol{goal, termType},
+		},
+	}
+	anti := &Node{
+		Op:       RuleAntiJoin,
+		Children: []*Node{left, right},
+		Data: &AntiJoin{
+			JoinSymbols:  []query.Symbol{goal, goalSet},
+			Required:     []query.Symbol{goalSet},
+			Output:       []query.Symbol{goal, goalSet},
+			ExplicitJoin: true,
+		},
+	}
+
+	analysis, err := Analyze(anti)
+	require.NoError(t, err)
+	require.Empty(t, analysis[anti].Required)
+
+	unused := datalog.NewSymbol("?unused")
+	invalid := *anti
+	invalid.Children = []*Node{algebraTestScan(goal, goalSet, unused), right}
+	invalidData := *anti.Data.(*AntiJoin)
+	invalidData.JoinSymbols = append(cloneSymbols(invalidData.JoinSymbols), unused)
+	invalidData.Required = []query.Symbol{unused}
+	invalidData.Output = []query.Symbol{goal, goalSet, unused}
+	invalid.Data = &invalidData
+	_, err = Analyze(&invalid)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "correlation requirement ?unused")
+	require.Contains(t, err.Error(), "not a free requirement of the right child")
+}
+
 func TestAnalyzeRejectsAggregateOutputWithWrongGroupPrefix(t *testing.T) {
 	group := datalog.NewSymbol("?group")
 	value := datalog.NewSymbol("?value")

--- a/datalog/algebra/compile.go
+++ b/datalog/algebra/compile.go
@@ -216,16 +216,36 @@ func compileNot(nc *query.NotClause, current *Node) (*Node, error) {
 		return nil, fmt.Errorf("NOT inner clauses: %w", err)
 	}
 
-	// Join symbols = variables shared between current and inner.
-	// The algebra bridge resolves NOT's context-dependent join variables
-	// statically and emits NotJoinClause so the executor needs no runtime
-	// inference. This is the not → not-join conversion.
+	// Join symbols include right-produced equality keys and predicate-only
+	// requirements supplied by the outer relation. The algebra bridge resolves
+	// NOT's context-dependent join variables statically and emits NotJoinClause
+	// so the executor needs no runtime inference.
 	joinSyms := sharedSymbols(current.Symbols(), inner.Symbols())
+	analysis, err := Analyze(inner)
+	if err != nil {
+		return nil, fmt.Errorf("NOT inner analysis: %w", err)
+	}
+	var required []query.Symbol
+	for _, symbol := range analysis[inner].Required {
+		if symbol.IsSource() {
+			continue
+		}
+		if !containsSymbol(current.Symbols(), symbol) {
+			return nil, fmt.Errorf("NOT body requires unbound outer symbol %s", symbol)
+		}
+		if !containsSymbol(joinSyms, symbol) {
+			joinSyms = append(joinSyms, symbol)
+		}
+		if !containsSymbol(inner.Symbols(), symbol) {
+			required = append(required, symbol)
+		}
+	}
 
 	return &Node{
 		Op: RuleAntiJoin,
 		Data: &AntiJoin{
 			JoinSymbols:  joinSyms,
+			Required:     required,
 			Output:       current.Symbols(),
 			ExplicitJoin: true,
 		},
@@ -243,11 +263,49 @@ func compileNotJoin(nj *query.NotJoinClause, current *Node) (*Node, error) {
 	if err != nil {
 		return nil, fmt.Errorf("NOT-JOIN inner clauses: %w", err)
 	}
+	analysis, err := Analyze(inner)
+	if err != nil {
+		return nil, fmt.Errorf("NOT-JOIN inner analysis: %w", err)
+	}
+	right := analysis[inner]
+	for _, symbol := range nj.JoinVars {
+		if !containsSymbol(current.Symbols(), symbol) {
+			return nil, fmt.Errorf("not-join header symbol %s is not bound by the outer relation", symbol)
+		}
+	}
+	for _, symbol := range right.Required {
+		if symbol.IsSource() {
+			continue
+		}
+		if !containsSymbol(current.Symbols(), symbol) {
+			return nil, fmt.Errorf("NOT-JOIN body requires unbound outer symbol %s", symbol)
+		}
+		if !containsSymbol(nj.JoinVars, symbol) {
+			return nil, fmt.Errorf(
+				"not-join header must declare outer requirement %s used by the body",
+				symbol,
+			)
+		}
+	}
+	var required []query.Symbol
+	for _, symbol := range nj.JoinVars {
+		if containsSymbol(inner.Symbols(), symbol) {
+			continue
+		}
+		if !containsSymbol(right.Required, symbol) {
+			return nil, fmt.Errorf(
+				"not-join header symbol %s is neither produced nor consumed by the body",
+				symbol,
+			)
+		}
+		required = append(required, symbol)
+	}
 
 	return &Node{
 		Op: RuleAntiJoin,
 		Data: &AntiJoin{
 			JoinSymbols:  nj.JoinVars,
+			Required:     required,
 			Output:       current.Symbols(),
 			ExplicitJoin: true, // NotJoinClause — user specified join vars
 		},

--- a/datalog/algebra/compile_test.go
+++ b/datalog/algebra/compile_test.go
@@ -161,6 +161,100 @@ func TestCompileDecompileWithNot(t *testing.T) {
 	assert.Equal(t, len(q.Where), len(clauses))
 }
 
+func TestCompileCorrelatedNotJoinSeparatesKeysAndRequirements(t *testing.T) {
+	q, err := parser.ParseQuery(`[:find ?goal
+		:where
+		[?goal :entity/type :type/goal]
+		[?setEvent :event/goal ?goal]
+		[?setEvent :event/type ?goalSet]
+		(not-join [?goal ?goalSet]
+			[?termEvent :event/goal ?goal]
+			[?termEvent :event/type ?termType]
+			[(!= ?termType ?goalSet)])]`)
+	require.NoError(t, err)
+
+	root, err := Compile(q)
+	require.NoError(t, err)
+	antiNode := findAlgebraNode(root, RuleAntiJoin)
+	require.NotNil(t, antiNode)
+	anti := antiNode.Data.(*AntiJoin)
+	require.Equal(t,
+		[]query.Symbol{datalog.NewSymbol("?goal"), datalog.NewSymbol("?goalSet")},
+		anti.JoinSymbols,
+	)
+	require.Equal(t,
+		[]query.Symbol{datalog.NewSymbol("?goalSet")},
+		anti.Required,
+	)
+
+	optimizer := NewOptimizer(DefaultPasses()...)
+	optimized, err := optimizer.Optimize(root)
+	require.NoError(t, err)
+	clauses, err := Decompile(optimized)
+	require.NoError(t, err)
+	notJoin, ok := clauses[len(clauses)-1].(*query.NotJoinClause)
+	require.True(t, ok)
+	require.Equal(t, anti.JoinSymbols, notJoin.JoinVars)
+}
+
+func TestCompileRejectsInvalidNotJoinHeaders(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name: "header symbol not bound outside",
+			query: `[:find ?goal
+				:where
+				[?goal :entity/type :type/goal]
+				(not-join [?goal ?missing]
+					[?event :event/goal ?goal])]`,
+			want: "header symbol ?missing is not bound by the outer relation",
+		},
+		{
+			name: "header symbol unused by body",
+			query: `[:find ?goal
+				:where
+				[?goal :entity/type :type/goal]
+				[?goal :entity/name ?name]
+				(not-join [?goal ?name]
+					[?event :event/goal ?goal])]`,
+			want: "header symbol ?name is neither produced nor consumed by the body",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			q, err := parser.ParseQuery(testCase.query)
+			require.NoError(t, err)
+			_, err = Compile(q)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), testCase.want)
+		})
+	}
+}
+
+func TestOrJoinSchemaDiagnosticExplainsHeaderContract(t *testing.T) {
+	q, err := parser.ParseQuery(`[:find ?entity
+		:in $ ?room ?crawl ?world
+		:where
+		[?entity :entity/location ?room]
+		(or-join [?entity ?crawl ?world]
+			[?entity :entity/crawl ?crawl]
+			[?entity :entity/world ?world])]`)
+	require.NoError(t, err)
+	root, err := Compile(q)
+	require.NoError(t, err)
+
+	optimizer := NewOptimizer(DefaultPasses()...)
+	_, err = optimizer.Optimize(root)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "or-join header declares ?world")
+	require.Contains(t, err.Error(), "every branch must bind every header variable")
+	require.Contains(t, err.Error(), "remove it from the header")
+}
+
 // TestCompileDecompileWithGetElse verifies get-else survives the pipeline.
 func TestCompileDecompileWithGetElse(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?e ?title

--- a/datalog/algebra/compile_test.go
+++ b/datalog/algebra/compile_test.go
@@ -235,6 +235,21 @@ func TestCompileRejectsInvalidNotJoinHeaders(t *testing.T) {
 	}
 }
 
+func TestCompileRejectsPlainNotWithUnboundOuterRequirement(t *testing.T) {
+	q, err := parser.ParseQuery(`[:find ?goal
+		:where
+		[?goal :entity/type :type/goal]
+		(not
+			[?event :event/goal ?goal]
+			[?event :event/type ?termType]
+			[(!= ?termType ?missing)])]`)
+	require.NoError(t, err)
+
+	_, err = Compile(q)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "NOT body requires unbound outer symbol ?missing")
+}
+
 func TestOrJoinSchemaDiagnosticExplainsHeaderContract(t *testing.T) {
 	q, err := parser.ParseQuery(`[:find ?entity
 		:in $ ?room ?crawl ?world

--- a/datalog/algebra/types.go
+++ b/datalog/algebra/types.go
@@ -165,6 +165,7 @@ func (j *Join) String() string {
 // Compiled from query.NotClause / query.NotJoinClause.
 type AntiJoin struct {
 	JoinSymbols  []query.Symbol // Variables to anti-join on
+	Required     []query.Symbol // Correlation inputs supplied by the left relation
 	Output       []query.Symbol // Same as left child's output
 	ExplicitJoin bool           // True if compiled from NotJoinClause (user specified join vars)
 }

--- a/datalog/storage/correlated_not_join_test.go
+++ b/datalog/storage/correlated_not_join_test.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+func TestCorrelatedNotJoinPredicateInputMatchesUnoptimizedExecution(t *testing.T) {
+	db, retained := openCorrelatedNotJoinDatabase(t)
+	source := `[:find ?goal
+		:where
+		[?goal :entity/type :type/goal]
+		[?setEvent :event/goal ?goal]
+		[?setEvent :event/type ?goalSet]
+		(not-join [?goal ?goalSet]
+			[?termEvent :event/goal ?goal]
+			[?termEvent :event/type ?termType]
+			[(!= ?termType ?goalSet)])]`
+
+	baselineOptions := DefaultPlannerOptions()
+	baselineOptions.EnableAlgebraOptimizer = false
+	baseline := executePlannerOptions(t, db, source, nil, baselineOptions)
+	require.Equal(t, [][]interface{}{{retained}}, baseline)
+
+	optimizedOptions := DefaultPlannerOptions()
+	optimizedOptions.EnableAlgebraOptimizer = true
+	optimized := executePlannerOptions(t, db, source, nil, optimizedOptions)
+	require.Equal(t, baseline, optimized)
+}
+
+func TestCorrelatedNotPredicateInputExecutesWithAlgebra(t *testing.T) {
+	db, retained := openCorrelatedNotJoinDatabase(t)
+	source := `[:find ?goal
+		:where
+		[?goal :entity/type :type/goal]
+		[?setEvent :event/goal ?goal]
+		[?setEvent :event/type ?goalSet]
+		(not
+			[?termEvent :event/goal ?goal]
+			[?termEvent :event/type ?termType]
+			[(!= ?termType ?goalSet)])]`
+
+	optimizedOptions := DefaultPlannerOptions()
+	optimizedOptions.EnableAlgebraOptimizer = true
+	optimized := executePlannerOptions(t, db, source, nil, optimizedOptions)
+	require.Equal(t, [][]interface{}{{retained}}, optimized)
+}
+
+func TestCorrelatedNotJoinRequiresOuterInputsInHeader(t *testing.T) {
+	db, _ := openCorrelatedNotJoinDatabase(t)
+	source := `[:find ?goal
+		:where
+		[?goal :entity/type :type/goal]
+		[?setEvent :event/goal ?goal]
+		[?setEvent :event/type ?goalSet]
+		(not-join [?goal]
+			[?termEvent :event/goal ?goal]
+			[?termEvent :event/type ?termType]
+			[(!= ?termType ?goalSet)])]`
+
+	_, err := db.Query(source)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not-join header")
+	require.Contains(t, err.Error(), "?goalSet")
+}
+
+func openCorrelatedNotJoinDatabase(t *testing.T) (*Database, datalog.Identity) {
+	t.Helper()
+	db, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	excluded := datalog.NewIdentity("goal:excluded")
+	retained := datalog.NewIdentity("goal:retained")
+	excludedSet := datalog.NewIdentity("event:excluded:set")
+	excludedTerm := datalog.NewIdentity("event:excluded:term")
+	retainedSet := datalog.NewIdentity("event:retained:set")
+	retainedTerm := datalog.NewIdentity("event:retained:term")
+	entityType := datalog.NewKeyword(":entity/type")
+	eventGoal := datalog.NewKeyword(":event/goal")
+	eventType := datalog.NewKeyword(":event/type")
+	goalType := datalog.NewKeyword(":type/goal")
+	goalSetType := datalog.NewKeyword(":event.type/goal-set")
+	goalTermType := datalog.NewKeyword(":event.type/goal-terminate")
+
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(excluded, entityType, goalType))
+	require.NoError(t, tx.Add(retained, entityType, goalType))
+	require.NoError(t, tx.Add(excludedSet, eventGoal, excluded))
+	require.NoError(t, tx.Add(excludedSet, eventType, goalSetType))
+	require.NoError(t, tx.Add(excludedTerm, eventGoal, excluded))
+	require.NoError(t, tx.Add(excludedTerm, eventType, goalTermType))
+	require.NoError(t, tx.Add(retainedSet, eventGoal, retained))
+	require.NoError(t, tx.Add(retainedSet, eventType, goalSetType))
+	require.NoError(t, tx.Add(retainedTerm, eventGoal, retained))
+	require.NoError(t, tx.Add(retainedTerm, eventType, goalSetType))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+	return db, retained
+}

--- a/docs/ALGEBRA.md
+++ b/docs/ALGEBRA.md
@@ -215,12 +215,22 @@ SubqueryPattern branch and default branch.
 
 For `not-join`: `(not-join [?e] [...])` → `AntiJoin(joinSymbols=[?e], explicitJoin=true)`
 
+Header variables produced by both sides are equality keys. Header variables
+consumed only as right-child predicate/expression inputs are recorded in
+`AntiJoin.Required` and supplied by the left relation. The compiler validates
+that every explicit header variable is left-bound and either right-produced or a
+real right free requirement; right outer requirements omitted from the header
+are rejected.
+
+Plain `not` infers both categories before lowering to explicit `not-join`.
+
 **Decompile:**
 - `AntiJoin(explicitJoin=false)` → `decompile(left) ++ (not <decompile(right)>)`
 - `AntiJoin(explicitJoin=true)` → `decompile(left) ++ (not-join [vars] <decompile(right)>)`
 
-**Round-trip invariant:** Join symbols preserved. Inner clauses wrapped in
-NotClause or NotJoinClause. Left clauses come first.
+**Round-trip invariant:** Join symbols and correlation requirements are
+preserved. Inner clauses are wrapped in NotClause or NotJoinClause. Left clauses
+come first.
 
 **Test:** Compile `[?e :type :foo] (not [?e :deleted true])`, decompile, assert
 DataPattern + NotClause.

--- a/docs/BREAKING_RELEASE_UPGRADE_v0.14.0.md
+++ b/docs/BREAKING_RELEASE_UPGRADE_v0.14.0.md
@@ -94,6 +94,32 @@ relation are now rejected during execution. This includes queries such as
 `[:find ?missing (count ?e) ...]`; they no longer reach aggregation with an
 undefined grouping symbol.
 
+### `not-join` outer requirements
+
+Every outer variable consumed inside an explicit `not-join` body must appear in
+the header, including variables used only by predicates or expressions:
+
+```clojure
+(not-join [?goal ?goalSet]
+  [?event :event/goal ?goal]
+  [?event :event/type ?eventType]
+  [(!= ?eventType ?goalSet)])
+```
+
+Omitting `?goalSet` is invalid because the body cannot resolve it from local
+patterns:
+
+```clojure
+(not-join [?goal]
+  ...
+  [(!= ?eventType ?goalSet)])
+```
+
+Earlier v0.14 releases rejected this shape later during execution with an
+unresolved-term error. The planner now reports the missing header requirement
+before constructing the anti-join. This changes diagnostic timing and clarity,
+not the accepted query set.
+
 ### `or-join` header validation
 
 v0.14 validates that every `or-join` branch binds every variable declared in the

--- a/docs/BREAKING_RELEASE_UPGRADE_v0.14.0.md
+++ b/docs/BREAKING_RELEASE_UPGRADE_v0.14.0.md
@@ -94,6 +94,32 @@ relation are now rejected during execution. This includes queries such as
 `[:find ?missing (count ?e) ...]`; they no longer reach aggregation with an
 undefined grouping symbol.
 
+### `or-join` header validation
+
+v0.14 validates that every `or-join` branch binds every variable declared in the
+header. v0.13 accepted over-declared headers and could silently derive the union
+schema from one branch.
+
+This query is invalid because neither branch binds the other branch's value:
+
+```clojure
+(or-join [?entity ?crawl ?world]
+  [?entity :entity/crawl ?crawl]
+  [?entity :entity/world ?world])
+```
+
+If `?crawl` and `?world` are branch-specific input filters rather than union
+outputs, reduce the header to the variables every branch binds:
+
+```clojure
+(or-join [?entity]
+  [?entity :entity/crawl ?crawl]
+  [?entity :entity/world ?world])
+```
+
+The stricter rule is Datomic-compatible and prevents branch-local values from
+being represented as shared union attributes.
+
 ## Legacy L85 physical databases
 
 Normal databases created through `db.Open` or `storage.NewDatabase` already use

--- a/docs/bugs/resolved/BUG_CORRELATED_NOT_JOIN_PREDICATE_INPUT_REJECTED.md
+++ b/docs/bugs/resolved/BUG_CORRELATED_NOT_JOIN_PREDICATE_INPUT_REJECTED.md
@@ -1,0 +1,175 @@
+# Correlated `not-join` Predicate Input Rejected by Algebra Analysis
+
+**Status:** Resolved (2026-07-14)
+**Reported:** 2026-07-14
+**Affected:** v0.14.0–v0.14.2
+**Last known working release:** v0.13.3
+**Severity:** High — valid Datomic-style queries fail during planning
+
+## Summary
+
+The v0.14 algebra schema-analysis pass rejects an explicit `not-join` when a
+header variable is supplied by the outer relation and consumed inside the
+negated body only by a predicate.
+
+```clojure
+[:find ?goal
+ :where
+ [?goal :entity/type :type/goal]
+ [?setEvent :event/goal ?goal]
+ [?setEvent :event/type ?goalSet]
+ (not-join [?goal ?goalSet]
+   [?termEvent :event/goal ?goal]
+   [?termEvent :event/type ?termType]
+   [(!= ?termType ?goalSet)])]
+```
+
+`?goalSet` is bound before `not-join`, declared in its header, and used as the
+right operand of the body predicate. It is a per-outer-tuple correlation input;
+the body does not and should not produce it as an output relation attribute.
+
+v0.13.3 executed this query. v0.14.x fails during algebra optimization:
+
+```text
+refresh algebra schemas: AntiJoin:
+anti-join symbol ?goalSet must be produced by both children
+```
+
+## Expected Semantics
+
+An explicit `not-join` header defines which outer bindings are available inside
+the negated subgoal. Each header variable must be bound by the outer relation and
+must participate in the body either as:
+
+1. A relation attribute produced by the body and compared as an anti-join key; or
+2. A free requirement consumed by a predicate or expression in the body.
+
+The body may introduce local variables such as `?termEvent` and `?termType`.
+Those variables are not header bindings and do not escape the negated subgoal.
+
+## Root Cause
+
+`compileNotJoin` compiles the body independently and emits:
+
+```go
+&AntiJoin{
+    JoinSymbols:  nj.JoinVars,
+    Output:       current.Symbols(),
+    ExplicitJoin: true,
+}
+```
+
+The right child analysis correctly records `?goalSet` as a free requirement:
+the `Select` predicate consumes it, while the child output remains
+`[?termEvent ?goal ?termType]`.
+
+`analyzeAntiJoin` then applies the pure equi-anti-join law to every header
+variable:
+
+```go
+for _, symbol := range data.JoinSymbols {
+    if !containsSymbol(left.Output, symbol) ||
+       !containsSymbol(right.Output, symbol) {
+        return error
+    }
+}
+```
+
+That law is correct for right-produced equality keys but incomplete for explicit
+`not-join` correlation inputs. The algebra node has no field corresponding to
+`Union.Required`, so the analyzer cannot distinguish the two categories.
+
+The optimizer began exposing the gap when v0.14 added `RefreshSchemas` and
+`Analyze` after every transform pass. The compiler and executor behavior did not
+newly become correlated in v0.14; the previously unvalidated intermediate
+schema became a hard planning error.
+
+## Fix
+
+Extend `AntiJoin` with:
+
+```go
+Required []query.Symbol
+```
+
+The field means “correlation bindings supplied by the left relation and consumed
+as free requirements by the right child.”
+
+For explicit `not-join`, compilation derives `Required` strictly:
+
+- The symbol appears in the declared header.
+- The left child produces it.
+- The right child does not produce it.
+- The right analysis lists it as a free requirement.
+
+Validation must reject:
+
+- Header variables not bound by the left relation.
+- Header variables neither produced nor required by the right child.
+- Right-child outer requirements omitted from the explicit header.
+- `Required` entries not present in both the header and right requirements.
+
+This is not a blanket schema exemption. It is a checked correlation contract.
+The optimizer still lowers back to Datalog, and `decompileAntiJoin` reconstructs
+the original `NotJoinClause`; the existing executor supplies these bindings per
+outer tuple.
+
+A new lateral anti-join operator is intentionally not introduced. Direct algebra
+execution does not exist, and adding a physical operator would duplicate the
+correlation semantics already represented by `NotJoinClause`.
+
+## Plain `not`
+
+Plain `not` infers its correlation interface instead of declaring a header.
+Variables produced by both sides are equality keys; right-child free requirements
+already available on the left are predicate/expression correlation inputs. Local
+variables produced only inside the body remain local. Compilation must include
+both inferred categories when it lowers plain `not` to an explicit
+`NotJoinClause`, while still rejecting right requirements that are not bound by
+the outer relation.
+
+## Separate `or-join` Migration Note
+
+v0.14 also began rejecting `or-join` headers that declare a variable not bound by
+every branch:
+
+```clojure
+(or-join [?entity ?crawl ?world]
+  [?entity :entity/crawl ?crawl]
+  [?entity :entity/world ?world])
+```
+
+That rejection is correct and Datomic-compatible. The header is an output
+interface, so every branch must bind every header variable. If `?crawl` and
+`?world` are branch-specific input filters, the correct header is:
+
+```clojure
+(or-join [?entity]
+  [?entity :entity/crawl ?crawl]
+  [?entity :entity/world ?world])
+```
+
+The implementation should retain the validation, improve the diagnostic, and
+document the v0.13-to-v0.14 migration.
+
+## Regression Tests
+
+- Exact downstream `not-join` reproduction with a predicate-only outer input.
+- Optimized/off semantic differential with one excluded and one retained goal.
+- Plain `not` inference of a predicate-only outer input.
+- Structural assertion for equality keys versus correlation requirements.
+- Missing explicit-header correlation input rejected during planning.
+- Header variable neither produced nor required by the body rejected.
+- Compile/optimize/decompile round trip preserves the complete header.
+- `or-join` branch-schema validation remains strict and emits an actionable
+  diagnostic.
+
+## Resolution Criteria
+
+- [x] The reported query plans and matches v0.13.3 execution semantics.
+- [x] Correlation inputs are represented explicitly in the algebra IR.
+- [x] Invalid or omitted header bindings fail before execution.
+- [x] Pure anti-join schema checks remain unchanged.
+- [x] `or-join` branch equality is not weakened.
+- [x] Upgrade documentation explains the `or-join` header tightening.
+- [x] Full, race, shuffled, and optimized/off differential gates pass.

--- a/docs/bugs/resolved/BUG_CORRELATED_NOT_JOIN_PREDICATE_INPUT_REJECTED.md
+++ b/docs/bugs/resolved/BUG_CORRELATED_NOT_JOIN_PREDICATE_INPUT_REJECTED.md
@@ -157,12 +157,28 @@ document the v0.13-to-v0.14 migration.
 - Exact downstream `not-join` reproduction with a predicate-only outer input.
 - Optimized/off semantic differential with one excluded and one retained goal.
 - Plain `not` inference of a predicate-only outer input.
+- Plain `not` rejects a right requirement unavailable from the outer relation.
 - Structural assertion for equality keys versus correlation requirements.
 - Missing explicit-header correlation input rejected during planning.
 - Header variable neither produced nor required by the body rejected.
 - Compile/optimize/decompile round trip preserves the complete header.
 - `or-join` branch-schema validation remains strict and emits an actionable
   diagnostic.
+
+## Verification Performed
+
+The following gates were run against the completed fix on 2026-07-14:
+
+```bash
+go test -count=1 ./...
+go vet ./...
+go test -race -count=1 ./datalog/algebra ./datalog/storage
+go test -count=1 -shuffle=on ./datalog/algebra ./datalog/storage
+```
+
+All completed successfully. The optimized/off execution differential is
+`TestCorrelatedNotJoinPredicateInputMatchesUnoptimizedExecution`; structural and
+diagnostic coverage lives in the algebra package tests listed above.
 
 ## Resolution Criteria
 
@@ -171,5 +187,6 @@ document the v0.13-to-v0.14 migration.
 - [x] Invalid or omitted header bindings fail before execution.
 - [x] Pure anti-join schema checks remain unchanged.
 - [x] `or-join` branch equality is not weakened.
-- [x] Upgrade documentation explains the `or-join` header tightening.
-- [x] Full, race, shuffled, and optimized/off differential gates pass.
+- [x] Upgrade documentation explains `not-join` correlation requirements and the
+  `or-join` header tightening.
+- [x] Semantic, structural, invalid-header, and diagnostic regressions pass.


### PR DESCRIPTION
## Summary

This PR restores valid Datomic-style `not-join` correlation when a header variable is bound by the outer relation and consumed inside the negated body only by a predicate or expression.

The downstream regression was:

```clojure
[:find ?goal
 :where
 [?goal :entity/type :type/goal]
 [?setEvent :event/goal ?goal]
 [?setEvent :event/type ?goalSet]
 (not-join [?goal ?goalSet]
   [?termEvent :event/goal ?goal]
   [?termEvent :event/type ?termType]
   [(!= ?termType ?goalSet)])]
```

`?goal` is produced by both sides and is an equality key. `?goalSet` is supplied by the current outer tuple and consumed by the right predicate; it is a correlation input, not a right output relation attribute.

v0.13.3 executed this query. v0.14.x rejected it during schema refresh:

```text
AntiJoin: anti-join symbol ?goalSet must be produced by both children
```

The regression appeared when v0.14 began validating algebra schemas after every optimizer pass. The compiler had always emitted a plain `AntiJoin` for `not-join`, but the operator could not represent predicate-only correlation requirements.

## Algebra model

`AntiJoin` now distinguishes:

- `JoinSymbols`: the complete correlation interface carried by the `not-join` header.
- Right-produced symbols: ordinary anti-join equality keys.
- `Required`: symbols supplied by the left relation and consumed as free requirements by the right child.
- `Output`: the unchanged left schema.

For the reported query:

```text
left output     = [?goal ?goalSet]
right output    = [?termEvent ?goal ?termType]
right required  = [?goalSet]
join symbols    = [?goal ?goalSet]
required        = [?goalSet]
```

This is a checked correlation contract, not a blanket analyzer exemption.

## Compilation and validation

Explicit `not-join` compilation now requires every header symbol to be:

1. Bound by the left relation; and
2. Either produced by the right child or consumed as one of its free requirements.

It rejects:

- Header variables not bound outside the clause.
- Right outer requirements omitted from the explicit header.
- Header variables neither produced nor consumed by the body.
- Correlation requirements that are not genuine right free requirements.

Plain `not` applies the same classification while inferring its interface. Shared left/right outputs become equality keys; predicate- or expression-only requirements already available on the left become correlation inputs; body-only variables remain local. Unbound right requirements remain errors.

`RefreshSchemas` clones the correlation requirements immutably. `Analyze` validates the complete law and retains the existing left-only anti-join output. Decompilation still emits `NotJoinClause` with the complete header, so the existing executor supplies correlation values per outer tuple.

A new lateral anti-join operator is intentionally not introduced. The optimizer lowers back to Datalog before execution, and `NotJoinClause` already carries the required runtime semantics.

## `or-join` diagnostic and migration note

This PR does not weaken the v0.14 `or-join` branch-schema rule. Every branch must still bind every variable declared in the header, matching Datomic.

The prior mechanical error:

```text
union branch 0 schema [?entity ?crawl] does not provide output symbol ?world
```

now explains that the `or-join` header declares a variable the branch does not bind, that every branch must bind every header variable, and that branch-specific input filters should be removed from the header.

The v0.14 upgrade guide now documents the tightening and the migration from an over-declared header such as `[?entity ?crawl ?world]` to the shared interface `[?entity]`.

## Tests

New coverage includes:

- The exact downstream correlated `not-join` shape.
- One excluded and one retained goal, proving result semantics rather than planning alone.
- Optimized/off differential execution for explicit `not-join`.
- Predicate-only correlation inferred for plain `not`.
- Structural separation of equality keys and correlation requirements.
- Compile/optimize/decompile preservation of the complete header.
- Header symbols not bound by the outer relation.
- Outer requirements omitted from the explicit header.
- Header symbols unused by the body.
- Invalid manually constructed `AntiJoin.Required` metadata.
- The strict `or-join` rule with the new actionable diagnostic.

## Test plan

- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./datalog/algebra ./datalog/storage`
- [x] Shuffled algebra/storage package suite
- [x] Exact optimized/off downstream differential
- [x] Focused compile, analysis, round-trip, and invalid-header tests

## Documentation

Updates `docs/ALGEBRA.md` with the anti-join equality/correlation model and `docs/BREAKING_RELEASE_UPGRADE_v0.14.0.md` with the `or-join` header migration.

Adds `docs/bugs/resolved/BUG_CORRELATED_NOT_JOIN_PREDICATE_INPUT_REJECTED.md` as the house-style regression record covering the failing query, root cause, strict model, plain `not` behavior, separate `or-join` note, tests, and resolution criteria.