### PR TITLE
Add seekable LZJ binary dump export and import

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -29,6 +29,7 @@ Configuration, semantics, and proofs in `docs/reference/`:
 - **[OP_POSITION_PROOF.md](docs/reference/OP_POSITION_PROOF.md)** - Why the Op byte goes last (key-decoding correctness)
 - **[SCHEMA.md](docs/reference/SCHEMA.md)** - Schema support: types, cardinality, uniqueness, Pull API integration
 - **[EXPORT_IMPORT.md](docs/reference/EXPORT_IMPORT.md)** - Database export/import to EDN format for backup and migration
+- **[BINARY_EXPORT.md](docs/reference/BINARY_EXPORT.md)** - Compressed seekable JDZL binary dump (`-export-bin` / `-import-bin`)
 
 **Query system:**
 - **[PLANNER_OPTIONS.md](docs/reference/PLANNER_OPTIONS.md)** - Complete planner options reference with performance guidance

--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -29,6 +29,8 @@ func main() {
 	var enableDecorrelation bool
 	var exportPath string
 	var importPath string
+	var exportBinPath string
+	var importBinPath string
 	var compressedExport bool
 	var showStats bool
 
@@ -43,6 +45,8 @@ func main() {
 	flag.StringVar(&exportPath, "export", "", "export database to EDN file")
 	flag.BoolVar(&compressedExport, "compressed", false, "use #lzj compressed tagged literals in export")
 	flag.StringVar(&importPath, "import", "", "import database from EDN file")
+	flag.StringVar(&exportBinPath, "export-bin", "", "export database to compressed binary JDZL file")
+	flag.StringVar(&importBinPath, "import-bin", "", "import database from compressed binary JDZL file")
 	flag.BoolVar(&showStats, "stats", false, "print per-attribute cardinality, value size, and duplication statistics")
 	flag.Var(&inputValues, "in", "input parameter as EDN value (repeatable, one per :in binding)")
 	flag.Usage = func() {
@@ -52,14 +56,16 @@ func main() {
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
 		fmt.Fprintf(os.Stderr, "  %s -i                 # Interactive mode with default database\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "  %s -i mydata.db      # Interactive mode with specific database\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "  %s -db /path/to/db   # Using -db flag\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -i mydata.db       # Interactive mode with specific database\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -db /path/to/db    # Using -db flag\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -verbose           # Verbose mode with query annotations\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -verbose -i        # Interactive mode with annotations\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -query '[:find ?x :where [?x :person/name _]]'  # Run single query\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -query '[:find ?n :in $ ?age :where [?p :person/age ?age] [?p :person/name ?n]]' -in 30  # With input binding\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -db mydata.db -export data.edn  # Export database to EDN file\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -db newdata.db -import data.edn # Import EDN file into database\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -db mydata.db -export-bin data.jdzl  # Compressed binary export\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -db newdata.db -import-bin data.jdzl # Binary import\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -db mydata.db -stats            # Print cardinality and value statistics\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -db dump.edn -query '...'       # Query an EDN dump directly (temporary database)\n", os.Args[0])
 	}
@@ -75,12 +81,24 @@ func main() {
 		dbPath = flag.Arg(0)
 	}
 
-	// Check for conflicting flags
-	if exportPath != "" && importPath != "" {
-		log.Fatalf("Cannot specify both -export and -import")
+	transferModes := 0
+	if exportPath != "" {
+		transferModes++
 	}
-	if showStats && (exportPath != "" || importPath != "") {
-		log.Fatalf("Cannot combine -stats with -export or -import")
+	if importPath != "" {
+		transferModes++
+	}
+	if exportBinPath != "" {
+		transferModes++
+	}
+	if importBinPath != "" {
+		transferModes++
+	}
+	if transferModes > 1 {
+		log.Fatalf("Specify only one of -export, -import, -export-bin, -import-bin")
+	}
+	if showStats && transferModes > 0 {
+		log.Fatalf("Cannot combine -stats with export/import flags")
 	}
 
 	// Default to datalog.db if no path specified
@@ -103,6 +121,16 @@ func main() {
 	// Handle import mode
 	if importPath != "" {
 		runImport(dbPath, importPath)
+		return
+	}
+
+	if exportBinPath != "" {
+		runExportBin(dbPath, exportBinPath)
+		return
+	}
+
+	if importBinPath != "" {
+		runImportBin(dbPath, importBinPath)
 		return
 	}
 
@@ -378,6 +406,51 @@ func runImport(dbPath, importPath string) {
 		log.Fatalf("Failed to import: %v", err)
 	}
 
+	fmt.Printf("Imported %s into database %s\n", importPath, dbPath)
+}
+
+func runExportBin(dbPath, exportPath string) {
+	db, cleanup, err := openDatabaseOrEDN(dbPath)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	defer cleanup()
+
+	f, err := os.Create(exportPath)
+	if err != nil {
+		log.Fatalf("Failed to create binary export file: %v", err)
+	}
+	defer f.Close()
+
+	if err := db.ExportBinary(f); err != nil {
+		log.Fatalf("Failed to export binary database: %v", err)
+	}
+	fmt.Printf("Exported database to %s\n", exportPath)
+}
+
+func runImportBin(dbPath, importPath string) {
+	if strings.HasSuffix(dbPath, ".edn") || strings.HasSuffix(dbPath, ".jdzl") {
+		log.Fatalf("Cannot import into %s: -db must be a database directory", dbPath)
+	}
+	if _, err := os.Stat(importPath); os.IsNotExist(err) {
+		log.Fatalf("Import file does not exist: %s", importPath)
+	}
+
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		log.Fatalf("Failed to open/create database: %v", err)
+	}
+	defer db.Close()
+
+	f, err := os.Open(importPath)
+	if err != nil {
+		log.Fatalf("Failed to open binary import file: %v", err)
+	}
+	defer f.Close()
+
+	if err := db.ImportBinary(f); err != nil {
+		log.Fatalf("Failed to import binary dump: %v", err)
+	}
 	fmt.Printf("Imported %s into database %s\n", importPath, dbPath)
 }
 

--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -410,22 +410,31 @@ func runImport(dbPath, importPath string) {
 }
 
 func runExportBin(dbPath, exportPath string) {
+	// Keep Fatalf outside the cleanup scope so deferred temp-dir removal runs
+	// on export failure (os.Exit from log.Fatalf skips defers).
+	if err := exportBinaryDatabase(dbPath, exportPath); err != nil {
+		log.Fatalf("%v", err)
+	}
+	fmt.Printf("Exported database to %s\n", exportPath)
+}
+
+func exportBinaryDatabase(dbPath, exportPath string) error {
 	db, cleanup, err := openDatabaseOrEDN(dbPath)
 	if err != nil {
-		log.Fatalf("%v", err)
+		return err
 	}
 	defer cleanup()
 
 	f, err := os.Create(exportPath)
 	if err != nil {
-		log.Fatalf("Failed to create binary export file: %v", err)
+		return fmt.Errorf("Failed to create binary export file: %v", err)
 	}
 	defer f.Close()
 
 	if err := db.ExportBinary(f); err != nil {
-		log.Fatalf("Failed to export binary database: %v", err)
+		return fmt.Errorf("Failed to export binary database: %v", err)
 	}
-	fmt.Printf("Exported database to %s\n", exportPath)
+	return nil
 }
 
 func runImportBin(dbPath, importPath string) {

--- a/cmd/datalog/main_test.go
+++ b/cmd/datalog/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -305,6 +306,162 @@ func TestCLI_BothFlagsError(t *testing.T) {
 
 	if !strings.Contains(string(out), "Specify only one of -export, -import, -export-bin, -import-bin") {
 		t.Errorf("Expected mutually-exclusive transfer-mode error, got: %s", out)
+	}
+}
+
+func TestCLI_BinaryFlagsMutualExclusion(t *testing.T) {
+	binPath := buildCLI(t)
+	cases := [][]string{
+		{"-export-bin", "out.jdzl", "-import-bin", "in.jdzl"},
+		{"-export", "out.edn", "-export-bin", "out.jdzl"},
+		{"-import", "in.edn", "-import-bin", "in.jdzl"},
+	}
+	for _, args := range cases {
+		cmdArgs := append([]string{"-db", "test.db"}, args...)
+		cmd := exec.Command(binPath, cmdArgs...)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Errorf("expected mutual-exclusion error for %v", args)
+		}
+		if !strings.Contains(string(out), "Specify only one of -export, -import, -export-bin, -import-bin") {
+			t.Errorf("expected transfer-mode error for %v, got: %s", args, out)
+		}
+	}
+}
+
+func TestCLI_StatsWithBinaryFlagError(t *testing.T) {
+	binPath := buildCLI(t)
+	cmd := exec.Command(binPath, "-db", "test.db", "-stats", "-export-bin", "out.jdzl")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Error("expected error combining -stats with -export-bin")
+	}
+	if !strings.Contains(string(out), "Cannot combine -stats with export/import flags") {
+		t.Errorf("expected -stats guard error, got: %s", out)
+	}
+}
+
+func TestCLI_ExportBinFlag(t *testing.T) {
+	binPath := buildCLI(t)
+	dbPath := createTestDatabase(t)
+	exportPath := filepath.Join(t.TempDir(), "export.jdzl")
+
+	cmd := exec.Command(binPath, "-db", dbPath, "-export-bin", exportPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Export-bin failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Exported database to") {
+		t.Errorf("Expected export success message, got: %s", out)
+	}
+	content, err := os.ReadFile(exportPath)
+	if err != nil {
+		t.Fatalf("Failed to read binary export: %v", err)
+	}
+	if len(content) < 4 || string(content[0:4]) != "JDZL" {
+		t.Errorf("Expected JDZL magic, got prefix %q (len=%d)", content, len(content))
+	}
+}
+
+func TestCLI_ImportBinFlag(t *testing.T) {
+	binPath := buildCLI(t)
+
+	sourceDir := t.TempDir()
+	sourceDBPath := filepath.Join(sourceDir, "source.db")
+	sourceDB, err := storage.NewDatabase(sourceDBPath)
+	if err != nil {
+		t.Fatalf("Failed to create source database: %v", err)
+	}
+	tx := sourceDB.NewTransaction()
+	entity := datalog.NewIdentity("test-entity")
+	tx.Add(entity, datalog.NewKeyword(":test/value"), "hello")
+	tx.Add(entity, datalog.NewKeyword(":test/count"), int64(42))
+	if _, err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	jdzlPath := filepath.Join(t.TempDir(), "import.jdzl")
+	jdzlFile, err := os.Create(jdzlPath)
+	if err != nil {
+		t.Fatalf("Failed to create jdzl file: %v", err)
+	}
+	if err := sourceDB.ExportBinary(jdzlFile); err != nil {
+		t.Fatalf("Failed to export source database: %v", err)
+	}
+	jdzlFile.Close()
+	sourceDB.Close()
+
+	dbPath := filepath.Join(t.TempDir(), "imported.db")
+	cmd := exec.Command(binPath, "-db", dbPath, "-import-bin", jdzlPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Import-bin failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Imported") {
+		t.Errorf("Expected import success message, got: %s", out)
+	}
+
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open imported database: %v", err)
+	}
+	defer db.Close()
+	result, err := executor.CollectTuples(db.Query(`[:find ?v :where [_ :test/value ?v]]`))
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(result))
+	}
+}
+
+func TestCLI_ExportImportBinRoundTrip(t *testing.T) {
+	binPath := buildCLI(t)
+	db1Path := createTestDatabase(t)
+	exportPath := filepath.Join(t.TempDir(), "roundtrip.jdzl")
+	db2Path := filepath.Join(t.TempDir(), "roundtrip.db")
+
+	cmd := exec.Command(binPath, "-db", db1Path, "-export-bin", exportPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Export-bin failed: %v\n%s", err, out)
+	}
+	cmd = exec.Command(binPath, "-db", db2Path, "-import-bin", exportPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Import-bin failed: %v\n%s", err, out)
+	}
+
+	db1, err := storage.NewDatabase(db1Path)
+	if err != nil {
+		t.Fatalf("open db1: %v", err)
+	}
+	defer db1.Close()
+	db2, err := storage.NewDatabase(db2Path)
+	if err != nil {
+		t.Fatalf("open db2: %v", err)
+	}
+	defer db2.Close()
+
+	var edn1, edn2 bytes.Buffer
+	if err := db1.Export(&edn1); err != nil {
+		t.Fatalf("export db1 edn: %v", err)
+	}
+	if err := db2.Export(&edn2); err != nil {
+		t.Fatalf("export db2 edn: %v", err)
+	}
+	if edn1.String() != edn2.String() {
+		t.Error("binary CLI round-trip produced different EDN dumps")
+	}
+}
+
+func TestCLI_ImportBinNonexistentFile(t *testing.T) {
+	binPath := buildCLI(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	cmd := exec.Command(binPath, "-db", dbPath, "-import-bin", "/nonexistent/file.jdzl")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Error("Expected error for nonexistent import-bin file")
+	}
+	if !strings.Contains(string(out), "does not exist") {
+		t.Errorf("Expected 'does not exist' error, got: %s", out)
 	}
 }
 

--- a/cmd/datalog/main_test.go
+++ b/cmd/datalog/main_test.go
@@ -303,9 +303,8 @@ func TestCLI_BothFlagsError(t *testing.T) {
 		t.Error("Expected error when both flags specified")
 	}
 
-	// Should mention cannot use both
-	if !strings.Contains(string(out), "Cannot specify both") {
-		t.Errorf("Expected 'Cannot specify both' error, got: %s", out)
+	if !strings.Contains(string(out), "Specify only one of -export, -import, -export-bin, -import-bin") {
+		t.Errorf("Expected mutually-exclusive transfer-mode error, got: %s", out)
 	}
 }
 

--- a/cmd/datalog/main_test.go
+++ b/cmd/datalog/main_test.go
@@ -331,13 +331,22 @@ func TestCLI_BinaryFlagsMutualExclusion(t *testing.T) {
 
 func TestCLI_StatsWithBinaryFlagError(t *testing.T) {
 	binPath := buildCLI(t)
-	cmd := exec.Command(binPath, "-db", "test.db", "-stats", "-export-bin", "out.jdzl")
-	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Error("expected error combining -stats with -export-bin")
+	cases := [][]string{
+		{"-stats", "-export-bin", "out.jdzl"},
+		{"-stats", "-import-bin", "in.jdzl"},
+		{"-stats", "-export", "out.edn"},
+		{"-stats", "-import", "in.edn"},
 	}
-	if !strings.Contains(string(out), "Cannot combine -stats with export/import flags") {
-		t.Errorf("expected -stats guard error, got: %s", out)
+	for _, args := range cases {
+		cmdArgs := append([]string{"-db", "test.db"}, args...)
+		cmd := exec.Command(binPath, cmdArgs...)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Errorf("expected error combining -stats with %v", args)
+		}
+		if !strings.Contains(string(out), "Cannot combine -stats with export/import flags") {
+			t.Errorf("expected -stats guard error for %v, got: %s", args, out)
+		}
 	}
 }
 

--- a/datalog/storage/export_bin.go
+++ b/datalog/storage/export_bin.go
@@ -178,8 +178,12 @@ func (d *Database) ExportBinary(w io.WriteSeeker, opts ...BinaryExportOptions) e
 
 // ImportBinary reads a JDZL file and asserts its datoms. r must be an
 // io.ReadSeeker. Chunks are decoded and asserted in parallel up to Workers.
-// The first worker error cancels remaining launches and in-flight work; the
-// store may still contain a partial import when an error is returned.
+//
+// The first worker error cancels remaining launches and in-flight work between
+// steps, then that error is returned. Import is not transactional across
+// chunks: workers that already Asserted leave a nondeterministic partial
+// subset of the file in the store. Retrying into the same database is not a
+// safe recovery; use a fresh database (or discard the target) after failure.
 func (d *Database) ImportBinary(r io.ReadSeeker, opts ...BinaryImportOptions) error {
 	workers := runtime.GOMAXPROCS(0)
 	if len(opts) > 0 && opts[0].Workers > 0 {
@@ -572,7 +576,9 @@ func decodeBinaryChunk(unc []byte) ([]datalog.Datom, error) {
 }
 
 func binaryUint32Len(n int, what string) (uint32, error) {
-	if n < 0 || n > math.MaxUint32 {
+	// Compare in uint64 space so this compiles when int is 32-bit
+	// (n > math.MaxUint32 is not a valid int comparison on 32-bit).
+	if n < 0 || uint64(n) > math.MaxUint32 {
 		return 0, fmt.Errorf("binary export: %s length %d exceeds uint32", what, n)
 	}
 	return uint32(n), nil

--- a/datalog/storage/export_bin.go
+++ b/datalog/storage/export_bin.go
@@ -1,0 +1,502 @@
+package storage
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"sync"
+
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/codec"
+)
+
+const (
+	binaryExportMagic       = "JDZL"
+	binaryIndexMagic        = "JDZI"
+	binaryExportVersion     = 1
+	binaryHeaderSize        = 32
+	binaryChunkHeaderSize   = 10
+	binaryIndexEntrySize    = 56
+	binaryChunkTypeData     = 1
+	binaryChunkFlagRaw      = 0x01
+	binaryRecordFlagAfterRef = 0x01
+	defaultBinarySoftBudget = 256 << 10
+)
+
+// BinaryExportOptions configures JDZL binary export.
+type BinaryExportOptions struct {
+	// SoftBudget is the advisory uncompressed chunk size in bytes. When the
+	// open chunk reaches this size, export closes at the next entity boundary.
+	// Zero selects the default (256KiB).
+	SoftBudget int
+	// SkipEntity, when non-nil, omits datoms whose entity returns true.
+	SkipEntity func(datalog.Identity) bool
+}
+
+// BinaryImportOptions configures JDZL binary import.
+type BinaryImportOptions struct {
+	// Workers is the maximum number of chunks decoded and asserted concurrently.
+	// Zero selects GOMAXPROCS.
+	Workers int
+}
+
+type binaryIndexEntry struct {
+	offset  uint64
+	cmpLen  uint32
+	uncLen  uint32
+	firstE  [20]byte
+	lastE   [20]byte
+}
+
+type binaryTrailer struct {
+	entries []binaryIndexEntry
+	maxTx   datalog.ElementID
+}
+
+// ExportBinary writes the complete EAVT datom log as a seekable JDZL file.
+// w must be an io.WriteSeeker so the trailer index offset can be patched.
+func (d *Database) ExportBinary(w io.WriteSeeker, opts ...BinaryExportOptions) error {
+	softBudget := defaultBinarySoftBudget
+	var skipEntity func(datalog.Identity) bool
+	if len(opts) > 0 {
+		if opts[0].SoftBudget > 0 {
+			softBudget = opts[0].SoftBudget
+		}
+		skipEntity = opts[0].SkipEntity
+	}
+
+	if _, err := w.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("binary export seek start: %w", err)
+	}
+	if err := writeBinaryHeader(w, softBudget, 0); err != nil {
+		return err
+	}
+
+	start := []byte{byte(EAVT)}
+	end := []byte{byte(EATV)}
+	iter, err := d.store.Scan(EAVT, start, end)
+	if err != nil {
+		return fmt.Errorf("binary export scan: %w", err)
+	}
+	defer iter.Close()
+
+	var (
+		trailer    binaryTrailer
+		chunk      []byte
+		openE      [20]byte
+		haveOpenE  bool
+		closeSoon  bool
+		firstE     [20]byte
+		lastE      [20]byte
+		chunkOpen  bool
+		fileOffset int64 = binaryHeaderSize
+	)
+
+	flush := func() error {
+		if len(chunk) == 0 {
+			return nil
+		}
+		entry, written, err := writeBinaryChunk(w, uint64(fileOffset), chunk, firstE, lastE)
+		if err != nil {
+			return err
+		}
+		trailer.entries = append(trailer.entries, entry)
+		fileOffset += written
+		chunk = chunk[:0]
+		haveOpenE = false
+		closeSoon = false
+		chunkOpen = false
+		return nil
+	}
+
+	for iter.Next() {
+		datom, err := iter.Datom()
+		if err != nil {
+			return fmt.Errorf("binary export datom: %w", err)
+		}
+		if skipEntity != nil && skipEntity(datom.E) {
+			continue
+		}
+
+		var eBytes [20]byte
+		copy(eBytes[:], datom.E.Bytes())
+
+		// Soft budget arms closeSoon; the chunk actually closes on the next
+		// entity boundary so an entity's datoms stay in one LZJ window.
+		if haveOpenE && eBytes != openE && closeSoon {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+
+		rec, err := encodeBinaryDatom(datom)
+		if err != nil {
+			return err
+		}
+
+		if !haveOpenE {
+			openE = eBytes
+			haveOpenE = true
+		} else if eBytes != openE {
+			openE = eBytes
+		}
+		if !chunkOpen {
+			firstE = eBytes
+			chunkOpen = true
+		}
+		lastE = eBytes
+
+		chunk = append(chunk, rec...)
+		if !datom.Tx.IsZero() && (trailer.maxTx.IsZero() || trailer.maxTx.Less(datom.Tx)) {
+			trailer.maxTx = datom.Tx
+		}
+		if len(chunk) >= softBudget {
+			closeSoon = true
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return fmt.Errorf("binary export scan: %w", err)
+	}
+	if err := flush(); err != nil {
+		return err
+	}
+
+	indexOffset := uint64(fileOffset)
+	if err := writeBinaryIndex(w, trailer); err != nil {
+		return err
+	}
+	if _, err := w.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("binary export patch header: %w", err)
+	}
+	return writeBinaryHeader(w, softBudget, indexOffset)
+}
+
+// ImportBinary reads a JDZL file and asserts its datoms. r must be an
+// io.ReadSeeker. Chunks are decoded and asserted in parallel up to Workers.
+func (d *Database) ImportBinary(r io.ReadSeeker, opts ...BinaryImportOptions) error {
+	workers := runtime.GOMAXPROCS(0)
+	if len(opts) > 0 && opts[0].Workers > 0 {
+		workers = opts[0].Workers
+	}
+
+	header, err := readBinaryHeader(r)
+	if err != nil {
+		return err
+	}
+	trailer, err := readBinaryIndex(r, header.indexOffset)
+	if err != nil {
+		return err
+	}
+
+	var seekMu sync.Mutex
+	sem := make(chan struct{}, workers)
+	errCh := make(chan error, len(trailer.entries))
+	var wg sync.WaitGroup
+	for i := range trailer.entries {
+		entry := trailer.entries[i]
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(entry binaryIndexEntry) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			unc, err := readBinaryChunkPayload(r, entry, &seekMu)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			datoms, err := decodeBinaryChunk(unc)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if len(datoms) == 0 {
+				return
+			}
+			if err := d.store.Assert(datoms); err != nil {
+				errCh <- fmt.Errorf("binary import assert chunk at %d: %w", entry.offset, err)
+			}
+		}(entry)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+
+	maxElementID := trailer.maxTx
+	if maxElementID.IsZero() {
+		maxElementID, err = d.store.MaxElementID()
+		if err != nil {
+			return fmt.Errorf("binary import max ElementID: %w", err)
+		}
+	}
+	if !maxElementID.IsZero() {
+		d.clock.Restore(maxElementID)
+	}
+	return nil
+}
+
+func writeBinaryHeader(w io.Writer, softBudget int, indexOffset uint64) error {
+	var hdr [binaryHeaderSize]byte
+	copy(hdr[0:4], binaryExportMagic)
+	hdr[4] = binaryExportVersion
+	binary.BigEndian.PutUint32(hdr[8:12], uint32(softBudget))
+	binary.BigEndian.PutUint64(hdr[16:24], indexOffset)
+	_, err := w.Write(hdr[:])
+	return err
+}
+
+type binaryFileHeader struct {
+	softBudget  uint32
+	indexOffset uint64
+}
+
+func readBinaryHeader(r io.ReadSeeker) (binaryFileHeader, error) {
+	var hdr [binaryHeaderSize]byte
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return binaryFileHeader{}, err
+	}
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return binaryFileHeader{}, fmt.Errorf("binary import header: %w", err)
+	}
+	if string(hdr[0:4]) != binaryExportMagic {
+		return binaryFileHeader{}, fmt.Errorf("binary import: bad magic %q", hdr[0:4])
+	}
+	if hdr[4] != binaryExportVersion {
+		return binaryFileHeader{}, fmt.Errorf("binary import: unsupported version %d", hdr[4])
+	}
+	return binaryFileHeader{
+		softBudget:  binary.BigEndian.Uint32(hdr[8:12]),
+		indexOffset: binary.BigEndian.Uint64(hdr[16:24]),
+	}, nil
+}
+
+func writeBinaryChunk(w io.Writer, offset uint64, unc []byte, firstE, lastE [20]byte) (binaryIndexEntry, int64, error) {
+	flags := byte(0)
+	payload := codec.Compress(unc)
+	if payload == nil {
+		flags = binaryChunkFlagRaw
+		payload = unc
+	}
+	var hdr [binaryChunkHeaderSize]byte
+	hdr[0] = binaryChunkTypeData
+	hdr[1] = flags
+	binary.BigEndian.PutUint32(hdr[2:6], uint32(len(unc)))
+	binary.BigEndian.PutUint32(hdr[6:10], uint32(len(payload)))
+	n, err := w.Write(hdr[:])
+	if err != nil {
+		return binaryIndexEntry{}, 0, err
+	}
+	m, err := w.Write(payload)
+	if err != nil {
+		return binaryIndexEntry{}, 0, err
+	}
+	return binaryIndexEntry{
+		offset: offset,
+		cmpLen: uint32(len(payload)),
+		uncLen: uint32(len(unc)),
+		firstE: firstE,
+		lastE:  lastE,
+	}, int64(n + m), nil
+}
+
+func writeBinaryIndex(w io.Writer, trailer binaryTrailer) error {
+	var hdr [24]byte
+	copy(hdr[0:4], binaryIndexMagic)
+	binary.BigEndian.PutUint32(hdr[4:8], uint32(len(trailer.entries)))
+	binary.BigEndian.PutUint64(hdr[8:16], trailer.maxTx.Lamport)
+	binary.BigEndian.PutUint64(hdr[16:24], trailer.maxTx.ReplicaID)
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	var entry [binaryIndexEntrySize]byte
+	for _, e := range trailer.entries {
+		binary.BigEndian.PutUint64(entry[0:8], e.offset)
+		binary.BigEndian.PutUint32(entry[8:12], e.cmpLen)
+		binary.BigEndian.PutUint32(entry[12:16], e.uncLen)
+		copy(entry[16:36], e.firstE[:])
+		copy(entry[36:56], e.lastE[:])
+		if _, err := w.Write(entry[:]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readBinaryIndex(r io.ReadSeeker, indexOffset uint64) (binaryTrailer, error) {
+	if indexOffset < binaryHeaderSize {
+		return binaryTrailer{}, errors.New("binary import: invalid index offset")
+	}
+	if _, err := r.Seek(int64(indexOffset), io.SeekStart); err != nil {
+		return binaryTrailer{}, fmt.Errorf("binary import seek index: %w", err)
+	}
+	var hdr [24]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return binaryTrailer{}, fmt.Errorf("binary import index header: %w", err)
+	}
+	if string(hdr[0:4]) != binaryIndexMagic {
+		return binaryTrailer{}, fmt.Errorf("binary import: bad index magic %q", hdr[0:4])
+	}
+	count := binary.BigEndian.Uint32(hdr[4:8])
+	trailer := binaryTrailer{
+		entries: make([]binaryIndexEntry, 0, count),
+		maxTx: datalog.ElementID{
+			Lamport:   binary.BigEndian.Uint64(hdr[8:16]),
+			ReplicaID: binary.BigEndian.Uint64(hdr[16:24]),
+		},
+	}
+	var entry [binaryIndexEntrySize]byte
+	for i := uint32(0); i < count; i++ {
+		if _, err := io.ReadFull(r, entry[:]); err != nil {
+			return binaryTrailer{}, fmt.Errorf("binary import index entry %d: %w", i, err)
+		}
+		var e binaryIndexEntry
+		e.offset = binary.BigEndian.Uint64(entry[0:8])
+		e.cmpLen = binary.BigEndian.Uint32(entry[8:12])
+		e.uncLen = binary.BigEndian.Uint32(entry[12:16])
+		copy(e.firstE[:], entry[16:36])
+		copy(e.lastE[:], entry[36:56])
+		trailer.entries = append(trailer.entries, e)
+	}
+	return trailer, nil
+}
+
+func readBinaryChunkPayload(r io.ReadSeeker, entry binaryIndexEntry, seekMu *sync.Mutex) ([]byte, error) {
+	seekMu.Lock()
+	defer seekMu.Unlock()
+	if _, err := r.Seek(int64(entry.offset), io.SeekStart); err != nil {
+		return nil, fmt.Errorf("binary import seek chunk: %w", err)
+	}
+	var hdr [binaryChunkHeaderSize]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, fmt.Errorf("binary import chunk header: %w", err)
+	}
+	if hdr[0] != binaryChunkTypeData {
+		return nil, fmt.Errorf("binary import: unexpected chunk type %d", hdr[0])
+	}
+	flags := hdr[1]
+	uncLen := binary.BigEndian.Uint32(hdr[2:6])
+	cmpLen := binary.BigEndian.Uint32(hdr[6:10])
+	if uncLen != entry.uncLen || cmpLen != entry.cmpLen {
+		return nil, fmt.Errorf("binary import: chunk length mismatch at %d", entry.offset)
+	}
+	payload := make([]byte, cmpLen)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, fmt.Errorf("binary import chunk payload: %w", err)
+	}
+	if flags&binaryChunkFlagRaw != 0 {
+		if uint32(len(payload)) != uncLen {
+			return nil, fmt.Errorf("binary import: raw chunk size mismatch")
+		}
+		return payload, nil
+	}
+	unc, err := codec.Decompress(payload)
+	if err != nil {
+		return nil, fmt.Errorf("binary import decompress: %w", err)
+	}
+	if uint32(len(unc)) != uncLen {
+		return nil, fmt.Errorf("binary import: decompressed length mismatch")
+	}
+	return unc, nil
+}
+
+func encodeBinaryDatom(d *datalog.Datom) ([]byte, error) {
+	if d.E == nil {
+		return nil, errors.New("binary export: nil entity")
+	}
+	if d.A == nil {
+		return nil, errors.New("binary export: nil attribute")
+	}
+	if len(d.A.String()) > datalog.MaxAttributeBytes {
+		return nil, fmt.Errorf("binary export: attribute %q exceeds %d bytes", d.A.String(), datalog.MaxAttributeBytes)
+	}
+
+	vBytes := datalog.ValueBytes(d.V)
+	recLen := 20 + 32 + 16 + 1 + 1 + 1 + 4 + len(vBytes)
+	if d.Op.HasAfterRef() {
+		recLen += 16
+	}
+	buf := make([]byte, recLen)
+	off := 0
+	copy(buf[off:off+20], d.E.Bytes())
+	off += 20
+	copy(buf[off:off+32], d.A.String())
+	off += 32
+	copy(buf[off:off+16], d.Tx.Bytes())
+	off += 16
+	buf[off] = byte(d.Op)
+	off++
+	flags := byte(0)
+	if d.Op.HasAfterRef() {
+		flags |= binaryRecordFlagAfterRef
+	}
+	buf[off] = flags
+	off++
+	if flags&binaryRecordFlagAfterRef != 0 {
+		copy(buf[off:off+16], d.AfterRef.Bytes())
+		off += 16
+	}
+	buf[off] = byte(datalog.Type(d.V))
+	off++
+	binary.BigEndian.PutUint32(buf[off:off+4], uint32(len(vBytes)))
+	off += 4
+	copy(buf[off:], vBytes)
+	return buf, nil
+}
+
+func decodeBinaryChunk(unc []byte) ([]datalog.Datom, error) {
+	var datoms []datalog.Datom
+	off := 0
+	for off < len(unc) {
+		need := 20 + 32 + 16 + 1 + 1 + 1 + 4
+		if off+need > len(unc) {
+			return nil, fmt.Errorf("binary import: truncated record at %d", off)
+		}
+		var eHash [20]byte
+		copy(eHash[:], unc[off:off+20])
+		off += 20
+		var aBytes [32]byte
+		copy(aBytes[:], unc[off:off+32])
+		off += 32
+		tx := datalog.ElementIDFromBytes(unc[off : off+16])
+		off += 16
+		op := datalog.CRDTOp(unc[off])
+		off++
+		flags := unc[off]
+		off++
+		var afterRef datalog.ElementID
+		if flags&binaryRecordFlagAfterRef != 0 {
+			if off+16 > len(unc) {
+				return nil, fmt.Errorf("binary import: truncated AfterRef at %d", off)
+			}
+			afterRef = datalog.ElementIDFromBytes(unc[off : off+16])
+			off += 16
+		}
+		vType := datalog.ValueType(unc[off])
+		off++
+		vLen := binary.BigEndian.Uint32(unc[off : off+4])
+		off += 4
+		if off+int(vLen) > len(unc) {
+			return nil, fmt.Errorf("binary import: truncated value at %d", off)
+		}
+		v, err := datalog.ValueFromBytes(vType, unc[off:off+int(vLen)])
+		if err != nil {
+			return nil, fmt.Errorf("binary import value: %w", err)
+		}
+		off += int(vLen)
+
+		datoms = append(datoms, datalog.Datom{
+			E:        datalog.NewIdentityFromHash(eHash),
+			A:        datalog.InternKeywordFromBytes(aBytes),
+			V:        v,
+			Tx:       tx,
+			Op:       op,
+			AfterRef: afterRef,
+		})
+	}
+	return datoms, nil
+}

--- a/datalog/storage/export_bin.go
+++ b/datalog/storage/export_bin.go
@@ -1,12 +1,15 @@
 package storage
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/wbrown/janus-datalog/datalog"
 	"github.com/wbrown/janus-datalog/datalog/codec"
@@ -175,6 +178,8 @@ func (d *Database) ExportBinary(w io.WriteSeeker, opts ...BinaryExportOptions) e
 
 // ImportBinary reads a JDZL file and asserts its datoms. r must be an
 // io.ReadSeeker. Chunks are decoded and asserted in parallel up to Workers.
+// The first worker error cancels remaining launches and in-flight work; the
+// store may still contain a partial import when an error is returned.
 func (d *Database) ImportBinary(r io.ReadSeeker, opts ...BinaryImportOptions) error {
 	workers := runtime.GOMAXPROCS(0)
 	if len(opts) > 0 && opts[0].Workers > 0 {
@@ -190,41 +195,63 @@ func (d *Database) ImportBinary(r io.ReadSeeker, opts ...BinaryImportOptions) er
 		return err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	var seekMu sync.Mutex
 	sem := make(chan struct{}, workers)
-	errCh := make(chan error, len(trailer.entries))
+	errCh := make(chan error, 1)
 	var wg sync.WaitGroup
+	var reported atomic.Bool
+	reportErr := func(err error) {
+		if err == nil || !reported.CompareAndSwap(false, true) {
+			return
+		}
+		cancel()
+		errCh <- err
+	}
+
 	for i := range trailer.entries {
 		entry := trailer.entries[i]
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(entry binaryIndexEntry) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			unc, err := readBinaryChunkPayload(r, entry, &seekMu)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			datoms, err := decodeBinaryChunk(unc)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			if len(datoms) == 0 {
-				return
-			}
-			if err := d.store.Assert(datoms); err != nil {
-				errCh <- fmt.Errorf("binary import assert chunk at %d: %w", entry.offset, err)
-			}
-		}(entry)
+		select {
+		case <-ctx.Done():
+			// Stop launching; in-flight workers still finish or exit on ctx checks.
+		case sem <- struct{}{}:
+			wg.Add(1)
+			go func(entry binaryIndexEntry) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				if ctx.Err() != nil {
+					return
+				}
+				unc, err := readBinaryChunkPayload(r, entry, &seekMu)
+				if err != nil {
+					reportErr(err)
+					return
+				}
+				if ctx.Err() != nil {
+					return
+				}
+				datoms, err := decodeBinaryChunk(unc)
+				if err != nil {
+					reportErr(err)
+					return
+				}
+				if len(datoms) == 0 || ctx.Err() != nil {
+					return
+				}
+				if err := d.store.Assert(datoms); err != nil {
+					reportErr(fmt.Errorf("binary import assert chunk at %d: %w", entry.offset, err))
+				}
+			}(entry)
+			continue
+		}
+		break
 	}
 	wg.Wait()
 	close(errCh)
-	for err := range errCh {
-		if err != nil {
-			return err
-		}
+	if err := <-errCh; err != nil {
+		return err
 	}
 
 	maxElementID := trailer.maxTx
@@ -282,11 +309,19 @@ func writeBinaryChunk(w io.Writer, offset uint64, unc []byte, firstE, lastE [20]
 		flags = binaryChunkFlagRaw
 		payload = unc
 	}
+	uncLen, err := binaryUint32Len(len(unc), "uncompressed chunk")
+	if err != nil {
+		return binaryIndexEntry{}, 0, err
+	}
+	cmpLen, err := binaryUint32Len(len(payload), "compressed chunk")
+	if err != nil {
+		return binaryIndexEntry{}, 0, err
+	}
 	var hdr [binaryChunkHeaderSize]byte
 	hdr[0] = binaryChunkTypeData
 	hdr[1] = flags
-	binary.BigEndian.PutUint32(hdr[2:6], uint32(len(unc)))
-	binary.BigEndian.PutUint32(hdr[6:10], uint32(len(payload)))
+	binary.BigEndian.PutUint32(hdr[2:6], uncLen)
+	binary.BigEndian.PutUint32(hdr[6:10], cmpLen)
 	n, err := w.Write(hdr[:])
 	if err != nil {
 		return binaryIndexEntry{}, 0, err
@@ -297,17 +332,21 @@ func writeBinaryChunk(w io.Writer, offset uint64, unc []byte, firstE, lastE [20]
 	}
 	return binaryIndexEntry{
 		offset: offset,
-		cmpLen: uint32(len(payload)),
-		uncLen: uint32(len(unc)),
+		cmpLen: cmpLen,
+		uncLen: uncLen,
 		firstE: firstE,
 		lastE:  lastE,
 	}, int64(n + m), nil
 }
 
 func writeBinaryIndex(w io.Writer, trailer binaryTrailer) error {
+	count, err := binaryUint32Len(len(trailer.entries), "index entry count")
+	if err != nil {
+		return err
+	}
 	var hdr [24]byte
 	copy(hdr[0:4], binaryIndexMagic)
-	binary.BigEndian.PutUint32(hdr[4:8], uint32(len(trailer.entries)))
+	binary.BigEndian.PutUint32(hdr[4:8], count)
 	binary.BigEndian.PutUint64(hdr[8:16], trailer.maxTx.Lamport)
 	binary.BigEndian.PutUint64(hdr[16:24], trailer.maxTx.ReplicaID)
 	if _, err := w.Write(hdr[:]); err != nil {
@@ -331,6 +370,13 @@ func readBinaryIndex(r io.ReadSeeker, indexOffset uint64) (binaryTrailer, error)
 	if indexOffset < binaryHeaderSize {
 		return binaryTrailer{}, errors.New("binary import: invalid index offset")
 	}
+	fileSize, err := seekerSize(r)
+	if err != nil {
+		return binaryTrailer{}, err
+	}
+	if indexOffset > uint64(fileSize) {
+		return binaryTrailer{}, errors.New("binary import: index offset past end of file")
+	}
 	if _, err := r.Seek(int64(indexOffset), io.SeekStart); err != nil {
 		return binaryTrailer{}, fmt.Errorf("binary import seek index: %w", err)
 	}
@@ -342,6 +388,11 @@ func readBinaryIndex(r io.ReadSeeker, indexOffset uint64) (binaryTrailer, error)
 		return binaryTrailer{}, fmt.Errorf("binary import: bad index magic %q", hdr[0:4])
 	}
 	count := binary.BigEndian.Uint32(hdr[4:8])
+	remaining := uint64(fileSize) - indexOffset - uint64(len(hdr))
+	maxEntries := remaining / binaryIndexEntrySize
+	if uint64(count) > maxEntries {
+		return binaryTrailer{}, fmt.Errorf("binary import: index count %d exceeds remaining file capacity %d", count, maxEntries)
+	}
 	trailer := binaryTrailer{
 		entries: make([]binaryIndexEntry, 0, count),
 		maxTx: datalog.ElementID{
@@ -368,6 +419,13 @@ func readBinaryIndex(r io.ReadSeeker, indexOffset uint64) (binaryTrailer, error)
 func readBinaryChunkPayload(r io.ReadSeeker, entry binaryIndexEntry, seekMu *sync.Mutex) ([]byte, error) {
 	seekMu.Lock()
 	defer seekMu.Unlock()
+	fileSize, err := seekerSize(r)
+	if err != nil {
+		return nil, err
+	}
+	if entry.offset > uint64(fileSize) {
+		return nil, fmt.Errorf("binary import: chunk offset %d past end of file", entry.offset)
+	}
 	if _, err := r.Seek(int64(entry.offset), io.SeekStart); err != nil {
 		return nil, fmt.Errorf("binary import seek chunk: %w", err)
 	}
@@ -383,6 +441,10 @@ func readBinaryChunkPayload(r io.ReadSeeker, entry binaryIndexEntry, seekMu *syn
 	cmpLen := binary.BigEndian.Uint32(hdr[6:10])
 	if uncLen != entry.uncLen || cmpLen != entry.cmpLen {
 		return nil, fmt.Errorf("binary import: chunk length mismatch at %d", entry.offset)
+	}
+	payloadEnd := entry.offset + uint64(binaryChunkHeaderSize) + uint64(cmpLen)
+	if payloadEnd > uint64(fileSize) {
+		return nil, fmt.Errorf("binary import: chunk payload at %d exceeds file size", entry.offset)
 	}
 	payload := make([]byte, cmpLen)
 	if _, err := io.ReadFull(r, payload); err != nil {
@@ -416,6 +478,10 @@ func encodeBinaryDatom(d *datalog.Datom) ([]byte, error) {
 	}
 
 	vBytes := datalog.ValueBytes(d.V)
+	vLen, err := binaryUint32Len(len(vBytes), "value")
+	if err != nil {
+		return nil, err
+	}
 	recLen := 20 + 32 + 16 + 1 + 1 + 1 + 4 + len(vBytes)
 	if d.Op.HasAfterRef() {
 		recLen += 16
@@ -442,7 +508,7 @@ func encodeBinaryDatom(d *datalog.Datom) ([]byte, error) {
 	}
 	buf[off] = byte(datalog.Type(d.V))
 	off++
-	binary.BigEndian.PutUint32(buf[off:off+4], uint32(len(vBytes)))
+	binary.BigEndian.PutUint32(buf[off:off+4], vLen)
 	off += 4
 	copy(buf[off:], vBytes)
 	return buf, nil
@@ -452,8 +518,9 @@ func decodeBinaryChunk(unc []byte) ([]datalog.Datom, error) {
 	var datoms []datalog.Datom
 	off := 0
 	for off < len(unc) {
-		need := 20 + 32 + 16 + 1 + 1 + 1 + 4
-		if off+need > len(unc) {
+		// Fixed prefix through flags; AfterRef and value header checked after.
+		const prefixLen = 20 + 32 + 16 + 1 + 1
+		if off+prefixLen > len(unc) {
 			return nil, fmt.Errorf("binary import: truncated record at %d", off)
 		}
 		var eHash [20]byte
@@ -476,11 +543,14 @@ func decodeBinaryChunk(unc []byte) ([]datalog.Datom, error) {
 			afterRef = datalog.ElementIDFromBytes(unc[off : off+16])
 			off += 16
 		}
+		if off+5 > len(unc) {
+			return nil, fmt.Errorf("binary import: truncated value header at %d", off)
+		}
 		vType := datalog.ValueType(unc[off])
 		off++
 		vLen := binary.BigEndian.Uint32(unc[off : off+4])
 		off += 4
-		if off+int(vLen) > len(unc) {
+		if uint64(off)+uint64(vLen) > uint64(len(unc)) {
 			return nil, fmt.Errorf("binary import: truncated value at %d", off)
 		}
 		v, err := datalog.ValueFromBytes(vType, unc[off:off+int(vLen)])
@@ -499,4 +569,26 @@ func decodeBinaryChunk(unc []byte) ([]datalog.Datom, error) {
 		})
 	}
 	return datoms, nil
+}
+
+func binaryUint32Len(n int, what string) (uint32, error) {
+	if n < 0 || n > math.MaxUint32 {
+		return 0, fmt.Errorf("binary export: %s length %d exceeds uint32", what, n)
+	}
+	return uint32(n), nil
+}
+
+func seekerSize(r io.ReadSeeker) (int64, error) {
+	cur, err := r.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return 0, fmt.Errorf("binary import tell: %w", err)
+	}
+	end, err := r.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, fmt.Errorf("binary import size: %w", err)
+	}
+	if _, err := r.Seek(cur, io.SeekStart); err != nil {
+		return 0, fmt.Errorf("binary import restore: %w", err)
+	}
+	return end, nil
 }

--- a/datalog/storage/export_bin_test.go
+++ b/datalog/storage/export_bin_test.go
@@ -252,25 +252,39 @@ func TestBinaryExportImport_RGAAfterRef(t *testing.T) {
 	var out seekBuffer
 	require.NoError(t, db1.ExportBinary(&out))
 
-	// At least one exported record must carry the AfterRef flag (RGA ops).
+	// Decode every RGA record and require a real AfterRef chain: first insert
+	// after HEAD (zero ElementID), later inserts after a prior insert's Tx.
+	// Byte-identity alone would miss an encode that truncates AfterRef.
 	hdr, err := readBinaryHeader(&out)
 	require.NoError(t, err)
 	trailer, err := readBinaryIndex(&out, hdr.indexOffset)
 	require.NoError(t, err)
 	var seekMu sync.Mutex
-	foundAfterRef := false
+	type rgaRec struct {
+		v        string
+		tx       datalog.ElementID
+		afterRef datalog.ElementID
+	}
+	var rga []rgaRec
 	for _, entry := range trailer.entries {
 		unc, err := readBinaryChunkPayload(&out, entry, &seekMu)
 		require.NoError(t, err)
 		datoms, err := decodeBinaryChunk(unc)
 		require.NoError(t, err)
 		for _, d := range datoms {
-			if d.Op.HasAfterRef() {
-				foundAfterRef = true
+			if !d.Op.HasAfterRef() {
+				continue
 			}
+			v, ok := d.V.(string)
+			require.True(t, ok, "RGA value should be string, got %T", d.V)
+			rga = append(rga, rgaRec{v: v, tx: d.Tx, afterRef: d.AfterRef})
 		}
 	}
-	require.True(t, foundAfterRef, "expected RGA AfterRef records in binary export")
+	require.Len(t, rga, 3, "expected three RGA insert records")
+	require.True(t, rga[0].afterRef.IsZero(), "first insert AfterRef should be HEAD (zero)")
+	require.Equal(t, rga[0].tx, rga[1].afterRef, "second insert AfterRef must equal first Tx")
+	require.Equal(t, rga[1].tx, rga[2].afterRef, "third insert AfterRef must equal second Tx")
+	require.Equal(t, []string{"first", "second", "third"}, []string{rga[0].v, rga[1].v, rga[2].v})
 
 	db2, err := NewDatabaseWithOptions(DatabaseOptions{
 		Path:   t.TempDir(),
@@ -279,6 +293,13 @@ func TestBinaryExportImport_RGAAfterRef(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { db2.Close() })
 	require.NoError(t, db2.ImportBinary(&out))
+
+	type docItems struct {
+		Items []string `datalog:"doc/items"`
+	}
+	var got docItems
+	require.NoError(t, db2.PullInto(id, &got))
+	require.Equal(t, []string{"first", "second", "third"}, got.Items)
 
 	var again seekBuffer
 	require.NoError(t, db2.ExportBinary(&again))
@@ -389,7 +410,16 @@ func TestBinaryImport_RejectsOversizedIndexCount(t *testing.T) {
 }
 
 func TestBinaryUint32Len_RejectsOverflow(t *testing.T) {
-	_, err := binaryUint32Len(int(math.MaxUint32)+1, "value")
+	_, err := binaryUint32Len(-1, "value")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds uint32")
+
+	// MaxUint32+1 is not representable as int on 32-bit hosts.
+	if ^uint(0)>>32 == 0 {
+		t.Skip("int cannot exceed MaxUint32 on this architecture")
+	}
+	n := int(uint64(math.MaxUint32) + 1)
+	_, err = binaryUint32Len(n, "value")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exceeds uint32")
 }

--- a/datalog/storage/export_bin_test.go
+++ b/datalog/storage/export_bin_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"math"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -223,4 +225,171 @@ func TestBinaryImport_ParallelWorkers(t *testing.T) {
 	require.NoError(t, db1.Export(&edn1))
 	require.NoError(t, db2.Export(&edn2))
 	require.Equal(t, edn1.String(), edn2.String())
+}
+
+func TestBinaryExportImport_RGAAfterRef(t *testing.T) {
+	sch, err := schema.NewBuilder().
+		Attribute(":doc/items").Type(schema.TypeString).Vector().Add().
+		Build()
+	require.NoError(t, err)
+
+	db1, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:   t.TempDir(),
+		Schema: sch,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db1.Close() })
+
+	id := datalog.NewIdentity("bin:rga")
+	items := datalog.NewKeyword(":doc/items")
+	tx := db1.NewTransaction()
+	require.NoError(t, tx.Add(id, items, "first"))
+	require.NoError(t, tx.Add(id, items, "second"))
+	require.NoError(t, tx.Add(id, items, "third"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	var out seekBuffer
+	require.NoError(t, db1.ExportBinary(&out))
+
+	// At least one exported record must carry the AfterRef flag (RGA ops).
+	hdr, err := readBinaryHeader(&out)
+	require.NoError(t, err)
+	trailer, err := readBinaryIndex(&out, hdr.indexOffset)
+	require.NoError(t, err)
+	var seekMu sync.Mutex
+	foundAfterRef := false
+	for _, entry := range trailer.entries {
+		unc, err := readBinaryChunkPayload(&out, entry, &seekMu)
+		require.NoError(t, err)
+		datoms, err := decodeBinaryChunk(unc)
+		require.NoError(t, err)
+		for _, d := range datoms {
+			if d.Op.HasAfterRef() {
+				foundAfterRef = true
+			}
+		}
+	}
+	require.True(t, foundAfterRef, "expected RGA AfterRef records in binary export")
+
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:   t.TempDir(),
+		Schema: sch,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db2.Close() })
+	require.NoError(t, db2.ImportBinary(&out))
+
+	var again seekBuffer
+	require.NoError(t, db2.ExportBinary(&again))
+	require.Equal(t, out.buf, again.buf)
+}
+
+func TestDecodeBinaryChunk_TruncatedAfterRef(t *testing.T) {
+	// Fixed prefix through flags (70 bytes), flag AfterRef, then only 8 of 16.
+	unc := make([]byte, 70+8)
+	unc[68] = byte(datalog.OpRGAInsert)
+	unc[69] = binaryRecordFlagAfterRef
+	_, err := decodeBinaryChunk(unc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AfterRef")
+}
+
+func TestDecodeBinaryChunk_TruncatedValueHeaderAfterAfterRef(t *testing.T) {
+	// Full AfterRef present, but cut before V_type / V_len — must not panic.
+	unc := make([]byte, 70+16)
+	unc[68] = byte(datalog.OpRGAInsert)
+	unc[69] = binaryRecordFlagAfterRef
+	_, err := decodeBinaryChunk(unc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "value header")
+}
+
+func TestBinaryImport_RejectsBadMagic(t *testing.T) {
+	db := openBinaryTestDB(t)
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(datalog.NewIdentity("bin:bad"), datalog.NewKeyword(":t/v"), "x"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var out seekBuffer
+	require.NoError(t, db.ExportBinary(&out))
+	out.buf[0] = 'X'
+
+	db2 := openBinaryTestDB(t)
+	err = db2.ImportBinary(&out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad magic")
+}
+
+func TestBinaryImport_RejectsUnsupportedVersion(t *testing.T) {
+	db := openBinaryTestDB(t)
+	tx := db.NewTransaction()
+	require.NoError(t, tx.Add(datalog.NewIdentity("bin:ver"), datalog.NewKeyword(":t/v"), "x"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var out seekBuffer
+	require.NoError(t, db.ExportBinary(&out))
+	out.buf[4] = binaryExportVersion + 1
+
+	db2 := openBinaryTestDB(t)
+	err = db2.ImportBinary(&out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported version")
+}
+
+func TestBinaryImport_RejectsCorruptChunk(t *testing.T) {
+	db1 := openBinaryTestDB(t)
+	tx := db1.NewTransaction()
+	for i := 0; i < 8; i++ {
+		e := datalog.NewIdentity("bin:corrupt:" + string(rune('a'+i)))
+		require.NoError(t, tx.Add(e, datalog.NewKeyword(":c/v"), int64(i)))
+	}
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var out seekBuffer
+	require.NoError(t, db1.ExportBinary(&out, BinaryExportOptions{SoftBudget: 1}))
+
+	hdr, err := readBinaryHeader(&out)
+	require.NoError(t, err)
+	trailer, err := readBinaryIndex(&out, hdr.indexOffset)
+	require.NoError(t, err)
+	require.NotEmpty(t, trailer.entries)
+
+	// Corrupt the first chunk's type byte — reliable whether the payload is
+	// LZJ-compressed or raw (small SoftBudget chunks often stay raw).
+	entry := trailer.entries[0]
+	require.Less(t, int(entry.offset), len(out.buf))
+	out.buf[entry.offset] = 0xff
+
+	db2 := openBinaryTestDB(t)
+	err = db2.ImportBinary(&out, BinaryImportOptions{Workers: 4})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected chunk type")
+}
+
+func TestBinaryImport_RejectsOversizedIndexCount(t *testing.T) {
+	// Minimal header + trailer claiming an absurd entry count for a tiny file.
+	var buf seekBuffer
+	require.NoError(t, writeBinaryHeader(&buf, 64, binaryHeaderSize))
+	var hdr [24]byte
+	copy(hdr[0:4], binaryIndexMagic)
+	binary.BigEndian.PutUint32(hdr[4:8], math.MaxUint32)
+	_, err := buf.Write(hdr[:])
+	require.NoError(t, err)
+
+	db := openBinaryTestDB(t)
+	err = db.ImportBinary(&buf)
+	require.Error(t, err)
+	require.True(t,
+		strings.Contains(err.Error(), "index count") || strings.Contains(err.Error(), "index"),
+		"got: %v", err)
+}
+
+func TestBinaryUint32Len_RejectsOverflow(t *testing.T) {
+	_, err := binaryUint32Len(int(math.MaxUint32)+1, "value")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds uint32")
 }

--- a/datalog/storage/export_bin_test.go
+++ b/datalog/storage/export_bin_test.go
@@ -1,0 +1,226 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+	"github.com/wbrown/janus-datalog/datalog/schema"
+)
+
+// seekBuffer is an in-memory io.ReadWriteSeeker for binary export tests.
+type seekBuffer struct {
+	buf []byte
+	off int64
+}
+
+func (s *seekBuffer) Write(p []byte) (int, error) {
+	end := int(s.off) + len(p)
+	if end > len(s.buf) {
+		nb := make([]byte, end)
+		copy(nb, s.buf)
+		s.buf = nb
+	}
+	n := copy(s.buf[s.off:], p)
+	s.off += int64(n)
+	return n, nil
+}
+
+func (s *seekBuffer) Read(p []byte) (int, error) {
+	if s.off >= int64(len(s.buf)) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.buf[s.off:])
+	s.off += int64(n)
+	return n, nil
+}
+
+func (s *seekBuffer) Seek(offset int64, whence int) (int64, error) {
+	var next int64
+	switch whence {
+	case io.SeekStart:
+		next = offset
+	case io.SeekCurrent:
+		next = s.off + offset
+	case io.SeekEnd:
+		next = int64(len(s.buf)) + offset
+	default:
+		return 0, io.ErrUnexpectedEOF
+	}
+	if next < 0 {
+		return 0, io.ErrUnexpectedEOF
+	}
+	s.off = next
+	return s.off, nil
+}
+
+func openBinaryTestDB(t *testing.T) *Database {
+	t.Helper()
+	db, err := NewDatabase(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestBinaryExportImport_RoundTrip(t *testing.T) {
+	db1 := openBinaryTestDB(t)
+	tx := db1.NewTransaction()
+	e1 := datalog.NewIdentity("bin:alice")
+	e2 := datalog.NewIdentity("bin:bob")
+	require.NoError(t, tx.Add(e1, datalog.NewKeyword(":person/name"), "Alice"))
+	require.NoError(t, tx.Add(e1, datalog.NewKeyword(":person/age"), int64(30)))
+	require.NoError(t, tx.Add(e1, datalog.NewKeyword(":person/active"), true))
+	require.NoError(t, tx.Add(e1, datalog.NewKeyword(":person/created"), time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)))
+	require.NoError(t, tx.Add(e1, datalog.NewKeyword(":person/data"), []byte{1, 2, 3, 4}))
+	require.NoError(t, tx.Add(e1, datalog.NewKeyword(":person/friend"), e2))
+	require.NoError(t, tx.Add(e2, datalog.NewKeyword(":person/name"), "Bob"))
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var out seekBuffer
+	require.NoError(t, db1.ExportBinary(&out, BinaryExportOptions{SoftBudget: 64}))
+
+	db2 := openBinaryTestDB(t)
+	require.NoError(t, db2.ImportBinary(&out, BinaryImportOptions{Workers: 2}))
+
+	var again seekBuffer
+	require.NoError(t, db2.ExportBinary(&again, BinaryExportOptions{SoftBudget: 64}))
+	require.Equal(t, out.buf, again.buf)
+}
+
+func TestBinaryExportImport_PreservesCRDTOps(t *testing.T) {
+	sch, err := schema.NewBuilder().
+		Attribute(":item/tags").Type(schema.TypeString).Many().Add().
+		Build()
+	require.NoError(t, err)
+
+	db1, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:   t.TempDir(),
+		Schema: sch,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db1.Close() })
+
+	e := datalog.NewIdentity("bin:crdt")
+	tx := db1.NewTransaction()
+	require.NoError(t, tx.Add(e, datalog.NewKeyword(":item/tags"), "a"))
+	require.NoError(t, tx.Add(e, datalog.NewKeyword(":item/tags"), "b"))
+	_, err = tx.Commit()
+	require.NoError(t, err)
+
+	tx2 := db1.NewTransaction()
+	require.NoError(t, tx2.Remove(e, datalog.NewKeyword(":item/tags"), "a"))
+	_, err = tx2.Commit()
+	require.NoError(t, err)
+
+	var out seekBuffer
+	require.NoError(t, db1.ExportBinary(&out))
+
+	db2, err := NewDatabaseWithOptions(DatabaseOptions{
+		Path:   t.TempDir(),
+		Schema: sch,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db2.Close() })
+	require.NoError(t, db2.ImportBinary(&out))
+
+	tags, err := db2.GetStrings(e, datalog.NewKeyword(":item/tags"))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"b"}, tags)
+}
+
+func TestBinaryExport_EntityAlignedSoftClose(t *testing.T) {
+	db := openBinaryTestDB(t)
+	tx := db.NewTransaction()
+	// Three entities; tiny soft budget forces closeSoon quickly, but each
+	// entity's datoms must remain in one chunk.
+	for _, name := range []string{"e0", "e1", "e2"} {
+		e := datalog.NewIdentity("bin:align:" + name)
+		require.NoError(t, tx.Add(e, datalog.NewKeyword(":x/a"), name+"-a"))
+		require.NoError(t, tx.Add(e, datalog.NewKeyword(":x/b"), name+"-b"))
+		require.NoError(t, tx.Add(e, datalog.NewKeyword(":x/c"), name+"-c"))
+	}
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var out seekBuffer
+	require.NoError(t, db.ExportBinary(&out, BinaryExportOptions{SoftBudget: 1}))
+
+	hdr, err := readBinaryHeader(&out)
+	require.NoError(t, err)
+	trailer, err := readBinaryIndex(&out, hdr.indexOffset)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(trailer.entries), 1)
+
+	for _, entry := range trailer.entries {
+		require.Equal(t, entry.firstE, entry.lastE,
+			"soft-close must not split an entity across chunks; first=%x last=%x", entry.firstE, entry.lastE)
+	}
+}
+
+func TestBinaryExport_IndexSeekable(t *testing.T) {
+	db := openBinaryTestDB(t)
+	tx := db.NewTransaction()
+	for i := 0; i < 5; i++ {
+		e := datalog.NewIdentity("bin:idx:" + string(rune('a'+i)))
+		require.NoError(t, tx.Add(e, datalog.NewKeyword(":n/v"), int64(i)))
+	}
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var out seekBuffer
+	require.NoError(t, db.ExportBinary(&out, BinaryExportOptions{SoftBudget: 1}))
+
+	require.Equal(t, binaryExportMagic, string(out.buf[0:4]))
+	indexOffset := binary.BigEndian.Uint64(out.buf[16:24])
+	require.Greater(t, indexOffset, uint64(binaryHeaderSize))
+	require.Equal(t, binaryIndexMagic, string(out.buf[indexOffset:indexOffset+4]))
+
+	hdr, err := readBinaryHeader(&out)
+	require.NoError(t, err)
+	trailer, err := readBinaryIndex(&out, hdr.indexOffset)
+	require.NoError(t, err)
+	require.NotEmpty(t, trailer.entries)
+
+	var seekMu sync.Mutex
+	for _, entry := range trailer.entries {
+		unc, err := readBinaryChunkPayload(&out, entry, &seekMu)
+		require.NoError(t, err)
+		datoms, err := decodeBinaryChunk(unc)
+		require.NoError(t, err)
+		require.NotEmpty(t, datoms)
+		var first, last [20]byte
+		copy(first[:], datoms[0].E.Bytes())
+		copy(last[:], datoms[len(datoms)-1].E.Bytes())
+		require.Equal(t, entry.firstE, first)
+		require.Equal(t, entry.lastE, last)
+	}
+}
+
+func TestBinaryImport_ParallelWorkers(t *testing.T) {
+	db1 := openBinaryTestDB(t)
+	tx := db1.NewTransaction()
+	for i := 0; i < 20; i++ {
+		e := datalog.NewIdentity("bin:par:" + string(rune('a'+i%26)) + string(rune('0'+i/26)))
+		require.NoError(t, tx.Add(e, datalog.NewKeyword(":p/n"), int64(i)))
+		require.NoError(t, tx.Add(e, datalog.NewKeyword(":p/s"), "payload-"+string(rune('a'+i%26))))
+	}
+	_, err := tx.Commit()
+	require.NoError(t, err)
+
+	var out seekBuffer
+	require.NoError(t, db1.ExportBinary(&out, BinaryExportOptions{SoftBudget: 32}))
+
+	db2 := openBinaryTestDB(t)
+	require.NoError(t, db2.ImportBinary(&out, BinaryImportOptions{Workers: 4}))
+
+	var edn1, edn2 bytes.Buffer
+	require.NoError(t, db1.Export(&edn1))
+	require.NoError(t, db2.Export(&edn2))
+	require.Equal(t, edn1.String(), edn2.String())
+}

--- a/docs/reference/BINARY_EXPORT.md
+++ b/docs/reference/BINARY_EXPORT.md
@@ -138,10 +138,17 @@ compressed payload, or value exceeds 4 GiB — it does not truncate.
 2. Fan out over index entries (worker limit configurable).
 3. Each worker: seek → read frame → decompress → decode records → `store.Assert`.
 4. The first worker error cancels further launches and asks in-flight workers
-   to stop between steps; `ImportBinary` then returns that error. The store may
-   already contain a partial import (import is not transactional across chunks).
+   to stop between steps; `ImportBinary` then returns that error.
 5. After all workers succeed, `clock.Restore` using the trailer max ElementID
    (or `store.MaxElementID()` as a cross-check).
+
+**Error semantics (non-transactional):** import is not all-or-nothing across
+chunks. Workers that already completed `Assert` before cancellation leave their
+datoms in the store. Which subset committed is scheduling-dependent
+(nondeterministic). A failed `ImportBinary` is therefore **not** a clean
+rollback, and retrying the same import into the same database is **not** a
+safe recovery path. After an error, import into a **fresh** database directory
+(or discard the partially mutated target) and run again.
 
 Index entry counts and chunk payload lengths are bounded against remaining file
 size before allocation. Chunks never split an entity, so workers do not

--- a/docs/reference/BINARY_EXPORT.md
+++ b/docs/reference/BINARY_EXPORT.md
@@ -128,18 +128,25 @@ The soft budget does **not** terminate a chunk mid-entity.
 
 A single entity larger than the soft budget produces one oversized chunk. Do
 not split mid-entity: keeping an entity’s datoms in one LZJ window maximizes
-compression of the repeated `E` field (and adjacent `A` runs).
+compression of the repeated `E` field (and adjacent `A` runs). Chunk and value
+lengths are `uint32` on the wire; export fails if an uncompressed chunk,
+compressed payload, or value exceeds 4 GiB — it does not truncate.
 
 ## Parallel import
 
 1. Read header; seek to `index_offset`; parse index.
 2. Fan out over index entries (worker limit configurable).
 3. Each worker: seek → read frame → decompress → decode records → `store.Assert`.
-4. After all workers succeed, `clock.Restore` using the trailer max ElementID
+4. The first worker error cancels further launches and asks in-flight workers
+   to stop between steps; `ImportBinary` then returns that error. The store may
+   already contain a partial import (import is not transactional across chunks).
+5. After all workers succeed, `clock.Restore` using the trailer max ElementID
    (or `store.MaxElementID()` as a cross-check).
 
-Chunks never split an entity, so workers do not coordinate on entity identity.
-`Assert` rebuilds all eight indices and blobs for each batch.
+Index entry counts and chunk payload lengths are bounded against remaining file
+size before allocation. Chunks never split an entity, so workers do not
+coordinate on entity identity. `Assert` rebuilds all eight indices and blobs
+for each batch.
 
 ## Semantics preserved (same as EDN dump)
 

--- a/docs/reference/BINARY_EXPORT.md
+++ b/docs/reference/BINARY_EXPORT.md
@@ -1,0 +1,159 @@
+# Binary Database Export (JDZL)
+
+Compressed, seekable sibling of the EDN dump. Same semantic contract: the
+complete EAVT datom log (not a current-view snapshot), including CRDT ops and
+AfterRefs. Values are inlined (Tier-3 blobs are decoded on export and
+re-encoded on import). Schema is not part of the dump.
+
+Compression uses the package `codec` LZJ compressor (`Compress` /
+`Decompress`) on **independent chunks**. LZJ is whole-buffer only; streaming
+I/O is framed chunks, not a byte-stream codec.
+
+## Goals
+
+- Smaller and faster than EDN for backup / migration / wasm host persistence
+- Streaming export from an EAVT scan with bounded memory
+- Seekable trailer index for parallel import
+- Reuse storage value encoding (`datalog.ValueBytes` / `ValueFromBytes`)
+- Attributes are keyword **strings** in the fixed 32-byte storage layout
+  (zero-padded), not hashes. Entity identities remain 20-byte hashes.
+
+## CLI
+
+```bash
+datalog -db mydata.db -export-bin backup.jdzl
+datalog -db newdata.db -import-bin backup.jdzl
+```
+
+EDN `-export` / `-import` are unchanged.
+
+## File layout
+
+```text
+┌─────────────────────────────────────────────┐
+│ File header (32 bytes, fixed)               │
+├─────────────────────────────────────────────┤
+│ Data chunk × N                              │
+├─────────────────────────────────────────────┤
+│ Trailer index (at header.index_offset)      │
+└─────────────────────────────────────────────┘
+```
+
+All multi-byte integers are big-endian.
+
+### File header (32 bytes)
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 4 | Magic `JDZL` |
+| 4 | 1 | Format version (`1`) |
+| 5 | 2 | Flags (reserved, write `0`) |
+| 7 | 1 | Reserved (`0`) |
+| 8 | 4 | Soft budget (uncompressed bytes; advisory) |
+| 12 | 4 | Reserved (`0`) |
+| 16 | 8 | Absolute file offset of trailer index |
+| 24 | 8 | Reserved (`0`) |
+
+Export requires an `io.WriteSeeker` so `index_offset` can be patched after the
+index is written. Import requires an `io.ReadSeeker` for indexed / parallel
+reads.
+
+### Data chunk frame
+
+| Field | Size | Notes |
+|-------|------|-------|
+| `type` | 1 | `1` = data |
+| `flags` | 1 | bit0 = payload is raw (LZJ declined) |
+| `unc_len` | 4 | Uncompressed payload length |
+| `cmp_len` | 4 | On-wire payload length |
+| `payload` | `cmp_len` | LZJ bytes, or raw when bit0 set |
+
+`Compress` is applied to the uncompressed chunk body. When it returns `nil`
+(no size benefit), the chunk is stored raw with bit0 set and
+`cmp_len == unc_len`.
+
+### Chunk body (uncompressed)
+
+A concatenation of binary datom records in **EAVT scan order**. No padding
+between records.
+
+#### Datom record
+
+| Field | Size | Notes |
+|-------|------|-------|
+| `E` | 20 | Identity hash |
+| `A` | 32 | Keyword string, zero-padded (`copy(a[:], kw.String())`) |
+| `Tx` | 16 | ElementID natural order (`ElementID.Bytes()`) |
+| `Op` | 1 | `CRDTOp` |
+| `flags` | 1 | bit0 = AfterRef present |
+| `AfterRef` | 0 or 16 | Present iff bit0; natural-order ElementID |
+| `V_type` | 1 | `datalog.ValueType` |
+| `V_len` | 4 | Length of `V_bytes` |
+| `V_bytes` | `V_len` | `datalog.ValueBytes(V)` (no per-value LZJ; chunk LZJ covers it) |
+
+Values are the decoded logical values from the EAVT scan (blobs already
+inlined). Record encoding does not emit Tier-3 blob hashes.
+
+### Trailer index
+
+| Field | Size | Notes |
+|-------|------|-------|
+| Magic | 4 | `JDZI` |
+| `chunk_count` | 4 | |
+| `max_lamport` | 8 | Max Tx ElementID (Lamport) |
+| `max_replica` | 8 | ReplicaID of that max ElementID |
+| Entries | `chunk_count × 56` | See below |
+
+#### Index entry (56 bytes)
+
+| Field | Size |
+|-------|------|
+| `file_offset` | 8 | Absolute offset of chunk `type` byte |
+| `cmp_len` | 4 | On-wire payload length (excludes 10-byte chunk header) |
+| `unc_len` | 4 | |
+| `first_E` | 20 | First entity hash in chunk |
+| `last_E` | 20 | Last entity hash in chunk |
+
+`cmp_len` / `unc_len` describe the payload only. The on-wire chunk occupies
+`10 + cmp_len` bytes starting at `file_offset`.
+
+## Entity-aligned soft close
+
+The soft budget does **not** terminate a chunk mid-entity.
+
+1. Append datoms while scanning EAVT.
+2. When uncompressed size ≥ soft budget, set `close_soon`.
+3. Continue while `datom.E` equals the open entity.
+4. On the first datom with a new entity (or end of scan), flush the chunk.
+
+A single entity larger than the soft budget produces one oversized chunk. Do
+not split mid-entity: keeping an entity’s datoms in one LZJ window maximizes
+compression of the repeated `E` field (and adjacent `A` runs).
+
+## Parallel import
+
+1. Read header; seek to `index_offset`; parse index.
+2. Fan out over index entries (worker limit configurable).
+3. Each worker: seek → read frame → decompress → decode records → `store.Assert`.
+4. After all workers succeed, `clock.Restore` using the trailer max ElementID
+   (or `store.MaxElementID()` as a cross-check).
+
+Chunks never split an entity, so workers do not coordinate on entity identity.
+`Assert` rebuilds all eight indices and blobs for each batch.
+
+## Semantics preserved (same as EDN dump)
+
+1. Complete EAVT log, including removes and RGA ops
+2. Exact ElementIDs on Tx / AfterRef
+3. Op + AfterRef pairing
+4. Entity identity by hash; attribute identity by keyword string
+5. Value type fidelity via storage value codec
+6. No schema in the dump; import bypasses schema validation (`store.Assert`)
+7. Deterministic EAVT order for byte-stable re-export of the binary form when
+   the soft budget and encoder settings match
+
+## Versioning
+
+Format version lives in the file header. Unknown versions must be rejected.
+LZJ’s internal compression version byte remains inside each compressed
+payload; the dump envelope does not reinterpret it.


### PR DESCRIPTION
## Summary

EDN export/import remains the human-readable interchange path, but large databases need a compact machine format that still carries the full EAVT history: every datom's Op and AfterRef, ElementIDs for Lamport-clock restore on import, and decoded values with out-of-line blobs inlined at export time. This PR adds that path as JDZL — framed LZJ chunks over the same storage value codecs used by Badger keys, with a trailer index so import can seek and decode chunks in parallel.

The CLI grows `-export-bin` / `-import-bin` siblings of the existing EDN transfer flags. The mutually exclusive transfer-mode check now covers all four modes.

## Format

Magic `JDZL` (file) / `JDZI` (trailer index), version 1. A fixed header records soft budget and the trailer offset. Payload is a sequence of LZJ-framed chunks of uncompressed datom records. Soft-close is advisory: when an open chunk reaches the soft budget the exporter sets `closeSoon` and flushes only at the next entity boundary, so each entity's datoms stay in one compression window and E-prefix redundancy pays for LZJ.

The trailer lists per-chunk file offset, compressed/uncompressed lengths, and first/last entity hashes, plus the max ElementID seen. Import seeks by index entry rather than streaming the whole file, then asserts decoded datoms through the normal store path and advances the clock from the trailer max.

Attributes remain keyword strings in the fixed 32-byte attribute field (zero-padded), matching on-disk storage — not attribute hashes. Entity identities are the usual 20-byte hashes. Values reuse `ValueBytes` / `ValueFromBytes`.

Contract and layout details live in `docs/reference/BINARY_EXPORT.md`.

## API and CLI

`Database.ExportBinary(io.WriteSeeker, ...)` and `Database.ImportBinary(io.ReadSeeker, ...)` take optional soft-budget / worker knobs. WriteSeeker is required so export can patch the trailer offset after writing chunks.

`datalog -db PATH -export-bin FILE.jdzl` and `-import-bin FILE.jdzl` mirror the EDN transfer entry points. Import refuses `.edn` / `.jdzl` as the `-db` target the same way EDN import requires a database directory.

## Tests

- Round-trip binary export/import with scalar, ref, byte, and instant values
- Cardinality-many add/remove preserved through binary transfer
- Entity-aligned soft-close under a tiny soft budget
- Trailer index seekability
- Parallel chunk import with multiple workers
- CLI mutually exclusive transfer-mode diagnostic updated for the four flags

## Test plan

- [x] `go test -count=1 ./...`
- [x] Focused `./datalog/storage/ -run TestBinary`
- [x] Focused `./cmd/datalog/` CLI suite including the updated both-flags diagnostic

Made with [Cursor](https://cursor.com)