### PR TITLE
Treat .jdzl as a peer dump source to .edn in the CLI

### DIFF
--- a/cmd/datalog/main.go
+++ b/cmd/datalog/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	var inputValues ednSliceFlag
 
-	flag.StringVar(&dbPath, "db", "", "database or EDN dump path (.edn dumps load into a temporary database)")
+	flag.StringVar(&dbPath, "db", "", "database directory, or .edn/.jdzl dump (dumps load into a temporary database)")
 	flag.BoolVar(&interactive, "i", false, "interactive mode")
 	flag.BoolVar(&help, "h", false, "show help")
 	flag.BoolVar(&verbose, "verbose", false, "verbose mode (show query annotations)")
@@ -50,7 +50,7 @@ func main() {
 	flag.BoolVar(&showStats, "stats", false, "print per-attribute cardinality, value size, and duplication statistics")
 	flag.Var(&inputValues, "in", "input parameter as EDN value (repeatable, one per :in binding)")
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [options] [database_or_edn_dump_path]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [options] [database_or_dump_path]\n\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "A Datalog query engine with persistent storage.\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
@@ -68,6 +68,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  %s -db newdata.db -import-bin data.jdzl # Binary import\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -db mydata.db -stats            # Print cardinality and value statistics\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  %s -db dump.edn -query '...'       # Query an EDN dump directly (temporary database)\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s -db dump.jdzl -query '...'      # Query a JDZL dump directly (temporary database)\n", os.Args[0])
 	}
 	flag.Parse()
 
@@ -134,7 +135,7 @@ func main() {
 		return
 	}
 
-	// Open database (BadgerDB directory or .edn dump)
+	// Open database (BadgerDB directory, or .edn/.jdzl dump)
 	db, cleanup, err := openDatabaseOrEDN(dbPath)
 	if err != nil {
 		log.Fatalf("%v", err)
@@ -302,17 +303,24 @@ func parseValue(s string) interface{} {
 	return s
 }
 
+// isDumpFilePath reports whether path is an EDN or JDZL dump file (not a
+// BadgerDB directory). Both formats load into a disposable temp database via
+// openDatabaseOrEDN.
+func isDumpFilePath(path string) bool {
+	return strings.HasSuffix(path, ".edn") || strings.HasSuffix(path, ".jdzl")
+}
+
 // openDatabaseOrEDN opens dbPath as a BadgerDB database, or — when the path
-// ends in .edn — imports the EDN dump into a database in a temporary
+// ends in .edn or .jdzl — imports that dump into a database in a temporary
 // directory. The returned cleanup function closes the database and removes
-// the temporary directory; callers must invoke it. Writes to an EDN-backed
+// the temporary directory; callers must invoke it. Writes to a dump-backed
 // database are discarded when the process exits.
 func openDatabaseOrEDN(dbPath string) (*storage.Database, func(), error) {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil, nil, fmt.Errorf("database does not exist: %s", dbPath)
 	}
 
-	if !strings.HasSuffix(dbPath, ".edn") {
+	if !isDumpFilePath(dbPath) {
 		db, err := storage.NewDatabase(dbPath)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to open database: %w", err)
@@ -337,21 +345,30 @@ func openDatabaseOrEDN(dbPath string) (*storage.Database, func(), error) {
 	f, err := os.Open(dbPath)
 	if err != nil {
 		cleanup()
-		return nil, nil, fmt.Errorf("failed to open EDN file: %w", err)
+		return nil, nil, fmt.Errorf("failed to open dump file: %w", err)
 	}
 	defer f.Close()
 
-	if err := db.Import(f); err != nil {
-		cleanup()
-		return nil, nil, fmt.Errorf("failed to import EDN dump: %w", err)
+	switch {
+	case strings.HasSuffix(dbPath, ".edn"):
+		if err := db.Import(f); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("failed to import EDN dump: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Loaded EDN dump %s into a temporary database (changes will be discarded)\n", dbPath)
+	case strings.HasSuffix(dbPath, ".jdzl"):
+		if err := db.ImportBinary(f); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("failed to import JDZL dump: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Loaded JDZL dump %s into a temporary database (changes will be discarded)\n", dbPath)
 	}
 
-	fmt.Fprintf(os.Stderr, "Loaded EDN dump %s into a temporary database (changes will be discarded)\n", dbPath)
 	return db, cleanup, nil
 }
 
 // runExport exports the database to an EDN file. The source may itself be an
-// EDN dump, which supports re-encoding (e.g. plain dump -> -compressed dump).
+// .edn or .jdzl dump (re-encode / convert via a temporary database).
 func runExport(dbPath, exportPath string, compressed bool) {
 	db, cleanup, err := openDatabaseOrEDN(dbPath)
 	if err != nil {
@@ -376,10 +393,10 @@ func runExport(dbPath, exportPath string, compressed bool) {
 
 // runImport imports an EDN file into the database
 func runImport(dbPath, importPath string) {
-	// Importing into an .edn path would load into a discarded temp database;
-	// the target must be a real database directory.
-	if strings.HasSuffix(dbPath, ".edn") {
-		log.Fatalf("Cannot import into %s: -db must be a database directory, not an EDN dump", dbPath)
+	// Importing into a dump path would open/create a Badger directory named
+	// after the dump file; the target must be a real database directory.
+	if isDumpFilePath(dbPath) {
+		log.Fatalf("Cannot import into %s: -db must be a database directory", dbPath)
 	}
 
 	// Check if import file exists
@@ -438,7 +455,7 @@ func exportBinaryDatabase(dbPath, exportPath string) error {
 }
 
 func runImportBin(dbPath, importPath string) {
-	if strings.HasSuffix(dbPath, ".edn") || strings.HasSuffix(dbPath, ".jdzl") {
+	if isDumpFilePath(dbPath) {
 		log.Fatalf("Cannot import into %s: -db must be a database directory", dbPath)
 	}
 	if _, err := os.Stat(importPath); os.IsNotExist(err) {

--- a/cmd/datalog/open_database_test.go
+++ b/cmd/datalog/open_database_test.go
@@ -35,6 +35,30 @@ func createTestEDNDump(t *testing.T) string {
 	return ednPath
 }
 
+// createTestJDZLDump exports the standard two-person test database to a JDZL file.
+func createTestJDZLDump(t *testing.T) string {
+	t.Helper()
+	dbPath := createTestDatabase(t)
+
+	db, err := storage.NewDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	jdzlPath := filepath.Join(t.TempDir(), "dump.jdzl")
+	f, err := os.Create(jdzlPath)
+	if err != nil {
+		t.Fatalf("Failed to create JDZL file: %v", err)
+	}
+	defer f.Close()
+
+	if err := db.ExportBinary(f); err != nil {
+		t.Fatalf("Failed to export binary: %v", err)
+	}
+	return jdzlPath
+}
+
 func TestOpenDatabaseOrEDN_BadgerPath(t *testing.T) {
 	dbPath := createTestDatabase(t)
 
@@ -71,10 +95,29 @@ func TestOpenDatabaseOrEDN_EDNDump(t *testing.T) {
 	}
 }
 
+func TestOpenDatabaseOrEDN_JDZLDump(t *testing.T) {
+	jdzlPath := createTestJDZLDump(t)
+
+	db, cleanup, err := openDatabaseOrEDN(jdzlPath)
+	if err != nil {
+		t.Fatalf("openDatabaseOrEDN(jdzl dump) failed: %v", err)
+	}
+	defer cleanup()
+
+	results, err := executor.CollectTuples(db.Query(`[:find ?name :where [_ :person/name ?name]]`))
+	if err != nil {
+		t.Fatalf("Query against JDZL-backed database failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("Expected 2 names from JDZL dump, got %d", len(results))
+	}
+}
+
 func TestOpenDatabaseOrEDN_MissingPath(t *testing.T) {
 	for _, path := range []string{
 		"/nonexistent/path/db",
 		"/nonexistent/path/dump.edn",
+		"/nonexistent/path/dump.jdzl",
 	} {
 		_, _, err := openDatabaseOrEDN(path)
 		if err == nil {
@@ -143,6 +186,69 @@ func TestCLI_ExportFromEDNDump(t *testing.T) {
 	}
 }
 
+func TestCLI_QueryFromJDZLDump(t *testing.T) {
+	binPath := buildCLI(t)
+	jdzlPath := createTestJDZLDump(t)
+
+	cmd := exec.Command(binPath, "-db", jdzlPath,
+		"-query", `[:find ?name :where [_ :person/name ?name]]`)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Query against JDZL dump failed: %v\n%s", err, out)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, "Alice") || !strings.Contains(output, "Bob") {
+		t.Errorf("Expected Alice and Bob in output:\n%s", output)
+	}
+}
+
+func TestCLI_ExportEDNFromJDZLDump(t *testing.T) {
+	binPath := buildCLI(t)
+	jdzlPath := createTestJDZLDump(t)
+	exportPath := filepath.Join(t.TempDir(), "from-jdzl.edn")
+
+	cmd := exec.Command(binPath, "-db", jdzlPath, "-export", exportPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Export EDN from JDZL dump failed: %v\n%s", err, out)
+	}
+
+	reexported, err := os.ReadFile(exportPath)
+	if err != nil {
+		t.Fatalf("Failed to read re-exported file: %v", err)
+	}
+	if !strings.Contains(string(reexported), ":person/name") {
+		t.Errorf("EDN from JDZL missing expected datoms:\n%s", reexported)
+	}
+}
+
+func TestCLI_ExportBinFromJDZLDump(t *testing.T) {
+	binPath := buildCLI(t)
+	jdzlPath := createTestJDZLDump(t)
+	exportPath := filepath.Join(t.TempDir(), "recompressed.jdzl")
+
+	cmd := exec.Command(binPath, "-db", jdzlPath, "-export-bin", exportPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Export-bin from JDZL dump failed: %v\n%s", err, out)
+	}
+
+	db, cleanup, err := openDatabaseOrEDN(exportPath)
+	if err != nil {
+		t.Fatalf("open recompressed JDZL failed: %v", err)
+	}
+	defer cleanup()
+
+	results, err := executor.CollectTuples(db.Query(`[:find ?name :where [_ :person/name ?name]]`))
+	if err != nil {
+		t.Fatalf("Query recompressed JDZL failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("Expected 2 names from recompressed JDZL, got %d", len(results))
+	}
+}
+
 func TestCLI_ImportIntoEDNPathRejected(t *testing.T) {
 	binPath := buildCLI(t)
 	ednPath := createTestEDNDump(t)
@@ -156,5 +262,26 @@ func TestCLI_ImportIntoEDNPathRejected(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "database directory") {
 		t.Errorf("Expected error to explain -db must be a database directory, got: %s", out)
+	}
+}
+
+func TestCLI_ImportIntoJDZLPathRejected(t *testing.T) {
+	binPath := buildCLI(t)
+	ednPath := createTestEDNDump(t)
+	jdzlPath := createTestJDZLDump(t)
+	target := filepath.Join(t.TempDir(), "target.jdzl")
+
+	for _, args := range [][]string{
+		{"-db", target, "-import", ednPath},
+		{"-db", target, "-import-bin", jdzlPath},
+	} {
+		cmd := exec.Command(binPath, args...)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Errorf("Expected error for %v", args)
+		}
+		if !strings.Contains(string(out), "database directory") {
+			t.Errorf("Expected database-directory rejection for %v, got: %s", args, out)
+		}
 	}
 }

--- a/cmd/datalog/stats.go
+++ b/cmd/datalog/stats.go
@@ -17,7 +17,7 @@ import (
 
 // runStats scans the full database (EAVT index, all history) and reports
 // per-attribute cardinality, value size distribution, and value duplication.
-// The source may be a BadgerDB directory or an .edn dump.
+// The source may be a BadgerDB directory or an .edn/.jdzl dump.
 func runStats(dbPath string) {
 	db, cleanup, err := openDatabaseOrEDN(dbPath)
 	if err != nil {

--- a/docs/reference/BINARY_EXPORT.md
+++ b/docs/reference/BINARY_EXPORT.md
@@ -23,9 +23,16 @@ I/O is framed chunks, not a byte-stream codec.
 ```bash
 datalog -db mydata.db -export-bin backup.jdzl
 datalog -db newdata.db -import-bin backup.jdzl
+
+# .jdzl is a peer dump source to .edn: query / stats / re-export via a temp DB
+datalog -db backup.jdzl -query '[:find ?e :where [?e :person/name _]]'
+datalog -db backup.jdzl -export backup.edn
+datalog -db backup.jdzl -export-bin recompressed.jdzl
 ```
 
-EDN `-export` / `-import` are unchanged.
+`-db` dump paths (`.edn` or `.jdzl`) load into a disposable temporary database.
+`-import` / `-import-bin` still require `-db` to be a real Badger directory —
+not a dump file.
 
 ## File layout
 


### PR DESCRIPTION
## Summary
- Wire `.jdzl` through `openDatabaseOrEDN` via `ImportBinary` into a temp DB — same paths as `.edn` for query, stats, `-export`, and `-export-bin`
- Share `isDumpFilePath` so `-import` and `-import-bin` both reject dump targets (closes the gap where `-db backup.jdzl -import …` would open a Badger dir named `backup.jdzl`)
- Cover query / EDN convert / JDZL recompress / target rejection in `open_database_test.go`; update CLI help and `BINARY_EXPORT.md`

## Test plan
- [x] `go test -count=1 ./cmd/datalog/ -run 'OpenDatabase|CLI_QueryFrom|CLI_Export|CLI_ImportInto'`
- [x] `go test -count=1 ./...`
- [ ] Manually: `datalog -db dump.jdzl -query '...'` and `-export` / `-export-bin` from a JDZL dump