### PR TITLE
Bound BadgerStore.Assert to Badger's transaction ceiling

### DIFF
--- a/datalog/storage/badger_store.go
+++ b/datalog/storage/badger_store.go
@@ -59,26 +59,41 @@ func NewBadgerStore(path string, encoder *BinaryKeyEncoder) (*BadgerStore, error
 	}, nil
 }
 
-// Assert adds datoms to the store
+// Assert adds datoms to the store.
+//
+// The writes go through a WriteBatch rather than one transaction. A caller
+// hands this arbitrarily many datoms, and at eight index keys each plus a blob
+// per out-of-line value, Badger's per-transaction ceiling arrives long before
+// a caller has reason to suspect a limit exists — a single entity's history is
+// enough. The batch splits at that ceiling itself, so the arithmetic stays
+// Badger's and cannot drift from it.
+//
+// The cost is that Assert is not atomic: a mid-way failure leaves the datoms
+// already committed in place. Re-asserting is safe, because an index key is
+// derived wholly from its datom and a repeated write reproduces it exactly.
+// A caller that needs a boundary uses BeginTx, whose StoreTx.Assert still
+// writes into the one transaction that caller owns.
 func (s *BadgerStore) Assert(datoms []datalog.Datom) error {
-	return s.db.Update(func(txn *badger.Txn) error {
-		for _, d := range datoms {
-			if err := s.assertDatom(txn, &d); err != nil {
-				return err
-			}
+	wb := s.db.NewWriteBatch()
+	defer wb.Cancel()
+	for _, d := range datoms {
+		if err := s.assertDatom(wb.Set, &d); err != nil {
+			return err
 		}
-		return nil
-	})
+	}
+	return wb.Flush()
 }
 
-// assertDatom adds a single datom to all indices
-func (s *BadgerStore) assertDatom(txn *badger.Txn, d *datalog.Datom) error {
+// assertDatom writes one datom's eight index keys, and its blob when the value
+// is stored out of line, through set: a transaction's Set where the caller owns
+// the transaction boundary, a write batch's where it does not.
+func (s *BadgerStore) assertDatom(set func(key, value []byte) error, d *datalog.Datom) error {
 	// Pre-encode value bytes once (avoids recomputing compression 7 times)
 	vBytes, blobData := s.encoder.EncodeValueBytes(d.V)
 
 	// Tier 3: write compressed data to blob store
 	if blobData != nil {
-		if err := putBlob(txn, blobData.Hash, blobData.CompressedBytes); err != nil {
+		if err := putBlob(set, blobData.Hash, blobData.CompressedBytes); err != nil {
 			return fmt.Errorf("failed to write blob: %w", err)
 		}
 	}
@@ -88,7 +103,7 @@ func (s *BadgerStore) assertDatom(txn *badger.Txn, d *datalog.Datom) error {
 	sd := ToStorageDatom(*d)
 	for _, idx := range Indices {
 		key := s.encoder.encodeKeyWithParts(idx, &sd, vBytes)
-		if err := txn.Set(key, nil); err != nil {
+		if err := set(key, nil); err != nil {
 			return fmt.Errorf("failed to write to %v index: %w", idx, err)
 		}
 	}
@@ -615,10 +630,12 @@ type BadgerTx struct {
 	txn   *badger.Txn
 }
 
-// Assert adds datoms within a transaction
+// Assert adds datoms within a transaction. Unlike BadgerStore.Assert this does
+// not split: the caller owns the transaction boundary, so an oversized commit
+// surfaces Badger's ErrTxnTooBig for the caller to handle.
 func (t *BadgerTx) Assert(datoms []datalog.Datom) error {
 	for _, d := range datoms {
-		if err := t.store.assertDatom(t.txn, &d); err != nil {
+		if err := t.store.assertDatom(t.txn.Set, &d); err != nil {
 			return err
 		}
 	}

--- a/datalog/storage/blob_store.go
+++ b/datalog/storage/blob_store.go
@@ -43,13 +43,14 @@ func (r badgerTxnBlobReader) ReadBlob(hash [20]byte, read func([]byte) error) er
 	return nil
 }
 
-// putBlob stores compressed data at its content-addressed key.
-// Idempotent: writing the same content twice is a no-op.
-func putBlob(txn *badger.Txn, hash [20]byte, data []byte) error {
+// putBlob stores compressed data at its content-addressed key, through
+// whatever accumulates the caller's writes — a transaction's Set or a write
+// batch's. Idempotent: writing the same content twice is a no-op.
+func putBlob(set func(key, value []byte) error, hash [20]byte, data []byte) error {
 	var key [21]byte
 	key[0] = blobKeyPrefix
 	copy(key[1:], hash[:])
-	return txn.Set(key[:], data)
+	return set(key[:], data)
 }
 
 // getBlob retrieves compressed data by its SHA1 hash.

--- a/datalog/storage/blob_store_test.go
+++ b/datalog/storage/blob_store_test.go
@@ -44,7 +44,7 @@ func TestBlobStore_PutGet(t *testing.T) {
 
 	// Put
 	err := db.Update(func(txn *badger.Txn) error {
-		return putBlob(txn, hash, data)
+		return putBlob(txn.Set, hash, data)
 	})
 	require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func TestBlobStore_ContentAddressing(t *testing.T) {
 	// Put twice
 	for i := 0; i < 2; i++ {
 		err := db.Update(func(txn *badger.Txn) error {
-			return putBlob(txn, hash, data)
+			return putBlob(txn.Set, hash, data)
 		})
 		require.NoError(t, err)
 	}

--- a/datalog/storage/import_transaction_ceiling_test.go
+++ b/datalog/storage/import_transaction_ceiling_test.go
@@ -1,0 +1,83 @@
+//go:build !(js && wasm)
+
+package storage
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+	"github.com/wbrown/janus-datalog/datalog"
+)
+
+// entityLargerThanOneTransaction builds one entity's datoms sized to overrun a
+// single Badger transaction.
+//
+// Two properties of the write path make this reachable by ordinary data. Every
+// datom writes eight index keys, and every index orders V, so the value is
+// carried inline in all eight. Values here stay under the 512-byte compression
+// threshold so they stay in the keys rather than moving out of line into the
+// blob store, which is what makes the keys — and therefore the transaction —
+// large. Badger's ceiling is 15% of MemTableSize, so a few thousand datoms on
+// one entity clear it.
+//
+// One entity matters: JDZL closes a chunk only at an entity boundary, so an
+// entity is the chunk floor and cannot be split by the exporter's soft budget.
+func entityLargerThanOneTransaction(seed string, count int) []datalog.Datom {
+	e := datalog.NewIdentity(seed)
+	attr := datalog.NewKeyword(":entry/payload")
+	filler := strings.Repeat("v", 392)
+	datoms := make([]datalog.Datom, count)
+	for i := range datoms {
+		datoms[i] = datalog.Datom{
+			E:  e,
+			A:  attr,
+			V:  filler + fmt.Sprintf("%08d", i),
+			Tx: datalog.ElementID{Lamport: uint64(i + 1), ReplicaID: 1},
+		}
+	}
+	return datoms
+}
+
+// TestBinaryImportEntityLargerThanOneTransaction pins that import survives an
+// entity whose datoms exceed what one Badger transaction can hold.
+//
+// Before the WriteBatch split in BadgerStore.Assert, ImportBinary asserted each
+// decoded chunk in a single transaction, so a dump containing such an entity
+// exported cleanly and then refused to import — the round trip was not closed.
+func TestBinaryImportEntityLargerThanOneTransaction(t *testing.T) {
+	large := entityLargerThanOneTransaction("ceiling:accumulator", 8000)
+	small := []datalog.Datom{{
+		E:  datalog.NewIdentity("ceiling:neighbour"),
+		A:  datalog.NewKeyword(":entry/label"),
+		V:  "neighbour",
+		Tx: datalog.ElementID{Lamport: 1, ReplicaID: 2},
+	}}
+
+	// The premise, asserted through StoreTx — the path that does not split,
+	// because its caller owns the transaction boundary. If the ceiling ever
+	// moves, this fails and says the fixture needs growing, rather than the
+	// test quietly ceasing to reproduce anything.
+	probe := openBinaryTestDB(t)
+	stx, err := probe.store.BeginTx()
+	require.NoError(t, err)
+	require.ErrorIs(t, stx.Assert(large), badger.ErrTxnTooBig,
+		"fixture no longer exceeds one transaction; raise the datom count")
+	require.NoError(t, stx.Rollback())
+
+	source := openBinaryTestDB(t)
+	require.NoError(t, source.store.Assert(large))
+	require.NoError(t, source.store.Assert(small))
+
+	var dump seekBuffer
+	require.NoError(t, source.ExportBinary(&dump))
+
+	target := openBinaryTestDB(t)
+	require.NoError(t, target.ImportBinary(&dump))
+
+	var reexported seekBuffer
+	require.NoError(t, target.ExportBinary(&reexported))
+	require.Equal(t, dump.buf, reexported.buf)
+}

--- a/docs/bugs/resolved/BUG_IMPORT_CHUNK_EXCEEDS_BADGER_TRANSACTION.md
+++ b/docs/bugs/resolved/BUG_IMPORT_CHUNK_EXCEEDS_BADGER_TRANSACTION.md
@@ -1,0 +1,145 @@
+# BUG: A Single Entity Can Exceed One Badger Transaction, So Export Writes Dumps Import Cannot Read
+
+**Date**: 2026-07-26 **Severity**: High - the JDZL round trip is not closed **Status**: Resolved 2026-07-26 **Affected**: `storage.Database.ImportBinary`, `storage.Database.Import`, `storage.BadgerStore.Assert`
+
+## Summary
+
+`ExportBinary` could write a JDZL file that `ImportBinary` then refused to read. The failure was reported against a large dump and reproduced identically by two independent tools reading the same file, at the same byte offset:
+
+```
+binary import assert chunk at 29697768: failed to write to 5 index: Txn is too big to fit into one request
+```
+
+Index 5 is AVET, the sixth of the eight index writes each datom performs. Nothing is special about AVET — it is simply where the transaction happened to fill.
+
+The stripped export of the same database imported fine. The difference was not the file size but which entities it contained: the stripped variant omitted the entity class whose accumulated datoms overran the ceiling.
+
+## The chunk floor is one entity
+
+`ExportBinary` closes a chunk on a soft budget — 256 KiB by default — but only *arms* at the budget and closes at the next entity boundary, so an entity's datoms stay inside one LZJ compression window:
+
+```go
+// Soft budget arms closeSoon; the chunk actually closes on the next
+// entity boundary so an entity's datoms stay in one LZJ window.
+if haveOpenE && eBytes != openE && closeSoon {
+    if err := flush(); err != nil {
+        return err
+    }
+}
+```
+
+That is deliberate and worth keeping, but it means **an entity is the chunk floor**, and an entity has no bound: a cardinality-many or cardinality-vector attribute accumulates a datom per write, for the life of the entity. There was no cap above that floor, and `binaryUint32Len` only rejects chunks past 4 GiB.
+
+`ImportBinary` then asserted each decoded chunk in exactly one call:
+
+```go
+if err := d.store.Assert(datoms); err != nil {
+    reportErr(fmt.Errorf("binary import assert chunk at %d: %w", entry.offset, err))
+}
+```
+
+and `BadgerStore.Assert` was one `db.Update` over the whole slice.
+
+## The ceiling, and how low it is
+
+`NewBadgerStore` sets `MemTableSize = 128 << 20`. Badger derives both transaction ceilings from it:
+
+```go
+opt.maxBatchSize = (15 * opt.MemTableSize) / 100
+opt.maxBatchCount = opt.maxBatchSize / int64(skl.MaxNodeSize)
+```
+
+With a 128 MiB memtable and `skl.MaxNodeSize` of 96 bytes that is **19.2 MiB or 209,715 entries**, whichever `Txn.checkSize` reaches first. Every datom writes eight index keys, plus one blob entry when its value is stored out of line, so the count ceiling arrives at roughly **26,200 datoms in a single `Assert` call** — and much sooner when values are large enough to matter but still under the 512-byte compression threshold, since every index orders V and therefore carries the value inline in all eight keys.
+
+Tens of thousands of datoms on one entity is ordinary for an append-heavy attribute. The ceiling was reachable by data, not by abuse.
+
+## Why raising `MemTableSize` is not the fix
+
+There is no knob for the transaction limit itself: `maxBatchSize` and `maxBatchCount` are unexported and derived only from `MemTableSize`, so batch headroom cannot be bought without buying memtables. Memtables are not a cap but a resident allocation — `newArena` is `make([]byte, n)` sized `MemTableSize + maxBatchSize + maxBatchCount*MaxNodeSize`, about 1.7× `MemTableSize` per memtable, with `NumMemtables` of them plus the active one under write pressure.
+
+Because the ceiling is 15% of `MemTableSize`, buying *X* bytes of headroom costs about `6.7X` of `MemTableSize` and `11X` of resident arena, on every database open, for every consumer including memory-constrained wasm targets. And it would not close the hole: entity size is unbounded, so any chosen ceiling is a deadline rather than a fix.
+
+## Why this is an import-only defect
+
+`Store.Assert` has three production call sites and all three are import — `Database.Import` twice (EDN, batched at 1000 datoms) and `Database.ImportBinary` once (JDZL, unbatched). Ordinary writes do not go through it.
+
+That is a consequence of [BUG_TRANSACTION_COMMIT_SPLIT_BADGER_TX](BUG_TRANSACTION_COMMIT_SPLIT_BADGER_TX.md). Before 2026-04-16 `Transaction.Commit` called `store.Assert`; that fix moved the whole logical commit onto a single `BeginTx`/`StoreTx` so retractions, assertions, and `:db/txInstant` commit or roll back together. Routing the commit off `Store.Assert` is precisely what makes it safe to split `Store.Assert` today — under the pre-2026-04-16 shape, splitting it would have broken commit atomicity.
+
+## Lesson
+
+**An entity is the unit of several floors in this system, and an entity is unbounded.**
+
+The export chunk is floored at one entity by the LZJ window rule. The import transaction was floored at one chunk, and therefore at one entity too. Neither floor was wrong on its own; the defect is that an unbounded quantity sat underneath a fixed ceiling with nothing in between.
+
+That shape generalizes beyond this bug. Anywhere the code groups by entity — a buffer, a transaction, a window, a batch — it has adopted an input whose size is set by how many times an attribute was written over the entity's life, which no caller declares and no schema constrains. Small-entity test data hides it completely: this fixture needed 8,000 datoms on one entity before anything went wrong, and every existing round-trip test used a handful.
+
+The corollary for fixes: when a fixed ceiling meets an unbounded input, raising the ceiling is never the repair. It converts a reproducible failure into a latent one that returns with the next larger dataset.
+
+## Resolution
+
+**Resolved**: 2026-07-26
+
+`BadgerStore.Assert` writes through a Badger `WriteBatch` rather than a single `db.Update`:
+
+```go
+// Before — one transaction, however many datoms the caller passed.
+func (s *BadgerStore) Assert(datoms []datalog.Datom) error {
+    return s.db.Update(func(txn *badger.Txn) error {
+        for _, d := range datoms {
+            if err := s.assertDatom(txn, &d); err != nil {
+                return err
+            }
+        }
+        return nil
+    })
+}
+
+// After — the batch splits at Badger's own ceiling.
+func (s *BadgerStore) Assert(datoms []datalog.Datom) error {
+    wb := s.db.NewWriteBatch()
+    defer wb.Cancel()
+    for _, d := range datoms {
+        if err := s.assertDatom(wb.Set, &d); err != nil {
+            return err
+        }
+    }
+    return wb.Flush()
+}
+``` `WriteBatch.handleEntry` commits and retries on Badger's own `ErrTxnTooBig`, so the ceiling arithmetic stays entirely on Badger's side and cannot drift from it. Computing the cost ourselves against the exported `MaxBatchCount()`/`MaxBatchSize()` was rejected for that reason: it would duplicate `Txn.checkSize`, including its per-entry overhead and value-threshold logic, in code that Badger has no obligation to keep in step with.
+
+`WriteBatch` is applicable because the assert path is write-only — every index write is `txn.Set(key, nil)` and `putBlob` is a bare `Set`, with no read inside the transaction.
+
+To let both destinations share one implementation, `assertDatom` takes a `set func(key, value []byte) error` instead of a `*badger.Txn`; `txn.Set` and `wb.Set` already have that signature, so the key-building logic did not move. `putBlob` takes the same parameter.
+
+Both importers inherit the fix and neither changed. `Import`'s `batchSize = 1000` is kept: it bounds the importer's own slice allocation, which is a separate concern from the transaction ceiling — and it was never a sufficient bound on its own, since 1000 datoms carrying large values can cross the size ceiling while sitting far under the count ceiling.
+
+### The cost, and where it stops
+
+`Store.Assert` is no longer atomic: a mid-way failure leaves already-committed datoms in place. That costs nothing here — its only callers are the importers, and `ImportBinary` already documents that import is not transactional across chunks and that retrying into the same database is not safe recovery.
+
+`BadgerTx.Assert` is deliberately **not** split. Its caller owns the transaction boundary, so an oversized commit still surfaces `ErrTxnTooBig` for that caller to handle, and the atomicity established by BUG_TRANSACTION_COMMIT_SPLIT_BADGER_TX is untouched.
+
+### Regression test
+
+`datalog/storage/import_transaction_ceiling_test.go::TestBinaryImportEntityLargerThanOneTransaction` builds one entity of 8,000 datoms with sub-threshold values, exports it, imports into a fresh database, and compares a re-export byte for byte.
+
+The test asserts its own premise first: the same datoms are driven through `StoreTx.Assert` — the path that does not split — and required to return `badger.ErrTxnTooBig`. That is the shape `BadgerStore.Assert` had before this fix, so the test demonstrates the old path failing inside the same run that shows the new one succeeding, and it stays honest about itself: if `MemTableSize` is ever raised, the premise fails and says the fixture needs growing rather than the test quietly ceasing to reproduce anything.
+
+Native-tagged, because it asserts a Badger-specific ceiling; `MemoryStore` has no transaction limit and nothing to reproduce.
+
+### What this does not include
+
+`BadgerStore.Retract` still uses one `db.Update`. `retractDatom` scans EAVT inside its transaction to find the stored datoms, so it is not write-only and `WriteBatch` does not apply. Import never retracts, so it is out of the path this bug describes.
+
+`ExportBinary` was not capped. Doing so would restore the round trip only for dumps written afterward — it cannot read a file that already exists, which was the problem in hand — and it would split entities across LZJ windows, giving up the compression property the entity-aligned soft close exists to protect.
+
+### Measurements
+
+`BenchmarkBadgerAssertBulk` against the pre-fix implementation, Apple M5, darwin/arm64:
+
+| size | before | after |
+|---|---|---|
+| 1000 | 8.73 ms/op, 5,133,920 B/op, 114,116 allocs/op | 9.19 ms/op, 5,105,416 B/op, 114,127 allocs/op |
+| 4000 | 18.19 ms/op, 20,574,826 B/op, 456,311 allocs/op | 18.08 ms/op, 20,238,459 B/op, 456,320 allocs/op |
+
+`WriteBatch` adds a constant ~10 allocations per `Assert` call rather than per datom, and byte totals came out marginally lower at both sizes. The two timings moved in opposite directions, which is run-to-run noise on a benchmark that constructs a Badger database per iteration.


### PR DESCRIPTION
`ExportBinary` could write a JDZL file that `ImportBinary` then refused to read — the round trip was not closed. Reported against a large dump and reproduced identically by two independent tools reading the same file at the same byte offset:

```
binary import assert chunk at 29697768: failed to write to 5 index: Txn is too big to fit into one request
```

Index 5 is AVET, the sixth of the eight index writes each datom performs. Nothing is special about AVET — it is where the transaction happened to fill.

## Why an ordinary dump can do this

`ExportBinary` arms its soft budget at 256 KiB but closes the chunk only at the next entity boundary, deliberately, so an entity's datoms stay inside one LZJ window. That makes **an entity the chunk floor** — and an entity is unbounded, since a cardinality-many or cardinality-vector attribute accumulates a datom per write for the entity's life. There was no cap above that floor.

`ImportBinary` then asserted each decoded chunk in one `d.store.Assert(datoms)` call, and `BadgerStore.Assert` was a single `db.Update` over the whole slice.

The ceiling is lower than the 53 MiB file suggests. `NewBadgerStore` sets `MemTableSize = 128 << 20`, from which Badger derives `maxBatchSize = 15% of MemTableSize` = 19.2 MiB and `maxBatchCount = maxBatchSize / skl.MaxNodeSize` = 209,715 entries. At eight index keys per datom that is roughly **26,200 datoms in a single `Assert` call**, and considerably fewer when values are large enough to matter but still under the 512-byte compression threshold, since every index orders V and so carries the value inline in all eight keys.

## Why not raise `MemTableSize`

There is no knob for the transaction limit: `maxBatchSize`/`maxBatchCount` are unexported and derived only from `MemTableSize`, so batch headroom cannot be bought without buying memtables — and memtables are resident, not a cap (`newArena` is `make([]byte, n)`, sized ~1.7× `MemTableSize`, one per memtable). Buying *X* bytes of headroom costs ~`6.7X` of `MemTableSize` and ~`11X` of resident arena on every database open, including wasm targets. It also would not close the hole: entity size is unbounded, so any chosen ceiling is a deadline rather than a fix.

## The fix

`BadgerStore.Assert` writes through a Badger `WriteBatch`. `WriteBatch.handleEntry` commits and retries on Badger's own `ErrTxnTooBig`, so the ceiling arithmetic stays on Badger's side. Computing it here against the exported `MaxBatchCount()`/`MaxBatchSize()` was rejected: it would duplicate `Txn.checkSize`, including its per-entry overhead and value-threshold logic, in code Badger has no obligation to keep in step with.

`WriteBatch` applies because the assert path is write-only — every index write is `txn.Set(key, nil)` and `putBlob` is a bare `Set`, with no read inside the transaction.

So both destinations share one implementation, `assertDatom` takes a `set func(key, value []byte) error` instead of a `*badger.Txn`; `txn.Set` and `wb.Set` already have that signature, so the key-building logic did not move. `putBlob` takes the same parameter.

Both importers inherit the fix and neither changed. `Import`'s `batchSize = 1000` is kept — it bounds the importer's own slice allocation, a separate concern, and was never sufficient on its own since 1000 datoms carrying large values can cross the size ceiling while far under the count ceiling.

## Scope

`Store.Assert` is no longer atomic; a mid-way failure leaves already-committed datoms in place. That costs nothing here — its only production callers are the two importers, and `ImportBinary` already documents that import is not transactional across chunks and that retrying into the same database is not safe recovery.

`BadgerTx.Assert` is deliberately **not** split. Its caller owns the transaction boundary, so an oversized commit still surfaces `ErrTxnTooBig`, and the atomicity established by `BUG_TRANSACTION_COMMIT_SPLIT_BADGER_TX` is untouched. That fix is in fact what makes this one safe: before 2026-04-16 `Transaction.Commit` called `store.Assert`, and splitting it then would have broken commit atomicity.

`Retract` is unchanged — `retractDatom` scans EAVT inside its transaction, so it is not write-only and `WriteBatch` does not apply. Import never retracts.

The exporter was not capped: that would restore the round trip only for dumps written afterward, cannot read a file that already exists, and would split entities across LZJ windows.

## Test

`TestBinaryImportEntityLargerThanOneTransaction` exports one entity of 8,000 datoms with sub-threshold values, imports into a fresh database, and compares a re-export byte for byte.

It asserts its own premise first: the same datoms are driven through `StoreTx.Assert` — the path that does not split, and the shape `BadgerStore.Assert` had before this change — and required to return `badger.ErrTxnTooBig`. The old path is therefore demonstrated failing inside the same run that shows the new one succeeding, and if `MemTableSize` is ever raised the premise fails saying the fixture needs growing, rather than the test quietly ceasing to reproduce anything.

Native-tagged, since it asserts a Badger-specific ceiling; `MemoryStore` has no transaction limit.

## Measurements

`BenchmarkBadgerAssertBulk`, Apple M5, darwin/arm64:

| size | before | after |
|---|---|---|
| 1000 | 8.73 ms/op, 5,133,920 B/op, 114,116 allocs/op | 9.19 ms/op, 5,105,416 B/op, 114,127 allocs/op |
| 4000 | 18.19 ms/op, 20,574,826 B/op, 456,311 allocs/op | 18.08 ms/op, 20,238,459 B/op, 456,320 allocs/op |

`WriteBatch` adds a constant ~10 allocations per `Assert` call rather than per datom, and byte totals came out marginally lower at both sizes. The two timings moved in opposite directions — noise on a benchmark that builds a Badger database per iteration.

`make test` green on both legs.
